### PR TITLE
docs: 更新 release notes generator 发布流程

### DIFF
--- a/agents/product_manager/skills/release-notes-generator/SKILL.md
+++ b/agents/product_manager/skills/release-notes-generator/SKILL.md
@@ -1,172 +1,105 @@
 ---
 name: release-notes-generator
-description: Generate user-facing release notes for a specific version from GitHub PRs and release tags. Unlike changelog-generator (developer-facing, exhaustive), release notes are benefit-oriented, concise, and written for end users or customers. Use this skill when the user asks to write release notes, draft a release announcement, create user-friendly version summary, publish what's new for a release, or describe changes in plain language. Trigger on phrases like "写发版说明", "生成 release notes", "发版公告", "用户友好的版本说明", "这个版本有什么新功能", "draft release announcement", "what's new in v1.x", or any request to describe a release to users or customers rather than developers.
+description: Generate user-facing release notes for a specific version from GitHub PRs and release tags. Unlike changelog-generator, release notes explain why changes matter to users. Use this skill when the user asks to write release notes, draft a release announcement, create a GitHub release body, prepare or publish a draft release, or summarize what changed in a version.
 ---
 
 # Release Notes Generator
 
-Generate user-facing release notes for a GitHub release. This is distinct from `changelog-generator` — while changelogs document *what* changed for developers, release notes explain *why it matters* to end users in plain language.
+Generate user-facing release notes and, when requested, prepare or publish GitHub releases from version tags, changelog archives, merged PRs, and release metadata.
 
-All data comes from `gh` CLI — no external MCP needed. Can read from an existing versioned changelog such as `docs/changelog/changelog-v1.2.0.md` as a shortcut, or fetch directly from GitHub PRs.
+Use this skill for:
 
-## Step 1 — Identify the target version
+- Writing release notes or a release announcement.
+- Drafting a GitHub Release body.
+- Updating an existing draft release body.
+- Publishing an approved GitHub draft release.
+- Explaining what changed in a version for users or customers.
 
-Ask if not specified: "Which version would you like release notes for?" Accept tag names (e.g. `v1.2.0`), "latest", or "last release".
+## Reference Files
+
+Read the relevant reference before acting:
+
+- `reference/release-outline.md` - release note structure, writing rules, and formatting expectations.
+- `reference/github-release-workflow.md` - standard tag, changelog, draft release, and publish workflow.
+
+## Step 1 - Identify Release Context
+
+Determine:
+
+- Target version, for example `v1.2.0`.
+- Previous version or compare range.
+- Whether the task is only writing notes, updating a draft, creating a tag, or publishing a release.
+- Whether the release should remain a draft.
+
+Ask only if the version or publish/draft intent is unclear.
+
+Useful commands:
 
 ```bash
-# Get the target release
-gh release view v1.2.0 --json tagName,publishedAt,name,body
-
-# Or get latest
-gh release list --json tagName,publishedAt,name --order desc --limit 5
+gh repo view --json nameWithOwner,url,defaultBranchRef
+gh release list --json tagName,publishedAt,name,isDraft --order desc --limit 20
+gh release view v{VERSION} --json tagName,name,body,isDraft,publishedAt,targetCommitish
+git tag --list --sort=version:refname
 ```
 
-Capture `VERSION`, `RELEASE_DATE`, `REPO_URL`, `OWNER/REPO`.
+## Step 2 - Gather Change Data
 
-## Step 2 — Gather change data
-
-**Preferred path — read existing changelog first:**
-
-If `docs/changelog/changelog-v{VERSION}.md` exists, read it and extract the section for this version. This saves re-fetching and avoids redundant work. Skip to Step 3 if the changelog section is complete.
-
-**Fallback — fetch from GitHub directly:**
+Prefer existing versioned changelog archives:
 
 ```bash
-# Get the previous release tag to define the PR window
-gh release list --json tagName,publishedAt --order desc --limit 20
+docs/changelog/changelog-v{VERSION}.md
+```
 
-# Fetch merged PRs between prev and current release
+If the changelog is missing or incomplete, fetch merged PRs and commits from GitHub:
+
+```bash
 gh pr list \
   --state merged \
-  --json number,title,body,mergedAt,author,labels \
+  --json number,title,body,mergedAt,author,labels,url \
   --search "merged:PREV_DATE..RELEASE_DATE" \
   --limit 200
 ```
 
-**Skip automatically:**
-- Bot authors (`dependabot[bot]`, `renovate[bot]`, any `[bot]` suffix)
-- Prefix `chore:` / `ci:` / `test:` / `build:` / `docs:` / `style:`
-- Scope `internal` (e.g. `feat(internal):`)
-- Generic infra bumps ("Bump X from Y to Z", "update lockfile")
-
-## Step 3 — Identify highlights
-
-Release notes are not an exhaustive list. The most important step is *curation*:
-
-- **Select 2–4 headline features** — `feat:` PRs that deliver clear user value. Prefer things that change what the user can *do*, not how the internals work.
-- **Group minor fixes** — don't list every `fix:` individually; summarize as "X bug fixes" unless a fix is significant enough that users should know about it.
-- **Surface breaking changes prominently** — anything marked `feat!:` / `fix!:` or with `BREAKING CHANGE:` in the body must be in a dedicated section at the top.
-- **Performance wins worth calling out** — only if measurably meaningful (e.g. "2× faster startup", "50% reduction in memory usage").
-
-The goal: someone who reads this in 60 seconds knows whether to upgrade and what to expect.
-
-## Step 4 — Write the release notes
-
-Use this structure. Omit sections with no content.
-
-```markdown
-# Release Notes — v{VERSION} ({RELEASE_DATE})
-
-> {One-sentence headline describing the release theme, e.g. "This release focuses on performance and easier onboarding."}
-
-## ✨ What's New
-
-### {Feature Name}
-{1–2 sentences describing the feature from the user's perspective. What can they do now that they couldn't before?}
-
-{Optional: when is this useful? 1–2 bullet points for library/framework releases, e.g. "Ideal for: live dashboards, AI streaming, real-time notifications."}
-
-{Optional: 3–5 line code example. Include when it dramatically clarifies usage — especially for CLI commands, SDK methods, or API patterns where seeing the syntax is worth more than a paragraph of prose. Skip for conceptual features.}
-
-### {Another Feature}
-{...}
-
-## 🐛 Bug Fixes
-
-{If ≤ 3 significant fixes: list them individually with one sentence each.}
-{If many minor fixes: "Fixed X issues including [short description of the most notable ones]."}
-
-## 💥 Breaking Changes
-
-> ⚠️ This section is required reading before upgrading.
-
-### {Breaking Change Title}
-**What changed:** {Describe the change in plain terms.}
-**How to update:** {Step-by-step migration, or link to migration guide.}
-
-## 🔧 Other Improvements
-
-{Optional: a brief bullet list for changes that don't fit above — performance tweaks, minor enhancements, dependency updates worth noting.}
-
-## ⚠️ Upgrade Actions
-
-{Include this section ONLY when the release requires users to take specific action beyond running the install command — e.g. import path changes, config key renames, minimum dependency bumps, error handler updates. Use a numbered list of concrete steps. Omit entirely if no action required beyond installing the new version.}
-
-1. {Specific action: "Update your import from `pkg.lib.X` to `pkg.X`"}
-2. {Specific action: "If you catch `OldError`, update to `NewError`"}
-
-## ⬆️ Upgrading
-
-```
-{install command, e.g. pip install pkg==VERSION or brew upgrade gh}
-```
-
-{State clearly if there are no breaking changes: "No breaking changes. Existing code works without modification."}
-
-{If this is a CLI tool, provide platform-specific commands:}
-- macOS: `brew upgrade {tool}`
-- Windows: `winget upgrade {tool-id}`
-- Linux: see [install docs]({URL})
-
----
-
-{Full changelog: REPO_URL/compare/PREV_TAG...THIS_TAG}
-
-{Optional — for open source projects with community contributors: "Thanks to our {N} first-time contributors: @user1, @user2, ..."}
-```
-
-**Writing tone:**
-- Write for the user, not the developer: "You can now do X" not "Implemented X via Y"
-- Use active voice and present tense
-- Avoid jargon unless the audience is clearly technical (e.g. a developer SDK release can use technical terms)
-- Keep feature prose to 2 sentences max — code examples can add clarity beyond that
-- Don't say "We are pleased to announce" — get to the point
-
-**When to include code examples:**
-Code examples are worth including when: the feature is a new command/flag, a new method call, or a new pattern where seeing the syntax saves users time. Keep them to 3–8 lines. Skip for conceptual changes, config defaults, or internal improvements.
-
-If a feature has a "before/after" migration (import path changed, API shape changed), a before/after code comparison is more useful than a description alone.
-
-**PR link format** — include links to key PRs for traceability, but don't clutter every line:
-- Highlight PRs: `([#N](REPO_URL/pull/N))` inline
-- Grouped fixes: list PR numbers at the end `(#N, #N, #N)`
-
-## Step 5 — Determine output location
-
-| Scenario | Output path |
-|----------|-------------|
-| First time, single file | `docs/release-notes.md` (append newest at top) |
-| Per-version files preferred | `docs/release-notes/v{VERSION}.md` |
-| GitHub Release body | Output to console, ready to paste into `gh release edit` |
-
-Ask the user if not clear from context. Default to `docs/release-notes/v{VERSION}.md` for new projects (easier to link to specific versions).
-
-If the file already exists, read it first, then insert the new version at the top without overwriting older entries.
-
-## Step 6 — Optionally update GitHub Release body
-
-If the user wants to publish directly to GitHub:
+For squash-heavy repositories, also inspect the compare range:
 
 ```bash
-gh release edit v{VERSION} --notes-file docs/release-notes/v{VERSION}.md
+git log PREV_TAG..HEAD --date=iso --pretty=format:'%h%x09%ad%x09%s'
+gh api repos/{OWNER}/{REPO}/compare/PREV_TAG...THIS_TAG
 ```
 
-Confirm before running this — it overwrites the existing GitHub Release description.
+## Step 3 - Write Or Update Release Notes
 
-## Edge cases
+Use `reference/release-outline.md` for the release body. Match the repository's existing release style before introducing a new outline.
 
