### PR TITLE
docs: 更新 Codex skill 安装路径

### DIFF
--- a/.codex/INSTALL.md
+++ b/.codex/INSTALL.md
@@ -2,6 +2,8 @@
 
 Install this repository into Codex via native skill discovery.
 
+This installer keeps the repository layout unchanged for Claude marketplace compatibility. Codex discovers skills through symlinks created under the selected `.agents/skills` directory.
+
 ## Before You Install
 
 Before making any filesystem changes, ask the user these two questions and wait for both answers:
@@ -22,23 +24,32 @@ If the user chooses a subset, allow multiple selections.
 
 ## Installation Model
 
-Use a single aggregate skill directory and expose only the requested agent folders inside it.
+Clone or update this repository under the selected `.agents` root, then expose each selected skill as a symlink under the selected `.agents/skills` directory.
 
 - Personal install:
-  - clone repo to `~/.codex/dev-agent-skills`
-  - expose skills from `~/.agents/skills/dev-agent-skills/`
+  - clone repo to `$HOME/.agents/dev-agent-skills`
+  - symlink skills to `$HOME/.agents/skills/<skill-name>`
 - Project install:
-  - clone repo to `<project>/.codex/dev-agent-skills`
-  - expose skills from `<project>/.agents/skills/dev-agent-skills/`
+  - clone repo to `<project>/.agents/dev-agent-skills`
+  - symlink skills to `<project>/.agents/skills/<skill-name>`
 
-Each selected agent should be linked into the aggregate directory using this mapping:
+Do not move, flatten, or rewrite the repository's `agents/*/skills/*` directories.
 
-- `pm-agent` -> `agents/product_manager`
-- `engineer-agent` -> `agents/engineer`
-- `qa-agent` -> `agents/qa`
-- `devops-agent` -> `agents/devops`
-- `designer-agent` -> `agents/designer`
-- `security-agent` -> `agents/security`
+Agent to source directory mapping:
+
+- `pm-agent` -> `agents/product_manager/skills/*`
+- `engineer-agent` -> `agents/engineer/skills/*`
+- `qa-agent` -> `agents/qa/skills/*`
+- `devops-agent` -> `agents/devops/skills/*`
+- `designer-agent` -> `agents/designer/skills/*`
+- `security-agent` -> `agents/security/skills/*`
+
+Each linked skill should end up as one of these forms:
+
+```text
+$HOME/.agents/skills/<skill-name> -> $HOME/.agents/dev-agent-skills/agents/<agent>/skills/<skill-name>
+<project>/.agents/skills/<skill-name> -> <project>/.agents/dev-agent-skills/agents/<agent>/skills/<skill-name>
+```
 
 ## Installation Steps
 
@@ -47,16 +58,16 @@ Each selected agent should be linked into the aggregate directory using this map
 For `personal`:
 
 ```bash
-CLONE_ROOT="$HOME/.codex/dev-agent-skills"
-SKILL_ROOT="$HOME/.agents/skills/dev-agent-skills"
+CLONE_ROOT="$HOME/.agents/dev-agent-skills"
+SKILL_ROOT="$HOME/.agents/skills"
 ```
 
 For `project`, from the project root:
 
 ```bash
 PROJECT_ROOT="$PWD"
-CLONE_ROOT="$PROJECT_ROOT/.codex/dev-agent-skills"
-SKILL_ROOT="$PROJECT_ROOT/.agents/skills/dev-agent-skills"
+CLONE_ROOT="$PROJECT_ROOT/.agents/dev-agent-skills"
+SKILL_ROOT="$PROJECT_ROOT/.agents/skills"
 ```
 
 ### 2. Clone or update the repository
@@ -74,34 +85,87 @@ mkdir -p "$(dirname "$CLONE_ROOT")"
 git clone https://github.com/Neplich/dev-agent-skills.git "$CLONE_ROOT"
 ```
 
-### 3. Rebuild the aggregate skill directory
+### 3. Create Codex skill symlinks
 
-Make the installed set exactly match the user's choice:
+Create the selected Codex skill root:
 
 ```bash
