### PR TITLE
docs: 补充 v0.1.2 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,5 @@
 
 仓库级发布变更记录按版本归档到 `docs/changelog/`。
 
+- [v0.1.2](./docs/changelog/changelog-v0.1.2.md)
 - [v0.1.0](./docs/changelog/changelog-v0.1.0.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,4 +3,5 @@
 仓库级发布变更记录按版本归档到 `docs/changelog/`。
 
 - [v0.1.2](./docs/changelog/changelog-v0.1.2.md)
+- [v0.1.1](./docs/changelog/changelog-v0.1.1.md)
 - [v0.1.0](./docs/changelog/changelog-v0.1.0.md)

--- a/docs/changelog/changelog-v0.1.1.md
+++ b/docs/changelog/changelog-v0.1.1.md
@@ -1,0 +1,32 @@
+# Changelog - v0.1.1
+
+## [v0.1.1] - 2026-05-20
+
+### Added
+
+- 将 `trd-gen` 从 PM 内部能力迁移为 Engineer Agent 的公开 skill，并注册到 marketplace；PRD 确认后由 Engineer 负责产出 `docs/engineer/{feature}/TRD.md`。([#19](https://github.com/Neplich/dev-agent-skills/pull/19))
+- 增加 Engineer Agent 复杂编码任务分工规则，明确主进程、实现 sub-agent 和验收 sub-agent 的职责边界。([#16](https://github.com/Neplich/dev-agent-skills/pull/16))
+- 增加 `feature-implementor` 文档驱动实现 eval fixture，并补充缺失 TRD 时不得直接实施的负向 eval。([#16](https://github.com/Neplich/dev-agent-skills/pull/16), [#19](https://github.com/Neplich/dev-agent-skills/pull/19))
+
+### Changed
+
+- 调整 Engineer 交付链路，明确 PRD 确认后移交 Engineer 编写 TRD，TRD 确认后再移交 `feature-implementor` 编写实现计划。([#19](https://github.com/Neplich/dev-agent-skills/pull/19))
+- 调整 `feature-implementor` planner、implementor 和 reviewer 内部指令，使复杂 spec 驱动任务可以区分计划、实现、验收和最终交付。([#16](https://github.com/Neplich/dev-agent-skills/pull/16))
+- 调整 `debugger` 复杂 bug 修复流程，保留复现优先路径，并支持最小修复与独立验收分工。([#16](https://github.com/Neplich/dev-agent-skills/pull/16))
+- 调整 QA 浏览器 E2E 执行策略，在 Claude Code / Codex 环境下优先使用 Chrome 插件或 browser connector；平台外或 standalone skill 无插件时使用 Playwright 兜底。([#13](https://github.com/Neplich/dev-agent-skills/pull/13))
+- 调整 Codex 安装入口和 README Quick Start，使用当前 `.agents` 路径模型暴露具体 skill 软链接。([#11](https://github.com/Neplich/dev-agent-skills/pull/11))
+
+### Fixed
+
+- 修复 Codex skill 旧聚合目录 `.agents/skills/dev-agent-skills` 的迁移兼容问题；子集重装或切换已选 Agent 时，会先清理本仓库 managed symlink，再创建本次选择的 skill 链接。([#17](https://github.com/Neplich/dev-agent-skills/pull/17))
+- 修复工程输入缺失 TRD 时可能继续进入实现的问题，通过负向 eval 固定 handoff 行为。([#19](https://github.com/Neplich/dev-agent-skills/pull/19))
+
+### Test
+
+- 更新 PM、Engineer、QA、Designer、DevOps 文档和 eval fixture 中的 TRD 路径与角色边界。([#19](https://github.com/Neplich/dev-agent-skills/pull/19))
+- 更新 QA E2E 策略相关 eval fixture，验证 Chrome 插件、browser connector 和 Playwright fallback 的执行路径选择。([#13](https://github.com/Neplich/dev-agent-skills/pull/13))
+- 完成 `trd-gen`、PM handoff、`feature-implementor`、缺失 TRD handoff 以及复杂工程分工相关 fresh sub-agent validation。([#16](https://github.com/Neplich/dev-agent-skills/pull/16), [#19](https://github.com/Neplich/dev-agent-skills/pull/19))
+
+### CI
+
+- 在本版本关联 PR 中通过 repository contract、eval contract、eval artifacts 和确定性 pytest 校验。([#11](https://github.com/Neplich/dev-agent-skills/pull/11), [#13](https://github.com/Neplich/dev-agent-skills/pull/13), [#16](https://github.com/Neplich/dev-agent-skills/pull/16), [#17](https://github.com/Neplich/dev-agent-skills/pull/17), [#19](https://github.com/Neplich/dev-agent-skills/pull/19))

--- a/docs/changelog/changelog-v0.1.2.md
+++ b/docs/changelog/changelog-v0.1.2.md
@@ -1,0 +1,34 @@
+# Changelog - v0.1.2
+
+## [v0.1.2] - 2026-06-04
+
+### Added
+
+- 增加 QA E2E 功能树持久化规范，统一 `docs/qa/e2e/{一级功能}/{二级功能}/{三级功能}/` 下的 `TEST_SUITE.md`、`FLOW_INDEX.md`、`cases/`、`scripts/`、`results/` 和 `_reports/` 目录结构。([#25](https://github.com/Neplich/dev-agent-skills/pull/25))
+- 增加 QA E2E 本地账号引用与测试报告 reference，明确 `.qa/e2e/accounts.local.json` 的本地凭据存储方式，避免明文账号、密码、token 或 session 进入测试文档。([#25](https://github.com/Neplich/dev-agent-skills/pull/25))
+- 增加 `docs/pm/qa-e2e-case-memory/PRD.md`、`docs/engineer/qa-e2e-case-memory/TRD.md` 和 `docs/engineer/qa-e2e-case-memory/IMPLEMENTATION_PLAN.md`，沉淀 QA E2E 用例记忆能力的产品、技术和实施计划。([#25](https://github.com/Neplich/dev-agent-skills/pull/25))
+- 增加 `debugger` 最小 failing-test eval workspace，让 bug 复现证据可以由真实 fixture 和测试命令给出。([#22](https://github.com/Neplich/dev-agent-skills/pull/22))
+
+### Changed
+
+- 调整 `feature-implementor` 实施流程，要求所有实现任务先产出或更新 `docs/engineer/{feature}/IMPLEMENTATION_PLAN.md`，并在用户确认后再修改代码；小功能、单文件变更和轻量 bug fix 也不能跳过实施计划。([#22](https://github.com/Neplich/dev-agent-skills/pull/22))
+- 调整 `engineer-agent`、`feature-implementor`、`debugger` 和 `trd-gen` 的现有功能变更路径，在进入实现或修复前先对齐 PRD/TRD 预期；需求变化回 PM，TRD 缺口回 `trd-gen`。([#22](https://github.com/Neplich/dev-agent-skills/pull/22))
+- 调整 `debugger` 流程，在根因分析后先汇报 bug 分析并询问是否产出 repair plan，修复计划确认前不直接修改代码。([#22](https://github.com/Neplich/dev-agent-skills/pull/22))
+- 调整 eval metadata 与 runner 边界，运行期 transcript、subagent verdict、diagnostics 和 scratch eval run 不再作为 durable eval output 提交。([#24](https://github.com/Neplich/dev-agent-skills/pull/24))
+- 迁移和补齐各 Agent 的 durable `comparison.md`，所有 eval item 都有显式 workspace、`eval_metadata.json` 和长期保留的 comparison 结果摘要。([#24](https://github.com/Neplich/dev-agent-skills/pull/24))
+
+### Fixed
+
+- 修复 skill eval 或 fresh Codex subagent validation 通过后，durable `comparison.md` 仍停留在 pending 状态的问题。([#24](https://github.com/Neplich/dev-agent-skills/pull/24))
+- 修复 QA eval 空跑、运行期输出路径检查和 E2E scaffold 残留路径校验问题，避免 runner-only 产物污染 durable fixture。([#25](https://github.com/Neplich/dev-agent-skills/pull/25))
+- 修复 eval contract 对 `workspace: null`、空 output metadata、diagnostics 目录和 runtime artifact 路径拦截不完整的问题。([#24](https://github.com/Neplich/dev-agent-skills/pull/24))
+
+### Test
+
+- 补充 `agents/test_eval_contract.py` 回归覆盖，校验 eval workspace、metadata output、runtime artifact blocklist 和 diagnostics path 约束。([#24](https://github.com/Neplich/dev-agent-skills/pull/24))
+- 更新 QA、Engineer、PM、Designer、DevOps、Security 的 eval fixture、comparison 和测试说明，使 skill 行为变更有对应 durable 评测证据。([#24](https://github.com/Neplich/dev-agent-skills/pull/24), [#25](https://github.com/Neplich/dev-agent-skills/pull/25))
+- 完成 QA E2E 用例持久化相关 fresh subagent validation，记录 23/23 PASS。([#25](https://github.com/Neplich/dev-agent-skills/pull/25))
+
+### CI
+
+- 保持 `repository-contract`、`eval-contract` 和 `python-tests` 作为 PR 必跑校验，并在本版本关联 PR 中通过。([#22](https://github.com/Neplich/dev-agent-skills/pull/22), [#24](https://github.com/Neplich/dev-agent-skills/pull/24), [#25](https://github.com/Neplich/dev-agent-skills/pull/25))


### PR DESCRIPTION
## 摘要

- 新增 `docs/changelog/changelog-v0.1.2.md`，记录 v0.1.1 到 v0.1.2 的版本变更。
- 补齐缺失的 `docs/changelog/changelog-v0.1.1.md`。
- 更新根目录 `CHANGELOG.md` 索引，补充 v0.1.2 和 v0.1.1 链接。

## 验证

- `git diff --check`
- `uv run scripts/check_repository_contract.py`

## 关联

- Release: v0.1.2