-- **No user-facing changes in a release**: write a short note — "This release contains internal improvements and dependency updates only. No user-facing changes." Don't produce an empty file.
-- **Major version (breaking-heavy)**: if more than 2 breaking changes, consider a "Migration Guide" section linking to a separate doc rather than inlining everything.
-- **Pre-release or RC tags** (e.g. `v2.0.0-rc.1`): note the pre-release status prominently at the top — "This is a release candidate. Not recommended for production."
-- **Very large releases (20+ features)**: group features into themes (e.g. "Developer Experience", "Performance", "New Integrations") instead of a flat list.
-- **No GitHub Releases, only tags**: use `gh api repos/{OWNER}/{REPO}/git/refs/tags` to get tag dates, then fetch PRs using the date window.
+Default rules:
+
+- Write in the repository's documentation language. For this repository, use Chinese release notes.
+- Keep the release user-facing and concise.
+- Include PR links for major highlights.
+- Include contributor mentions in the final change details, using `by @user in [#N](...)`.
+- Put the full compare link after the change details section.
+
+## Step 4 - Draft Or Publish On GitHub
+
+Use `reference/github-release-workflow.md` before mutating tags or releases.
+
+High-level rule:
+
+- If the user asks for a draft, create or update a draft release only.
+- If the user approves publishing, run the publishing preflight first, including changelog archive checks.
+- Never publish before required changelog archives and root `CHANGELOG.md` index entries are present.
+
+Common commands:
+
+```bash
+gh release create v{VERSION} --draft --title "{TITLE}" --notes-file {NOTES_FILE}
+gh release edit v{VERSION} --notes-file {NOTES_FILE}
+gh release edit v{VERSION} --draft=false --latest
+```
+
+## Edge Cases
+
+- If the release tag points at an older commit and release checklist files are added afterward, merge those files first, then delete and recreate the tag at the new release commit before publishing.
+- If GitHub returns an `untagged-*` URL for a draft release, verify it by querying `gh release view v{VERSION}` and checking `tagName` and `isDraft`.
+- If a target changelog archive is missing, create it with `changelog-generator` style content before publishing.
+- If the user only wants release notes text, do not mutate GitHub releases or tags.

--- a/agents/product_manager/skills/release-notes-generator/SKILL.md
+++ b/agents/product_manager/skills/release-notes-generator/SKILL.md
@@ -50,6 +50,13 @@ Prefer existing versioned changelog archives:
 docs/changelog/changelog-v{VERSION}.md
 ```
 
+Always audit the full compare range before writing release notes:
+
+- Inspect all commits in `PREV_TAG..THIS_TAG`.
+- Inspect all merged PRs in the same release window.
+- Do not discard bot, documentation, chore, or internal-looking changes before the audit. Use the complete source set as the basis for release decisions.
+- The final release notes may group, summarize, or omit low-signal items, but the decision should come after the full source audit.
+
 If the changelog is missing or incomplete, fetch merged PRs and commits from GitHub:
 
 ```bash

--- a/agents/product_manager/skills/release-notes-generator/SKILL.md
+++ b/agents/product_manager/skills/release-notes-generator/SKILL.md
@@ -26,10 +26,18 @@ Read the relevant reference before acting:
 
 Determine:
 
-- Target version, for example `v1.2.0`.
-- Previous version or compare range.
+- Target tag (`THIS_TAG`), for example `v1.2.0`.
+- Normalized version (`VERSION`), for example `1.2.0`, used only for versioned changelog filenames or titles that intentionally add a `v`.
+- Previous tag (`PREV_TAG`) or compare range.
 - Whether the task is only writing notes, updating a draft, creating a tag, or publishing a release.
 - Whether the release should remain a draft.
+
+Normalize before templating commands:
+
+- `THIS_TAG` is the exact GitHub release tag, including a leading `v` when the repository uses one.
+- `VERSION` strips exactly one leading `v` from `THIS_TAG`.
+- Never prepend another `v` to `THIS_TAG`.
+- Never use `VERSION` in Git tag, GitHub release, or compare commands unless the repository's tags are known to be unprefixed.
 
 Ask only if the version or publish/draft intent is unclear.
 
@@ -38,7 +46,7 @@ Useful commands:
 ```bash
 gh repo view --json nameWithOwner,url,defaultBranchRef
 gh release list --json tagName,publishedAt,name,isDraft --order desc --limit 20
-gh release view v{VERSION} --json tagName,name,body,isDraft,publishedAt,targetCommitish
+gh release view {THIS_TAG} --json tagName,name,body,isDraft,publishedAt,targetCommitish
 git tag --list --sort=version:refname
 ```
 
@@ -70,8 +78,8 @@ gh pr list \
 For squash-heavy repositories, also inspect the compare range:
 
 ```bash
-git log PREV_TAG..HEAD --date=iso --pretty=format:'%h%x09%ad%x09%s'
-gh api repos/{OWNER}/{REPO}/compare/PREV_TAG...THIS_TAG
+git log {PREV_TAG}..{THIS_TAG} --date=iso --pretty=format:'%h%x09%ad%x09%s'
+gh api repos/{OWNER}/{REPO}/compare/{PREV_TAG}...{THIS_TAG}
 ```
 
 ## Step 3 - Write Or Update Release Notes
@@ -99,14 +107,14 @@ High-level rule:
 Common commands:
 
 ```bash
-gh release create v{VERSION} --draft --title "{TITLE}" --notes-file {NOTES_FILE}
-gh release edit v{VERSION} --notes-file {NOTES_FILE}
-gh release edit v{VERSION} --draft=false --latest
+gh release create {THIS_TAG} --draft --title "{TITLE}" --notes-file {NOTES_FILE}
+gh release edit {THIS_TAG} --notes-file {NOTES_FILE}
+gh release edit {THIS_TAG} --draft=false --latest
 ```
 
 ## Edge Cases
 
 - If the release tag points at an older commit and release checklist files are added afterward, merge those files first, then delete and recreate the tag at the new release commit before publishing.
-- If GitHub returns an `untagged-*` URL for a draft release, verify it by querying `gh release view v{VERSION}` and checking `tagName` and `isDraft`.
+- If GitHub returns an `untagged-*` URL for a draft release, verify it by querying `gh release view {THIS_TAG}` and checking `tagName` and `isDraft`.
 - If a target changelog archive is missing, create it with `changelog-generator` style content before publishing.
 - If the user only wants release notes text, do not mutate GitHub releases or tags.

--- a/agents/product_manager/skills/release-notes-generator/reference/github-release-workflow.md
+++ b/agents/product_manager/skills/release-notes-generator/reference/github-release-workflow.md
@@ -1,0 +1,185 @@
+# GitHub Release Workflow
+
+Use this workflow when creating, updating, or publishing GitHub releases.
+
+## Modes
+
+| Mode | User intent | Allowed mutations |
+| --- | --- | --- |
+| Notes only | Write release notes text | Do not change tags or releases |
+| Draft release | Create or update a release draft | Create or update tag only if requested or required |
+| Publish release | User confirms draft can be published | Run preflight, ensure changelog archives, update tag if needed, publish |
+
+## Publishing Preflight
+
+Before publishing an approved draft release:
+
+1. Get local time.
+2. Verify repo and branch state.
+3. Verify target version and release draft state.
+4. Verify local and remote tag.
+5. Verify required changelog archives exist.
+6. Verify root `CHANGELOG.md` links to the versioned changelog archives.
+7. If changelog files are missing, create them first through the normal branch and PR flow.
+
+Commands:
+
+```bash
+date '+%Y-%m-%d %H:%M:%S %Z'
+git status --short --branch
+git branch --show-current
+gh release view v{VERSION} --json tagName,name,isDraft,publishedAt,targetCommitish
+git show --no-patch --format='%H%n%D%n%s' v{VERSION}
+git ls-remote --tags origin v{VERSION}
+test -f docs/changelog/changelog-v{VERSION}.md
+```
+
+For this repository, the root index must include the version:
+
+```bash
+rg -n "changelog-v{VERSION}\\.md" CHANGELOG.md
+```
+
+## Changelog Archive Repair
+
+If `docs/changelog/changelog-v{VERSION}.md` is missing:
+
+1. Create a maintenance branch from `main`.
+2. Add the versioned changelog file.
+3. Update root `CHANGELOG.md` as an index only.
+4. Run repository checks.
+5. Commit and push.
+6. Create a PR.
+7. Wait for required CI.
+8. Merge the PR.
+9. Sync local `main`.
+
+Commands:
+
+```bash
+git checkout -b neplich-codex/changelog-v{VERSION}
+uv run scripts/check_repository_contract.py
+git diff --check
+git add CHANGELOG.md docs/changelog/changelog-v{VERSION}.md
+git commit -m "docs: 补充 v{VERSION} changelog"
+git push -u origin neplich-codex/changelog-v{VERSION}
+gh pr create --base main --head neplich-codex/changelog-v{VERSION} \
+  --title "docs: 补充 v{VERSION} changelog" \
+  --body "..."
+gh pr checks {PR_NUMBER} --watch
+gh pr merge {PR_NUMBER} --squash --delete-branch
+```
+
+If earlier version changelog archives are missing and the release checklist depends on a complete archive index, add those missing version files in the same PR.
+
+## Tag Handling
+
+If changelog repair changes the release commit after a tag was already created, recreate the tag at the new `main` HEAD before publishing.
+
+Pre-check:
+
+```bash
+git rev-parse HEAD
+git rev-parse origin/main
+git show --no-patch --format='%H%n%D%n%s' v{VERSION}
+```
+
+Recreate tag:
+
+```bash
+git tag -d v{VERSION}
+git push origin :refs/tags/v{VERSION}
+git tag -a v{VERSION} -m "v{VERSION}"
+git push origin v{VERSION}
+```
+
+If the remote reports repository rule bypass messages for tag deletion or creation, verify success with:
+
+```bash
+git ls-remote --tags origin v{VERSION}
+git show --no-patch --format='%H%n%D%n%s' v{VERSION}
+```
+
+## Draft Release Creation
+
+Create a draft release when the user asks for a release but says not to publish:
+
+```bash
+gh release create v{VERSION} \
+  --draft \
+  --title "{TITLE}" \
+  --notes-file {NOTES_FILE}
+```
+
+GitHub may return an `untagged-*` URL for draft releases. Verify by querying the tag:
+
+```bash
+gh release view v{VERSION} --json tagName,name,isDraft,publishedAt,targetCommitish
+```
+
+Expected draft state:
+
+```text
+tagName = v{VERSION}
+isDraft = true
+publishedAt = null
+```
+
+## Draft Release Updates
+
+After editing release notes, update the draft body:
+
+```bash
+gh release edit v{VERSION} --notes-file {NOTES_FILE}
+```
+
+Re-check:
+
+```bash
+gh release view v{VERSION} --json tagName,name,isDraft,publishedAt,body
+```
+
+## Publishing
+
+Only publish after:
+
+- The user explicitly approves publishing.
+- Required changelog archives exist.
+- Root `CHANGELOG.md` contains version links.
+- Tag points at the final release commit.
+- Draft release body is final.
+
+Publish:
+
+```bash
+gh release edit v{VERSION} --notes-file {NOTES_FILE} --target main --verify-tag
+gh release edit v{VERSION} --draft=false --latest
+```
+
+Final verification:
+
+```bash
+gh release view v{VERSION} \
+  --json tagName,name,isDraft,isPrerelease,publishedAt,url,targetCommitish
+git show --no-patch --format='%H%n%D%n%s' v{VERSION}
+git ls-remote --tags origin v{VERSION}
+```
+
+Expected final state:
+
+```text
+isDraft = false
+isPrerelease = false
+publishedAt is not null
+tag points at the final release commit
+```
+
+## Final Response Checklist
+
+Report:
+
+- Published release URL or draft URL.
+- Final tag target commit.
+- Whether `isDraft` and `publishedAt` match the requested state.
+- PR number if changelog repair was needed.
+- Checks that ran and their result.

