### PR TITLE
docs: 规范实施计划与 marketplace 版本规则

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Role-based dispatcher agents for PM, engineering, QA, DevOps, design, and security workflows with generalized routing to specialist skills",
-    "version": "1.0.0"
+    "version": "0.1.3"
   },
   "plugins": [
     {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@
 **市场注册**
 
 - `.claude-plugin/marketplace.json` 定义所有 Agent 及其 skills
+- `.claude-plugin/marketplace.json` 的 `metadata.version` 必须等于当前仓库 release 版本但不带 `v` 前缀；每次创建 release tag 前，先把该字段更新到目标版本，并确认存在对应 `docs/changelog/changelog-v{version}.md` 与根 `CHANGELOG.md` 索引
 - `skills-lock.json` 保存已安装 skill 的元数据
 
 ### Agent 协作流
@@ -71,7 +72,7 @@ PM Agent → Designer Agent → Engineer Agent → QA Agent → DevOps Agent →
 - Branch、tag、release、bypass 和仓库设置权限默认只授予唯一管理员；需要维护者或机器人时再显式添加。
 - 维护变更不得直接在 `main` 上进行；开始修改前先创建工作分支，完成后通过 PR 合入。
 - PR 创建后的更新默认追加新 commit 并普通 push；除非用户明确要求整理提交历史，否则不要 amend、rebase 或 force push。
-- 当前仓库仍处于早期维护阶段，暂不新增 Release CI；发布前使用手动 release checklist：确认 `docs/changelog/changelog-v{version}.md` 存在、tag 使用 `v` 前缀 SemVer、PR 必跑 CI 全部通过，必要时手动触发 eval workflow 并记录结果；每次使用 tag 发版时，按 skill 维度汇总 skill eval 后的 `comparison.md` 最新结论。不要自动创建 GitHub Release，不要自动上传 marketplace package，也不要配置 release bot bypass tag ruleset。
+- 当前仓库仍处于早期维护阶段，暂不新增 Release CI；发布前使用手动 release checklist：确认 `.claude-plugin/marketplace.json` 的 `metadata.version` 已更新为目标版本且不带 `v` 前缀，确认 `docs/changelog/changelog-v{version}.md` 存在并已被根 `CHANGELOG.md` 索引，tag 使用 `v` 前缀 SemVer，PR 必跑 CI 全部通过，必要时手动触发 eval workflow 并记录结果；每次使用 tag 发版时，按 skill 维度汇总 skill eval 后的 `comparison.md` 最新结论。不要自动创建 GitHub Release，不要自动上传 marketplace package，也不要配置 release bot bypass tag ruleset。
 
 ### 新增 Agent
 

--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ uv run python -m json.tool skills-lock.json >/tmp/skills-lock.json.out
 - Follow the existing `agents/*` structure when adding a new agent or skill.
 - Keep `AGENTS.md` as the only edited guidance source; `CLAUDE.md` must remain a symlink to it.
 - Update versioned changelog files under [`docs/changelog/`](./docs/changelog/) for release-facing, user-facing, or developer-facing changes; keep root [`CHANGELOG.md`](./CHANGELOG.md) as an index and keep README focused on the current project state.
+- Keep `.claude-plugin/marketplace.json` `metadata.version` aligned with the repository release version without the `v` prefix. Before creating a release tag, update `metadata.version`, add the matching `docs/changelog/changelog-v{version}.md`, and update the root changelog index.
 - Restrictive repository permissions default to the sole administrator; add maintainers or bots explicitly when needed.
 - Skill evals should verify role boundaries, context reading, execution-path selection, and structured artifacts instead of generic answer quality alone.
 - All skill eval definitions use the shared `evals.json` schema v1.0; do not add agent-specific schema exceptions.

--- a/README_zh.md
+++ b/README_zh.md
@@ -235,6 +235,7 @@ uv run python -m json.tool skills-lock.json >/tmp/skills-lock.json.out
 - 新增 Agent 或 skill 时，优先遵循现有 `agents/*` 结构。
 - `AGENTS.md` 是唯一编辑源；`CLAUDE.md` 必须保持为指向它的软链接。
 - 涉及发布、面向用户或面向开发者的变更时，同步维护 [`docs/changelog/`](./docs/changelog/) 下的版本化 changelog；根目录 [`CHANGELOG.md`](./CHANGELOG.md) 只作为索引，README 只保留当前项目状态。
+- `.claude-plugin/marketplace.json` 的 `metadata.version` 必须与仓库 release 版本保持一致，但不带 `v` 前缀。创建 release tag 前，先更新 `metadata.version`、新增对应的 `docs/changelog/changelog-v{version}.md`，并同步根目录 changelog 索引。
 - 仓库限制性权限默认只授予唯一管理员；后续需要维护者或机器人时再显式添加。
 - Skill eval 应验证角色边界、上下文读取、执行路径和结构化产物，而不是只检查泛化回答质量。
 - 所有 skill eval 定义统一使用 `evals.json` schema v1.0，不新增 agent 专属 schema 例外。

--- a/agents/engineer/skills/feature-implementor/SKILL.md
+++ b/agents/engineer/skills/feature-implementor/SKILL.md
@@ -98,6 +98,17 @@ with the codebase, stop and hand back to `engineer-agent:trd-gen` with the
 specific blocker and TRD gap packet. Do not hide TRD gaps inside
 `IMPLEMENTATION_PLAN.md`.
 
+Implementation plan frontmatter is part of the confirmed engineering artifact.
+New plans should start with `version: "0.1.0"` unless the repository has a
+stricter convention. When an existing plan's body, scope, ordered steps,
+delegation model, verification commands, status, or diagrams change
+substantively, update both `version` and `last_updated` in the same edit. Use a
+PATCH bump for clarifications that preserve scope, a MINOR bump for changed
+implementation scope or sequencing, and a MAJOR bump only for replacing the
+confirmed plan contract. Typo, formatting, or other non-semantic edits may
+leave `version` unchanged, but should still refresh `last_updated` when the
+file is touched.
+
 All implementation plan document writing must be delegated to a fresh
 document-writing sub-agent when sub-agent capabilities are available. The main
 process keeps the source docs, repository context, and final approval decision.

--- a/agents/engineer/skills/feature-implementor/_internal/_shared/output-conventions.md
+++ b/agents/engineer/skills/feature-implementor/_internal/_shared/output-conventions.md
@@ -19,6 +19,19 @@ After writing each file:
 2. If using TypeScript, ensure no type errors
 3. If the project has a lint command, ensure no new lint violations
 
+## Implementation Plan Documents
+
+When creating or updating `docs/engineer/{feature}/IMPLEMENTATION_PLAN.md`:
+
+1. Include frontmatter with `feature`, `version`, `date`, and `last_updated`
+2. Start new implementation plans at `version: "0.1.0"` unless the repository
+   specifies a stricter convention
+3. Update both `version` and `last_updated` when the plan body changes
+   substantively, including scope, steps, file lists, delegation, verification,
+   status, rollout checks, or diagrams
+4. Keep `version` unchanged for typo, formatting, or non-semantic copy edits,
+   but refresh `last_updated` when the document is touched
+
 ## Commit Granularity
 
 When used with `delivery` skill:

--- a/agents/engineer/skills/feature-implementor/_internal/planner/INSTRUCTIONS.md
+++ b/agents/engineer/skills/feature-implementor/_internal/planner/INSTRUCTIONS.md
@@ -109,6 +109,7 @@ a fresh document-writing sub-agent. The delegated task must include:
 - PRD alignment result and source-document evidence
 - exact output path: `docs/engineer/{feature}/IMPLEMENTATION_PLAN.md`
 - file change list, sequence, tests, delegation split, forbidden areas, blockers
+- frontmatter maintenance for `version` and `last_updated`
 - instruction not to write code or revise TRD decisions
 
 For small changes, write a short plan that still names the target file, planned
@@ -116,6 +117,25 @@ edit, source requirement, verification command, and why complex sub-agent
 delegation is not needed. Small changes still need a PRD alignment result; do
 not convert "single file" or "small bug fix" into implicit PM approval or
 permission to skip `IMPLEMENTATION_PLAN.md`.
+
+#### Frontmatter version rules
+
+`IMPLEMENTATION_PLAN.md` frontmatter must stay in sync with the plan body:
+
+- New plans should start at `version: "0.1.0"` unless the repository has a
+  stricter convention, and must include `feature`, `date`, and `last_updated`.
+- Substantive plan changes must update both `version` and `last_updated` in the
+  same edit. Substantive changes include changed implementation scope, ordered
+  steps, file list, delegation model, verification commands, status, rollout
+  checks, or architecture / flow diagrams.
+- Use PATCH for clarifications that preserve the confirmed scope, MINOR for
+  changed implementation scope or sequencing, and MAJOR only when replacing the
+  confirmed plan contract.
+- Typo, formatting, or non-semantic copy edits may keep the existing `version`,
+  but should refresh `last_updated` when the file is touched.
+- Preserve existing optional frontmatter fields such as `related_issue`,
+  `related_pr`, `author`, and `generated_by` unless the current edit directly
+  invalidates them.
 
 The main process reviews the document before asking for implementation
 confirmation.

--- a/agents/engineer/test/feature-implementor/evals/evals.json
+++ b/agents/engineer/test/feature-implementor/evals/evals.json
@@ -25,6 +25,11 @@
           "id": "does_not_implement_directly",
           "description": "不直接实施",
           "text": "输出不得声称已经创建或修改代码文件、运行实现步骤或完成自检。"
+        },
+        {
+          "id": "maintains_plan_metadata",
+          "description": "维护实施计划元数据",
+          "text": "输出必须说明 `docs/engineer/notification-center/IMPLEMENTATION_PLAN.md` 的 frontmatter 需要包含 `version` 和 `last_updated`；新建计划使用初始版本，实质性更新计划正文时同步更新 `version` 和 `last_updated`，纯格式或错别字修正可不提升版本。"
         }
       ]
     },

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-001-implement-from-prd-trd/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-001-implement-from-prd-trd/comparison.md
@@ -7,12 +7,12 @@
 - Eval: `eval-001-implement-from-prd-trd`
 - Test case: implement-from-prd-trd
 - Workspace: `workspace/eval-001-implement-from-prd-trd`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-06-04 against the current uncommitted `feature-implementor` skill
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-06-11 against the current uncommitted `feature-implementor` skill
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: Verifies that feature-implementor handles implement-from-prd-trd by producing an implementation plan and waiting for confirmation before coding.
+- Fixture: Verifies that feature-implementor handles implement-from-prd-trd by producing an implementation plan, maintaining plan metadata, and waiting for confirmation before coding.
 - Expected output: IMPLEMENTATION_PLAN.md + 文件变更清单 + 实现顺序 + 用户确认门禁，不直接写代码
 - Validation input: current `agents/engineer/skills/feature-implementor/SKILL.md`, Engineer README, `evals.json`, workspace metadata, and this comparison.
 
