### PR TITLE
ci: 添加手动 eval workflow

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -1,0 +1,67 @@
+name: Manual Evals
+
+"on":
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  designer-evals:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+      - run: uv run agents/designer/test/run_all_evals.py
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: designer-eval-runtime-artifacts
+          if-no-files-found: ignore
+          retention-days: 7
+          path: |
+            agents/designer/test/**/comparison.auto.md
+
+  qa-evals:
+    runs-on: ubuntu-latest
+    env:
+      CODEX_HOME: ${{ runner.temp }}/codex-home
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+      - uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+      - name: Require OpenAI API key
+        run: |
+          if [ -z "${OPENAI_API_KEY:-}" ]; then
+            echo "::error::Set the OPENAI_API_KEY repository secret before running QA evals."
+            exit 1
+          fi
+      - name: Install Codex CLI
+        run: npm install -g @openai/codex
+      - name: Authenticate Codex CLI
+        run: printenv OPENAI_API_KEY | codex login --with-api-key
+      - run: uv run agents/qa/test/run_all_evals.py
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: qa-eval-runtime-artifacts
+          if-no-files-found: ignore
+          retention-days: 7
+          path: |
+            agents/qa/test/**/comparison.auto.md
+            agents/qa/test/**/with_skill/outputs/**
+            agents/qa/test/**/without_skill/outputs/**
+            agents/qa/test/**/diagnostics/**

--- a/README.md
+++ b/README.md
@@ -205,6 +205,8 @@ uv run agents/qa/test/run_all_evals.py
 
 For changes that affect skill behavior, routing, eval fixtures, or release readiness, an administrator should run the manual model eval workflow before merging and use the result as merge evidence. Model evals are not required status checks because model output, runtime, and environment can vary.
 
+The same manual checks are available from GitHub Actions: open `Manual Evals`, choose `Run workflow`, and review the uploaded short-lived runtime artifacts. The QA eval job requires the `OPENAI_API_KEY` repository secret because it calls `codex exec`.
+
 Extra static format checks:
 
 ```bash

--- a/README_zh.md
+++ b/README_zh.md
@@ -205,6 +205,8 @@ uv run agents/qa/test/run_all_evals.py
 
 涉及 skill 行为、routing、eval fixture 或 release 前变更时，管理员应在合并前运行手动模型 eval workflow，并把结果作为 merge 判断依据。模型 eval 不作为 required status check，因为模型输出、运行耗时和环境都可能波动。
 
+同一组手动检查也可在 GitHub Actions 中触发：打开 `Manual Evals`，点击 `Run workflow`，再查看上传的短期运行 artifact。QA eval job 会调用 `codex exec`，因此需要仓库 secret `OPENAI_API_KEY`。
+
 额外静态格式检查：
 
 ```bash


### PR DESCRIPTION
## Summary

- 新增 `.github/workflows/evals.yml`，提供 `workflow_dispatch` 手动触发入口。
- 增加 `designer-evals` 和 `qa-evals` 两个 job，分别运行 Designer / QA eval runner。
- QA eval job 安装 Codex CLI，并要求仓库配置 `OPENAI_API_KEY` secret。
- 上传短期 runtime artifacts，便于管理员查看手动 eval 结果。
- README / README_zh 补充 GitHub Actions 触发入口说明。

## Validation

- `ruby -e 'require "yaml"; y=YAML.load_file(".github/workflows/evals.yml"); raise "bad name" unless y["name"] == "Manual Evals"; raise "bad jobs" unless y["jobs"].keys.sort == ["designer-evals", "qa-evals"]; puts "PASS: evals workflow parses"'`
- `uv run scripts/check_repository_contract.py`
- `uv run scripts/check_eval_contract.py`
- `uv run scripts/check_eval_artifacts.py`
- `git diff --check`

## Notes

- `Manual Evals` 不作为 required status check。
- QA eval 会调用 `codex exec`，需要管理员先配置 `OPENAI_API_KEY` repository secret。