--- a/agents/product_manager/skills/release-notes-generator/reference/github-release-workflow.md
+++ b/agents/product_manager/skills/release-notes-generator/reference/github-release-workflow.md
@@ -10,6 +10,16 @@ Use this workflow when creating, updating, or publishing GitHub releases.
 | Draft release | Create or update a release draft | Create or update tag only if requested or required |
 | Publish release | User confirms draft can be published | Run preflight, ensure changelog archives, update tag if needed, publish |
 
+## Version Variables
+
+Normalize release variables before running commands:
+
+- `THIS_TAG`: the exact GitHub release tag, for example `v1.2.0`.
+- `VERSION`: the version without one leading `v`, for example `1.2.0`.
+- `PREV_TAG`: the exact previous release tag.
+
+Use `THIS_TAG` for Git tags, GitHub releases, and compare URLs. Use `VERSION` for changelog archive paths such as `docs/changelog/changelog-v{VERSION}.md`.
+
 ## Publishing Preflight
 
 Before publishing an approved draft release:
@@ -28,9 +38,9 @@ Commands:
 date '+%Y-%m-%d %H:%M:%S %Z'
 git status --short --branch
 git branch --show-current
-gh release view v{VERSION} --json tagName,name,isDraft,publishedAt,targetCommitish
-git show --no-patch --format='%H%n%D%n%s' v{VERSION}
-git ls-remote --tags origin v{VERSION}
+gh release view {THIS_TAG} --json tagName,name,isDraft,publishedAt,targetCommitish
+git show --no-patch --format='%H%n%D%n%s' {THIS_TAG}
+git ls-remote --tags origin {THIS_TAG}
 test -f docs/changelog/changelog-v{VERSION}.md
 ```
 
@@ -61,10 +71,10 @@ git checkout -b neplich-codex/changelog-v{VERSION}
 uv run scripts/check_repository_contract.py
 git diff --check
 git add CHANGELOG.md docs/changelog/changelog-v{VERSION}.md
-git commit -m "docs: 补充 v{VERSION} changelog"
+git commit -m "docs: 补充 {THIS_TAG} changelog"
 git push -u origin neplich-codex/changelog-v{VERSION}
 gh pr create --base main --head neplich-codex/changelog-v{VERSION} \
-  --title "docs: 补充 v{VERSION} changelog" \
+  --title "docs: 补充 {THIS_TAG} changelog" \
   --body "..."
 gh pr checks {PR_NUMBER} --watch
 gh pr merge {PR_NUMBER} --squash --delete-branch
@@ -81,23 +91,23 @@ Pre-check:
 ```bash
 git rev-parse HEAD
 git rev-parse origin/main
-git show --no-patch --format='%H%n%D%n%s' v{VERSION}
+git show --no-patch --format='%H%n%D%n%s' {THIS_TAG}
 ```
 
 Recreate tag:
 
 ```bash
-git tag -d v{VERSION}
-git push origin :refs/tags/v{VERSION}
-git tag -a v{VERSION} -m "v{VERSION}"
-git push origin v{VERSION}
+git tag -d {THIS_TAG}
+git push origin :refs/tags/{THIS_TAG}
+git tag -a {THIS_TAG} -m "{THIS_TAG}"
+git push origin {THIS_TAG}
 ```
 
 If the remote reports repository rule bypass messages for tag deletion or creation, verify success with:
 
 ```bash
-git ls-remote --tags origin v{VERSION}
-git show --no-patch --format='%H%n%D%n%s' v{VERSION}
+git ls-remote --tags origin {THIS_TAG}
+git show --no-patch --format='%H%n%D%n%s' {THIS_TAG}
 ```
 
 ## Draft Release Creation
@@ -105,7 +115,7 @@ git show --no-patch --format='%H%n%D%n%s' v{VERSION}
 Create a draft release when the user asks for a release but says not to publish:
 
 ```bash
-gh release create v{VERSION} \
+gh release create {THIS_TAG} \
   --draft \
   --title "{TITLE}" \
   --notes-file {NOTES_FILE}
@@ -114,13 +124,13 @@ gh release create v{VERSION} \
 GitHub may return an `untagged-*` URL for draft releases. Verify by querying the tag:
 
 ```bash
-gh release view v{VERSION} --json tagName,name,isDraft,publishedAt,targetCommitish
+gh release view {THIS_TAG} --json tagName,name,isDraft,publishedAt,targetCommitish
 ```
 
 Expected draft state:
 
 ```text
-tagName = v{VERSION}
+tagName = {THIS_TAG}
 isDraft = true
 publishedAt = null
 ```
@@ -130,13 +140,13 @@ publishedAt = null
 After editing release notes, update the draft body:
 
 ```bash
-gh release edit v{VERSION} --notes-file {NOTES_FILE}
+gh release edit {THIS_TAG} --notes-file {NOTES_FILE}
 ```
 
 Re-check:
 
 ```bash
-gh release view v{VERSION} --json tagName,name,isDraft,publishedAt,body
+gh release view {THIS_TAG} --json tagName,name,isDraft,publishedAt,body
 ```
 
 ## Publishing
@@ -152,17 +162,17 @@ Only publish after:
 Publish:
 
 ```bash
-gh release edit v{VERSION} --notes-file {NOTES_FILE} --target main --verify-tag
-gh release edit v{VERSION} --draft=false --latest
+gh release edit {THIS_TAG} --notes-file {NOTES_FILE} --target main --verify-tag
+gh release edit {THIS_TAG} --draft=false --latest
 ```
 
 Final verification:
 
 ```bash
-gh release view v{VERSION} \
+gh release view {THIS_TAG} \
   --json tagName,name,isDraft,isPrerelease,publishedAt,url,targetCommitish
-git show --no-patch --format='%H%n%D%n%s' v{VERSION}
-git ls-remote --tags origin v{VERSION}
+git show --no-patch --format='%H%n%D%n%s' {THIS_TAG}
+git ls-remote --tags origin {THIS_TAG}
 ```
 
 Expected final state:

--- a/agents/product_manager/skills/release-notes-generator/reference/release-outline.md
+++ b/agents/product_manager/skills/release-notes-generator/reference/release-outline.md
@@ -59,6 +59,7 @@ Fetch and follow instructions from {INSTALL_URL}
 - Do not include an `已关闭 Issue` section unless the user explicitly asks for it.
 - Keep `变更明细` as the final section.
 - Mention contributors in `变更明细` with `by @user in [#N](PR_URL)`.
+- Preserve conventional commit prefixes in `变更明细` items when the source PR title or commit subject has one, for example `feat:`, `fix:`, `docs:`, `test:`, or `chore:`.
 - Link major highlights inline, but avoid linking every sentence.
 - Keep release notes in Chinese for this repository.
 

--- a/agents/product_manager/skills/release-notes-generator/reference/release-outline.md
+++ b/agents/product_manager/skills/release-notes-generator/reference/release-outline.md
@@ -2,10 +2,12 @@
 
 Use the repository's existing release outline before introducing a new structure.
 
+Use `THIS_TAG` for the full release tag, for example `v1.2.0`. Use `VERSION` only when a normalized version without one leading `v` is required.
+
 For this repository, match the `v0.1.1` release outline:
 
 ```markdown
-# Release Notes - v{VERSION} ({YYYY-MM-DD})
+# Release Notes - {THIS_TAG} ({YYYY-MM-DD})
 
 {One short paragraph describing the release theme and why it matters.}
 
@@ -50,7 +52,7 @@ Fetch and follow instructions from {INSTALL_URL}
 
 - {conventional title} by @{author} in [#{number}]({PR_URL})
 
-完整变更： {REPO_URL}/compare/{PREV_TAG}...{VERSION}
+完整变更： {REPO_URL}/compare/{PREV_TAG}...{THIS_TAG}
 ```
 
 ## Structure Rules
@@ -99,7 +101,7 @@ If a change came from a direct commit and no PR exists, use the commit author an
 For repositories without an existing release style, use:
 
 ```markdown
-# Release Notes - v{VERSION} ({YYYY-MM-DD})
+# Release Notes - {THIS_TAG} ({YYYY-MM-DD})
 
 {One short release theme paragraph.}
 
@@ -125,5 +127,5 @@ For repositories without an existing release style, use:
 
 - {conventional title} by @{author} in [#{number}]({PR_URL})
 
-Full changelog: {REPO_URL}/compare/{PREV_TAG}...{VERSION}
+Full changelog: {REPO_URL}/compare/{PREV_TAG}...{THIS_TAG}
 ```