@@ -21,13 +21,15 @@
 - `writes_implementation_plan`: 生成实现计划
 - `requires_user_confirmation`: 等待用户确认
 - `does_not_implement_directly`: 不直接实施
+- `maintains_plan_metadata`: 维护实施计划元数据
 
 ## With Skill
 
 Observed behavior:
 
-- PASS - fresh Codex subagent validation completed on 2026-06-04 against the current uncommitted `feature-implementor` skill.
+- PASS - fresh Codex subagent validation completed on 2026-06-11 against the current uncommitted `feature-implementor` skill.
 - Current `SKILL.md` consumes confirmed PRD/TRD, enters Phase 1 before any code changes, delegates or writes `docs/engineer/{feature}/IMPLEMENTATION_PLAN.md`, includes the file change list, implementation order, PRD alignment result, split decision, and blockers, then presents the plan and asks for confirmation.
+- The plan metadata rules require `IMPLEMENTATION_PLAN.md` frontmatter to include `version` and `last_updated`; new plans start from an initial version, substantive body updates change both `version` and `last_updated`, and typo or formatting-only edits may keep `version` unchanged.
 - The skill explicitly says to stop after presenting the plan and not start implementation in the same turn unless the user has already confirmed the exact plan.
 - Phase 2 code work and implementor module loading are gated behind user confirmation of the implementation plan.
 
@@ -42,7 +44,7 @@ Observed behavior:
 
 ## Next Steps
 
-- Keep this eval focused on the confirmed-PRD/TRD plan gate and no-direct-code boundary.
+- Keep this eval focused on the confirmed-PRD/TRD plan gate, plan metadata maintenance, and no-direct-code boundary.
 
 ## Runtime Artifacts Policy
 

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-002-subagent-division-from-docs/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-002-subagent-division-from-docs/comparison.md
@@ -7,7 +7,7 @@
 - Eval: `eval-002-subagent-division-from-docs`
 - Test case: subagent-division-from-docs
 - Workspace: `workspace/eval-002-subagent-division-from-docs`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-06-04 against the current uncommitted `feature-implementor` skill
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-06-11 against the current uncommitted `feature-implementor` skill
 
 ## Test Set / Fixture Version
 