-rm -rf "$SKILL_ROOT"
 mkdir -p "$SKILL_ROOT"
 ```
 
-Then create symlinks for each selected agent. Example for `pm-agent` and `engineer-agent`:
+Use this helper to link every skill from a selected agent:
 
 ```bash
-ln -s "$CLONE_ROOT/agents/product_manager" "$SKILL_ROOT/product_manager"
-ln -s "$CLONE_ROOT/agents/engineer" "$SKILL_ROOT/engineer"
+link_agent_skills() {
+  agent_skills_dir="$CLONE_ROOT/$1"
+
+  find "$agent_skills_dir" -mindepth 1 -maxdepth 1 -type d | while IFS= read -r skill_dir; do
+    [ -f "$skill_dir/SKILL.md" ] || continue
+
+    skill_name="$(basename "$skill_dir")"
+    dest="$SKILL_ROOT/$skill_name"
+
+    if [ -L "$dest" ]; then
+      current_target="$(readlink "$dest")"
+      case "$current_target" in
+        "$CLONE_ROOT"/*)
+          rm "$dest"
+          ;;
+        *)
+          echo "Skip existing symlink not managed by this installer: $dest -> $current_target"
+          continue
+          ;;
+      esac
+    elif [ -e "$dest" ]; then
+      echo "Skip existing non-symlink skill directory: $dest"
+      continue
+    fi
+
+    ln -s "$skill_dir" "$dest"
+    echo "Linked $skill_name"
+  done
+}
 ```
 
-If the user chose `all`, create all six links.
+If the user chose `all`, run:
+
+```bash
+link_agent_skills "agents/product_manager/skills"
+link_agent_skills "agents/engineer/skills"
+link_agent_skills "agents/qa/skills"
+link_agent_skills "agents/devops/skills"
+link_agent_skills "agents/designer/skills"
+link_agent_skills "agents/security/skills"
+```
+
+If the user chose a subset, run only the matching lines.
+
+For example, for `pm-agent`, `engineer-agent`, and `qa-agent`:
+
+```bash
+link_agent_skills "agents/product_manager/skills"
+link_agent_skills "agents/engineer/skills"
+link_agent_skills "agents/qa/skills"
+```
 
 ### 4. Restart Codex
 
-Quit and relaunch Codex so it discovers the new skills.
+Quit and relaunch Codex so it discovers the new skills. For a `project` install, reopen Codex in that same project directory.
 
 ## Verify
 
-Check the aggregate directory:
+Check that Codex can see symlinked skill directories:
 
 ```bash
-ls -la "$SKILL_ROOT"
+find -L "$SKILL_ROOT" -maxdepth 2 -name SKILL.md -print | sort
+```
+
+For this repository, expected entries include paths such as:
+
+```text
+$SKILL_ROOT/pm-agent/SKILL.md
+$SKILL_ROOT/engineer-agent/SKILL.md
+$SKILL_ROOT/qa-agent/SKILL.md
 ```
 
 After restarting Codex, verify that the installed agent commands are available, such as:
@@ -127,10 +191,18 @@ The links continue to work after the pull. Restart Codex if the updated skills d
 
 ## Uninstalling
 
-Remove the aggregate skill directory:
+Remove only symlinks that point into the selected clone:
 
 ```bash
-rm -rf "$SKILL_ROOT"
+find "$SKILL_ROOT" -maxdepth 1 -type l -print | while IFS= read -r link; do
+  target="$(readlink "$link")"
+  case "$target" in
+    "$CLONE_ROOT"/*)
+      rm "$link"
+      echo "Removed $link"
+      ;;
+  esac
+done
 ```
 
 Optionally remove the cloned repository:
@@ -142,5 +214,6 @@ rm -rf "$CLONE_ROOT"
 ## Troubleshooting
 
 - If commands do not appear, verify the links under `"$SKILL_ROOT"` and restart Codex.
-- If the user changes from `all` to a subset, rebuild `"$SKILL_ROOT"` so only the selected agent links remain.
-- If the project install is used, confirm the user opened that same project in Codex after installation.
+- If a skill name already exists under `"$SKILL_ROOT"` and is not a symlink to this repository, keep it and report the conflict instead of overwriting it.
+- If the user changes from `all` to a subset, remove this repository's old symlinks first, then recreate only the selected agent skills.
+- If the user chooses `project`, confirm Codex is opened in that same project directory after installation.

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ The install flow will ask:
 - whether this should be a `personal` or `project` install
 - whether to install `all` agents or a selected subset
 
+Codex installs the repository at the selected `.agents/dev-agent-skills` root and symlinks each selected skill into `.agents/skills/<skill-name>`. The repository layout stays unchanged for Claude marketplace compatibility.
+
 See [docs/README.codex.md](./docs/README.codex.md) for the full Codex guide.
 
 ## Usage Examples

--- a/README_zh.md
+++ b/README_zh.md
@@ -104,6 +104,8 @@ Fetch and follow instructions from https://raw.githubusercontent.com/Neplich/dev
 - 安装到 `personal` 还是 `project` 层级
 - 安装 `all` agents，还是选择其中一部分
 
+Codex 安装会把仓库 clone 到对应层级的 `.agents/dev-agent-skills`，并把已选 Agent 下的每个 skill 软链接到 `.agents/skills/<skill-name>`。仓库目录结构保持不变，继续兼容 Claude marketplace。
+
 完整说明见 [docs/README.codex.md](./docs/README.codex.md)。
 
 ## 使用示例

--- a/docs/README.codex.md
+++ b/docs/README.codex.md
@@ -32,15 +32,17 @@ Codex 会先反问你两个问题，再执行安装：
 
 适合希望在所有项目里复用这些 Agent 的场景。
 
-- 仓库 clone 到 `~/.codex/dev-agent-skills`
-- skills 暴露到 `~/.agents/skills/dev-agent-skills/`
+- 仓库 clone 到 `~/.agents/dev-agent-skills`
+- 每个已选 Agent 下的 skills 软链接到 `~/.agents/skills/<skill-name>`
 
 ### Project
 
 适合只想在当前项目里启用这些 Agent 的场景。
 
-- 仓库 clone 到 `<project>/.codex/dev-agent-skills`
-- skills 暴露到 `<project>/.agents/skills/dev-agent-skills/`
+- 仓库 clone 到 `<project>/.agents/dev-agent-skills`
+- 每个已选 Agent 下的 skills 软链接到 `<project>/.agents/skills/<skill-name>`
+
+两种安装方式都保持仓库内的 `agents/*/skills/*` 目录不变，用于兼容 Claude marketplace。
 
 ## 手动安装
 
@@ -56,16 +58,16 @@ Codex 会先反问你两个问题，再执行安装：
 Personal:
 
 ```bash
-CLONE_ROOT="$HOME/.codex/dev-agent-skills"
-SKILL_ROOT="$HOME/.agents/skills/dev-agent-skills"
+CLONE_ROOT="$HOME/.agents/dev-agent-skills"
+SKILL_ROOT="$HOME/.agents/skills"
 ```
 
 Project:
 
 ```bash
 PROJECT_ROOT="$PWD"
-CLONE_ROOT="$PROJECT_ROOT/.codex/dev-agent-skills"
-SKILL_ROOT="$PROJECT_ROOT/.agents/skills/dev-agent-skills"
+CLONE_ROOT="$PROJECT_ROOT/.agents/dev-agent-skills"
+SKILL_ROOT="$PROJECT_ROOT/.agents/skills"
 ```
 
 ### 2. clone 或更新仓库
@@ -83,57 +85,102 @@ mkdir -p "$(dirname "$CLONE_ROOT")"
 git clone https://github.com/Neplich/dev-agent-skills.git "$CLONE_ROOT"
 ```
 
-### 3. 选择安装全部或部分 Agent
-
-安装时使用一个聚合目录，只暴露你选中的 Agent：
+### 3. 创建 Codex skill 软链接
 
 ```bash
-rm -rf "$SKILL_ROOT"
 mkdir -p "$SKILL_ROOT"
+```
+
+使用下面的函数链接某个 Agent 下的所有 skills：
+
+```bash
+link_agent_skills() {
+  agent_skills_dir="$CLONE_ROOT/$1"
+
+  find "$agent_skills_dir" -mindepth 1 -maxdepth 1 -type d | while IFS= read -r skill_dir; do
+    [ -f "$skill_dir/SKILL.md" ] || continue
+
+    skill_name="$(basename "$skill_dir")"
+    dest="$SKILL_ROOT/$skill_name"
+
+    if [ -L "$dest" ]; then
+      current_target="$(readlink "$dest")"
+      case "$current_target" in
+        "$CLONE_ROOT"/*)
+          rm "$dest"
+          ;;
+        *)
+          echo "Skip existing symlink not managed by this installer: $dest -> $current_target"
+          continue
+          ;;
+      esac
+    elif [ -e "$dest" ]; then
+      echo "Skip existing non-symlink skill directory: $dest"
+      continue
+    fi
+
+    ln -s "$skill_dir" "$dest"
+    echo "Linked $skill_name"
+  done
+}
 ```
 
 Agent 到目录的映射如下：
 
-- `pm-agent` -> `agents/product_manager`
-- `engineer-agent` -> `agents/engineer`
-- `qa-agent` -> `agents/qa`
-- `devops-agent` -> `agents/devops`
-- `designer-agent` -> `agents/designer`
-- `security-agent` -> `agents/security`
+- `pm-agent` -> `agents/product_manager/skills`
+- `engineer-agent` -> `agents/engineer/skills`
+- `qa-agent` -> `agents/qa/skills`
+- `devops-agent` -> `agents/devops/skills`
+- `designer-agent` -> `agents/designer/skills`
+- `security-agent` -> `agents/security/skills`
+
+安装全部 Agent：
+
+```bash
+link_agent_skills "agents/product_manager/skills"
+link_agent_skills "agents/engineer/skills"
+link_agent_skills "agents/qa/skills"
+link_agent_skills "agents/devops/skills"
+link_agent_skills "agents/designer/skills"
+link_agent_skills "agents/security/skills"
+```
 
 例如只安装 `pm-agent`、`engineer-agent`、`qa-agent`：
 
 ```bash
-ln -s "$CLONE_ROOT/agents/product_manager" "$SKILL_ROOT/product_manager"
-ln -s "$CLONE_ROOT/agents/engineer" "$SKILL_ROOT/engineer"
-ln -s "$CLONE_ROOT/agents/qa" "$SKILL_ROOT/qa"
+link_agent_skills "agents/product_manager/skills"
+link_agent_skills "agents/engineer/skills"
+link_agent_skills "agents/qa/skills"
 ```
-
-如果要安装全部 Agent，就把六个目录都链接进去。
 
 ### 4. 重启 Codex
 
-退出并重新打开 Codex，让它重新发现 skills。
+退出并重新打开 Codex，让它重新发现 skills。Project 安装需要在同一个项目目录里重新打开 Codex。
 
 ## 这套安装方式是怎么工作的
 
-Codex 会在启动时扫描 skill 目录。这里采用的是“聚合目录 + 按 Agent 暴露”的方式。
+Codex 会在启动时扫描 `.agents/skills`。这里采用的是“保持仓库结构 + 为每个 skill 创建软链接”的方式。
 
 Personal 安装示意：
 
 ```text
-~/.agents/skills/dev-agent-skills/
-├── product_manager -> ~/.codex/dev-agent-skills/agents/product_manager
-├── engineer -> ~/.codex/dev-agent-skills/agents/engineer
-├── qa -> ~/.codex/dev-agent-skills/agents/qa
-├── devops -> ~/.codex/dev-agent-skills/agents/devops
-├── designer -> ~/.codex/dev-agent-skills/agents/designer
-└── security -> ~/.codex/dev-agent-skills/agents/security
+~/.agents/dev-agent-skills/
+└── agents/
+    └── engineer/
+        └── skills/
+            ├── engineer-agent/
+            ├── codebase-analyzer/
+            └── feature-implementor/
+
+~/.agents/skills/
+├── engineer-agent -> ~/.agents/dev-agent-skills/agents/engineer/skills/engineer-agent
+├── codebase-analyzer -> ~/.agents/dev-agent-skills/agents/engineer/skills/codebase-analyzer
+└── feature-implementor -> ~/.agents/dev-agent-skills/agents/engineer/skills/feature-implementor
 ```
 
-Project 安装时，路径换成当前项目下的 `.codex/` 和 `.agents/`。
+Project 安装时，路径换成当前项目下的 `.agents/`。
 
-虽然底层暴露的是 Agent 目录，但用户使用时仍然只需要使用 Agent 入口命令，例如 `/pm-agent`、`/engineer-agent`。
+Claude marketplace 继续读取仓库内的 Agent 目录；Codex 通过 `.agents/skills/<skill-name>/SKILL.md` 识别 skills。
 
 ## 使用示例
 
@@ -148,42 +195,55 @@ Project 安装时，路径换成当前项目下的 `.codex/` 和 `.agents/`。
 /security-agent "进行安全审查"
 ```
 
-## 更新
-
-### Personal
+## 验证
 
 ```bash
-git -C "$HOME/.codex/dev-agent-skills" pull --ff-only
+find -L "$SKILL_ROOT" -maxdepth 2 -name SKILL.md -print | sort
 ```
 
-### Project
+预期能看到类似路径：
+
+```text
+$SKILL_ROOT/pm-agent/SKILL.md
+$SKILL_ROOT/engineer-agent/SKILL.md
+$SKILL_ROOT/qa-agent/SKILL.md
+```
+
+## 更新
 
 ```bash
-git -C "$PWD/.codex/dev-agent-skills" pull --ff-only
+git -C "$CLONE_ROOT" pull --ff-only
 ```
 
 更新后如果没有立即生效，重启 Codex。
 
 ## 卸载
 
-### Personal
+删除指向本仓库的 Codex skill 软链接：
 
 ```bash
-rm -rf "$HOME/.agents/skills/dev-agent-skills"
-rm -rf "$HOME/.codex/dev-agent-skills"
+find "$SKILL_ROOT" -maxdepth 1 -type l -print | while IFS= read -r link; do
+  target="$(readlink "$link")"
+  case "$target" in
+    "$CLONE_ROOT"/*)
+      rm "$link"
+      echo "Removed $link"
+      ;;
+  esac
+done
 ```
 
-### Project
+如果需要同时删除仓库 clone：
 
 ```bash
-rm -rf "$PWD/.agents/skills/dev-agent-skills"
-rm -rf "$PWD/.codex/dev-agent-skills"
+rm -rf "$CLONE_ROOT"
 ```
 
-如果你只想减少已安装 Agent，不需要删 clone，只需要重建 `SKILL_ROOT` 并只保留需要的 Agent 链接。
+如果只想减少已安装 Agent，不需要删 clone，只需要删除本仓库旧软链接，再重新链接需要的 Agent skills。
 
 ## 排障
 
-- 看不到命令时，先检查 `SKILL_ROOT` 下的符号链接是否正确，再重启 Codex。
+- 看不到命令时，先检查 `"$SKILL_ROOT"/<skill-name>/SKILL.md` 是否存在，再重启 Codex。
+- 如果 `"$SKILL_ROOT"/<skill-name>` 已存在且不是指向本仓库的软链接，不要覆盖，先报告冲突。
+- 如果从全部 Agent 改成部分 Agent，先删除本仓库旧软链接，再创建本次选择的软链接。
 - 使用 `project` 安装时，需要在同一个项目目录里打开 Codex。
-- 如果你原先安装的是全部 Agent，后来改成部分安装，记得重建聚合目录，不要保留旧链接。


### PR DESCRIPTION
## Summary

- 将 Codex 安装入口更新为当前 `.agents` 路径模型：`personal` 使用 `~/.agents/dev-agent-skills` 和 `~/.agents/skills/<skill-name>`，`project` 使用项目内 `.agents` 路径。
- 保留仓库内部 `agents/*/skills/*` 结构不变，仅通过软链接暴露具体 skill，避免影响 Claude marketplace。
- 同步更新 Codex 中文指南和中英文 README 快速开始摘要。

## Testing

- `uv run scripts/check_repository_contract.py`
- 使用临时目录验证 `link_agent_skills` 能在 `.agents/skills` 下生成可扫描的 `SKILL.md` 软链接。