--- a/agents/product_manager/skills/release-notes-generator/reference/release-outline.md
+++ b/agents/product_manager/skills/release-notes-generator/reference/release-outline.md
@@ -1,0 +1,127 @@
+# Release Outline
+
+Use the repository's existing release outline before introducing a new structure.
+
+For this repository, match the `v0.1.1` release outline:
+
+```markdown
+# Release Notes - v{VERSION} ({YYYY-MM-DD})
+
+{One short paragraph describing the release theme and why it matters.}
+
+## 重点更新
+
+### {Highlight title}
+
+{One concise user-facing paragraph. Include the key PR link inline, for example ([#25](https://github.com/owner/repo/pull/25)).}
+
+### {Another highlight title}
+
+{One concise user-facing paragraph.}
+
+## 其他改进
+
+- {Short improvement.}
+- {Short improvement.}
+
+## 升级说明
+
+{State whether there are breaking changes. If there are no breaking changes, say so clearly.}
+
+### Claude Code
+
+{Only include when the repository/plugin uses Claude Code installation or update commands.}
+
+```text
+/plugin marketplace update {marketplace}
+/plugin update {agent}@{marketplace}
+/reload-plugins
+```
+
+### Codex
+
+{Only include when the repository/plugin uses a Codex install or update entrypoint.}
+
+```text
+Fetch and follow instructions from {INSTALL_URL}
+```
+
+## 变更明细
+
+- {conventional title} by @{author} in [#{number}]({PR_URL})
+
+完整变更： {REPO_URL}/compare/{PREV_TAG}...{VERSION}
+```
+
+## Structure Rules
+
+- Put `完整变更` after `变更明细`, not before it.
+- Do not include an `已关闭 Issue` section unless the user explicitly asks for it.
+- Keep `变更明细` as the final section.
+- Mention contributors in `变更明细` with `by @user in [#N](PR_URL)`.
+- Link major highlights inline, but avoid linking every sentence.
+- Keep release notes in Chinese for this repository.
+
+## Content Rules
+
+- Write for users and maintainers, not as an internal implementation log.
+- Start with the release outcome, then list details.
+- Prefer 3 to 5 highlights. Group smaller changes under `其他改进`.
+- Keep each highlight to one short paragraph unless an upgrade action needs more detail.
+- Include upgrade commands only when they are stable and useful for the release audience.
+- If a release has breaking changes, place them near the top and add concrete migration steps.
+- If there are no breaking changes, say `无破坏性变更。已有安装可以继续使用。`
+
+## Change Detail Rules
+
+Fetch PR authors before writing `变更明细`:
+
+```bash
+gh pr view {NUMBER} --json number,title,author,url
+```
+
+Format each item as:
+
+```markdown
+- feat: 示例更新 by @Neplich in [#25](https://github.com/Neplich/dev-agent-skills/pull/25)
+```
+
+If a change came from a direct commit and no PR exists, use the commit author and short SHA:
+
+```markdown
+- fix: 示例修复 by @user in `abc1234`
+```
+
+## Optional Generic Outline
+
+For repositories without an existing release style, use:
+
+```markdown
+# Release Notes - v{VERSION} ({YYYY-MM-DD})
+
+{One short release theme paragraph.}
+
+## What's New
+
+### {Feature Name}
+
+{User-facing description.}
+
+## Bug Fixes
+
+- {Fix summary.}
+
+## Other Improvements
+
+- {Improvement summary.}
+
+## Upgrade Guide
+
+{Upgrade guidance or no-breaking-change statement.}
+
+## What's Changed
+
+- {conventional title} by @{author} in [#{number}]({PR_URL})
+
+Full changelog: {REPO_URL}/compare/{PREV_TAG}...{VERSION}
+```

--- a/agents/product_manager/skills/release-notes-generator/reference/release-outline.md
+++ b/agents/product_manager/skills/release-notes-generator/reference/release-outline.md
@@ -65,6 +65,7 @@ Fetch and follow instructions from {INSTALL_URL}
 ## Content Rules
 
 - Write for users and maintainers, not as an internal implementation log.
+- Audit all commits and PRs in the release compare range before deciding what to highlight, group, summarize, or omit.
 - Start with the release outcome, then list details.
 - Prefer 3 to 5 highlights. Group smaller changes under `其他改进`.
 - Keep each highlight to one short paragraph unless an upgrade action needs more detail.