@@ -30,7 +30,7 @@
 
 Observed behavior:
 
-- PASS - fresh Codex subagent validation completed on 2026-06-04 against the current uncommitted `feature-implementor` skill.
+- PASS - fresh Codex subagent validation completed on 2026-06-11 against the current uncommitted `feature-implementor` skill.
 - Current `SKILL.md` says the main process keeps PM/design context, repository constraints, implementation boundaries, final integration, and delivery risk while complex coding can be delegated.
 - Phase 1 requires a fresh document-writing sub-agent for `docs/engineer/{feature}/IMPLEMENTATION_PLAN.md` when available, and states the plan must not rewrite TRD decisions.
 - The complex coding section requires separate implementation and validation sub-agents for multi-file, multi-module, spec-backed, or context-heavy work. It requires implementation tasks to include owned files/modules, source document references, test expectations, forbidden areas, and a reminder not to revert unrelated user changes.

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-003-missing-trd-handoff/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-003-missing-trd-handoff/comparison.md
@@ -7,7 +7,7 @@
 - Eval: `eval-003-missing-trd-handoff`
 - Test case: missing-trd-handoff
 - Workspace: `workspace/eval-003-missing-trd-handoff`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-06-04 against the current uncommitted `feature-implementor` skill
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-06-11 against the current uncommitted `feature-implementor` skill
 
 ## Test Set / Fixture Version
 
@@ -28,7 +28,7 @@
 
 Observed behavior:
 
-- PASS - fresh Codex subagent validation completed on 2026-06-04 against the current uncommitted `feature-implementor` skill.
+- PASS - fresh Codex subagent validation completed on 2026-06-11 against the current uncommitted `feature-implementor` skill.
 - Current `SKILL.md` requires reading PM and Engineer docs before existing-feature implementation planning and explicitly stops when PRD is stable but TRD is missing, incomplete, or stale.
 - The skill hands back to `engineer-agent:trd-gen` with a TRD gap packet instead of creating `IMPLEMENTATION_PLAN.md`, code, tests, or a file-change implementation plan.
 - The required gap packet covers unresolved technical decisions, affected components/modules, data flow/API/integration impacts, verification commands, release or rollout risks, and error handling, observability, or security strategy when relevant.

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-004-small-change-plan-gate/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-004-small-change-plan-gate/comparison.md
@@ -7,7 +7,7 @@
 - Eval: `eval-004-small-change-plan-gate`
 - Test case: small-change-plan-gate
 - Workspace: `workspace/eval-004-small-change-plan-gate`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-06-04 against the current uncommitted `feature-implementor` skill
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-06-11 against the current uncommitted `feature-implementor` skill
 
 ## Test Set / Fixture Version
 
@@ -29,7 +29,7 @@
 
 Observed behavior:
 
-- PASS - fresh Codex subagent validation completed on 2026-06-04 against the current uncommitted `feature-implementor` skill.
+- PASS - fresh Codex subagent validation completed on 2026-06-11 against the current uncommitted `feature-implementor` skill.
 - Current `SKILL.md` requires existing-feature changes to read PRD and TRD, plus DECISIONS only when present, so a missing standalone `DECISIONS.md` does not block an otherwise covered PRD/TRD change.
 - The implementation planner is explicitly the first step for every implementation task, including single-file, small, and low-risk changes.
 - The plan must be written to `docs/engineer/{feature}/IMPLEMENTATION_PLAN.md`, include the PRD alignment result and implementation/validation sub-agent split decision, then wait for user confirmation.

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-005-existing-behavior-change-needs-pm/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-005-existing-behavior-change-needs-pm/comparison.md
@@ -7,7 +7,7 @@
 - Eval: `eval-005-existing-behavior-change-needs-pm`
 - Test case: existing-behavior-change-needs-pm
 - Workspace: `workspace/eval-005-existing-behavior-change-needs-pm`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-06-04 against the current uncommitted `feature-implementor` skill
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-06-11 against the current uncommitted `feature-implementor` skill
 
 ## Test Set / Fixture Version
 
@@ -28,7 +28,7 @@
 
 Observed behavior:
 
-- PASS - fresh Codex subagent validation completed on 2026-06-04 against the current uncommitted `feature-implementor` skill.
+- PASS - fresh Codex subagent validation completed on 2026-06-11 against the current uncommitted `feature-implementor` skill.
 - Current `SKILL.md` requires existing-feature behavior changes to complete the PRD alignment gate before planning, including PRD, TRD, and product decision records when present.
 - If a request changes approved product behavior, the skill stops before implementation planning and hands off to `pm-agent:idea-to-spec` using the `existing-project-update` lane.
 - If PRD/product decisions need updates, the skill does not create `docs/engineer/notifications/IMPLEMENTATION_PLAN.md`, does not update tests, and does not implement code just because the change is small or single-file.

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-006-small-bug-fix-plan-gate/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-006-small-bug-fix-plan-gate/comparison.md
@@ -7,7 +7,7 @@
 - Eval: `eval-006-small-bug-fix-plan-gate`
 - Test case: small-bug-fix-plan-gate
 - Workspace: `workspace/eval-006-small-bug-fix-plan-gate`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-06-04 against the current uncommitted `feature-implementor` skill
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-06-11 against the current uncommitted `feature-implementor` skill
 
 ## Test Set / Fixture Version
 
@@ -28,7 +28,7 @@
 
 Observed behavior:
 
-- PASS - fresh Codex subagent validation completed on 2026-06-04 against the current uncommitted `feature-implementor` skill.
+- PASS - fresh Codex subagent validation completed on 2026-06-11 against the current uncommitted `feature-implementor` skill.
 - Current `SKILL.md` says bug fixes with no spec use `debugger`, but spec-backed bug fixes may enter `feature-implementor` after debugger or Engineer routing confirms the fix is implementation work against approved PRD/TRD behavior.
 - The same section says spec-backed bug fixes still require `IMPLEMENTATION_PLAN.md` and explicit user confirmation before code changes.
 - The planner phase applies to every implementation task, including spec-backed bug-fix changes, and must include file scope, verification commands, PRD alignment result, and implementation/validation split decision.

--- a/agents/test_eval_contract.py
+++ b/agents/test_eval_contract.py
@@ -568,6 +568,91 @@ class EvalContractTests(unittest.TestCase):
         self.assertEqual(latest_version, "1.2.3-rc.10")
         self.assertEqual("\n".join(error.render(root) for error in errors), "")
 
