### PR TITLE
ci: 修复手动 eval workflow 触发

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -2,13 +2,25 @@ name: Manual Evals
 
 "on":
   workflow_dispatch:
+    inputs:
+      target:
+        description: "Eval suite to run"
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - designer
+          - qa
 
 permissions:
   contents: read
 
 jobs:
   designer-evals:
+    if: ${{ github.event.inputs.target == 'all' || github.event.inputs.target == 'designer' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -17,7 +29,15 @@ jobs:
       - uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
-      - run: uv run agents/designer/test/run_all_evals.py
+      - name: Run designer eval diagnostics
+        id: run-designer-evals
+        continue-on-error: true
+        run: uv run agents/designer/test/run_all_evals.py
+      - name: Explain designer eval diagnostics
+        if: ${{ steps.run-designer-evals.outcome == 'failure' }}
+        run: |
+          echo "::warning::Designer eval diagnostics found missing or failing runtime outputs."
+          echo "::warning::Review the uploaded comparison.auto.md artifacts before using this run as merge evidence."
       - uses: actions/upload-artifact@v4
         if: always()
         with:
@@ -28,10 +48,11 @@ jobs:
             agents/designer/test/**/comparison.auto.md
 
   qa-evals:
+    if: ${{ github.event.inputs.target == 'all' || github.event.inputs.target == 'qa' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     env:
-      CODEX_HOME: ${{ runner.temp }}/codex-home
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      CODEX_HOME: /tmp/codex-home
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -44,6 +65,8 @@ jobs:
         with:
           enable-cache: true
       - name: Require OpenAI API key
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           if [ -z "${OPENAI_API_KEY:-}" ]; then
             echo "::error::Set the OPENAI_API_KEY repository secret before running QA evals."
@@ -52,6 +75,8 @@ jobs:
       - name: Install Codex CLI
         run: npm install -g @openai/codex
       - name: Authenticate Codex CLI
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: printenv OPENAI_API_KEY | codex login --with-api-key
       - run: uv run agents/qa/test/run_all_evals.py
       - uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -196,16 +196,16 @@ uv run --with pytest pytest \
 Additional local model evals are manual quality checks, not first-version PR required checks:
 
 ```bash
-# Designer eval
+# Designer eval diagnostics
 uv run agents/designer/test/run_all_evals.py
 
-# QA eval
+# QA model eval
 uv run agents/qa/test/run_all_evals.py
 ```
 
 For changes that affect skill behavior, routing, eval fixtures, or release readiness, an administrator should run the manual model eval workflow before merging and use the result as merge evidence. Model evals are not required status checks because model output, runtime, and environment can vary.
 
-The same manual checks are available from GitHub Actions: open `Manual Evals`, choose `Run workflow`, and review the uploaded short-lived runtime artifacts. The QA eval job requires the `OPENAI_API_KEY` repository secret because it calls `codex exec`.
+The same manual checks are available from GitHub Actions: open `Manual Evals`, choose `Run workflow`, select `all`, `designer`, or `qa`, and review the uploaded short-lived runtime artifacts. The QA eval job requires the `OPENAI_API_KEY` repository secret because it calls `codex exec`; `designer` can be run independently without that secret and reports runtime-output gaps as warnings for artifact review.
 
 Extra static format checks:
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -196,16 +196,16 @@ uv run --with pytest pytest \
 额外本地模型 eval 是质量检查，不属于第一版 PR 必跑门禁：
 
 ```bash
-# Designer eval
+# Designer eval diagnostics
 uv run agents/designer/test/run_all_evals.py
 
-# QA eval
+# QA model eval
 uv run agents/qa/test/run_all_evals.py
 ```
 
 涉及 skill 行为、routing、eval fixture 或 release 前变更时，管理员应在合并前运行手动模型 eval workflow，并把结果作为 merge 判断依据。模型 eval 不作为 required status check，因为模型输出、运行耗时和环境都可能波动。
 
-同一组手动检查也可在 GitHub Actions 中触发：打开 `Manual Evals`，点击 `Run workflow`，再查看上传的短期运行 artifact。QA eval job 会调用 `codex exec`，因此需要仓库 secret `OPENAI_API_KEY`。
+同一组手动检查也可在 GitHub Actions 中触发：打开 `Manual Evals`，点击 `Run workflow`，选择 `all`、`designer` 或 `qa`，再查看上传的短期运行 artifact。QA eval job 会调用 `codex exec`，因此需要仓库 secret `OPENAI_API_KEY`；`designer` 可独立运行，不依赖该 secret，并把运行期输出缺口作为 warning 提醒人工查看 artifact。
 
 额外静态格式检查：
 


### PR DESCRIPTION
## Summary

- 修复 Manual Evals workflow 解析失败的问题：不再在 job 级 env 使用不支持的 `runner.temp` context
- 增加 `target` 输入，支持 `all` / `designer` / `qa` 按需触发
- Designer eval 在 Actions 中作为诊断路径运行，运行期输出缺口以 warning 和 artifact 形式呈现；QA eval 仍需要 `OPENAI_API_KEY` 并保留失败门禁
- 同步 README / README_zh 的手动 eval 触发说明

## Validation

- `uv run scripts/check_repository_contract.py`
- `uv run scripts/check_eval_contract.py`
- `uv run scripts/check_eval_artifacts.py`
- `uv run --with pytest pytest agents/product_manager/test/idea-to-spec agents/qa/test/test_qa_run_eval.py agents/designer/test/test_designer_run_eval.py agents/devops/test/test_devops_run_eval.py agents/test_eval_contract.py`
- `git diff --check`
- GitHub workflow_dispatch designer-only: https://github.com/Neplich/dev-agent-skills/actions/runs/25442584676