--- a/agents/product_manager/test/release-notes-generator/evals/evals.json
+++ b/agents/product_manager/test/release-notes-generator/evals/evals.json
@@ -27,6 +27,11 @@
           "text": "保留正确版本、仓库和 PR 或 release 相关链接"
         },
         {
+          "id": "source_audit",
+          "description": "先审计版本范围内所有 commit 和 PR，再决定 release notes 的分组、摘要或省略",
+          "text": "先审计版本范围内所有 commit 和 PR，再决定 release notes 的分组、摘要或省略"
+        },
+        {
           "id": "requested_output",
           "description": "按用户要求写入或明确给出目标 release notes 产物",
           "text": "按用户要求写入或明确给出目标 release notes 产物"
@@ -58,6 +63,11 @@
           "text": "保留正确版本、仓库和 PR 或 release 相关链接"
         },
         {
+          "id": "source_audit",
+          "description": "先审计版本范围内所有 commit 和 PR，再决定 release notes 的分组、摘要或省略",
+          "text": "先审计版本范围内所有 commit 和 PR，再决定 release notes 的分组、摘要或省略"
+        },
+        {
           "id": "requested_output",
           "description": "按用户要求写入或明确给出目标 release notes 产物",
           "text": "按用户要求写入或明确给出目标 release notes 产物"
@@ -87,6 +97,11 @@
           "id": "source_links",
           "description": "保留正确版本、仓库和 PR 或 release 相关链接",
           "text": "保留正确版本、仓库和 PR 或 release 相关链接"
+        },
+        {
+          "id": "source_audit",
+          "description": "先审计版本范围内所有 commit 和 PR，再决定 release notes 的分组、摘要或省略",
+          "text": "先审计版本范围内所有 commit 和 PR，再决定 release notes 的分组、摘要或省略"
         },
         {
           "id": "requested_output",

--- a/agents/product_manager/test/release-notes-generator/evals/evals.json
+++ b/agents/product_manager/test/release-notes-generator/evals/evals.json
@@ -32,6 +32,11 @@
           "text": "先审计版本范围内所有 commit 和 PR，再决定 release notes 的分组、摘要或省略"
         },
         {
+          "id": "change_detail_prefix",
+          "description": "变更明细保留来源 PR 标题或 commit subject 中的 conventional commit 前缀",
+          "text": "变更明细保留来源 PR 标题或 commit subject 中的 conventional commit 前缀，例如 feat:、fix:、docs:、test: 或 chore:"
+        },
+        {
           "id": "requested_output",
           "description": "按用户要求写入或明确给出目标 release notes 产物",
           "text": "按用户要求写入或明确给出目标 release notes 产物"
@@ -68,6 +73,11 @@
           "text": "先审计版本范围内所有 commit 和 PR，再决定 release notes 的分组、摘要或省略"
         },
         {
+          "id": "change_detail_prefix",
+          "description": "变更明细保留来源 PR 标题或 commit subject 中的 conventional commit 前缀",
+          "text": "变更明细保留来源 PR 标题或 commit subject 中的 conventional commit 前缀，例如 feat:、fix:、docs:、test: 或 chore:"
+        },
+        {
           "id": "requested_output",
           "description": "按用户要求写入或明确给出目标 release notes 产物",
           "text": "按用户要求写入或明确给出目标 release notes 产物"
@@ -102,6 +112,11 @@
           "id": "source_audit",
           "description": "先审计版本范围内所有 commit 和 PR，再决定 release notes 的分组、摘要或省略",
           "text": "先审计版本范围内所有 commit 和 PR，再决定 release notes 的分组、摘要或省略"
+        },
+        {
+          "id": "change_detail_prefix",
+          "description": "变更明细保留来源 PR 标题或 commit subject 中的 conventional commit 前缀",
+          "text": "变更明细保留来源 PR 标题或 commit subject 中的 conventional commit 前缀，例如 feat:、fix:、docs:、test: 或 chore:"
         },
         {
           "id": "requested_output",

--- a/agents/product_manager/test/release-notes-generator/evals/evals.json
+++ b/agents/product_manager/test/release-notes-generator/evals/evals.json
@@ -32,6 +32,16 @@
           "text": "先审计版本范围内所有 commit 和 PR，再决定 release notes 的分组、摘要或省略"
         },
         {
+          "id": "tag_normalization",
+          "description": "输入带 v 的 tag 时不会在 release、tag 或 changelog 模板中生成双 v",
+          "text": "将目标 tag 归一化为完整 THIS_TAG 和无前导 v 的 VERSION；release/tag/compare 命令使用 THIS_TAG，changelog 路径使用 changelog-v{VERSION}.md，不能生成 vv1.2.0"
+        },
+        {
+          "id": "target_tag_audit_range",
+          "description": "commit 审计范围使用目标 tag 而不是 HEAD",
+          "text": "commit 审计必须使用 PREV_TAG..THIS_TAG 或等价 compare range，不能使用 PREV_TAG..HEAD 作为已发布版本的来源审计"
+        },
+        {
           "id": "change_detail_prefix",
           "description": "变更明细保留来源 PR 标题或 commit subject 中的 conventional commit 前缀",
           "text": "变更明细保留来源 PR 标题或 commit subject 中的 conventional commit 前缀，例如 feat:、fix:、docs:、test: 或 chore:"
@@ -73,6 +83,16 @@
           "text": "先审计版本范围内所有 commit 和 PR，再决定 release notes 的分组、摘要或省略"
         },
         {
+          "id": "tag_normalization",
+          "description": "输入带 v 的 tag 时不会在 release、tag 或 changelog 模板中生成双 v",
+          "text": "将目标 tag 归一化为完整 THIS_TAG 和无前导 v 的 VERSION；release/tag/compare 命令使用 THIS_TAG，changelog 路径使用 changelog-v{VERSION}.md，不能生成 vv1.2.0"
+        },
+        {
+          "id": "target_tag_audit_range",
+          "description": "commit 审计范围使用目标 tag 而不是 HEAD",
+          "text": "commit 审计必须使用 PREV_TAG..THIS_TAG 或等价 compare range，不能使用 PREV_TAG..HEAD 作为已发布版本的来源审计"
+        },
+        {
           "id": "change_detail_prefix",
           "description": "变更明细保留来源 PR 标题或 commit subject 中的 conventional commit 前缀",
           "text": "变更明细保留来源 PR 标题或 commit subject 中的 conventional commit 前缀，例如 feat:、fix:、docs:、test: 或 chore:"
@@ -112,6 +132,16 @@
           "id": "source_audit",
           "description": "先审计版本范围内所有 commit 和 PR，再决定 release notes 的分组、摘要或省略",
           "text": "先审计版本范围内所有 commit 和 PR，再决定 release notes 的分组、摘要或省略"
+        },
+        {
+          "id": "tag_normalization",
+          "description": "输入带 v 的 tag 时不会在 release、tag 或 changelog 模板中生成双 v",
+          "text": "将目标 tag 归一化为完整 THIS_TAG 和无前导 v 的 VERSION；release/tag/compare 命令使用 THIS_TAG，changelog 路径使用 changelog-v{VERSION}.md，不能生成 vv1.2.0"
+        },
+        {
+          "id": "target_tag_audit_range",
+          "description": "commit 审计范围使用目标 tag 而不是 HEAD",
+          "text": "commit 审计必须使用 PREV_TAG..THIS_TAG 或等价 compare range，不能使用 PREV_TAG..HEAD 作为已发布版本的来源审计"
         },
         {
           "id": "change_detail_prefix",

--- a/agents/product_manager/test/release-notes-generator/workspace/eval-1-cli-feature/comparison.md
+++ b/agents/product_manager/test/release-notes-generator/workspace/eval-1-cli-feature/comparison.md
@@ -7,7 +7,7 @@
 - Eval: `eval-001-cli-feature-release`
 - Test case: cli-feature-release
 - Workspace: `workspace/eval-1-cli-feature`
-- Latest result: PASS - Codex CLI eval generation completed on 2026-06-06
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-06-06 after tag normalization repair
 
 ## Test Set / Fixture Version
 
@@ -21,6 +21,8 @@
 - `change_grouping`: 按 features、fixes、breaking changes 或等价分组组织变更
 - `source_links`: 保留正确版本、仓库和 PR 或 release 相关链接
 - `source_audit`: 先审计版本范围内所有 commit 和 PR，再决定 release notes 的分组、摘要或省略
+- `tag_normalization`: 输入带 v 的 tag 时不会在 release、tag 或 changelog 模板中生成双 v
+- `target_tag_audit_range`: commit 审计范围使用目标 tag 而不是 HEAD
 - `change_detail_prefix`: 变更明细保留来源 PR 标题或 commit subject 中的 conventional commit 前缀
 - `requested_output`: 按用户要求写入或明确给出目标 release notes 产物
 
@@ -30,6 +32,8 @@ Observed behavior:
 
 - 当前 skill 通过 `reference/release-outline.md` 保持用户价值导向、分组组织、PR/compare 链接和请求产物输出要求。
 - 当前 skill 明确要求先审计 compare 范围内全部 commit 和 merged PR，再决定哪些内容进入高亮、分组、摘要或省略。
+- 当前 skill 明确区分 `THIS_TAG` 和 `VERSION`，release/tag/compare 命令使用完整 tag，changelog 路径使用去掉前导 `v` 的版本号，避免 `vv2.88.0`。
+- 当前 skill 的 commit audit 命令使用 `PREV_TAG..THIS_TAG`，避免已发布旧版本被当前 `HEAD` 后续提交污染。
 - 新增 release 大纲规范要求沿用仓库既有结构，`变更明细` 使用 `by @user in [#N](PR_URL)`，并把完整变更链接放在变更明细之后。
 - `变更明细` 保留来源标题中的 conventional commit prefix，例如 `feat:`、`fix:`、`docs:`、`test:` 或 `chore:`。
 - 新增 GitHub release workflow 覆盖 approved draft 发布前的 changelog archive、根 `CHANGELOG.md` 索引、tag 指向、draft 更新、发布和最终状态复核。
@@ -43,7 +47,7 @@ Observed behavior:
 
 ## Failures
 
-- None found in Codex CLI eval generation on 2026-06-06.
+- None found in fresh Codex subagent validation on 2026-06-06.
 
 ## Next Steps
 

--- a/agents/product_manager/test/release-notes-generator/workspace/eval-1-cli-feature/comparison.md
+++ b/agents/product_manager/test/release-notes-generator/workspace/eval-1-cli-feature/comparison.md
@@ -7,7 +7,7 @@
 - Eval: `eval-001-cli-feature-release`
 - Test case: cli-feature-release
 - Workspace: `workspace/eval-1-cli-feature`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-06-04
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-06-06
 
 ## Test Set / Fixture Version
 
@@ -20,6 +20,7 @@
 - `audience_value`: 面向目标用户说明发布价值，而不是只罗列提交或 PR
 - `change_grouping`: 按 features、fixes、breaking changes 或等价分组组织变更
 - `source_links`: 保留正确版本、仓库和 PR 或 release 相关链接
+- `source_audit`: 先审计版本范围内所有 commit 和 PR，再决定 release notes 的分组、摘要或省略
 - `requested_output`: 按用户要求写入或明确给出目标 release notes 产物
 
 ## With Skill
@@ -27,6 +28,7 @@
 Observed behavior:
 
 - 当前 skill 通过 `reference/release-outline.md` 保持用户价值导向、分组组织、PR/compare 链接和请求产物输出要求。
+- 当前 skill 明确要求先审计 compare 范围内全部 commit 和 merged PR，再决定哪些内容进入高亮、分组、摘要或省略。
 - 新增 release 大纲规范要求沿用仓库既有结构，`变更明细` 使用 `by @user in [#N](PR_URL)`，并把完整变更链接放在变更明细之后。
 - 新增 GitHub release workflow 覆盖 approved draft 发布前的 changelog archive、根 `CHANGELOG.md` 索引、tag 指向、draft 更新、发布和最终状态复核。
 
@@ -37,7 +39,7 @@ Observed behavior:
 
 ## Failures
 
-- None found in fresh Codex subagent validation on 2026-06-04.
+- None found in fresh Codex subagent validation on 2026-06-06.
 
 ## Next Steps
 

--- a/agents/product_manager/test/release-notes-generator/workspace/eval-1-cli-feature/comparison.md
+++ b/agents/product_manager/test/release-notes-generator/workspace/eval-1-cli-feature/comparison.md
@@ -21,6 +21,7 @@
 - `change_grouping`: 按 features、fixes、breaking changes 或等价分组组织变更
 - `source_links`: 保留正确版本、仓库和 PR 或 release 相关链接
 - `source_audit`: 先审计版本范围内所有 commit 和 PR，再决定 release notes 的分组、摘要或省略
+- `change_detail_prefix`: 变更明细保留来源 PR 标题或 commit subject 中的 conventional commit 前缀
 - `requested_output`: 按用户要求写入或明确给出目标 release notes 产物
 
 ## With Skill
@@ -30,6 +31,7 @@ Observed behavior:
 - 当前 skill 通过 `reference/release-outline.md` 保持用户价值导向、分组组织、PR/compare 链接和请求产物输出要求。
 - 当前 skill 明确要求先审计 compare 范围内全部 commit 和 merged PR，再决定哪些内容进入高亮、分组、摘要或省略。
 - 新增 release 大纲规范要求沿用仓库既有结构，`变更明细` 使用 `by @user in [#N](PR_URL)`，并把完整变更链接放在变更明细之后。
+- `变更明细` 保留来源标题中的 conventional commit prefix，例如 `feat:`、`fix:`、`docs:`、`test:` 或 `chore:`。
 - 新增 GitHub release workflow 覆盖 approved draft 发布前的 changelog archive、根 `CHANGELOG.md` 索引、tag 指向、draft 更新、发布和最终状态复核。
 
 ## Without Skill / Baseline

--- a/agents/product_manager/test/release-notes-generator/workspace/eval-1-cli-feature/comparison.md
+++ b/agents/product_manager/test/release-notes-generator/workspace/eval-1-cli-feature/comparison.md
@@ -7,7 +7,7 @@
 - Eval: `eval-001-cli-feature-release`
 - Test case: cli-feature-release
 - Workspace: `workspace/eval-1-cli-feature`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-06-02
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-06-04
 
 ## Test Set / Fixture Version
 
@@ -26,7 +26,9 @@
 
 Observed behavior:
 
-- 当前 skill 要求为指定版本生成面向用户的 release notes，突出价值、按功能/修复/breaking 等分组、保留 PR/release 链接，并在用户给定路径时输出目标产物。
+- 当前 skill 通过 `reference/release-outline.md` 保持用户价值导向、分组组织、PR/compare 链接和请求产物输出要求。
+- 新增 release 大纲规范要求沿用仓库既有结构，`变更明细` 使用 `by @user in [#N](PR_URL)`，并把完整变更链接放在变更明细之后。
+- 新增 GitHub release workflow 覆盖 approved draft 发布前的 changelog archive、根 `CHANGELOG.md` 索引、tag 指向、draft 更新、发布和最终状态复核。
 
 ## Without Skill / Baseline
 
@@ -35,7 +37,7 @@ Observed behavior:
 
 ## Failures
 
-- None found in fresh Codex subagent validation.
+- None found in fresh Codex subagent validation on 2026-06-04.
 
 ## Next Steps
 

--- a/agents/product_manager/test/release-notes-generator/workspace/eval-1-cli-feature/comparison.md
+++ b/agents/product_manager/test/release-notes-generator/workspace/eval-1-cli-feature/comparison.md
@@ -7,7 +7,7 @@
 - Eval: `eval-001-cli-feature-release`
 - Test case: cli-feature-release
 - Workspace: `workspace/eval-1-cli-feature`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-06-06
+- Latest result: PASS - Codex CLI eval generation completed on 2026-06-06
 
 ## Test Set / Fixture Version
 
@@ -33,6 +33,8 @@ Observed behavior:
 - 新增 release 大纲规范要求沿用仓库既有结构，`变更明细` 使用 `by @user in [#N](PR_URL)`，并把完整变更链接放在变更明细之后。
 - `变更明细` 保留来源标题中的 conventional commit prefix，例如 `feat:`、`fix:`、`docs:`、`test:` 或 `chore:`。
 - 新增 GitHub release workflow 覆盖 approved draft 发布前的 changelog archive、根 `CHANGELOG.md` 索引、tag 指向、draft 更新、发布和最终状态复核。
+- 实际生成 `cli/cli` v2.88.0 release notes 时，输出包含 `What's New`、bug fixes、other improvements、upgrading、PR links 和 full changelog。`What's Changed` 中保留了 `feat(pr diff):`、`feat(repo):`、`fix:`、`docs:`、`build:`、`refactor:`、`chore(deps):` 等来源前缀。
+- 运行记录显示先审计 `v2.87.3...v2.88.0` compare range 的 135 个 commits 和 release 范围内 39 个 merged PR，再进行分组和摘要；bot、dependency 和 internal-looking 条目被纳入审计。
 
 ## Without Skill / Baseline
 
@@ -41,11 +43,11 @@ Observed behavior:
 
 ## Failures
 
-- None found in fresh Codex subagent validation on 2026-06-06.
+- None found in Codex CLI eval generation on 2026-06-06.
 
 ## Next Steps
 
-- 真实运行时需 gh release/PR 数据验证。
+- 保留该 eval 继续覆盖完整 source audit、PR 链接、升级说明和 conventional prefix 保留行为。
 
 ## Runtime Artifacts Policy
 

--- a/agents/product_manager/test/release-notes-generator/workspace/eval-1-cli-feature/eval_metadata.json
+++ b/agents/product_manager/test/release-notes-generator/workspace/eval-1-cli-feature/eval_metadata.json
@@ -29,9 +29,9 @@
       "check": "text contains at least one link matching pattern [#\\d+](https://github.com/cli/cli/pull/\\d+)"
     },
     {
-      "id": "no_bot_content",
-      "description": "No bot PR content (dependabot/renovate) in release notes body",
-      "check": "text does not contain 'dependabot' or 'renovate[bot]'"
+      "id": "source_audit_all_commits_and_prs",
+      "description": "Release generation audits all commits and merged PRs in the compare range before curation",
+      "check": "semantic validation confirms the release was generated from a complete commit and PR audit; bot, docs, chore, and internal-looking changes are considered before any grouping or omission"
     },
     {
       "id": "has_upgrade_section",

--- a/agents/product_manager/test/release-notes-generator/workspace/eval-1-cli-feature/eval_metadata.json
+++ b/agents/product_manager/test/release-notes-generator/workspace/eval-1-cli-feature/eval_metadata.json
@@ -34,6 +34,16 @@
       "check": "semantic validation confirms the release was generated from a complete commit and PR audit; bot, docs, chore, and internal-looking changes are considered before any grouping or omission"
     },
     {
+      "id": "tag_normalization_no_double_v",
+      "description": "Tag and version placeholders avoid double-v expansion",
+      "check": "semantic validation confirms a target tag like v2.88.0 is represented as THIS_TAG=v2.88.0 and VERSION=2.88.0; release/tag/compare commands do not render vv2.88.0 and changelog paths render changelog-v2.88.0.md"
+    },
+    {
+      "id": "commit_audit_uses_target_tag",
+      "description": "Commit audit uses the target tag instead of HEAD",
+      "check": "semantic validation confirms commit audit commands use PREV_TAG..THIS_TAG, not PREV_TAG..HEAD, so old releases do not include post-release commits"
+    },
+    {
       "id": "has_upgrade_section",
       "description": "Has an Upgrading section",
       "check": "text contains '⬆️ Upgrading' or '## Upgrading'"

--- a/agents/product_manager/test/release-notes-generator/workspace/eval-1-cli-feature/eval_metadata.json
+++ b/agents/product_manager/test/release-notes-generator/workspace/eval-1-cli-feature/eval_metadata.json
@@ -39,9 +39,9 @@
       "check": "text contains '⬆️ Upgrading' or '## Upgrading'"
     },
     {
-      "id": "no_raw_cc_prefix",
-      "description": "No raw conventional commit prefixes in body (feat:, fix: etc.)",
-      "check": "text does not contain bullet lines starting with 'feat:' or 'fix:' or 'chore:'"
+      "id": "change_detail_preserves_conventional_prefix",
+      "description": "Change detail entries preserve conventional commit prefixes from source PR titles or commit subjects",
+      "check": "semantic validation confirms What's Changed or equivalent change detail entries keep prefixes such as 'feat:', 'fix:', 'docs:', 'test:', or 'chore:' when present in the source title"
     }
   ]
 }