+    def test_repository_contract_rejects_invalid_prerelease_metadata_version(self):
+        checker = load_repository_checker_module()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            marketplace = root / ".claude-plugin/marketplace.json"
+            skill_doc = root / "agents/engineer/skills/example/SKILL.md"
+            changelog = root / "docs/changelog/changelog-v1.2.3-rc.1.md"
+            marketplace.parent.mkdir(parents=True)
+            skill_doc.parent.mkdir(parents=True)
+            changelog.parent.mkdir(parents=True)
+            skill_doc.write_text(
+                "---\n"
+                "name: example\n"
+                "description: Example skill\n"
+                "---\n"
+            )
+            changelog.write_text("# Changelog - v1.2.3-rc.1\n")
+            marketplace.write_text(
+                json.dumps(
+                    {
+                        "name": "dev-agent-skills",
+                        "owner": {"name": "Neplich"},
+                        "metadata": {"version": "1.2.3-rc.01"},
+                        "plugins": [
+                            {
+                                "name": "engineer-agent",
+                                "source": "./agents/engineer",
+                                "skills": ["./skills/example"],
+                            }
+                        ],
+                    }
+                )
+            )
+
+            errors = []
+            checker.validate_marketplace(root, errors)
+
+        rendered = "\n".join(error.render(root) for error in errors)
+        self.assertIn("metadata.version must be SemVer without a leading 'v'", rendered)
+
+    def test_repository_contract_rejects_invalid_prerelease_changelog_filename(self):
+        checker = load_repository_checker_module()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            marketplace = root / ".claude-plugin/marketplace.json"
+            skill_doc = root / "agents/engineer/skills/example/SKILL.md"
+            changelog = root / "docs/changelog/changelog-v1.2.3-rc..1.md"
+            marketplace.parent.mkdir(parents=True)
+            skill_doc.parent.mkdir(parents=True)
+            changelog.parent.mkdir(parents=True)
+            skill_doc.write_text(
+                "---\n"
+                "name: example\n"
+                "description: Example skill\n"
+                "---\n"
+            )
+            changelog.write_text("# Changelog - v1.2.3-rc..1\n")
+            marketplace.write_text(
+                json.dumps(
+                    {
+                        "name": "dev-agent-skills",
+                        "owner": {"name": "Neplich"},
+                        "metadata": {"version": "1.2.3-rc.1"},
+                        "plugins": [
+                            {
+                                "name": "engineer-agent",
+                                "source": "./agents/engineer",
+                                "skills": ["./skills/example"],
+                            }
+                        ],
+                    }
+                )
+            )
+
+            errors = []
+            checker.validate_marketplace(root, errors)
+
+        rendered = "\n".join(error.render(root) for error in errors)
+        self.assertIn(
+            "docs/changelog must contain at least one changelog-v{version}.md file",
+            rendered,
+        )
+
     def test_repository_contract_rejects_missing_root_changelog_index(self):
         checker = load_repository_checker_module()
 

--- a/agents/test_eval_contract.py
+++ b/agents/test_eval_contract.py
@@ -1,5 +1,6 @@
 import importlib.util
 import json
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -514,6 +515,31 @@ class EvalContractTests(unittest.TestCase):
 
         rendered = "\n".join(error.render(root) for error in errors)
         self.assertIn("metadata.version must match latest changelog version '0.1.3'", rendered)
+
+    def test_repository_contract_rejects_missing_implementation_plan_base_ref(self):
+        checker = load_repository_checker_module()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            plan = root / "docs/engineer/example/IMPLEMENTATION_PLAN.md"
+            plan.parent.mkdir(parents=True)
+            plan.write_text(
+                "---\n"
+                'feature: "example"\n'
+                'version: "0.1.0"\n'
+                'date: "2026-06-12"\n'
+                'last_updated: "2026-06-12"\n'
+                "---\n\n"
+                "# Example Plan\n"
+            )
+            subprocess.run(["git", "init", "-b", "feature"], cwd=root, check=True)
+            subprocess.run(["git", "add", plan.relative_to(root).as_posix()], cwd=root, check=True)
+
+            errors = []
+            checker.validate_implementation_plan_metadata(root, errors)
+
+        rendered = "\n".join(error.render(root) for error in errors)
+        self.assertIn("no base ref is available", rendered)
 
 
 if __name__ == "__main__":

--- a/agents/test_eval_contract.py
+++ b/agents/test_eval_contract.py
@@ -8,6 +8,9 @@ from pathlib import Path
 
 CHECKER_PATH = Path(__file__).resolve().parents[1] / "scripts/check_eval_contract.py"
 ARTIFACT_CHECKER_PATH = Path(__file__).resolve().parents[1] / "scripts/check_eval_artifacts.py"
+REPOSITORY_CHECKER_PATH = (
+    Path(__file__).resolve().parents[1] / "scripts/check_repository_contract.py"
+)
 
 
 def load_checker_module():
@@ -27,6 +30,18 @@ def load_artifact_checker_module():
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
     sys.modules["check_eval_artifacts"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_repository_checker_module():
+    spec = importlib.util.spec_from_file_location(
+        "check_repository_contract",
+        REPOSITORY_CHECKER_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules["check_repository_contract"] = module
     spec.loader.exec_module(module)
     return module
 
@@ -458,6 +473,47 @@ class EvalContractTests(unittest.TestCase):
                 "agents/qa/skills/example/with_skill/README.md"
             )
         )
+
+    def test_repository_contract_rejects_stale_marketplace_metadata_version(self):
+        checker = load_repository_checker_module()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            marketplace = root / ".claude-plugin/marketplace.json"
+            skill_doc = root / "agents/engineer/skills/example/SKILL.md"
+            changelog = root / "docs/changelog/changelog-v0.1.3.md"
+            marketplace.parent.mkdir(parents=True)
+            skill_doc.parent.mkdir(parents=True)
+            changelog.parent.mkdir(parents=True)
+            skill_doc.write_text(
+                "---\n"
+                "name: example\n"
+                "description: Example skill\n"
+                "---\n"
+            )
+            changelog.write_text("# Changelog - v0.1.3\n")
+            marketplace.write_text(
+                json.dumps(
+                    {
+                        "name": "dev-agent-skills",
+                        "owner": {"name": "Neplich"},
+                        "metadata": {"version": "0.1.2"},
+                        "plugins": [
+                            {
+                                "name": "engineer-agent",
+                                "source": "./agents/engineer",
+                                "skills": ["./skills/example"],
+                            }
+                        ],
+                    }
+                )
+            )
+
+            errors = []
+            checker.validate_marketplace(root, errors)
+
+        rendered = "\n".join(error.render(root) for error in errors)
+        self.assertIn("metadata.version must match latest changelog version '0.1.3'", rendered)
 
 
 if __name__ == "__main__":