--- a/agents/product_manager/test/release-notes-generator/workspace/eval-2-sdk-release/comparison.md
+++ b/agents/product_manager/test/release-notes-generator/workspace/eval-2-sdk-release/comparison.md
@@ -7,7 +7,7 @@
 - Eval: `eval-002-sdk-breaking-changes`
 - Test case: sdk-breaking-changes
 - Workspace: `workspace/eval-2-sdk-release`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-06-04
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-06-06
 
 ## Test Set / Fixture Version
 
@@ -20,6 +20,7 @@
 - `audience_value`: 面向目标用户说明发布价值，而不是只罗列提交或 PR
 - `change_grouping`: 按 features、fixes、breaking changes 或等价分组组织变更
 - `source_links`: 保留正确版本、仓库和 PR 或 release 相关链接
+- `source_audit`: 先审计版本范围内所有 commit 和 PR，再决定 release notes 的分组、摘要或省略
 - `requested_output`: 按用户要求写入或明确给出目标 release notes 产物
 
 ## With Skill
@@ -27,6 +28,7 @@
 Observed behavior:
 
 - 当前 skill 仍要求面向技术受众保持用户价值导向，突出 breaking changes 或说明无破坏性变更，并保留升级指引、关键 PR 链接和版本信息。
+- 当前 skill 明确要求完整检查版本范围内所有 commit 和 merged PR，不能在审计前过滤 bot、docs、chore 或内部变更。
 - `reference/release-outline.md` 保留通用 SDK / library release notes 结构，同时要求按仓库既有大纲输出中文 release notes。
 - `reference/github-release-workflow.md` 补充 approved draft 发布前的 changelog、tag 和 draft release 复核流程，不削弱 SDK release notes 的断言。
 
@@ -37,7 +39,7 @@ Observed behavior:
 
 ## Failures
 
-- None found in fresh Codex subagent validation on 2026-06-04.
+- None found in fresh Codex subagent validation on 2026-06-06.
 
 ## Next Steps
 

--- a/agents/product_manager/test/release-notes-generator/workspace/eval-2-sdk-release/comparison.md
+++ b/agents/product_manager/test/release-notes-generator/workspace/eval-2-sdk-release/comparison.md
@@ -7,7 +7,7 @@
 - Eval: `eval-002-sdk-breaking-changes`
 - Test case: sdk-breaking-changes
 - Workspace: `workspace/eval-2-sdk-release`
-- Latest result: PASS - Codex CLI eval generation completed on 2026-06-06
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-06-06 after tag normalization repair
 
 ## Test Set / Fixture Version
 
@@ -21,6 +21,8 @@
 - `change_grouping`: 按 features、fixes、breaking changes 或等价分组组织变更
 - `source_links`: 保留正确版本、仓库和 PR 或 release 相关链接
 - `source_audit`: 先审计版本范围内所有 commit 和 PR，再决定 release notes 的分组、摘要或省略
+- `tag_normalization`: 输入带 v 的 tag 时不会在 release、tag 或 changelog 模板中生成双 v
+- `target_tag_audit_range`: commit 审计范围使用目标 tag 而不是 HEAD
 - `change_detail_prefix`: 变更明细保留来源 PR 标题或 commit subject 中的 conventional commit 前缀
 - `requested_output`: 按用户要求写入或明确给出目标 release notes 产物
 
@@ -30,6 +32,8 @@ Observed behavior:
 
 - 当前 skill 仍要求面向技术受众保持用户价值导向，突出 breaking changes 或说明无破坏性变更，并保留升级指引、关键 PR 链接和版本信息。
 - 当前 skill 明确要求完整检查版本范围内所有 commit 和 merged PR，不能在审计前过滤 bot、docs、chore 或内部变更。
+- 当前 skill 明确区分 `THIS_TAG` 和 `VERSION`，release/tag/compare 命令使用完整 tag，changelog 路径使用去掉前导 `v` 的版本号，避免 `vv0.86.0`。
+- 当前 skill 的 commit audit 命令使用 `PREV_TAG..THIS_TAG`，避免已发布旧版本被当前 `HEAD` 后续提交污染。
 - `reference/release-outline.md` 保留通用 SDK / library release notes 结构，同时要求按仓库既有大纲输出中文 release notes。
 - `变更明细` 保留来源标题中的 conventional commit prefix，例如 `feat:`、`fix:`、`docs:`、`test:` 或 `chore:`。
 - `reference/github-release-workflow.md` 补充 approved draft 发布前的 changelog、tag 和 draft release 复核流程，不削弱 SDK release notes 的断言。
@@ -43,7 +47,7 @@ Observed behavior:
 
 ## Failures
 
-- None found in Codex CLI eval generation on 2026-06-06.
+- None found in fresh Codex subagent validation on 2026-06-06.
 
 ## Next Steps
 

--- a/agents/product_manager/test/release-notes-generator/workspace/eval-2-sdk-release/comparison.md
+++ b/agents/product_manager/test/release-notes-generator/workspace/eval-2-sdk-release/comparison.md
@@ -7,7 +7,7 @@
 - Eval: `eval-002-sdk-breaking-changes`
 - Test case: sdk-breaking-changes
 - Workspace: `workspace/eval-2-sdk-release`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-06-02
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-06-04
 
 ## Test Set / Fixture Version
 
@@ -26,7 +26,9 @@
 
 Observed behavior:
 
-- 当前 skill 明确面向技术受众但保持用户价值导向，突出 breaking changes 或说明无 breaking，包含升级命令、关键 PR 链接和版本信息，满足 SDK release notes 断言。
+- 当前 skill 仍要求面向技术受众保持用户价值导向，突出 breaking changes 或说明无破坏性变更，并保留升级指引、关键 PR 链接和版本信息。
+- `reference/release-outline.md` 保留通用 SDK / library release notes 结构，同时要求按仓库既有大纲输出中文 release notes。
+- `reference/github-release-workflow.md` 补充 approved draft 发布前的 changelog、tag 和 draft release 复核流程，不削弱 SDK release notes 的断言。
 
 ## Without Skill / Baseline
 
@@ -35,7 +37,7 @@ Observed behavior:
 
 ## Failures
 
-- None found in fresh Codex subagent validation.
+- None found in fresh Codex subagent validation on 2026-06-04.
 
 ## Next Steps
 

--- a/agents/product_manager/test/release-notes-generator/workspace/eval-2-sdk-release/comparison.md
+++ b/agents/product_manager/test/release-notes-generator/workspace/eval-2-sdk-release/comparison.md
@@ -21,6 +21,7 @@
 - `change_grouping`: 按 features、fixes、breaking changes 或等价分组组织变更
 - `source_links`: 保留正确版本、仓库和 PR 或 release 相关链接
 - `source_audit`: 先审计版本范围内所有 commit 和 PR，再决定 release notes 的分组、摘要或省略
+- `change_detail_prefix`: 变更明细保留来源 PR 标题或 commit subject 中的 conventional commit 前缀
 - `requested_output`: 按用户要求写入或明确给出目标 release notes 产物
 
 ## With Skill
@@ -30,6 +31,7 @@ Observed behavior:
 - 当前 skill 仍要求面向技术受众保持用户价值导向，突出 breaking changes 或说明无破坏性变更，并保留升级指引、关键 PR 链接和版本信息。
 - 当前 skill 明确要求完整检查版本范围内所有 commit 和 merged PR，不能在审计前过滤 bot、docs、chore 或内部变更。
 - `reference/release-outline.md` 保留通用 SDK / library release notes 结构，同时要求按仓库既有大纲输出中文 release notes。
+- `变更明细` 保留来源标题中的 conventional commit prefix，例如 `feat:`、`fix:`、`docs:`、`test:` 或 `chore:`。
 - `reference/github-release-workflow.md` 补充 approved draft 发布前的 changelog、tag 和 draft release 复核流程，不削弱 SDK release notes 的断言。
 
 ## Without Skill / Baseline

--- a/agents/product_manager/test/release-notes-generator/workspace/eval-2-sdk-release/comparison.md
+++ b/agents/product_manager/test/release-notes-generator/workspace/eval-2-sdk-release/comparison.md
@@ -7,7 +7,7 @@
 - Eval: `eval-002-sdk-breaking-changes`
 - Test case: sdk-breaking-changes
 - Workspace: `workspace/eval-2-sdk-release`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-06-06
+- Latest result: PASS - Codex CLI eval generation completed on 2026-06-06
 
 ## Test Set / Fixture Version
 
@@ -33,6 +33,8 @@ Observed behavior:
 - `reference/release-outline.md` 保留通用 SDK / library release notes 结构，同时要求按仓库既有大纲输出中文 release notes。
 - `变更明细` 保留来源标题中的 conventional commit prefix，例如 `feat:`、`fix:`、`docs:`、`test:` 或 `chore:`。
 - `reference/github-release-workflow.md` 补充 approved draft 发布前的 changelog、tag 和 draft release 复核流程，不削弱 SDK release notes 的断言。
+- 实际生成 `anthropics/anthropic-sdk-python` v0.86.0 release notes 时，输出包含 breaking changes、What's New、fixes and compatibility、upgrade guide、PR links 和 full changelog。
+- 运行记录显示先审计 `v0.85.0...v0.86.0` compare range 的 8 个 commits 和 included merged PR，再进行分组和摘要；`stainless-app[bot]`、internal、generated API 和 release commit 均被纳入审计。`What's Changed` 保留了 `feat:`、`feat(api):`、`fix(client):`、`fix(deps):`、`fix(pydantic):`、`chore(internal):`、`release:` 等前缀。
 
 ## Without Skill / Baseline
 
@@ -41,11 +43,11 @@ Observed behavior:
 
 ## Failures
 
-- None found in fresh Codex subagent validation on 2026-06-06.
+- None found in Codex CLI eval generation on 2026-06-06.
 
 ## Next Steps
 
-- 真实运行时需验证 v0.86.0 release 数据。
+- 保留该 eval 继续覆盖 SDK breaking-change 判断、完整 source audit、升级命令和 conventional prefix 保留行为。
 
 ## Runtime Artifacts Policy
 