--- a/agents/test_eval_contract.py
+++ b/agents/test_eval_contract.py
@@ -516,6 +516,58 @@ class EvalContractTests(unittest.TestCase):
         rendered = "\n".join(error.render(root) for error in errors)
         self.assertIn("metadata.version must match latest changelog version '0.1.3'", rendered)
 
+    def test_repository_contract_orders_prerelease_changelog_versions(self):
+        checker = load_repository_checker_module()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            marketplace = root / ".claude-plugin/marketplace.json"
+            skill_doc = root / "agents/engineer/skills/example/SKILL.md"
+            changelog_dir = root / "docs/changelog"
+            changelog_index = root / "CHANGELOG.md"
+            marketplace.parent.mkdir(parents=True)
+            skill_doc.parent.mkdir(parents=True)
+            changelog_dir.mkdir(parents=True)
+            skill_doc.write_text(
+                "---\n"
+                "name: example\n"
+                "description: Example skill\n"
+                "---\n"
+            )
+            (changelog_dir / "changelog-v1.2.3-rc.2.md").write_text(
+                "# Changelog - v1.2.3-rc.2\n"
+            )
+            (changelog_dir / "changelog-v1.2.3-rc.10.md").write_text(
+                "# Changelog - v1.2.3-rc.10\n"
+            )
+            changelog_index.write_text(
+                "# Changelog\n\n"
+                "- [v1.2.3-rc.10](./docs/changelog/changelog-v1.2.3-rc.10.md)\n"
+            )
+            marketplace.write_text(
+                json.dumps(
+                    {
+                        "name": "dev-agent-skills",
+                        "owner": {"name": "Neplich"},
+                        "metadata": {"version": "1.2.3-rc.10"},
+                        "plugins": [
+                            {
+                                "name": "engineer-agent",
+                                "source": "./agents/engineer",
+                                "skills": ["./skills/example"],
+                            }
+                        ],
+                    }
+                )
+            )
+
+            errors = []
+            latest_version = checker.latest_changelog_version(root)
+            checker.validate_marketplace(root, errors)
+
+        self.assertEqual(latest_version, "1.2.3-rc.10")
+        self.assertEqual("\n".join(error.render(root) for error in errors), "")
+
     def test_repository_contract_rejects_missing_root_changelog_index(self):
         checker = load_repository_checker_module()
 

--- a/agents/test_eval_contract.py
+++ b/agents/test_eval_contract.py
@@ -649,7 +649,118 @@ class EvalContractTests(unittest.TestCase):
 
         rendered = "\n".join(error.render(root) for error in errors)
         self.assertIn(
-            "docs/changelog must contain at least one changelog-v{version}.md file",
+            "changelog-v1.2.3-rc..1.md: changelog filename must use changelog-v{SemVer}.md",
+            rendered,
+        )
+
+    def test_repository_contract_rejects_invalid_changelog_filename_alongside_valid_file(self):
+        checker = load_repository_checker_module()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            marketplace = root / ".claude-plugin/marketplace.json"
+            skill_doc = root / "agents/engineer/skills/example/SKILL.md"
+            changelog_dir = root / "docs/changelog"
+            changelog_index = root / "CHANGELOG.md"
+            marketplace.parent.mkdir(parents=True)
+            skill_doc.parent.mkdir(parents=True)
+            changelog_dir.mkdir(parents=True)
+            skill_doc.write_text(
+                "---\n"
+                "name: example\n"
+                "description: Example skill\n"
+                "---\n"
+            )
+            (changelog_dir / "changelog-v1.2.3.md").write_text(
+                "# Changelog - v1.2.3\n"
+            )
+            (changelog_dir / "changelog-v1.2.4-rc..1.md").write_text(
+                "# Changelog - v1.2.4-rc..1\n"
+            )
+            (changelog_dir / "changelog-v01.2.4.md").write_text(
+                "# Changelog - v01.2.4\n"
+            )
+            changelog_index.write_text(
+                "# Changelog\n\n"
+                "- [v1.2.3](./docs/changelog/changelog-v1.2.3.md)\n"
+            )
+            marketplace.write_text(
+                json.dumps(
+                    {
+                        "name": "dev-agent-skills",
+                        "owner": {"name": "Neplich"},
+                        "metadata": {"version": "1.2.3"},
+                        "plugins": [
+                            {
+                                "name": "engineer-agent",
+                                "source": "./agents/engineer",
+                                "skills": ["./skills/example"],
+                            }
+                        ],
+                    }
+                )
+            )
+
+            errors = []
+            checker.validate_marketplace(root, errors)
+
+        rendered = "\n".join(error.render(root) for error in errors)
+        self.assertIn(
+            "changelog-v1.2.4-rc..1.md: changelog filename must use changelog-v{SemVer}.md",
+            rendered,
+        )
+        self.assertIn(
+            "changelog-v01.2.4.md: changelog filename must use changelog-v{SemVer}.md",
+            rendered,
+        )
+
+    def test_repository_contract_rejects_changelog_version_directory(self):
+        checker = load_repository_checker_module()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            marketplace = root / ".claude-plugin/marketplace.json"
+            skill_doc = root / "agents/engineer/skills/example/SKILL.md"
+            changelog_dir = root / "docs/changelog"
+            changelog = changelog_dir / "changelog-v1.2.3.md"
+            changelog_index = root / "CHANGELOG.md"
+            marketplace.parent.mkdir(parents=True)
+            skill_doc.parent.mkdir(parents=True)
+            changelog.mkdir(parents=True)
+            skill_doc.write_text(
+                "---\n"
+                "name: example\n"
+                "description: Example skill\n"
+                "---\n"
+            )
+            (changelog / "README.md").write_text("# Not a changelog file\n")
+            changelog_index.write_text(
+                "# Changelog\n\n"
+                "- [v1.2.3](./docs/changelog/changelog-v1.2.3.md)\n"
+            )
+            marketplace.write_text(
+                json.dumps(
+                    {
+                        "name": "dev-agent-skills",
+                        "owner": {"name": "Neplich"},
+                        "metadata": {"version": "1.2.3"},
+                        "plugins": [
+                            {
+                                "name": "engineer-agent",
+                                "source": "./agents/engineer",
+                                "skills": ["./skills/example"],
+                            }
+                        ],
+                    }
+                )
+            )
+
+            errors = []
+            checker.validate_marketplace(root, errors)
+
+        rendered = "\n".join(error.render(root) for error in errors)
+        self.assertIn(
+            "changelog-v1.2.3.md: changelog entry must be a file",
             rendered,
         )
 

--- a/agents/test_eval_contract.py
+++ b/agents/test_eval_contract.py
@@ -516,6 +516,55 @@ class EvalContractTests(unittest.TestCase):
         rendered = "\n".join(error.render(root) for error in errors)
         self.assertIn("metadata.version must match latest changelog version '0.1.3'", rendered)
 
+    def test_repository_contract_rejects_missing_root_changelog_index(self):
+        checker = load_repository_checker_module()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            marketplace = root / ".claude-plugin/marketplace.json"
+            skill_doc = root / "agents/engineer/skills/example/SKILL.md"
+            changelog = root / "docs/changelog/changelog-v0.1.3.md"
+            changelog_index = root / "CHANGELOG.md"
+            marketplace.parent.mkdir(parents=True)
+            skill_doc.parent.mkdir(parents=True)
+            changelog.parent.mkdir(parents=True)
+            skill_doc.write_text(
+                "---\n"
+                "name: example\n"
+                "description: Example skill\n"
+                "---\n"
+            )
+            changelog.write_text("# Changelog - v0.1.3\n")
+            changelog_index.write_text(
+                "# Changelog\n\n"
+                "- [v0.1.2](./docs/changelog/changelog-v0.1.2.md)\n"
+            )
+            marketplace.write_text(
+                json.dumps(
+                    {
+                        "name": "dev-agent-skills",
+                        "owner": {"name": "Neplich"},
+                        "metadata": {"version": "0.1.3"},
+                        "plugins": [
+                            {
+                                "name": "engineer-agent",
+                                "source": "./agents/engineer",
+                                "skills": ["./skills/example"],
+                            }
+                        ],
+                    }
+                )
+            )
+
+            errors = []
+            checker.validate_marketplace(root, errors)
+
+        rendered = "\n".join(error.render(root) for error in errors)
+        self.assertIn(
+            "CHANGELOG.md: must reference docs/changelog/changelog-v0.1.3.md",
+            rendered,
+        )
+
     def test_repository_contract_rejects_missing_implementation_plan_base_ref(self):
         checker = load_repository_checker_module()
 

--- a/scripts/check_repository_contract.py
+++ b/scripts/check_repository_contract.py
@@ -15,6 +15,9 @@ from typing import Any
 
 SKILL_NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 LOCK_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
+SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$")
+DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+IMPLEMENTATION_PLAN_RE = re.compile(r"^docs/engineer/[^/]+/IMPLEMENTATION_PLAN\.md$")
 BLOCKED_TRACKED_PATTERNS = (
     re.compile(r"(^|/)\.DS_Store$"),
     re.compile(r"(^|/)\.pytest_cache(/|$)"),
@@ -104,6 +107,49 @@ def parse_frontmatter(path: Path, errors: list[ContractError]) -> dict[str, str]
 
     add_error(errors, path, "unterminated YAML frontmatter")
     return None
+
+
+def parse_markdown_frontmatter(
+    path: Path,
+    content: str,
+    errors: list[ContractError] | None = None,
+) -> tuple[dict[str, str], str] | None:
+    lines = content.splitlines()
+    if not lines or lines[0].strip() != "---":
+        if errors is not None:
+            add_error(errors, path, "missing YAML frontmatter")
+        return None
+
+    end_index: int | None = None
+    for index, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            end_index = index
+            break
+
+    if end_index is None:
+        if errors is not None:
+            add_error(errors, path, "unterminated YAML frontmatter")
+        return None
+
+    fields: dict[str, str] = {}
+    for line in lines[1:end_index]:
+        if not line.strip() or line.startswith((" ", "\t", "-")) or ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        key = key.strip()
+        value = value.strip()
+        if not key:
+            continue
+        if (
+            len(value) >= 2
+            and value[0] == value[-1]
+            and value[0] in {'"', "'"}
+        ):
+            value = value[1:-1]
+        fields[key] = value
+
+    body = "\n".join(lines[end_index + 1 :])
+    return fields, body
 
 
 def validate_skill(root: Path, skill_dir: Path, errors: list[ContractError]) -> None:
@@ -292,6 +338,107 @@ def tracked_files(root: Path) -> list[str]:
     return [path for path in result.stdout.decode("utf-8").split("\0") if path]
 
 
+def git_output(root: Path, args: list[str]) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=root,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+    except subprocess.CalledProcessError:
+        return None
+    return result.stdout.decode("utf-8")
+
+
+def implementation_plan_base_ref(root: Path) -> str | None:
+    for ref in ("origin/main", "main"):
+        if git_output(root, ["rev-parse", "--verify", ref]) is None:
+            continue
+        merge_base = git_output(root, ["merge-base", "HEAD", ref])
+        if merge_base:
+            return merge_base.strip()
+    return None
+
+
+def changed_files_against(root: Path, base_ref: str) -> list[str]:
+    output = git_output(root, ["diff", "--name-only", "-z", base_ref, "--", "docs/engineer"])
+    if output is None:
+        return []
+    return [path for path in output.split("\0") if path]
+
+
+def content_at_ref(root: Path, ref: str, rel: str) -> str | None:
+    return git_output(root, ["show", f"{ref}:{rel}"])
+
+
+def validate_implementation_plan_metadata(root: Path, errors: list[ContractError]) -> None:
+    implementation_plans = [
+        rel
+        for rel in tracked_files(root)
+        if IMPLEMENTATION_PLAN_RE.fullmatch(rel) and (root / rel).exists()
+    ]
+
+    for rel in implementation_plans:
+        path = root / rel
+        parsed = parse_markdown_frontmatter(path, path.read_text(), errors)
+        if parsed is None:
+            continue
+        metadata, _ = parsed
+
+        for field in ("feature", "version", "date", "last_updated"):
+            value = metadata.get(field)
+            if not isinstance(value, str) or not value.strip():
+                add_error(errors, path, f"frontmatter {field!r} must be non-empty")
+
+        version = metadata.get("version", "")
+        if version and not SEMVER_RE.fullmatch(version):
+            add_error(errors, path, "frontmatter 'version' must be SemVer, for example 0.1.0")
+
+        for field in ("date", "last_updated"):
+            value = metadata.get(field, "")
+            if value and not DATE_RE.fullmatch(value):
+                add_error(errors, path, f"frontmatter {field!r} must use YYYY-MM-DD")
+
+    base_ref = implementation_plan_base_ref(root)
+    if base_ref is None:
+        return
+
+    for rel in changed_files_against(root, base_ref):
+        if not IMPLEMENTATION_PLAN_RE.fullmatch(rel) or not (root / rel).exists():
+            continue
+
+        current_path = root / rel
+        base_content = content_at_ref(root, base_ref, rel)
+        if base_content is None:
+            continue
+
+        current_parsed = parse_markdown_frontmatter(current_path, current_path.read_text())
+        base_parsed = parse_markdown_frontmatter(current_path, base_content)
+        if current_parsed is None or base_parsed is None:
+            continue
+
+        current_metadata, current_body = current_parsed
+        base_metadata, base_body = base_parsed
+        body_changed = current_body != base_body
+        version_changed = current_metadata.get("version") != base_metadata.get("version")
+        last_updated_changed = current_metadata.get("last_updated") != base_metadata.get("last_updated")
+
+        if body_changed and not version_changed and not last_updated_changed:
+            add_error(
+                errors,
+                current_path,
+                "body changed without updating frontmatter 'version' or 'last_updated'",
+            )
+        if version_changed and not last_updated_changed:
+            add_error(
+                errors,
+                current_path,
+                "frontmatter 'version' changed without updating 'last_updated'",
+            )
+
+
 def validate_tracked_file_policy(root: Path, errors: list[ContractError]) -> None:
     for rel in tracked_files(root):
         if any(pattern.search(rel) for pattern in BLOCKED_TRACKED_PATTERNS):
@@ -304,6 +451,7 @@ def validate_all(root: Path | None = None) -> list[ContractError]:
     validate_claude_symlink(root, errors)
     validate_marketplace(root, errors)
     validate_skills_lock(root, errors)
+    validate_implementation_plan_metadata(root, errors)
     validate_tracked_file_policy(root, errors)
     return errors
 

--- a/scripts/check_repository_contract.py
+++ b/scripts/check_repository_contract.py
@@ -15,9 +15,18 @@ from typing import Any
 
 SKILL_NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 LOCK_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
-SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$")
+SEMVER_CORE_PATTERN = r"(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)"
+SEMVER_PRERELEASE_IDENTIFIER_PATTERN = (
+    r"(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)"
+)
+SEMVER_PRERELEASE_PATTERN = (
+    rf"{SEMVER_PRERELEASE_IDENTIFIER_PATTERN}"
+    rf"(?:\.{SEMVER_PRERELEASE_IDENTIFIER_PATTERN})*"
+)
+SEMVER_PATTERN = rf"{SEMVER_CORE_PATTERN}(?:-{SEMVER_PRERELEASE_PATTERN})?"
+SEMVER_RE = re.compile(rf"^{SEMVER_PATTERN}$")
 DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
-CHANGELOG_VERSION_RE = re.compile(r"^changelog-v(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)\.md$")
+CHANGELOG_VERSION_RE = re.compile(rf"^changelog-v({SEMVER_PATTERN})\.md$")
 IMPLEMENTATION_PLAN_RE = re.compile(r"^docs/engineer/[^/]+/IMPLEMENTATION_PLAN\.md$")
 BLOCKED_TRACKED_PATTERNS = (
     re.compile(r"(^|/)\.DS_Store$"),

--- a/scripts/check_repository_contract.py
+++ b/scripts/check_repository_contract.py
@@ -206,16 +206,32 @@ def semver_key(version: str) -> tuple[int, int, int, int, tuple[tuple[int, int |
     return major, minor, patch, release_rank, prerelease_key(prerelease)
 
 
-def latest_changelog_version(root: Path) -> str | None:
+def latest_changelog_version(
+    root: Path,
+    errors: list[ContractError] | None = None,
+) -> str | None:
     versions: list[str] = []
     changelog_dir = root / "docs" / "changelog"
     if not changelog_dir.exists():
         return None
 
     for path in changelog_dir.iterdir():
+        if not path.name.startswith("changelog-v"):
+            continue
         match = CHANGELOG_VERSION_RE.fullmatch(path.name)
-        if match:
-            versions.append(match.group(1))
+        if match is None:
+            if errors is not None:
+                add_error(
+                    errors,
+                    path,
+                    "changelog filename must use changelog-v{SemVer}.md",
+                )
+            continue
+        if not path.is_file():
+            if errors is not None:
+                add_error(errors, path, "changelog entry must be a file")
+            continue
+        versions.append(match.group(1))
 
     if not versions:
         return None
@@ -266,7 +282,7 @@ def validate_marketplace(root: Path, errors: list[ContractError]) -> None:
         )
         if not metadata_version_valid:
             add_error(errors, path, "metadata.version must be SemVer without a leading 'v'")
-        latest_version = latest_changelog_version(root)
+        latest_version = latest_changelog_version(root, errors)
         if latest_version is None:
             add_error(
                 errors,

--- a/scripts/check_repository_contract.py
+++ b/scripts/check_repository_contract.py
@@ -198,6 +198,27 @@ def latest_changelog_version(root: Path) -> str | None:
     return max(versions, key=semver_key)
 
 
+def validate_root_changelog_entry(
+    root: Path,
+    metadata_version: str,
+    errors: list[ContractError],
+) -> None:
+    path = root / "CHANGELOG.md"
+    expected_link = f"docs/changelog/changelog-v{metadata_version}.md"
+    try:
+        content = path.read_text()
+    except OSError as exc:
+        add_error(errors, path, f"cannot read changelog index: {exc}")
+        return
+
+    if expected_link not in content:
+        add_error(
+            errors,
+            path,
+            f"must reference {expected_link} for marketplace metadata.version",
+        )
+
+
 def validate_marketplace(root: Path, errors: list[ContractError]) -> None:
     path = root / ".claude-plugin" / "marketplace.json"
     payload = load_json(path, errors)
@@ -215,7 +236,11 @@ def validate_marketplace(root: Path, errors: list[ContractError]) -> None:
         add_error(errors, path, "metadata must be an object")
     else:
         metadata_version = metadata.get("version")
-        if not isinstance(metadata_version, str) or not SEMVER_RE.fullmatch(metadata_version):
+        metadata_version_valid = (
+            isinstance(metadata_version, str)
+            and SEMVER_RE.fullmatch(metadata_version) is not None
+        )
+        if not metadata_version_valid:
             add_error(errors, path, "metadata.version must be SemVer without a leading 'v'")
         latest_version = latest_changelog_version(root)
         if latest_version is None:
@@ -224,12 +249,14 @@ def validate_marketplace(root: Path, errors: list[ContractError]) -> None:
                 path,
                 "docs/changelog must contain at least one changelog-v{version}.md file",
             )
-        elif metadata_version != latest_version:
+        elif metadata_version_valid and metadata_version != latest_version:
             add_error(
                 errors,
                 path,
                 f"metadata.version must match latest changelog version {latest_version!r}",
             )
+        elif metadata_version_valid:
+            validate_root_changelog_entry(root, metadata_version, errors)
 
     for index, plugin in enumerate(plugins):
         if not isinstance(plugin, dict):

--- a/scripts/check_repository_contract.py
+++ b/scripts/check_repository_contract.py
@@ -17,6 +17,7 @@ SKILL_NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 LOCK_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
 SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$")
 DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+CHANGELOG_VERSION_RE = re.compile(r"^changelog-v(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)\.md$")
 IMPLEMENTATION_PLAN_RE = re.compile(r"^docs/engineer/[^/]+/IMPLEMENTATION_PLAN\.md$")
 BLOCKED_TRACKED_PATTERNS = (
     re.compile(r"(^|/)\.DS_Store$"),
@@ -174,6 +175,29 @@ def validate_skill(root: Path, skill_dir: Path, errors: list[ContractError]) -> 
         add_error(errors, skill_doc, "frontmatter name must use lowercase letters, digits, and hyphens only")
 
 
+def semver_key(version: str) -> tuple[int, int, int, int, str]:
+    core, _, prerelease = version.partition("-")
+    major, minor, patch = (int(part) for part in core.split("."))
+    release_rank = 0 if prerelease else 1
+    return major, minor, patch, release_rank, prerelease
+
+
+def latest_changelog_version(root: Path) -> str | None:
+    versions: list[str] = []
+    changelog_dir = root / "docs" / "changelog"
+    if not changelog_dir.exists():
+        return None
+
+    for path in changelog_dir.iterdir():
+        match = CHANGELOG_VERSION_RE.fullmatch(path.name)
+        if match:
+            versions.append(match.group(1))
+
+    if not versions:
+        return None
+    return max(versions, key=semver_key)
+
+
 def validate_marketplace(root: Path, errors: list[ContractError]) -> None:
     path = root / ".claude-plugin" / "marketplace.json"
     payload = load_json(path, errors)
@@ -185,6 +209,27 @@ def validate_marketplace(root: Path, errors: list[ContractError]) -> None:
     if not isinstance(plugins, list):
         add_error(errors, path, "plugins must be an array")
         return
+
+    metadata = payload.get("metadata")
+    if not isinstance(metadata, dict):
+        add_error(errors, path, "metadata must be an object")
+    else:
+        metadata_version = metadata.get("version")
+        if not isinstance(metadata_version, str) or not SEMVER_RE.fullmatch(metadata_version):
+            add_error(errors, path, "metadata.version must be SemVer without a leading 'v'")
+        latest_version = latest_changelog_version(root)
+        if latest_version is None:
+            add_error(
+                errors,
+                path,
+                "docs/changelog must contain at least one changelog-v{version}.md file",
+            )
+        elif metadata_version != latest_version:
+            add_error(
+                errors,
+                path,
+                f"metadata.version must match latest changelog version {latest_version!r}",
+            )
 
     for index, plugin in enumerate(plugins):
         if not isinstance(plugin, dict):

--- a/scripts/check_repository_contract.py
+++ b/scripts/check_repository_contract.py
@@ -448,6 +448,11 @@ def validate_implementation_plan_metadata(root: Path, errors: list[ContractError
 
     base_ref = implementation_plan_base_ref(root)
     if base_ref is None:
+        add_error(
+            errors,
+            root / "docs" / "engineer",
+            "cannot compare implementation plan metadata because no base ref is available; fetch origin/main or main before running repository contract",
+        )
         return
 
     for rel in changed_files_against(root, base_ref):

--- a/scripts/check_repository_contract.py
+++ b/scripts/check_repository_contract.py
@@ -175,11 +175,26 @@ def validate_skill(root: Path, skill_dir: Path, errors: list[ContractError]) -> 
         add_error(errors, skill_doc, "frontmatter name must use lowercase letters, digits, and hyphens only")
 
 
-def semver_key(version: str) -> tuple[int, int, int, int, str]:
+def prerelease_identifier_key(identifier: str) -> tuple[int, int | str]:
+    if identifier.isdigit():
+        return 0, int(identifier)
+    return 1, identifier
+
+
+def prerelease_key(prerelease: str) -> tuple[tuple[int, int | str], ...]:
+    if not prerelease:
+        return ()
+    return tuple(
+        prerelease_identifier_key(identifier)
+        for identifier in prerelease.split(".")
+    )
+
+
+def semver_key(version: str) -> tuple[int, int, int, int, tuple[tuple[int, int | str], ...]]:
     core, _, prerelease = version.partition("-")
     major, minor, patch = (int(part) for part in core.split("."))
     release_rank = 0 if prerelease else 1
-    return major, minor, patch, release_rank, prerelease
+    return major, minor, patch, release_rank, prerelease_key(prerelease)
 
 
 def latest_changelog_version(root: Path) -> str | None:

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -64,7 +64,7 @@
     "feature-implementor": {
       "source": "agents/engineer/skills/feature-implementor",
       "sourceType": "local",
-      "computedHash": "cbc5963604164f3abce6f3f8de9f02c0c34b5f848c68cb8c67f4b066b6af8001"
+      "computedHash": "231f7b6d6d79944b5fef08d5025afd53f19a4eb64f993dccdf2c4a43506df59d"
     },
     "test-writer": {
       "source": "agents/engineer/skills/test-writer",


### PR DESCRIPTION
## Summary

- 明确 `feature-implementor` 产出或更新 `IMPLEMENTATION_PLAN.md` 时的 `version` / `last_updated` 维护规则。
- 增加 repository contract，校验实施计划元数据和 marketplace `metadata.version` 版本同步规则。
- 将 `.claude-plugin/marketplace.json` 的 `metadata.version` 同步到当前 release 版本 `0.1.3`，并补充打 tag 前置约束。
- 更新 `feature-implementor` eval 断言与 durable comparison，覆盖实施计划元数据维护要求。

## Related Issues

Closes #33
Closes #30

## Testing

- `uv run scripts/check_repository_contract.py`
- `uv run scripts/check_eval_contract.py`
- `uv run scripts/check_eval_artifacts.py`
- `uv run --with pytest pytest agents/product_manager/test/idea-to-spec agents/qa/test/test_qa_run_eval.py agents/designer/test/test_designer_run_eval.py agents/devops/test/test_devops_run_eval.py agents/test_eval_contract.py`
- `uv run python -m json.tool .claude-plugin/marketplace.json >/tmp/marketplace.json.out`
- `git diff --check`