--- a/agents/product_manager/test/release-notes-generator/workspace/eval-2-sdk-release/eval_metadata.json
+++ b/agents/product_manager/test/release-notes-generator/workspace/eval-2-sdk-release/eval_metadata.json
@@ -34,6 +34,11 @@
       "check": "semantic validation confirms the release was generated from a complete commit and PR audit; bot, docs, chore, and internal-looking changes are considered before any grouping or omission"
     },
     {
+      "id": "change_detail_preserves_conventional_prefix",
+      "description": "Change detail entries preserve conventional commit prefixes from source PR titles or commit subjects",
+      "check": "semantic validation confirms What's Changed or equivalent change detail entries keep prefixes such as 'feat:', 'fix:', 'docs:', 'test:', or 'chore:' when present in the source title"
+    },
+    {
       "id": "pr_links_format",
       "description": "PR links follow correct github.com format",
       "check": "any PR link matches pattern [#\\d+](https://github.com/anthropics/anthropic-sdk-python/pull/\\d+)"

--- a/agents/product_manager/test/release-notes-generator/workspace/eval-2-sdk-release/eval_metadata.json
+++ b/agents/product_manager/test/release-notes-generator/workspace/eval-2-sdk-release/eval_metadata.json
@@ -34,6 +34,16 @@
       "check": "semantic validation confirms the release was generated from a complete commit and PR audit; bot, docs, chore, and internal-looking changes are considered before any grouping or omission"
     },
     {
+      "id": "tag_normalization_no_double_v",
+      "description": "Tag and version placeholders avoid double-v expansion",
+      "check": "semantic validation confirms a target tag like v0.86.0 is represented as THIS_TAG=v0.86.0 and VERSION=0.86.0; release/tag/compare commands do not render vv0.86.0 and changelog paths render changelog-v0.86.0.md"
+    },
+    {
+      "id": "commit_audit_uses_target_tag",
+      "description": "Commit audit uses the target tag instead of HEAD",
+      "check": "semantic validation confirms commit audit commands use PREV_TAG..THIS_TAG, not PREV_TAG..HEAD, so old releases do not include post-release commits"
+    },
+    {
       "id": "change_detail_preserves_conventional_prefix",
       "description": "Change detail entries preserve conventional commit prefixes from source PR titles or commit subjects",
       "check": "semantic validation confirms What's Changed or equivalent change detail entries keep prefixes such as 'feat:', 'fix:', 'docs:', 'test:', or 'chore:' when present in the source title"

--- a/agents/product_manager/test/release-notes-generator/workspace/eval-2-sdk-release/eval_metadata.json
+++ b/agents/product_manager/test/release-notes-generator/workspace/eval-2-sdk-release/eval_metadata.json
@@ -29,9 +29,9 @@
       "check": "text contains 'pip install anthropic==0.86.0' or 'pip install anthropic' near version reference"
     },
     {
-      "id": "no_stainless_bot",
-      "description": "No stainless-app[bot] PR content in body",
-      "check": "text does not mention 'stainless-app' or 'stainless[bot]'"
+      "id": "source_audit_all_commits_and_prs",
+      "description": "Release generation audits all commits and merged PRs in the compare range before curation",
+      "check": "semantic validation confirms the release was generated from a complete commit and PR audit; bot, docs, chore, and internal-looking changes are considered before any grouping or omission"
     },
     {
       "id": "pr_links_format",

--- a/agents/product_manager/test/release-notes-generator/workspace/eval-3-library-release/comparison.md
+++ b/agents/product_manager/test/release-notes-generator/workspace/eval-3-library-release/comparison.md
@@ -7,7 +7,7 @@
 - Eval: `eval-003-library-release-notes`
 - Test case: library-release-notes
 - Workspace: `workspace/eval-3-library-release`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-06-04
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-06-06
 
 ## Test Set / Fixture Version
 
@@ -20,6 +20,7 @@
 - `audience_value`: 面向目标用户说明发布价值，而不是只罗列提交或 PR
 - `change_grouping`: 按 features、fixes、breaking changes 或等价分组组织变更
 - `source_links`: 保留正确版本、仓库和 PR 或 release 相关链接
+- `source_audit`: 先审计版本范围内所有 commit 和 PR，再决定 release notes 的分组、摘要或省略
 - `requested_output`: 按用户要求写入或明确给出目标 release notes 产物
 
 ## With Skill
@@ -27,6 +28,7 @@
 Observed behavior:
 
 - 当前 skill 继续支持库版本 release notes：feature/fix/upgrade 分组、升级命令、PR 链接、用户视角语气和可选无 breaking 说明均被协议覆盖。
+- 当前 skill 明确要求用完整 commit/PR 审计作为 release notes 依据，再进行用户可读的归并和取舍。
 - `reference/release-outline.md` 拆出 release 大纲与格式规则，确保 `变更明细`、贡献者 mention 和完整变更链接位置稳定。
 - `reference/github-release-workflow.md` 拆出 tag、draft release、changelog preflight 和发布复核流程，不影响库 release notes 的请求产物输出要求。
 
@@ -37,7 +39,7 @@ Observed behavior:
 
 ## Failures
 
-- None found in fresh Codex subagent validation on 2026-06-04.
+- None found in fresh Codex subagent validation on 2026-06-06.
 
 ## Next Steps
 

--- a/agents/product_manager/test/release-notes-generator/workspace/eval-3-library-release/comparison.md
+++ b/agents/product_manager/test/release-notes-generator/workspace/eval-3-library-release/comparison.md
@@ -7,7 +7,7 @@
 - Eval: `eval-003-library-release-notes`
 - Test case: library-release-notes
 - Workspace: `workspace/eval-3-library-release`
-- Latest result: PASS - Codex CLI eval generation completed on 2026-06-06
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-06-06 after tag normalization repair
 
 ## Test Set / Fixture Version
 
@@ -21,6 +21,8 @@
 - `change_grouping`: 按 features、fixes、breaking changes 或等价分组组织变更
 - `source_links`: 保留正确版本、仓库和 PR 或 release 相关链接
 - `source_audit`: 先审计版本范围内所有 commit 和 PR，再决定 release notes 的分组、摘要或省略
+- `tag_normalization`: 输入带 v 的 tag 时不会在 release、tag 或 changelog 模板中生成双 v
+- `target_tag_audit_range`: commit 审计范围使用目标 tag 而不是 HEAD
 - `change_detail_prefix`: 变更明细保留来源 PR 标题或 commit subject 中的 conventional commit 前缀
 - `requested_output`: 按用户要求写入或明确给出目标 release notes 产物
 
@@ -30,6 +32,8 @@ Observed behavior:
 
 - 当前 skill 继续支持库版本 release notes：feature/fix/upgrade 分组、升级命令、PR 链接、用户视角语气和可选无 breaking 说明均被协议覆盖。
 - 当前 skill 明确要求用完整 commit/PR 审计作为 release notes 依据，再进行用户可读的归并和取舍。
+- 当前 skill 明确区分 `THIS_TAG` 和 `VERSION`，release/tag/compare 命令使用完整 tag，changelog 路径使用去掉前导 `v` 的版本号，避免双 `v`。
+- 当前 skill 的 commit audit 命令使用 `PREV_TAG..THIS_TAG`，避免已发布旧版本被当前 `HEAD` 后续提交污染。
 - `reference/release-outline.md` 拆出 release 大纲与格式规则，确保 `变更明细`、贡献者 mention 和完整变更链接位置稳定。
 - `变更明细` 保留来源标题中的 conventional commit prefix，例如 `feat:`、`fix:`、`docs:`、`test:` 或 `chore:`。
 - `reference/github-release-workflow.md` 拆出 tag、draft release、changelog preflight 和发布复核流程，不影响库 release notes 的请求产物输出要求。
@@ -43,7 +47,7 @@ Observed behavior:
 
 ## Failures
 
-- None found in Codex CLI eval generation on 2026-06-06.
+- None found in fresh Codex subagent validation on 2026-06-06.
 
 ## Next Steps
 

--- a/agents/product_manager/test/release-notes-generator/workspace/eval-3-library-release/comparison.md
+++ b/agents/product_manager/test/release-notes-generator/workspace/eval-3-library-release/comparison.md
@@ -7,7 +7,7 @@
 - Eval: `eval-003-library-release-notes`
 - Test case: library-release-notes
 - Workspace: `workspace/eval-3-library-release`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-06-02
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-06-04
 
 ## Test Set / Fixture Version
 
@@ -26,7 +26,9 @@
 
 Observed behavior:
 
-- 当前 skill 支持库版本 release notes：What's New、Bug Fixes/Other Improvements、升级命令、PR 链接、用户视角语气和可选无 breaking 说明均被协议覆盖。
+- 当前 skill 继续支持库版本 release notes：feature/fix/upgrade 分组、升级命令、PR 链接、用户视角语气和可选无 breaking 说明均被协议覆盖。
+- `reference/release-outline.md` 拆出 release 大纲与格式规则，确保 `变更明细`、贡献者 mention 和完整变更链接位置稳定。
+- `reference/github-release-workflow.md` 拆出 tag、draft release、changelog preflight 和发布复核流程，不影响库 release notes 的请求产物输出要求。
 
 ## Without Skill / Baseline
 
@@ -35,7 +37,7 @@ Observed behavior:
 
 ## Failures
 
-- None found in fresh Codex subagent validation.
+- None found in fresh Codex subagent validation on 2026-06-04.
 
 ## Next Steps
 

--- a/agents/product_manager/test/release-notes-generator/workspace/eval-3-library-release/comparison.md
+++ b/agents/product_manager/test/release-notes-generator/workspace/eval-3-library-release/comparison.md
@@ -7,7 +7,7 @@
 - Eval: `eval-003-library-release-notes`
 - Test case: library-release-notes
 - Workspace: `workspace/eval-3-library-release`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-06-06
+- Latest result: PASS - Codex CLI eval generation completed on 2026-06-06
 
 ## Test Set / Fixture Version
 
@@ -33,6 +33,8 @@ Observed behavior:
 - `reference/release-outline.md` 拆出 release 大纲与格式规则，确保 `变更明细`、贡献者 mention 和完整变更链接位置稳定。
 - `变更明细` 保留来源标题中的 conventional commit prefix，例如 `feat:`、`fix:`、`docs:`、`test:` 或 `chore:`。
 - `reference/github-release-workflow.md` 拆出 tag、draft release、changelog preflight 和发布复核流程，不影响库 release notes 的请求产物输出要求。
+- 实际生成 `fastapi/fastapi` 0.135.0 release notes 时，输出包含 SSE feature highlight、bug-fix absence statement、documentation notes、upgrade guide、PR link 和 full changelog。
+- 运行记录显示先审计 `0.134.0...0.135.0` compare range 的 3 个 commits 和 merged PR [#15030](https://github.com/fastapi/fastapi/pull/15030)，再进行分组和摘要；release metadata commit 与 bot-authored release note commit 均被纳入审计。该 release 来源标题未使用 conventional prefix，因此输出按来源保留 emoji/title 格式。
 
 ## Without Skill / Baseline
 
@@ -41,11 +43,11 @@ Observed behavior:
 
 ## Failures
 
-- None found in fresh Codex subagent validation on 2026-06-06.
+- None found in Codex CLI eval generation on 2026-06-06.
 
 ## Next Steps
 
-- 真实运行时需验证 fastapi 0.135.0 release 数据。
+- 保留该 eval 继续覆盖 library release notes、完整 source audit、升级命令和来源标题保留行为。
 
 ## Runtime Artifacts Policy
 

--- a/agents/product_manager/test/release-notes-generator/workspace/eval-3-library-release/comparison.md
+++ b/agents/product_manager/test/release-notes-generator/workspace/eval-3-library-release/comparison.md
@@ -21,6 +21,7 @@
 - `change_grouping`: 按 features、fixes、breaking changes 或等价分组组织变更
 - `source_links`: 保留正确版本、仓库和 PR 或 release 相关链接
 - `source_audit`: 先审计版本范围内所有 commit 和 PR，再决定 release notes 的分组、摘要或省略
+- `change_detail_prefix`: 变更明细保留来源 PR 标题或 commit subject 中的 conventional commit 前缀
 - `requested_output`: 按用户要求写入或明确给出目标 release notes 产物
 
 ## With Skill
@@ -30,6 +31,7 @@ Observed behavior:
 - 当前 skill 继续支持库版本 release notes：feature/fix/upgrade 分组、升级命令、PR 链接、用户视角语气和可选无 breaking 说明均被协议覆盖。
 - 当前 skill 明确要求用完整 commit/PR 审计作为 release notes 依据，再进行用户可读的归并和取舍。
 - `reference/release-outline.md` 拆出 release 大纲与格式规则，确保 `变更明细`、贡献者 mention 和完整变更链接位置稳定。
+- `变更明细` 保留来源标题中的 conventional commit prefix，例如 `feat:`、`fix:`、`docs:`、`test:` 或 `chore:`。
 - `reference/github-release-workflow.md` 拆出 tag、draft release、changelog preflight 和发布复核流程，不影响库 release notes 的请求产物输出要求。
 
 ## Without Skill / Baseline

--- a/agents/product_manager/test/release-notes-generator/workspace/eval-3-library-release/eval_metadata.json
+++ b/agents/product_manager/test/release-notes-generator/workspace/eval-3-library-release/eval_metadata.json
@@ -29,6 +29,11 @@
       "check": "any PR link matches pattern [#\\d+](https://github.com/fastapi/fastapi/pull/\\d+)"
     },
     {
+      "id": "source_audit_all_commits_and_prs",
+      "description": "Release generation audits all commits and merged PRs in the compare range before curation",
+      "check": "semantic validation confirms the release was generated from a complete commit and PR audit; bot, docs, chore, and internal-looking changes are considered before any grouping or omission"
+    },
+    {
       "id": "user_perspective_tone",
       "description": "Feature descriptions avoid pure implementation language — no bullet lines beginning with 'Implemented', 'Refactored', 'Added support for' as the only description",
       "check": "fewer than 30% of feature bullet points start with 'Implemented' or 'Refactored'"

--- a/agents/product_manager/test/release-notes-generator/workspace/eval-3-library-release/eval_metadata.json
+++ b/agents/product_manager/test/release-notes-generator/workspace/eval-3-library-release/eval_metadata.json
@@ -34,6 +34,11 @@
       "check": "semantic validation confirms the release was generated from a complete commit and PR audit; bot, docs, chore, and internal-looking changes are considered before any grouping or omission"
     },
     {
+      "id": "change_detail_preserves_conventional_prefix",
+      "description": "Change detail entries preserve conventional commit prefixes from source PR titles or commit subjects",
+      "check": "semantic validation confirms What's Changed or equivalent change detail entries keep prefixes such as 'feat:', 'fix:', 'docs:', 'test:', or 'chore:' when present in the source title"
+    },
+    {
       "id": "user_perspective_tone",
       "description": "Feature descriptions avoid pure implementation language — no bullet lines beginning with 'Implemented', 'Refactored', 'Added support for' as the only description",
       "check": "fewer than 30% of feature bullet points start with 'Implemented' or 'Refactored'"

--- a/agents/product_manager/test/release-notes-generator/workspace/eval-3-library-release/eval_metadata.json
+++ b/agents/product_manager/test/release-notes-generator/workspace/eval-3-library-release/eval_metadata.json
@@ -34,6 +34,16 @@
       "check": "semantic validation confirms the release was generated from a complete commit and PR audit; bot, docs, chore, and internal-looking changes are considered before any grouping or omission"
     },
     {
+      "id": "tag_normalization_no_double_v",
+      "description": "Tag and version placeholders avoid double-v expansion",
+      "check": "semantic validation confirms a target tag like 0.135.0 or v0.135.0 is represented with THIS_TAG as the exact tag and VERSION without one leading v; release/tag/compare commands do not render double-v values"
+    },
+    {
+      "id": "commit_audit_uses_target_tag",
+      "description": "Commit audit uses the target tag instead of HEAD",
+      "check": "semantic validation confirms commit audit commands use PREV_TAG..THIS_TAG, not PREV_TAG..HEAD, so old releases do not include post-release commits"
+    },
+    {
       "id": "change_detail_preserves_conventional_prefix",
       "description": "Change detail entries preserve conventional commit prefixes from source PR titles or commit subjects",
       "check": "semantic validation confirms What's Changed or equivalent change detail entries keep prefixes such as 'feat:', 'fix:', 'docs:', 'test:', or 'chore:' when present in the source title"

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -29,7 +29,7 @@
     "release-notes-generator": {
       "source": "agents/product_manager/skills/release-notes-generator",
       "sourceType": "local",
-      "computedHash": "75fecc90efb06dc9b3360a7067e0a5029f5aa25b684232166284569d3b9dbda0"
+      "computedHash": "c77448e8c5c6109169ade598d80de465d63696e92f69cf09ff3aec674cc6b53e"
     },
     "roadmap-generator": {
       "source": "agents/product_manager/skills/roadmap-generator",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -29,7 +29,7 @@
     "release-notes-generator": {
       "source": "agents/product_manager/skills/release-notes-generator",
       "sourceType": "local",
-      "computedHash": "656d26573e497fbc9f50bba054eeab58e42328c048d6c26bdf058f673297626f"
+      "computedHash": "7bf02ae7f0c2c069a2078be65c269fbb55ff4ef88633176451ec9fa43e63e1b1"
     },
     "roadmap-generator": {
       "source": "agents/product_manager/skills/roadmap-generator",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -29,7 +29,7 @@
     "release-notes-generator": {
       "source": "agents/product_manager/skills/release-notes-generator",
       "sourceType": "local",
-      "computedHash": "7bf02ae7f0c2c069a2078be65c269fbb55ff4ef88633176451ec9fa43e63e1b1"
+      "computedHash": "75fecc90efb06dc9b3360a7067e0a5029f5aa25b684232166284569d3b9dbda0"
     },
     "roadmap-generator": {
       "source": "agents/product_manager/skills/roadmap-generator",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -29,7 +29,7 @@
     "release-notes-generator": {
       "source": "agents/product_manager/skills/release-notes-generator",
       "sourceType": "local",
-      "computedHash": "018d801aaa2fd691909de41c220f72ec8fd2be7996fe91e4d2216649538cd8bf"
+      "computedHash": "656d26573e497fbc9f50bba054eeab58e42328c048d6c26bdf058f673297626f"
     },
     "roadmap-generator": {
       "source": "agents/product_manager/skills/roadmap-generator",


### PR DESCRIPTION
## 摘要

- 将 release-notes-generator 的 release 大纲规范拆到 `reference/release-outline.md`。
- 将 GitHub draft release、changelog preflight、tag 重打和发布复核流程拆到 `reference/github-release-workflow.md`。
- 更新 `SKILL.md` 为轻量入口，并刷新 `skills-lock.json`。
- 运行 fresh Codex subagent validation，并更新 release-notes-generator 三个 durable `comparison.md`。

## 验证

- `uv run scripts/check_repository_contract.py`
- `uv run scripts/check_eval_contract.py`
- `uv run scripts/check_eval_artifacts.py`
- `uv run --with pytest pytest agents/test_eval_contract.py`
- Fresh Codex subagent validation: PASS