### PR TITLE
fix: 补齐实施计划收尾门禁

### DIFF
--- a/agents/engineer/skills/feature-implementor/SKILL.md
+++ b/agents/engineer/skills/feature-implementor/SKILL.md
@@ -20,6 +20,7 @@ This is the public entry point. It owns:
 - Delegation to internal modules and, for complex coding tasks, scoped
   implementation/validation sub-agents
 - Quality self-check before handoff
+- Implementation plan closeout after implementation and validation
 - QA E2E documentation handoff after code completion when user-facing flows or
   acceptance paths may be affected
 
@@ -373,6 +374,37 @@ Output a brief review summary:
 - 安全检查: ✅ 无明显安全问题
 - 规范检查: ✅ 命名和结构符合项目规范
 ```
+
+## Implementation Plan Closeout Gate
+
+After implementation and deterministic checks, update or confirm the confirmed
+`docs/engineer/{feature_path}/IMPLEMENTATION_PLAN.md` before QA E2E handoff or
+delivery. The reviewer must validate this closeout before handoff. This keeps
+the durable plan artifact aligned with the implemented state.
+
+The closeout must record:
+
+- the final frontmatter status, such as `status: "Implemented"` when the plan
+  has been fully implemented
+- the implementation result and changed file summary
+- deterministic check commands that actually ran and their results
+- commands not run, with skipped or blocked reasons
+- skill eval or fresh subagent validation results when they ran, including the
+  durable `comparison.md` paths
+- residual risks, open follow-ups, and next owner when applicable
+
+If skill eval or fresh subagent validation did not run, say so explicitly with
+the skipped or blocked reason. Do not imply model eval passed without durable
+`comparison.md` evidence. Runtime artifacts such as transcripts, outputs,
+diagnostics, timing data, and run status files must remain outside git.
+
+Before handoff, check that a completed plan does not still contain stale
+planning-state wording. When frontmatter says `Implemented` or an equivalent
+complete state, the plan body must not contradict it with unresolved status such
+as "waiting for confirmation", "not started", "pending execution", or "model
+eval not executed" unless those phrases are clearly historical context with a
+current resolved result. If stale state remains, update the plan closeout before
+continuing.
 
 ## QA E2E Documentation Handoff
 

--- a/agents/engineer/skills/feature-implementor/_internal/_shared/output-conventions.md
+++ b/agents/engineer/skills/feature-implementor/_internal/_shared/output-conventions.md
@@ -40,6 +40,30 @@ When creating or updating `docs/engineer/{feature_path}/IMPLEMENTATION_PLAN.md`:
    `related_trd` points to `docs/engineer/{feature_path}/TRD.md`; mismatches
    block plan writing and must be handed back to PM or `trd-gen`.
 
+## Implementation Plan Closeout
+
+When implementation is complete, update or confirm
+`docs/engineer/{feature_path}/IMPLEMENTATION_PLAN.md` before QA E2E handoff or
+delivery:
+
+1. Set or confirm the final status, such as `status: "Implemented"` when the
+   plan has been fully implemented.
+2. Add an implementation result section or status table that records completed
+   files, completed checks, remaining risks, and next owner.
+3. Record deterministic check commands exactly as run, with pass/fail/blocked
+   results.
+4. For commands not run, record skipped or blocked reasons instead of leaving
+   them as pending.
+5. If skill eval or fresh subagent validation ran, cite the durable
+   `comparison.md` paths. If it did not run, record the skipped or blocked
+   reason.
+6. Do not commit runtime eval artifacts such as transcripts, diagnostics,
+   outputs, timing data, run status files, or `comparison.auto.md`.
+7. A completed plan must not keep unresolved planning-state wording such as
+   "waiting for confirmation", "not started", "pending execution", or "model
+   eval not executed" unless the same section clearly marks it as historical and
+   records the current resolved result.
+
 ## Commit Granularity
 
 When used with `delivery` skill:

--- a/agents/engineer/skills/feature-implementor/_internal/implementor/INSTRUCTIONS.md
+++ b/agents/engineer/skills/feature-implementor/_internal/implementor/INSTRUCTIONS.md
@@ -14,6 +14,8 @@ Execute the implementation plan step by step, writing code that follows project 
 - Confirmed Engineer TRD for reference
 - For complex coding tasks: implementation sub-agent scope, forbidden areas,
   expected behavior, and verification commands
+- Closeout evidence to collect: changed files, deterministic commands run,
+  command results, commands not run with reasons, eval status, and residual risks
 
 ## Entry Gate
 
@@ -87,7 +89,21 @@ After each file:
 
 If the build fails, fix it before moving to the next step.
 
-### 4. Progress update
+### 4. Collect closeout evidence
+
+Track the evidence needed to update the confirmed `IMPLEMENTATION_PLAN.md` after
+implementation:
+
+- files created or modified
+- deterministic check commands run and their results
+- commands skipped or blocked, with reasons
+- skill eval or fresh subagent validation status, when applicable
+- residual risks, open issues, or follow-up owners
+
+Do not write runtime eval artifacts into the repository. Transcript,
+diagnostic, output, timing, and run-status files are temporary only.
+
+### 5. Progress update
 
 After each step, briefly report:
 

--- a/agents/engineer/skills/feature-implementor/_internal/reviewer/INSTRUCTIONS.md
+++ b/agents/engineer/skills/feature-implementor/_internal/reviewer/INSTRUCTIONS.md
@@ -13,6 +13,7 @@ Review the implemented code against PM documents and project conventions before 
 - Engineer documents (TRD, IMPLEMENTATION_PLAN, API Spec)
 - Project Profile
 - Deterministic test results, when available
+- Implementation plan closeout evidence and updated closeout state
 - For complex coding tasks: implementation sub-agent summary and assigned
   write scope
 
@@ -73,6 +74,22 @@ For each P0 acceptance criterion in PRD:
 - [ ] Import style matches existing code
 - [ ] Error handling follows project patterns
 
+### 6. Implementation Plan Closeout
+
+- [ ] Completed implementations update or confirm
+      `docs/engineer/{feature_path}/IMPLEMENTATION_PLAN.md` before QA E2E
+      handoff or delivery
+- [ ] If frontmatter uses `status: Implemented` or an equivalent complete
+      state, the body no longer contains unresolved planning-state text such as
+      "waiting for confirmation", "not started", "pending execution", or
+      "model eval not executed"
+- [ ] Deterministic checks that ran are listed with actual commands and results
+- [ ] Commands not run are listed with skipped or blocked reasons
+- [ ] Skill eval or fresh subagent validation that ran links to durable
+      `comparison.md`; if it did not run, the reason is explicit
+- [ ] Runtime eval artifacts such as transcripts, diagnostics, outputs, timing
+      data, and run-status files are not committed
+
 ## Output
 
 ```text
@@ -85,6 +102,7 @@ For each P0 acceptance criterion in PRD:
 | PRD 覆盖 | ✅/⚠️/❌ | <details> |
 | 安全检查 | ✅/⚠️/❌ | <details> |
 | 规范检查 | ✅/⚠️/❌ | <details> |
+| 实施计划收尾 | ✅/⚠️/❌ | <details> |
 | 独立验收 | ✅/⚠️/❌/N/A | <details> |
 
 ### 问题 (如有)
@@ -106,3 +124,5 @@ For each P0 acceptance criterion in PRD:
 | ❌ | Blocking issues | Must fix before handoff |
 
 If any ❌ issues found, go back to Phase 2 to fix them before producing the final review.
+If the ❌ issue is stale `IMPLEMENTATION_PLAN.md` closeout state, update the
+plan closeout and re-run this review before handoff.

--- a/agents/engineer/test/feature-implementor/evals/evals.json
+++ b/agents/engineer/test/feature-implementor/evals/evals.json
@@ -322,6 +322,46 @@
           "text": "输出不得声称已经修改前端代码、运行测试或完成实现。"
         }
       ]
+    },
+    {
+      "id": "eval-010-implementation-plan-closeout-sync",
+      "name": "implementation-plan-closeout-sync",
+      "description": "Verifies that feature-implementor detects and blocks stale IMPLEMENTATION_PLAN closeout state after implementation is marked complete.",
+      "prompt": "docs/pm/sample-feature/PRD.md、docs/engineer/sample-feature/TRD.md 和 docs/engineer/sample-feature/IMPLEMENTATION_PLAN.md 都存在。实现和 deterministic checks 已完成，IMPLEMENTATION_PLAN frontmatter 已是 status: Implemented，但正文仍写 Implementation plan 待用户确认、Code / skill edits 未开始、Eval execution 待确认，并写模型 eval 尚未执行。请进入 feature-implementor 做实施收尾检查，不要继续 delivery。",
+      "workspace": "workspace/eval-010-implementation-plan-closeout-sync",
+      "expected_output": "识别 IMPLEMENTATION_PLAN 的 frontmatter 完成态与正文计划期状态矛盾，阻止 QA handoff 或 delivery，要求更新实施结果区、状态表、deterministic checks 命令和结果、eval / comparison 记录或 skipped / blocked 原因，并保持运行期 eval 产物不入库。",
+      "assertions": [
+        {
+          "id": "detects_closeout_state_conflict",
+          "description": "识别完成态和正文状态冲突",
+          "text": "输出必须明确 `docs/engineer/sample-feature/IMPLEMENTATION_PLAN.md` 的 `status: Implemented` 与正文中的待确认、未开始或未执行状态冲突。"
+        },
+        {
+          "id": "blocks_handoff_until_plan_updated",
+          "description": "同步计划前阻断交付",
+          "text": "输出必须阻止继续 QA handoff、delivery、PR 创建或关闭 issue，直到 IMPLEMENTATION_PLAN 的 closeout 状态被同步。"
+        },
+        {
+          "id": "requires_implementation_result_update",
+          "description": "要求更新实施结果",
+          "text": "输出必须要求更新 IMPLEMENTATION_PLAN 的状态表或实施结果区，记录已完成的文件、验证结果、剩余风险和下一步。"
+        },
+        {
+          "id": "records_deterministic_checks",
+          "description": "记录确定性检查",
+          "text": "输出必须要求记录实际运行过的 deterministic check 命令和结果；未运行的命令必须写明 skipped 或 blocked 原因。"
+        },
+        {
+          "id": "records_eval_evidence",
+          "description": "记录 eval 证据",
+          "text": "输出必须要求 skill eval 或 fresh subagent validation 已执行时引用 durable `comparison.md`；未执行时明确 skipped 或 blocked 原因，不得声称模型 eval 已通过。"
+        },
+        {
+          "id": "keeps_runtime_artifacts_out_of_git",
+          "description": "运行期产物不入库",
+          "text": "输出必须说明 transcript、diagnostics、outputs、timing、run status 或 `comparison.auto.md` 这类运行期 eval 产物不得提交到 git。"
+        }
+      ]
     }
   ]
 }

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-010-implementation-plan-closeout-sync/README.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-010-implementation-plan-closeout-sync/README.md
@@ -1,0 +1,5 @@
+# eval-010-implementation-plan-closeout-sync
+
+This fixture verifies that `feature-implementor` blocks handoff when an
+implementation plan is marked implemented in frontmatter but still contains
+unresolved planning-state text in the body.

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-010-implementation-plan-closeout-sync/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-010-implementation-plan-closeout-sync/comparison.md
@@ -7,12 +7,13 @@
 - Eval: `eval-010-implementation-plan-closeout-sync`
 - Test case: implementation-plan-closeout-sync
 - Workspace: `workspace/eval-010-implementation-plan-closeout-sync`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-06-24; deterministic checks passed, the first validation caught stale durable closeout evidence, and the final validation confirmed the synchronized PRD/SKILL/internal/eval direction covers stale closeout state
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-06-24; with-skill run `019ef5f3-bf60-7922-bcc0-2a296cd3be0b` passed, without-skill baseline run `019ef5f3-e0e2-7ef3-adb9-5f89535a79f3` passed, and deterministic checks passed
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
 - Fixture: Confirmed PRD/TRD plus an `IMPLEMENTATION_PLAN.md` whose frontmatter is implemented while the body still contains planning-state text.
+- Run set: actual with-skill subagent validation plus actual without-skill baseline subagent validation against the same prompt and fixture.
 - Expected output: block QA handoff or delivery until the implementation plan closeout state, implementation result, deterministic checks, and eval evidence are synchronized.
 
 ## Assertions
@@ -26,19 +27,19 @@
 
 ## With Skill
 
-- PASS. Fresh subagent validation confirmed the PRD/TRD, `SKILL.md`, implementor/reviewer/output conventions, eval definition, fixture, and lockfile direction satisfy the closeout-gate plan. The first validation blocked delivery because this durable comparison and the implementation plan closeout had not yet been synchronized; after those artifacts were updated, the final validation passed.
+- PASS. Subagent `019ef5f3-bf60-7922-bcc0-2a296cd3be0b` used `feature-implementor` and confirmed the PRD/TRD, `SKILL.md`, implementor/reviewer/output conventions, eval definition, and fixture satisfy the closeout-gate plan. The candidate output blocked QA handoff, delivery, PR creation, and issue closeout until the durable `IMPLEMENTATION_PLAN.md` closeout state, deterministic checks, eval evidence, and runtime artifact policy are synchronized.
 
 ## Without Skill / Baseline
 
-- BLOCKED / not generated. This PR did not produce a separate without-skill transcript for `eval-010`, and the deterministic checks do not provide a runner mode that disables only `feature-implementor` while preserving the same prompt and workspace. No baseline pass/fail is inferred. The recorded baseline risk remains: without this closeout gate, an implementation can proceed to handoff or delivery while the durable plan artifact still contradicts the implemented state.
+- PASS. Subagent `019ef5f3-e0e2-7ef3-adb9-5f89535a79f3` ran the same prompt and fixture without reading or using `feature-implementor` or its internal instructions. The baseline response still detected the stale `IMPLEMENTATION_PLAN.md` closeout state, blocked QA handoff and delivery, required implementation-result, deterministic-check, eval-evidence, and runtime-artifact updates, and satisfied all six assertions. Baseline weakness: it could not confirm the `feature-implementor`-specific closeout templates, wording, or ordering beyond the prompt, fixture, and repository-level eval constraints.
 
 ## Failures
 
-- None in the skill/eval contract after closeout synchronization. The initial subagent validation found all deterministic commands passing and identified only stale durable closeout artifacts; the final validation passed after this comparison and the implementation plan were synchronized.
+- None in the skill/eval contract after closeout synchronization. Both actual with-skill and without-skill baseline runs passed; the remaining distinction is that the with-skill run also validates the `feature-implementor`-specific closeout contract.
 
 ## Next Steps
 
-- Keep this eval as regression coverage for stale `IMPLEMENTATION_PLAN.md` closeout state. Re-run fresh subagent validation if `feature-implementor` closeout behavior, implementation plan output conventions, or eval fixture docs change.
+- Keep this eval as regression coverage for stale `IMPLEMENTATION_PLAN.md` closeout state. Re-run both with-skill and without-skill baseline validation if `feature-implementor` closeout behavior, implementation plan output conventions, or eval fixture docs change.
 
 ## Runtime Artifacts Policy
 

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-010-implementation-plan-closeout-sync/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-010-implementation-plan-closeout-sync/comparison.md
@@ -1,0 +1,45 @@
+# Eval Result: eval-010-implementation-plan-closeout-sync
+
+## Evaluation Target
+
+- Agent: `engineer`
+- Skill: `feature-implementor`
+- Eval: `eval-010-implementation-plan-closeout-sync`
+- Test case: implementation-plan-closeout-sync
+- Workspace: `workspace/eval-010-implementation-plan-closeout-sync`
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-06-24; deterministic checks passed and the subagent confirmed the new PRD/SKILL/internal/eval direction covers stale closeout state
+
+## Test Set / Fixture Version
+
+- Schema: `evals.json` v1.0
+- Fixture: Confirmed PRD/TRD plus an `IMPLEMENTATION_PLAN.md` whose frontmatter is implemented while the body still contains planning-state text.
+- Expected output: block QA handoff or delivery until the implementation plan closeout state, implementation result, deterministic checks, and eval evidence are synchronized.
+
+## Assertions
+
+- PASS `detects_closeout_state_conflict`: the updated skill and reviewer instructions identify conflict between `status: Implemented` and unresolved pending/not-started/not-executed body state.
+- PASS `blocks_handoff_until_plan_updated`: the closeout gate runs before QA handoff or delivery and blocks when the durable plan is stale.
+- PASS `requires_implementation_result_update`: output conventions require implementation result, status table, completed files, checks, risks, and next owner.
+- PASS `records_deterministic_checks`: output conventions require actual deterministic commands and results, or skipped/blocked reasons.
+- PASS `records_eval_evidence`: output conventions require durable `comparison.md` references for executed evals, or skipped/blocked reasons.
+- PASS `keeps_runtime_artifacts_out_of_git`: skill and output conventions keep transcripts, diagnostics, outputs, timing, run status, and `comparison.auto.md` out of git.
+
+## With Skill
+
+- PASS. Fresh subagent validation confirmed the PRD/TRD, `SKILL.md`, implementor/reviewer/output conventions, eval definition, fixture, and lockfile direction satisfy the closeout-gate plan. The subagent's first delivery verdict was blocked only because this durable comparison and the implementation plan closeout had not yet been synchronized; both are now updated.
+
+## Without Skill / Baseline
+
+- Baseline risk: without this closeout gate, an implementation can proceed to handoff or delivery while the durable plan artifact still contradicts the implemented state.
+
+## Failures
+
+- None in the skill/eval contract after closeout synchronization. The initial subagent validation found all deterministic commands passing and identified only stale durable closeout artifacts, which this update resolves.
+
+## Next Steps
+
+- Keep this eval as regression coverage for stale `IMPLEMENTATION_PLAN.md` closeout state. Re-run fresh subagent validation if `feature-implementor` closeout behavior, implementation plan output conventions, or eval fixture docs change.
+
+## Runtime Artifacts Policy
+
+- Runtime transcripts, verdicts, timing, outputs, diagnostics, run status files, and `comparison.auto.md` should not be committed.

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-010-implementation-plan-closeout-sync/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-010-implementation-plan-closeout-sync/comparison.md
@@ -7,7 +7,7 @@
 - Eval: `eval-010-implementation-plan-closeout-sync`
 - Test case: implementation-plan-closeout-sync
 - Workspace: `workspace/eval-010-implementation-plan-closeout-sync`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-06-24; deterministic checks passed and the subagent confirmed the new PRD/SKILL/internal/eval direction covers stale closeout state
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-06-24; deterministic checks passed, the first validation caught stale durable closeout evidence, and the final validation confirmed the synchronized PRD/SKILL/internal/eval direction covers stale closeout state
 
 ## Test Set / Fixture Version
 
@@ -26,15 +26,15 @@
 
 ## With Skill
 
-- PASS. Fresh subagent validation confirmed the PRD/TRD, `SKILL.md`, implementor/reviewer/output conventions, eval definition, fixture, and lockfile direction satisfy the closeout-gate plan. The subagent's first delivery verdict was blocked only because this durable comparison and the implementation plan closeout had not yet been synchronized; both are now updated.
+- PASS. Fresh subagent validation confirmed the PRD/TRD, `SKILL.md`, implementor/reviewer/output conventions, eval definition, fixture, and lockfile direction satisfy the closeout-gate plan. The first validation blocked delivery because this durable comparison and the implementation plan closeout had not yet been synchronized; after those artifacts were updated, the final validation passed.
 
 ## Without Skill / Baseline
 
-- Baseline risk: without this closeout gate, an implementation can proceed to handoff or delivery while the durable plan artifact still contradicts the implemented state.
+- BLOCKED / not generated. This PR did not produce a separate without-skill transcript for `eval-010`, and the deterministic checks do not provide a runner mode that disables only `feature-implementor` while preserving the same prompt and workspace. No baseline pass/fail is inferred. The recorded baseline risk remains: without this closeout gate, an implementation can proceed to handoff or delivery while the durable plan artifact still contradicts the implemented state.
 
 ## Failures
 
-- None in the skill/eval contract after closeout synchronization. The initial subagent validation found all deterministic commands passing and identified only stale durable closeout artifacts, which this update resolves.
+- None in the skill/eval contract after closeout synchronization. The initial subagent validation found all deterministic commands passing and identified only stale durable closeout artifacts; the final validation passed after this comparison and the implementation plan were synchronized.
 
 ## Next Steps
 

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-010-implementation-plan-closeout-sync/docs/engineer/sample-feature/IMPLEMENTATION_PLAN.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-010-implementation-plan-closeout-sync/docs/engineer/sample-feature/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,36 @@
+---
+title: "Sample Feature Implementation Plan"
+type: IMPLEMENTATION_PLAN
+version: "0.1.1"
+status: Implemented
+author: "Neplich Codex"
+date: "2026-06-24"
+last_updated: "2026-06-24"
+generated_by: "feature-implementor"
+feature: "sample-feature"
+feature_path: "sample-feature"
+parent_feature: "N/A"
+feature_level: "1"
+related_prd: "docs/pm/sample-feature/PRD.md"
+related_trd: "docs/engineer/sample-feature/TRD.md"
+---
+
+# Sample Feature Implementation Plan
+
+## Current Gate Status
+
+| Gate | Status | Evidence |
+| --- | --- | --- |
+| PRD alignment | Complete | `docs/pm/sample-feature/PRD.md` |
+| TRD alignment | Complete | `docs/engineer/sample-feature/TRD.md` |
+| Implementation plan | 待用户确认 | This text is stale and should have been updated. |
+| Code / skill edits | 未开始 | This text is stale and should have been updated. |
+| Eval execution | 待确认 | This text is stale and should have been updated. |
+
+## Planned Steps
+
+1. Modify `src/settings.ts`.
+2. Run deterministic checks.
+3. Ask whether to run model eval.
+
+模型 eval 尚未执行。

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-010-implementation-plan-closeout-sync/docs/engineer/sample-feature/TRD.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-010-implementation-plan-closeout-sync/docs/engineer/sample-feature/TRD.md
@@ -1,0 +1,21 @@
+---
+title: "Sample Feature TRD"
+type: TRD
+version: "0.1.0"
+status: Approved
+author: "Neplich Codex"
+date: "2026-06-24"
+last_updated: "2026-06-24"
+generated_by: "trd-gen"
+feature: "sample-feature"
+feature_path: "sample-feature"
+parent_feature: "N/A"
+feature_level: "1"
+related_prd: "docs/pm/sample-feature/PRD.md"
+---
+
+# Sample Feature TRD
+
+## Implementation
+
+Update `src/settings.ts` and verify the repository contract and focused tests.

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-010-implementation-plan-closeout-sync/docs/pm/sample-feature/PRD.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-010-implementation-plan-closeout-sync/docs/pm/sample-feature/PRD.md
@@ -1,0 +1,21 @@
+---
+title: "Sample Feature PRD"
+type: PRD
+version: "0.1.0"
+status: Approved
+author: "Neplich Codex"
+date: "2026-06-24"
+last_updated: "2026-06-24"
+generated_by: "idea-to-spec"
+feature: "sample-feature"
+feature_path: "sample-feature"
+parent_feature: "N/A"
+feature_level: "1"
+---
+
+# Sample Feature PRD
+
+## Requirement
+
+The sample feature must add a user-visible setting label and pass the existing
+deterministic validation commands.

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-010-implementation-plan-closeout-sync/eval_metadata.json
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-010-implementation-plan-closeout-sync/eval_metadata.json
@@ -1,0 +1,12 @@
+{
+  "eval_id": "eval-010-implementation-plan-closeout-sync",
+  "eval_name": "implementation-plan-closeout-sync",
+  "workspace_root": "agents/engineer/test/feature-implementor/evals/workspace/eval-010-implementation-plan-closeout-sync",
+  "skill_availability_goal": "Verify that feature-implementor detects stale IMPLEMENTATION_PLAN closeout state and blocks handoff until the durable plan artifact is synchronized.",
+  "prompt": "docs/pm/sample-feature/PRD.md、docs/engineer/sample-feature/TRD.md 和 docs/engineer/sample-feature/IMPLEMENTATION_PLAN.md 都存在。实现和 deterministic checks 已完成，IMPLEMENTATION_PLAN frontmatter 已是 status: Implemented，但正文仍写 Implementation plan 待用户确认、Code / skill edits 未开始、Eval execution 待确认，并写模型 eval 尚未执行。请进入 feature-implementor 做实施收尾检查，不要继续 delivery。",
+  "fixture_context": [
+    "docs/pm/sample-feature/PRD.md",
+    "docs/engineer/sample-feature/TRD.md",
+    "docs/engineer/sample-feature/IMPLEMENTATION_PLAN.md"
+  ]
+}

--- a/docs/engineer/implementation-plan-closeout-gate-review-fix/IMPLEMENTATION_PLAN.md
+++ b/docs/engineer/implementation-plan-closeout-gate-review-fix/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,169 @@
+---
+title: "IMPLEMENTATION_PLAN 收尾门禁 Review 修复实施计划"
+type: IMPLEMENTATION_PLAN
+version: "0.1.1"
+status: "Implemented"
+author: "Neplich Codex"
+date: "2026-06-24"
+last_updated: "2026-06-24"
+generated_by: "feature-implementor"
+feature: "implementation-plan-closeout-gate-review-fix"
+feature_path: "implementation-plan-closeout-gate-review-fix"
+parent_feature: "N/A"
+feature_level: "1"
+related_prd: "docs/pm/implementation-plan-closeout-gate-review-fix/PRD.md"
+related_trd: "docs/engineer/implementation-plan-closeout-gate-review-fix/TRD.md"
+related_issue: "https://github.com/Neplich/dev-agent-skills/issues/44"
+related_pr: "https://github.com/Neplich/dev-agent-skills/pull/45"
+related_review:
+  - "https://github.com/Neplich/dev-agent-skills/pull/45#discussion_r3461935792"
+---
+
+# IMPLEMENTATION_PLAN 收尾门禁 Review 修复实施计划
+
+## 1. 实施上下文
+
+PR #45 已完成 implementation plan closeout gate 主体实现，并通过 CI。当前
+review 修复聚焦 durable evidence 补强，不改变 skill 行为。
+
+本计划承接：
+
+- PRD：`docs/pm/implementation-plan-closeout-gate-review-fix/PRD.md`
+- TRD：`docs/engineer/implementation-plan-closeout-gate-review-fix/TRD.md`
+- PR review：`https://github.com/Neplich/dev-agent-skills/pull/45#discussion_r3461935792`
+
+### 1.1 当前门禁状态
+
+| Gate | Status | Evidence |
+| --- | --- | --- |
+| PRD alignment | 已补齐 review-fix PRD | `docs/pm/implementation-plan-closeout-gate-review-fix/PRD.md` |
+| TRD alignment | 已补齐 review-fix TRD | `docs/engineer/implementation-plan-closeout-gate-review-fix/TRD.md` |
+| Implementation plan | 已确认并实施 | 本文件已更新为 `status: "Implemented"` |
+| Code / document edits | 已完成 | 已更新 baseline evidence、主 closeout 计划和本 review-fix closeout |
+| Validation | 已完成 | 本地完整检查 PASS；fresh subagent `019ef5bb-27cd-7b22-b11b-cd9910c9457f` PASS |
+
+## 2. 修复范围
+
+| 来源 | 文件 | 问题 | 修复处理 | 验证方式 |
+| --- | --- | --- | --- | --- |
+| PR review 未解决线程 | `agents/engineer/test/feature-implementor/evals/workspace/eval-010-implementation-plan-closeout-sync/comparison.md` | `Without Skill / Baseline` 只写了假设风险，没有真实 baseline 结果，也没有 blocked 原因。 | 更新 `Without Skill / Baseline`：记录本轮未生成独立 without-skill transcript，并按仓库 eval 规则写清 blocked / skipped 原因；说明本 eval 的对比依据来自 fresh subagent validation，不伪造 baseline pass。 | `uv run scripts/check_eval_artifacts.py`；人工确认 comparison 里 baseline 不再是纯假设。 |
+| 本地 review 补强项 | `docs/engineer/implementation-plan-closeout-gate/IMPLEMENTATION_PLAN.md` | closeout 证据只记录第一轮 subagent FAIL，未记录最终第二轮 PASS。 | 在 Fresh subagent validation / 实施结果中补充第二轮 subagent `019ef5a6-5558-7a02-a5e7-a14bd3c6e272` 的 PASS 结论和完整测试命令全绿结果。 | 人工确认 closeout plan 能支撑 `status: "Implemented"`。 |
+| 一致性补强 | 同上两个文件 | 两处 durable evidence 应互相一致。 | 让 `IMPLEMENTATION_PLAN.md` 和 `comparison.md` 对 fresh validation、baseline / skipped、runtime artifact policy 的描述一致。 | `git diff --check`；人工 review 两个文件证据链。 |
+| 回归检查 | 全仓库 | 文档和 eval fixture 修改可能影响契约。 | 修完后复跑完整确定性检查。 | repository contract、eval contract、eval artifacts、pytest。 |
+
+## 3. 非目标
+
+- 不修改 `feature-implementor` 的 SKILL.md 或 internal instructions。
+- 不新增 eval item。
+- 不刷新 `skills-lock.json`。
+- 不提交 runtime transcript、diagnostics、outputs、timing 或 run status。
+- 不关闭或回复 GitHub review thread，除非用户后续明确要求。
+
+## 4. 实施顺序
+
+```mermaid
+flowchart TD
+    A["确认本计划"] --> B["更新 eval-010 comparison baseline"]
+    B --> C["更新主 closeout IMPLEMENTATION_PLAN 最终 PASS 证据"]
+    C --> D["检查两份 durable evidence 一致性"]
+    D --> E["运行确定性检查"]
+    E --> F["运行 fresh subagent validation"]
+    F --> G["更新本 review-fix 计划实施结果"]
+```
+
+### Step 1: 更新 `eval-010` baseline section
+
+修改 `agents/engineer/test/feature-implementor/evals/workspace/eval-010-implementation-plan-closeout-sync/comparison.md`：
+
+- 将 `Without Skill / Baseline` 从假设风险改成明确结果。
+- 如果没有实际 baseline transcript，写明 blocked / skipped 原因。
+- 明确不把 fresh subagent validation 当作伪造 baseline。
+
+### Step 2: 更新主 closeout 实施计划
+
+修改 `docs/engineer/implementation-plan-closeout-gate/IMPLEMENTATION_PLAN.md`：
+
+- 在 Fresh subagent validation 中补充第二轮 subagent：
+  `019ef5a6-5558-7a02-a5e7-a14bd3c6e272`。
+- 记录最终结论 PASS。
+- 记录完整确定性流程全 PASS。
+
+### Step 3: 一致性检查
+
+人工检查两份 durable evidence：
+
+- 是否都说明第一轮 subagent 发现 stale closeout。
+- 是否都说明第二轮 fresh validation PASS。
+- 是否都说明 runtime artifacts 不入库。
+- 是否没有互相矛盾的 baseline / skipped 描述。
+
+### Step 4: 验证
+
+```bash
+git diff --check
+uv run scripts/check_repository_contract.py
+uv run scripts/check_eval_contract.py
+uv run scripts/check_eval_artifacts.py
+uv run --with pytest pytest agents/test_eval_contract.py
+```
+
+## 5. Sub-Agent 分工
+
+本次只改两个 durable evidence 文件和本 review-fix 计划，默认不需要复杂 implementation / validation sub-agent 分工。
+
+如用户要求额外验收，可使用 fresh subagent 只读复核：
+
+- baseline / skipped 描述是否满足 PR review；
+- closeout plan 是否包含最终 PASS；
+- 确定性检查是否通过。
+
+## 6. 风险与处理
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| 把 skipped baseline 写成 pass/fail | 伪造 eval 对比结论 | 明确写 blocked / skipped 原因，不虚构运行结果。 |
+| 只补 comparison，不补实施计划 | closeout 证据仍不完整 | 同步更新主 closeout IMPLEMENTATION_PLAN。 |
+| 为修 review 改动 skill 行为 | 扩大 PR 范围 | 本轮只改 durable evidence 文档。 |
+
+## 7. 实施结果
+
+本计划已按确认范围实施：
+
+- 已更新
+  `agents/engineer/test/feature-implementor/evals/workspace/eval-010-implementation-plan-closeout-sync/comparison.md`，
+  将 `Without Skill / Baseline` 明确记录为未生成独立 baseline transcript，并说明未推断 baseline pass/fail。
+- 已更新
+  `docs/engineer/implementation-plan-closeout-gate/IMPLEMENTATION_PLAN.md`，
+  补充最终 subagent `019ef5a6-5558-7a02-a5e7-a14bd3c6e272` PASS 证据。
+- 已确认两份 durable evidence 均描述第一轮 subagent 发现 stale closeout，最终同步后 PASS，且没有伪造 baseline 结果。
+
+已完成确定性校验：
+
+```bash
+git diff --check
+uv run scripts/check_repository_contract.py
+uv run scripts/check_eval_contract.py
+uv run scripts/check_eval_artifacts.py
+uv run --with pytest pytest agents/test_eval_contract.py
+```
+
+结果：
+
+- `git diff --check`: PASS
+- `uv run scripts/check_repository_contract.py`: PASS
+- `uv run scripts/check_eval_contract.py`: PASS
+- `uv run scripts/check_eval_artifacts.py`: PASS
+- `uv run --with pytest pytest agents/test_eval_contract.py`: PASS, 29 passed
+
+Fresh subagent validation：
+
+- Subagent: `019ef5bb-27cd-7b22-b11b-cd9910c9457f`
+- Result: PASS
+- Coverage: subagent confirmed the `comparison.md` baseline section records `BLOCKED / not generated`, no baseline pass/fail is inferred, the main closeout plan includes final PASS evidence, and the complete deterministic check flow passed.
+
+## 8. 残余风险
+
+| Risk | Status | Note |
+| --- | --- | --- |
+| Separate without-skill transcript is not available | Accepted | 本轮明确记录未生成原因，不推断 baseline pass/fail。 |
+| Runtime eval artifacts accidentally committed | Mitigated | `check_eval_artifacts.py` PASS；本轮未提交 runtime transcript、diagnostics、outputs、timing 或 run status。 |

--- a/docs/engineer/implementation-plan-closeout-gate-review-fix/IMPLEMENTATION_PLAN.md
+++ b/docs/engineer/implementation-plan-closeout-gate-review-fix/IMPLEMENTATION_PLAN.md
@@ -1,7 +1,7 @@
 ---
 title: "IMPLEMENTATION_PLAN 收尾门禁 Review 修复实施计划"
 type: IMPLEMENTATION_PLAN
-version: "0.1.1"
+version: "0.1.2"
 status: "Implemented"
 author: "Neplich Codex"
 date: "2026-06-24"
@@ -17,6 +17,7 @@ related_issue: "https://github.com/Neplich/dev-agent-skills/issues/44"
 related_pr: "https://github.com/Neplich/dev-agent-skills/pull/45"
 related_review:
   - "https://github.com/Neplich/dev-agent-skills/pull/45#discussion_r3461935792"
+  - "https://github.com/Neplich/dev-agent-skills/pull/45#discussion_r3462072967"
 ---
 
 # IMPLEMENTATION_PLAN 收尾门禁 Review 修复实施计划
@@ -40,13 +41,13 @@ review 修复聚焦 durable evidence 补强，不改变 skill 行为。
 | TRD alignment | 已补齐 review-fix TRD | `docs/engineer/implementation-plan-closeout-gate-review-fix/TRD.md` |
 | Implementation plan | 已确认并实施 | 本文件已更新为 `status: "Implemented"` |
 | Code / document edits | 已完成 | 已更新 baseline evidence、主 closeout 计划和本 review-fix closeout |
-| Validation | 已完成 | 本地完整检查 PASS；fresh subagent `019ef5bb-27cd-7b22-b11b-cd9910c9457f` PASS |
+| Validation | 已完成 | 本地完整检查 PASS；with-skill baseline 对照 PASS；without-skill baseline 对照 PASS |
 
 ## 2. 修复范围
 
 | 来源 | 文件 | 问题 | 修复处理 | 验证方式 |
 | --- | --- | --- | --- | --- |
-| PR review 未解决线程 | `agents/engineer/test/feature-implementor/evals/workspace/eval-010-implementation-plan-closeout-sync/comparison.md` | `Without Skill / Baseline` 只写了假设风险，没有真实 baseline 结果，也没有 blocked 原因。 | 更新 `Without Skill / Baseline`：记录本轮未生成独立 without-skill transcript，并按仓库 eval 规则写清 blocked / skipped 原因；说明本 eval 的对比依据来自 fresh subagent validation，不伪造 baseline pass。 | `uv run scripts/check_eval_artifacts.py`；人工确认 comparison 里 baseline 不再是纯假设。 |
+| PR review 未解决线程 | `agents/engineer/test/feature-implementor/evals/workspace/eval-010-implementation-plan-closeout-sync/comparison.md` | `Without Skill / Baseline` 最初缺少真实 baseline；补成 blocked 后又与 `Latest result: PASS` 冲突。 | 生成实际 without-skill baseline 结果，并更新 `Without Skill / Baseline`、`Latest result`、`Failures` 和 `Next Steps`，让完整 PASS 有真实 baseline 支撑。 | `uv run scripts/check_eval_artifacts.py`；with-skill / without-skill subagent 对照；人工确认 comparison 不再出现 blocked baseline 与 PASS 冲突。 |
 | 本地 review 补强项 | `docs/engineer/implementation-plan-closeout-gate/IMPLEMENTATION_PLAN.md` | closeout 证据只记录第一轮 subagent FAIL，未记录最终第二轮 PASS。 | 在 Fresh subagent validation / 实施结果中补充第二轮 subagent `019ef5a6-5558-7a02-a5e7-a14bd3c6e272` 的 PASS 结论和完整测试命令全绿结果。 | 人工确认 closeout plan 能支撑 `status: "Implemented"`。 |
 | 一致性补强 | 同上两个文件 | 两处 durable evidence 应互相一致。 | 让 `IMPLEMENTATION_PLAN.md` 和 `comparison.md` 对 fresh validation、baseline / skipped、runtime artifact policy 的描述一致。 | `git diff --check`；人工 review 两个文件证据链。 |
 | 回归检查 | 全仓库 | 文档和 eval fixture 修改可能影响契约。 | 修完后复跑完整确定性检查。 | repository contract、eval contract、eval artifacts、pytest。 |
@@ -63,11 +64,11 @@ review 修复聚焦 durable evidence 补强，不改变 skill 行为。
 
 ```mermaid
 flowchart TD
-    A["确认本计划"] --> B["更新 eval-010 comparison baseline"]
-    B --> C["更新主 closeout IMPLEMENTATION_PLAN 最终 PASS 证据"]
-    C --> D["检查两份 durable evidence 一致性"]
-    D --> E["运行确定性检查"]
-    E --> F["运行 fresh subagent validation"]
+    A["确认本计划"] --> B["生成 without-skill baseline"]
+    B --> C["更新 eval-010 comparison baseline"]
+    C --> D["更新主 closeout IMPLEMENTATION_PLAN 最终 PASS 证据"]
+    D --> E["检查两份 durable evidence 一致性"]
+    E --> F["运行确定性检查"]
     F --> G["更新本 review-fix 计划实施结果"]
 ```
 
@@ -75,9 +76,9 @@ flowchart TD
 
 修改 `agents/engineer/test/feature-implementor/evals/workspace/eval-010-implementation-plan-closeout-sync/comparison.md`：
 
-- 将 `Without Skill / Baseline` 从假设风险改成明确结果。
-- 如果没有实际 baseline transcript，写明 blocked / skipped 原因。
-- 明确不把 fresh subagent validation 当作伪造 baseline。
+- 将 `Without Skill / Baseline` 从 blocked / skipped 改成实际 without-skill baseline 结果。
+- 记录 baseline subagent id、PASS 结论和相对 with-skill 的弱化点。
+- 明确 `Latest result: PASS` 由 with-skill 和 without-skill baseline 两侧实际结果支撑。
 
 ### Step 2: 更新主 closeout 实施计划
 
@@ -113,7 +114,7 @@ uv run --with pytest pytest agents/test_eval_contract.py
 
 如用户要求额外验收，可使用 fresh subagent 只读复核：
 
-- baseline / skipped 描述是否满足 PR review；
+- baseline 结果是否满足 PR review；
 - closeout plan 是否包含最终 PASS；
 - 确定性检查是否通过。
 
@@ -121,7 +122,7 @@ uv run --with pytest pytest agents/test_eval_contract.py
 
 | Risk | Impact | Mitigation |
 | --- | --- | --- |
-| 把 skipped baseline 写成 pass/fail | 伪造 eval 对比结论 | 明确写 blocked / skipped 原因，不虚构运行结果。 |
+| 把缺失 baseline 写成 pass/fail | 伪造 eval 对比结论 | 已实际运行 without-skill baseline，并只记录真实结果。 |
 | 只补 comparison，不补实施计划 | closeout 证据仍不完整 | 同步更新主 closeout IMPLEMENTATION_PLAN。 |
 | 为修 review 改动 skill 行为 | 扩大 PR 范围 | 本轮只改 durable evidence 文档。 |
 
@@ -131,11 +132,11 @@ uv run --with pytest pytest agents/test_eval_contract.py
 
 - 已更新
   `agents/engineer/test/feature-implementor/evals/workspace/eval-010-implementation-plan-closeout-sync/comparison.md`，
-  将 `Without Skill / Baseline` 明确记录为未生成独立 baseline transcript，并说明未推断 baseline pass/fail。
+  将 `Without Skill / Baseline` 更新为实际 without-skill baseline 结果，并同步 `Latest result`。
 - 已更新
   `docs/engineer/implementation-plan-closeout-gate/IMPLEMENTATION_PLAN.md`，
-  补充最终 subagent `019ef5a6-5558-7a02-a5e7-a14bd3c6e272` PASS 证据。
-- 已确认两份 durable evidence 均描述第一轮 subagent 发现 stale closeout，最终同步后 PASS，且没有伪造 baseline 结果。
+  补充最终 subagent `019ef5a6-5558-7a02-a5e7-a14bd3c6e272` PASS 证据和 eval-010 with/baseline 对照证据。
+- 已确认两份 durable evidence 均描述第一轮 subagent 发现 stale closeout，最终同步后 PASS，且完整 PASS 由实际 baseline 结果支撑。
 
 已完成确定性校验：
 
@@ -159,11 +160,17 @@ Fresh subagent validation：
 
 - Subagent: `019ef5bb-27cd-7b22-b11b-cd9910c9457f`
 - Result: PASS
-- Coverage: subagent confirmed the `comparison.md` baseline section records `BLOCKED / not generated`, no baseline pass/fail is inferred, the main closeout plan includes final PASS evidence, and the complete deterministic check flow passed.
+- Coverage: subagent confirmed the first review-fix pass did not infer baseline pass/fail while the baseline was missing. The later review required an actual baseline for a full eval PASS, which is addressed by the baseline generation result below.
+
+Baseline generation：
+
+- With-skill subagent: `019ef5f3-bf60-7922-bcc0-2a296cd3be0b`, PASS.
+- Without-skill baseline subagent: `019ef5f3-e0e2-7ef3-adb9-5f89535a79f3`, PASS.
+- Result: `comparison.md` now records an actual baseline result; the previous `BLOCKED / not generated` state has been removed.
 
 ## 8. 残余风险
 
 | Risk | Status | Note |
 | --- | --- | --- |
-| Separate without-skill transcript is not available | Accepted | 本轮明确记录未生成原因，不推断 baseline pass/fail。 |
+| Separate without-skill baseline may be weaker than skill run | Accepted | baseline 已实际生成并通过；弱化点是未读取 `feature-implementor` 专属模板和内部规则。 |
 | Runtime eval artifacts accidentally committed | Mitigated | `check_eval_artifacts.py` PASS；本轮未提交 runtime transcript、diagnostics、outputs、timing 或 run status。 |

--- a/docs/engineer/implementation-plan-closeout-gate-review-fix/TRD.md
+++ b/docs/engineer/implementation-plan-closeout-gate-review-fix/TRD.md
@@ -1,0 +1,64 @@
+---
+title: "IMPLEMENTATION_PLAN 收尾门禁 Review 修复 TRD"
+type: TRD
+version: "0.1.0"
+status: Draft
+author: "Neplich Codex"
+date: "2026-06-24"
+last_updated: "2026-06-24"
+generated_by: "trd-gen"
+feature: "implementation-plan-closeout-gate-review-fix"
+feature_path: "implementation-plan-closeout-gate-review-fix"
+parent_feature: "N/A"
+feature_level: "1"
+related_prd: "docs/pm/implementation-plan-closeout-gate-review-fix/PRD.md"
+related_issue: "https://github.com/Neplich/dev-agent-skills/issues/44"
+related_pr: "https://github.com/Neplich/dev-agent-skills/pull/45"
+---
+
+# IMPLEMENTATION_PLAN 收尾门禁 Review 修复 TRD
+
+## 1. 技术目标
+
+补齐 PR #45 review 后的 durable evidence，不改变 `feature-implementor`
+closeout gate 行为。
+
+## 2. 影响范围
+
+| Area | File | Change |
+| --- | --- | --- |
+| Eval durable result | `agents/engineer/test/feature-implementor/evals/workspace/eval-010-implementation-plan-closeout-sync/comparison.md` | 补充真实 baseline 结果或 blocked / skipped 原因。 |
+| Implementation closeout | `docs/engineer/implementation-plan-closeout-gate/IMPLEMENTATION_PLAN.md` | 记录最终 PASS 的 fresh subagent validation。 |
+| Review-fix plan | `docs/engineer/implementation-plan-closeout-gate-review-fix/IMPLEMENTATION_PLAN.md` | 记录本轮 review 修复计划和后续实施结果。 |
+
+## 3. 修复策略
+
+### Baseline evidence
+
+`comparison.md` 的 `Without Skill / Baseline` section 必须选择一种明确状态：
+
+- 如果已经生成 baseline / without-skill 结果，记录实际结果和观察到的行为。
+- 如果没有生成 baseline / without-skill 结果，明确写出 blocked 或 skipped 原因，不用假设性风险替代结果。
+
+本次修复不伪造 baseline pass/fail。
+
+### Final validation evidence
+
+`docs/engineer/implementation-plan-closeout-gate/IMPLEMENTATION_PLAN.md` 需要补充最终验证：
+
+- subagent id：`019ef5a6-5558-7a02-a5e7-a14bd3c6e272`
+- 结论：PASS
+- 覆盖命令：`git diff --check`、repository contract、eval contract、eval artifacts、pytest
+- 说明第一轮 FAIL 已被后续 closeout 同步修复
+
+## 4. 验证策略
+
+```bash
+git diff --check
+uv run scripts/check_repository_contract.py
+uv run scripts/check_eval_contract.py
+uv run scripts/check_eval_artifacts.py
+uv run --with pytest pytest agents/test_eval_contract.py
+```
+
+本轮只改 durable Markdown 文档和本 review-fix 计划，不需要刷新 `skills-lock.json`。

--- a/docs/engineer/implementation-plan-closeout-gate/IMPLEMENTATION_PLAN.md
+++ b/docs/engineer/implementation-plan-closeout-gate/IMPLEMENTATION_PLAN.md
@@ -34,7 +34,7 @@ related_issue: "https://github.com/Neplich/dev-agent-skills/issues/44"
 | Implementation plan | 已确认并实施 | 本文件已更新为 `status: "Implemented"` |
 | Code / skill edits | 已完成 | PRD、SKILL.md、internal instructions、eval fixture 和 `skills-lock.json` 已更新 |
 | Deterministic checks | 已完成 | 见 `## 7. 实施结果` |
-| Fresh subagent validation | 已完成并已处理反馈 | subagent `019ef5a2-e27a-7df2-8fd1-11614b8e8664` 完整测试命令 PASS，并指出 closeout durable 产物待同步；本节已完成该同步 |
+| Fresh subagent validation | 已完成并已处理反馈 | subagent `019ef5a2-e27a-7df2-8fd1-11614b8e8664` 完整测试命令 PASS，并指出 closeout durable 产物待同步；最终 subagent `019ef5a6-5558-7a02-a5e7-a14bd3c6e272` PASS |
 
 ### 1.2 成功标准
 
@@ -228,9 +228,10 @@ uv run --with pytest pytest agents/test_eval_contract.py
 
 Fresh subagent validation:
 
-- Subagent: `019ef5a2-e27a-7df2-8fd1-11614b8e8664`
-- Result: deterministic checks PASS; initial delivery verdict FAIL because this implementation plan and the new eval comparison were still in pre-closeout state.
-- Resolution: this closeout update changes the plan to implemented state and updates the durable eval comparison.
+- Initial validation: subagent `019ef5a2-e27a-7df2-8fd1-11614b8e8664` ran the full deterministic check flow successfully, then blocked delivery because this implementation plan and the new eval comparison were still in pre-closeout state.
+- Resolution: this closeout update changed the plan to implemented state and updated the durable eval comparison.
+- Final validation: subagent `019ef5a6-5558-7a02-a5e7-a14bd3c6e272` passed after the closeout sync and confirmed there was no unresolved stale closeout state.
+- Final command coverage: `git diff --check`, `uv run scripts/check_repository_contract.py`, `uv run scripts/check_eval_contract.py`, `uv run scripts/check_eval_artifacts.py`, and `uv run --with pytest pytest agents/test_eval_contract.py`.
 
 ## 8. 残余风险
 

--- a/docs/engineer/implementation-plan-closeout-gate/IMPLEMENTATION_PLAN.md
+++ b/docs/engineer/implementation-plan-closeout-gate/IMPLEMENTATION_PLAN.md
@@ -1,7 +1,7 @@
 ---
 title: "IMPLEMENTATION_PLAN 收尾门禁实施计划"
 type: IMPLEMENTATION_PLAN
-version: "0.1.1"
+version: "0.1.2"
 status: "Implemented"
 author: "Neplich Codex"
 date: "2026-06-24"
@@ -34,7 +34,7 @@ related_issue: "https://github.com/Neplich/dev-agent-skills/issues/44"
 | Implementation plan | 已确认并实施 | 本文件已更新为 `status: "Implemented"` |
 | Code / skill edits | 已完成 | PRD、SKILL.md、internal instructions、eval fixture 和 `skills-lock.json` 已更新 |
 | Deterministic checks | 已完成 | 见 `## 7. 实施结果` |
-| Fresh subagent validation | 已完成并已处理反馈 | subagent `019ef5a2-e27a-7df2-8fd1-11614b8e8664` 完整测试命令 PASS，并指出 closeout durable 产物待同步；最终 subagent `019ef5a6-5558-7a02-a5e7-a14bd3c6e272` PASS |
+| Fresh subagent validation | 已完成并已处理反馈 | closeout validation PASS；eval-010 with-skill subagent `019ef5f3-bf60-7922-bcc0-2a296cd3be0b` PASS，without-skill baseline subagent `019ef5f3-e0e2-7ef3-adb9-5f89535a79f3` PASS |
 
 ### 1.2 成功标准
 
@@ -231,6 +231,7 @@ Fresh subagent validation:
 - Initial validation: subagent `019ef5a2-e27a-7df2-8fd1-11614b8e8664` ran the full deterministic check flow successfully, then blocked delivery because this implementation plan and the new eval comparison were still in pre-closeout state.
 - Resolution: this closeout update changed the plan to implemented state and updated the durable eval comparison.
 - Final validation: subagent `019ef5a6-5558-7a02-a5e7-a14bd3c6e272` passed after the closeout sync and confirmed there was no unresolved stale closeout state.
+- Eval baseline validation: subagent `019ef5f3-bf60-7922-bcc0-2a296cd3be0b` passed with `feature-implementor`; subagent `019ef5f3-e0e2-7ef3-adb9-5f89535a79f3` passed as the without-skill baseline against the same prompt and fixture. The durable `comparison.md` now records an actual baseline result instead of a blocked baseline.
 - Final command coverage: `git diff --check`, `uv run scripts/check_repository_contract.py`, `uv run scripts/check_eval_contract.py`, `uv run scripts/check_eval_artifacts.py`, and `uv run --with pytest pytest agents/test_eval_contract.py`.
 
 ## 8. 残余风险
@@ -239,4 +240,4 @@ Fresh subagent validation:
 | --- | --- | --- |
 | Runtime eval artifacts accidentally committed | Mitigated | `check_eval_artifacts.py` PASS；runtime artifacts policy 已写入 skill 和 comparison。 |
 | Closeout rule later regresses | Mitigated | `eval-010-implementation-plan-closeout-sync` 覆盖 stale closeout state。 |
-| Model transcript not generated as separate artifact | Accepted | 本轮按用户要求使用 fresh subagent validation；未提交 runtime transcript。 |
+| Runtime transcript files are not committed | Mitigated | with-skill 和 without-skill baseline subagent 结果已汇总到 durable `comparison.md`；runtime transcript 文件仍不入库。 |

--- a/docs/engineer/implementation-plan-closeout-gate/IMPLEMENTATION_PLAN.md
+++ b/docs/engineer/implementation-plan-closeout-gate/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,241 @@
+---
+title: "IMPLEMENTATION_PLAN 收尾门禁实施计划"
+type: IMPLEMENTATION_PLAN
+version: "0.1.1"
+status: "Implemented"
+author: "Neplich Codex"
+date: "2026-06-24"
+last_updated: "2026-06-24"
+generated_by: "feature-implementor"
+feature: "implementation-plan-closeout-gate"
+feature_path: "implementation-plan-closeout-gate"
+parent_feature: "N/A"
+feature_level: "1"
+related_prd: "docs/pm/implementation-plan-closeout-gate/PRD.md"
+related_trd: "docs/engineer/implementation-plan-closeout-gate/TRD.md"
+related_issue: "https://github.com/Neplich/dev-agent-skills/issues/44"
+---
+
+# IMPLEMENTATION_PLAN 收尾门禁实施计划
+
+## 1. 实施上下文
+
+本计划承接 GitHub issue #44、`docs/pm/implementation-plan-closeout-gate/PRD.md`
+和 `docs/engineer/implementation-plan-closeout-gate/TRD.md`。目标是在
+`feature-implementor` 的实现完成阶段增加 closeout gate，防止
+`IMPLEMENTATION_PLAN.md` 出现 frontmatter 已完成但正文仍停留在计划期状态的矛盾。
+
+### 1.1 当前门禁状态
+
+| Gate | Status | Evidence |
+| --- | --- | --- |
+| PRD alignment | 已补齐 issue 级 PRD | `docs/pm/implementation-plan-closeout-gate/PRD.md` |
+| TRD alignment | 已补齐 issue 级 TRD | `docs/engineer/implementation-plan-closeout-gate/TRD.md` |
+| Implementation plan | 已确认并实施 | 本文件已更新为 `status: "Implemented"` |
+| Code / skill edits | 已完成 | PRD、SKILL.md、internal instructions、eval fixture 和 `skills-lock.json` 已更新 |
+| Deterministic checks | 已完成 | 见 `## 7. 实施结果` |
+| Fresh subagent validation | 已完成并已处理反馈 | subagent `019ef5a2-e27a-7df2-8fd1-11614b8e8664` 完整测试命令 PASS，并指出 closeout durable 产物待同步；本节已完成该同步 |
+
+### 1.2 成功标准
+
+- `feature-implementor` 在实现和验证完成后必须同步更新 `IMPLEMENTATION_PLAN.md`。
+- reviewer 能发现 `status: Implemented` 与正文计划期状态残留之间的矛盾。
+- 已运行 deterministic checks 时记录实际命令和结果。
+- 已运行 skill eval / fresh subagent validation 时引用 durable `comparison.md`。
+- 未运行 eval 时记录 blocked / skipped 原因。
+- 不提交 eval 运行期 transcript、diagnostics、outputs、timing 或 run status。
+
+## 2. 范围
+
+### 2.1 必改文件
+
+| Path | Operation | Change |
+| --- | --- | --- |
+| `docs/pm/agents/engineer-agent/skills/feature-implementor/PRD.md` | Modify | 增加 `Implementation Plan Closeout Gate` 产品契约。 |
+| `agents/engineer/skills/feature-implementor/SKILL.md` | Modify | 在 Phase 3 后、QA E2E handoff 前加入 closeout gate。 |
+| `agents/engineer/skills/feature-implementor/_internal/implementor/INSTRUCTIONS.md` | Modify | 要求实现阶段收集 closeout evidence。 |
+| `agents/engineer/skills/feature-implementor/_internal/reviewer/INSTRUCTIONS.md` | Modify | 增加 stale plan state 检查。 |
+| `agents/engineer/skills/feature-implementor/_internal/_shared/output-conventions.md` | Modify | 增加 `IMPLEMENTATION_PLAN.md` 收尾写法。 |
+| `agents/engineer/test/feature-implementor/evals/evals.json` | Modify | 新增 closeout sync 回归 eval。 |
+| `agents/engineer/test/feature-implementor/evals/workspace/eval-010-implementation-plan-closeout-sync/` | Create | 新增 fixture、metadata 和 durable `comparison.md`。 |
+| `skills-lock.json` | Modify | 刷新 `feature-implementor` computed hash。 |
+
+### 2.2 非目标
+
+- 不修改其他 agent 的 QA E2E 归档规则。
+- 不改变实施前 PRD/TRD/IMPLEMENTATION_PLAN 确认门禁。
+- 不批量迁移历史 `IMPLEMENTATION_PLAN.md`。
+- 不提交模型 eval 运行期产物。
+
+## 3. 实施流程
+
+```mermaid
+flowchart TD
+    Start["确认本计划"] --> PRD["更新 feature-implementor PRD"]
+    PRD --> Skill["更新 feature-implementor public skill"]
+    Skill --> Implementor["更新 implementor closeout evidence 规则"]
+    Implementor --> Reviewer["更新 reviewer stale-state 检查"]
+    Reviewer --> Output["更新 output conventions"]
+    Output --> Eval["新增 eval-010 fixture 和断言"]
+    Eval --> Lock["刷新 skills-lock.json"]
+    Lock --> Checks["运行确定性检查"]
+    Checks --> AskEval["运行 fresh subagent validation"]
+```
+
+## 4. 文件级步骤
+
+### Step 1: 更新 owning PRD
+
+修改 `docs/pm/agents/engineer-agent/skills/feature-implementor/PRD.md`：
+
+- 在功能需求中新增 closeout gate。
+- 在当前实现工作流中加入“实现完成后同步 IMPLEMENTATION_PLAN 结果”。
+- 在验收标准中加入 stale-state 检查。
+
+验证：
+
+- PRD 不把 closeout gate 写成每次必须运行模型 eval。
+- PRD 允许 eval skipped / blocked，但必须记录原因。
+
+### Step 2: 更新 `feature-implementor/SKILL.md`
+
+修改 `agents/engineer/skills/feature-implementor/SKILL.md`：
+
+- 在 Phase 3 自检之后增加 `Implementation Plan Closeout Gate`。
+- 明确 closeout 必须发生在 QA E2E handoff 和 delivery 建议之前。
+- 要求更新或确认以下内容：
+  - frontmatter status；
+  - 当前门禁状态表；
+  - 实施结果；
+  - deterministic checks 命令和结果；
+  - skill eval / fresh subagent validation 的 durable `comparison.md`；
+  - skipped / blocked 原因；
+  - 运行期产物不提交策略。
+
+验证：
+
+- 不削弱 Phase 1 计划确认门禁。
+- 不要求每次实现都必须运行模型 eval。
+
+### Step 3: 更新 internal modules
+
+修改 `implementor/INSTRUCTIONS.md`：
+
+- 要求实现阶段保留 changed files、验证命令、命令结果、未执行原因和 eval 状态。
+- 这些信息作为 closeout gate 输入。
+
+修改 `reviewer/INSTRUCTIONS.md`：
+
+- checklist 增加 `Implementation Plan Closeout`。
+- 如果 `status: Implemented` 与正文计划期状态冲突，输出 blocking finding。
+
+修改 `_shared/output-conventions.md`：
+
+- 增加 `IMPLEMENTATION_PLAN.md` 收尾内容结构。
+- 明确已执行 eval 引用 durable `comparison.md`，运行期产物不入库。
+
+### Step 4: 新增 eval 覆盖
+
+新增 `eval-010-implementation-plan-closeout-sync`：
+
+- fixture 中包含一个矛盾的 `docs/engineer/sample-feature/IMPLEMENTATION_PLAN.md`。
+- frontmatter 为 `status: Implemented`。
+- 正文保留计划期状态残留，用于验证 closeout gate 能发现 durable plan 矛盾。
+
+断言：
+
+- skill 必须识别 stale closeout 状态。
+- skill 必须要求更新实施结果和状态表。
+- skill 必须要求记录 deterministic checks。
+- skill 必须要求 eval 已执行时引用 durable `comparison.md`，未执行时说明原因。
+- skill 不得直接建议 delivery 或 QA handoff。
+
+### Step 5: 刷新 lockfile
+
+修改 skill 文档后刷新 `skills-lock.json` 中 `feature-implementor` 的 computed hash。
+
+### Step 6: 验证
+
+确定性检查：
+
+```bash
+git diff --check
+uv run scripts/check_repository_contract.py
+uv run scripts/check_eval_contract.py
+uv run scripts/check_eval_artifacts.py
+uv run --with pytest pytest agents/test_eval_contract.py
+```
+
+Fresh subagent validation：
+
+- 用户已要求实施完成后直接使用 subagent 运行完整测试流程。
+- 已执行 fresh Codex subagent validation，并按反馈更新
+  `eval-010-implementation-plan-closeout-sync/comparison.md` 和本 closeout。
+
+## 5. Sub-Agent 分工
+
+本次变更触及 skill 文档、internal instructions、eval fixture 和 lockfile，建议使用分工：
+
+| Role | Scope | Output |
+| --- | --- | --- |
+| Implementation worker | 更新 feature-implementor PRD、SKILL、internal instructions、eval、lockfile。 | 变更文件清单和确定性检查结果。 |
+| Validation worker | 对照 issue #44、PRD/TRD 和 eval 断言检查 closeout gate 是否完整。 | pass/fail、阻塞项和残余风险。 |
+| Main process | 保留 issue、PRD/TRD、仓库规则和交付判断。 | 最终交付说明和是否请求运行 eval。 |
+
+小范围串行实施也可接受，但必须保留独立自检。
+
+## 6. 风险与处理
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| closeout 内容过多 | 实施计划变成流水账 | 只记录状态、结果、命令、eval 证据和风险摘要。 |
+| 未执行 eval 被误判为失败 | 合理交付被阻塞 | 明确允许 skipped / blocked 原因。 |
+| 只改 skill 不改 eval | 规则可能回退 | 新增 eval-010 固化回归场景。 |
+| 历史计划存在旧格式 | 批量迁移范围扩大 | 本次不批量迁移，只约束后续实施收尾。 |
+
+## 7. 实施结果
+
+本计划已按确认范围实施：
+
+- 已新增 issue 级 PRD / TRD / IMPLEMENTATION_PLAN：
+  - `docs/pm/implementation-plan-closeout-gate/PRD.md`
+  - `docs/engineer/implementation-plan-closeout-gate/TRD.md`
+  - `docs/engineer/implementation-plan-closeout-gate/IMPLEMENTATION_PLAN.md`
+- 已更新 `docs/pm/agents/engineer-agent/skills/feature-implementor/PRD.md`，新增 FR-S11 和 closeout workflow。
+- 已更新 `agents/engineer/skills/feature-implementor/SKILL.md`，在 QA E2E handoff 和 delivery 前增加 closeout gate。
+- 已更新 implementor、reviewer 和 output conventions，收集并检查 closeout evidence。
+- 已新增 `eval-010-implementation-plan-closeout-sync` eval 定义和 fixture。
+- 已更新 durable `comparison.md`，记录 fresh subagent validation 结论。
+- 已刷新 `skills-lock.json` 中 `feature-implementor` 的 computed hash。
+
+已完成确定性校验：
+
+```bash
+git diff --check
+uv run scripts/check_repository_contract.py
+uv run scripts/check_eval_contract.py
+uv run scripts/check_eval_artifacts.py
+uv run --with pytest pytest agents/test_eval_contract.py
+```
+
+结果：
+
+- `git diff --check`: PASS
+- `uv run scripts/check_repository_contract.py`: PASS
+- `uv run scripts/check_eval_contract.py`: PASS
+- `uv run scripts/check_eval_artifacts.py`: PASS
+- `uv run --with pytest pytest agents/test_eval_contract.py`: PASS, 29 passed
+
+Fresh subagent validation:
+
+- Subagent: `019ef5a2-e27a-7df2-8fd1-11614b8e8664`
+- Result: deterministic checks PASS; initial delivery verdict FAIL because this implementation plan and the new eval comparison were still in pre-closeout state.
+- Resolution: this closeout update changes the plan to implemented state and updates the durable eval comparison.
+
+## 8. 残余风险
+
+| Risk | Status | Note |
+| --- | --- | --- |
+| Runtime eval artifacts accidentally committed | Mitigated | `check_eval_artifacts.py` PASS；runtime artifacts policy 已写入 skill 和 comparison。 |
+| Closeout rule later regresses | Mitigated | `eval-010-implementation-plan-closeout-sync` 覆盖 stale closeout state。 |
+| Model transcript not generated as separate artifact | Accepted | 本轮按用户要求使用 fresh subagent validation；未提交 runtime transcript。 |

--- a/docs/engineer/implementation-plan-closeout-gate/TRD.md
+++ b/docs/engineer/implementation-plan-closeout-gate/TRD.md
@@ -1,0 +1,95 @@
+---
+title: "IMPLEMENTATION_PLAN 收尾门禁 TRD"
+type: TRD
+version: "0.1.0"
+status: Draft
+author: "Neplich Codex"
+date: "2026-06-24"
+last_updated: "2026-06-24"
+generated_by: "trd-gen"
+feature: "implementation-plan-closeout-gate"
+feature_path: "implementation-plan-closeout-gate"
+parent_feature: "N/A"
+feature_level: "1"
+related_prd: "docs/pm/implementation-plan-closeout-gate/PRD.md"
+related_issue: "https://github.com/Neplich/dev-agent-skills/issues/44"
+---
+
+# IMPLEMENTATION_PLAN 收尾门禁 TRD
+
+## 1. 技术目标
+
+为 `feature-implementor` 增加实施完成后的 closeout gate，确保
+`docs/engineer/{feature_path}/IMPLEMENTATION_PLAN.md` 的 frontmatter、正文状态、
+实施结果和验证证据保持一致。
+
+## 2. 影响范围
+
+| Area | File | Change |
+| --- | --- | --- |
+| Public skill contract | `agents/engineer/skills/feature-implementor/SKILL.md` | 在 Phase 3 后、QA E2E handoff 前增加 closeout gate。 |
+| Implementor module | `agents/engineer/skills/feature-implementor/_internal/implementor/INSTRUCTIONS.md` | 要求实现阶段收集 closeout evidence。 |
+| Reviewer module | `agents/engineer/skills/feature-implementor/_internal/reviewer/INSTRUCTIONS.md` | 增加 stale implementation plan state 检查。 |
+| Output conventions | `agents/engineer/skills/feature-implementor/_internal/_shared/output-conventions.md` | 增加 `IMPLEMENTATION_PLAN.md` 收尾写法。 |
+| Eval contract | `agents/engineer/test/feature-implementor/evals/evals.json` | 新增回归 eval。 |
+| Eval fixture | `agents/engineer/test/feature-implementor/evals/workspace/eval-010-implementation-plan-closeout-sync/` | 提供矛盾计划 fixture 和 durable `comparison.md`。 |
+| Skill lock | `skills-lock.json` | 刷新受影响 skill hash。 |
+
+## 3. Closeout Gate 设计
+
+`feature-implementor` 完成实现、自检和验证后，需要读取本次确认过的
+`IMPLEMENTATION_PLAN.md`，并检查以下内容：
+
+| Check | Required Behavior |
+| --- | --- |
+| Frontmatter status | 如果实现完成，`status` 可更新为 `Implemented` 或仓库采用的等价完成态。 |
+| Gate/status table | 计划正文中的门禁表必须与完成态一致，不得保留“待确认 / 未开始 / 未执行”。 |
+| Implementation result | 记录已完成的文件或文档变更摘要。 |
+| Deterministic checks | 记录实际命令和结果；未执行则写 skipped / blocked 原因。 |
+| Skill eval evidence | 实际执行 eval 或 fresh subagent validation 后引用 durable `comparison.md`。 |
+| Runtime artifact policy | 不提交 transcript、diagnostics、outputs、timing 或 run status。 |
+
+## 4. Reviewer 检查
+
+reviewer 需要在输出 pass 之前执行 stale-state 检查：
+
+- `status: Implemented` 时，正文不得残留“待确认”“未开始”“待执行”“未执行”“模型 eval 尚未执行”等与完成态冲突的描述。
+- 如果正文声明 eval 已完成，必须列出对应 durable `comparison.md`。
+- 如果正文声明 deterministic checks 已完成，必须列出实际命令。
+- 如果 eval 或检查未执行，必须说明 skipped 或 blocked 原因。
+
+发现冲突时，reviewer 返回 blocking finding，并回到 closeout 更新步骤。
+
+## 5. Eval 设计
+
+新增 `eval-010-implementation-plan-closeout-sync`：
+
+| Field | Value |
+| --- | --- |
+| Workspace | `workspace/eval-010-implementation-plan-closeout-sync` |
+| Scenario | fixture 中已有一个 `status: Implemented` 但正文仍写“待确认 / 未开始 / 未执行”的 `IMPLEMENTATION_PLAN.md`。 |
+| Expected Output | skill 必须发现 stale closeout 状态，要求同步结果和验证证据，不得直接 handoff 或 delivery。 |
+
+核心断言：
+
+- 检测 frontmatter 与正文状态冲突。
+- 要求更新实施结果区和状态表。
+- 要求记录 deterministic checks 的命令和结果。
+- 要求 eval 已执行时引用 durable `comparison.md`，未执行时写明原因。
+- 不提交运行期 eval 产物。
+
+## 6. 验证策略
+
+```bash
+git diff --check
+uv run scripts/check_repository_contract.py
+uv run scripts/check_eval_contract.py
+uv run scripts/check_eval_artifacts.py
+uv run --with pytest pytest agents/test_eval_contract.py
+```
+
+如果实际执行 feature-implementor eval 或 fresh Codex subagent validation，需要在同一轮变更中更新对应 durable `comparison.md`。
+
+## 7. 回滚
+
+标准 git revert 可回滚 skill 文档、internal instructions、eval fixture、durable comparison 和 `skills-lock.json` 变更。回滚后现有实施前计划门禁仍保持不变。

--- a/docs/pm/agents/engineer-agent/skills/feature-implementor/PRD.md
+++ b/docs/pm/agents/engineer-agent/skills/feature-implementor/PRD.md
@@ -5,13 +5,15 @@ feature: "skill-feature-implementor"
 feature_path: "agents/engineer-agent/skills/feature-implementor"
 parent_feature: "agents/engineer-agent/skills"
 feature_level: "4"
-version: "1.3.0"
+version: "1.4.0"
 status: Draft
 author: "Neplich Codex"
 date: "2026-06-12"
 last_updated: "2026-06-24"
 generated_by: "prd-gen"
 related_docs:
+  - "docs/pm/implementation-plan-closeout-gate/PRD.md"
+  - "docs/engineer/implementation-plan-closeout-gate/TRD.md"
   - "agents/engineer/README.md"
   - "agents/engineer/README_zh.md"
   - "agents/engineer/skills/engineer-agent/SKILL.md"
@@ -26,6 +28,9 @@ related_docs:
   - "agents/engineer/skills/feature-implementor/_internal/reviewer/INSTRUCTIONS.md"
   - "agents/engineer/test/feature-implementor/evals/evals.json"
 changelog:
+  - version: "1.4.0"
+    date: "2026-06-24"
+    changes: "Add implementation plan closeout gate after implementation and validation"
   - version: "1.3.0"
     date: "2026-06-24"
     changes: "Add UI design handoff gate before implementation planning"
@@ -89,6 +94,7 @@ changelog:
 | FR-S08 | Author Metadata | `feature-implementor` 创建或更新 `docs/engineer/{feature_path}/IMPLEMENTATION_PLAN.md` 时必须使用“生成触发者展示名 + Agent 平台名”的 `author`；平台名可以是用户自定义值。 | P0 | IMPLEMENTATION_PLAN frontmatter 使用已填写的可追踪 author，例如 `Neplich Codex`，不使用空值或 `AI Assistant` 这类占位泛称。 |
 | FR-S09 | Feature Path Plan Gate | 写实施计划前必须校验 PRD/TRD 的 `feature_path`、`parent_feature`、`feature_level` 和 TRD `related_prd` 一致。 | P0 | 缺 PRD 回 PM；缺 TRD、TRD stale 或路径/字段不一致回 `trd-gen`；只有 PRD/TRD 已确认且路径一致时才允许创建 Engineer 目标目录并写计划。 |
 | FR-S10 | UI Design Handoff Gate | 前端 UI 行为、视觉或交互变化进入实施计划前必须检查设计交付物。 | P0 | 实施计划必须引用覆盖当前变化的 `docs/design/{feature_path}/ui-ux-spec.md` 和/或 `visual-system.md`，或明确说明无需 Designer 更新的理由；设计缺失、过期或冲突时停止并 handoff 回 `engineer-agent -> designer-agent`。 |
+| FR-S11 | Implementation Plan Closeout Gate | 实现和验证完成后，必须同步更新 `docs/engineer/{feature_path}/IMPLEMENTATION_PLAN.md` 的实施结果、验证证据和剩余状态。 | P0 | `status: Implemented` 或等价完成态不得与正文“待确认 / 未开始 / 未执行”矛盾；已运行 deterministic checks 时记录实际命令；已运行 skill eval 或 fresh subagent validation 时引用 durable `comparison.md`；未运行时记录 skipped / blocked 原因。 |
 
 ## 当前实现对齐
 
@@ -101,7 +107,8 @@ changelog:
 - 等待用户明确确认
 - 加载 implementor 执行；复杂任务委派 implementation sub-agent
 - 测试后按需委派 validation sub-agent
-- 自检并准备 QA E2E handoff
+- 实现和验证完成后同步 `IMPLEMENTATION_PLAN.md` 的 closeout 状态、结果和验证证据
+- 自检确认 closeout 并准备 QA E2E handoff
 - 写入或维护 IMPLEMENTATION_PLAN frontmatter 时使用可追踪 `author`
 
 ## 验收标准
@@ -111,6 +118,7 @@ changelog:
 | AC-01 | P0 trigger、context、workflow、artifact 和 handoff 与当前实现文档一致。 | 对照 related_docs 中的 README、SKILL.md、internal/reference 或 eval 文件人工 review。 |
 | AC-02 | 文档不包含自路由、全量默认执行或将 specialist 行为泛化为整个 Agent 的错误描述。 | 检查 route matrix、非目标、边界和 Mermaid flow。 |
 | AC-03 | 产物要求必须指向具体文件、报告、代码变更或 blocked 输出，不使用模糊替代表述。 | 检查功能需求和用户流程中的 artifact 节点。 |
+| AC-04 | 实施完成态的 `IMPLEMENTATION_PLAN.md` 不得保留计划期状态残留。 | reviewer checklist 和 feature-implementor closeout eval。 |
 
 ## 非功能需求
 
@@ -133,8 +141,9 @@ flowchart LR
     Step3 --> Step4["等待用户明确确认"]
     Step4 --> Step5["执行实现；复杂任务委派 implementation sub-agent"]
     Step5 --> Step6["测试后按需委派 validation sub-agent"]
-    Step6 --> Step7["自检并准备 QA E2E handoff"]
-    Step7 --> Artifact["输出具体产物或 blocked 结果"]
+    Step6 --> Step7["同步 IMPLEMENTATION_PLAN closeout"]
+    Step7 --> Step8["自检并准备 QA E2E handoff"]
+    Step8 --> Artifact["输出具体产物或 blocked 结果"]
     Artifact --> Handoff["交接或结束"]
 ```
 

--- a/docs/pm/implementation-plan-closeout-gate-review-fix/PRD.md
+++ b/docs/pm/implementation-plan-closeout-gate-review-fix/PRD.md
@@ -1,0 +1,56 @@
+---
+title: "IMPLEMENTATION_PLAN 收尾门禁 Review 修复 PRD"
+type: PRD
+version: "0.1.0"
+status: Draft
+author: "Neplich Codex"
+date: "2026-06-24"
+last_updated: "2026-06-24"
+generated_by: "idea-to-spec"
+feature: "implementation-plan-closeout-gate-review-fix"
+feature_path: "implementation-plan-closeout-gate-review-fix"
+parent_feature: "N/A"
+feature_level: "1"
+related_issue: "https://github.com/Neplich/dev-agent-skills/issues/44"
+related_pr: "https://github.com/Neplich/dev-agent-skills/pull/45"
+---
+
+# IMPLEMENTATION_PLAN 收尾门禁 Review 修复 PRD
+
+## 背景
+
+PR #45 已实现 `feature-implementor` 的 implementation plan closeout gate。
+PR review 进一步指出新增 eval 的 durable `comparison.md` 缺少真实 baseline
+结果或 blocked / skipped 原因。本地 review 同时指出实施计划 closeout 证据应记录
+最终 PASS 的 subagent 验证结果。
+
+本修复只补齐 durable 证据链，不改变 closeout gate 的产品范围。
+
+## 目标
+
+1. 让新增 eval 的 `Without Skill / Baseline` section 不再只是描述假设风险。
+2. 让实施计划 closeout 记录最终 PASS 的 fresh subagent validation。
+3. 保持两个 durable evidence 文件对 baseline、validation 和 runtime artifact policy 的表述一致。
+
+## 非目标
+
+- 不修改 `feature-implementor` skill 行为。
+- 不新增新的 eval item。
+- 不提交 runtime transcript、diagnostics、outputs、timing 或 run status。
+- 不重写 PR #45 的主实施计划范围。
+
+## 功能需求
+
+| ID | Feature | Description | Priority | Acceptance Criteria |
+| --- | --- | --- | --- | --- |
+| FR-001 | Baseline Evidence | `eval-010` 的 durable comparison 必须记录 baseline 结果，或明确 baseline 被 blocked / skipped 的原因。 | P0 | `Without Skill / Baseline` section 不再只有假设风险。 |
+| FR-002 | Final Validation Evidence | closeout gate 实施计划必须记录最终 PASS 的 fresh subagent validation。 | P0 | 实施计划中可看到最终 subagent id、PASS 结论和测试命令摘要。 |
+| FR-003 | Evidence Consistency | `IMPLEMENTATION_PLAN.md` 与 `comparison.md` 的 validation / baseline / runtime artifact policy 表述一致。 | P1 | 两份文档不会互相矛盾。 |
+
+## 验收标准
+
+| ID | Criteria | Verification |
+| --- | --- | --- |
+| AC-01 | PR review thread 的 baseline 缺口被直接处理。 | 人工 review `comparison.md`。 |
+| AC-02 | 本地 review 提到的最终 PASS subagent 证据已写回实施计划。 | 人工 review `IMPLEMENTATION_PLAN.md`。 |
+| AC-03 | 仓库确定性检查通过。 | 运行 repository / eval contract 和 pytest。 |

--- a/docs/pm/implementation-plan-closeout-gate/PRD.md
+++ b/docs/pm/implementation-plan-closeout-gate/PRD.md
@@ -1,0 +1,80 @@
+---
+title: "IMPLEMENTATION_PLAN 收尾门禁 PRD"
+type: PRD
+version: "0.1.0"
+status: Draft
+author: "Neplich Codex"
+date: "2026-06-24"
+last_updated: "2026-06-24"
+generated_by: "idea-to-spec"
+feature: "implementation-plan-closeout-gate"
+feature_path: "implementation-plan-closeout-gate"
+parent_feature: "N/A"
+feature_level: "1"
+related_issue: "https://github.com/Neplich/dev-agent-skills/issues/44"
+---
+
+# IMPLEMENTATION_PLAN 收尾门禁 PRD
+
+## 背景
+
+`feature-implementor` 已经要求所有实现任务先写
+`docs/engineer/{feature_path}/IMPLEMENTATION_PLAN.md` 并等待用户确认。
+当前缺口在实施结束阶段：计划 frontmatter 可能已经更新为
+`status: "Implemented"`，但正文仍保留“待确认”“未开始”“未执行”等计划期状态。
+
+该矛盾会降低后续 reviewer、QA、release 审查对 durable 工程文档的信任度。
+
+## 目标
+
+1. 为 `feature-implementor` 增加实施收尾门禁。
+2. 确保 `IMPLEMENTATION_PLAN.md` 在实施完成后同步记录实施结果和验证证据。
+3. 让自检或 eval 能发现 `status: Implemented` 与正文状态矛盾。
+
+## 非目标
+
+- 不改变现有 PRD/TRD/IMPLEMENTATION_PLAN 进入实现前的确认门禁。
+- 不改变 QA E2E 文档归档规则。
+- 不提交模型 eval 的运行期 transcript、diagnostics、outputs 或 timing 文件。
+
+## 功能需求
+
+| ID | Feature | Description | Priority | Acceptance Criteria |
+| --- | --- | --- | --- | --- |
+| FR-001 | Closeout Gate | `feature-implementor` 在实现和验证完成后，必须同步更新对应 `IMPLEMENTATION_PLAN.md` 的实施状态和结果。 | P0 | 计划正文包含实施结果、验证结果、剩余风险和下一步状态。 |
+| FR-002 | Stale State Detection | 自检阶段必须发现 `status: Implemented` 与正文“待确认 / 未开始 / 未执行”矛盾。 | P0 | reviewer checklist 或 eval 断言能阻止矛盾计划进入交付。 |
+| FR-003 | Verification Evidence | 已运行的 deterministic checks 必须记录实际命令；未运行的检查必须记录原因。 | P0 | `IMPLEMENTATION_PLAN.md` 中能看到命令、结果和 skipped / blocked 原因。 |
+| FR-004 | Eval Evidence | 实际执行 skill eval 或 fresh subagent validation 后，必须引用 durable `comparison.md`。 | P0 | 已执行 eval 的结论与 durable comparison 一致；未执行 eval 时说明原因。 |
+| FR-005 | Artifact Policy | 收尾门禁不得要求提交运行期 eval 产物。 | P1 | 只提交 eval 定义、fixture metadata 和 durable `comparison.md`。 |
+
+## 用户流程
+
+```mermaid
+flowchart TD
+    A["实施计划已确认"] --> B["执行实现"]
+    B --> C["运行确定性检查和必要 eval"]
+    C --> D["自检"]
+    D --> E{"IMPLEMENTATION_PLAN 是否同步结果?"}
+    E -->|否| F["更新状态表、实施结果、验证证据"]
+    E -->|是| G["QA handoff 或 delivery"]
+    F --> H{"是否仍有计划期残留?"}
+    H -->|有| I["阻断交付并修正文档"]
+    H -->|无| G
+```
+
+## 验收标准
+
+| ID | Criteria | Verification |
+| --- | --- | --- |
+| AC-01 | `feature-implementor` 文档明确实施收尾门禁。 | 人工 review `SKILL.md` 和 internal instructions。 |
+| AC-02 | reviewer checklist 覆盖 stale plan state。 | 人工 review reviewer instructions。 |
+| AC-03 | eval 覆盖 `status: Implemented` 但正文未同步的回归场景。 | `uv run scripts/check_eval_contract.py` 和 fresh subagent validation。 |
+| AC-04 | repository / eval artifact contract 不受影响。 | 运行仓库确定性检查。 |
+
+## 风险
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| 收尾规则过宽导致计划文档冗长 | 文档维护成本上升 | 只要求状态、结果、命令、eval 证据和风险摘要。 |
+| 未执行 eval 的场景被误判为失败 | 阻塞合理交付 | 允许记录 skipped / blocked 原因。 |
+| 只改文档不改 eval | 规则后续回退 | 增加 feature-implementor eval 覆盖。 |

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -64,7 +64,7 @@
     "feature-implementor": {
       "source": "agents/engineer/skills/feature-implementor",
       "sourceType": "local",
-      "computedHash": "fa2ef0c323db6b09deb40074ab191b690a0822c2b54ff518fdf4ee3f9b5f4f5a"
+      "computedHash": "7038818f636ebded70054fb9f9c5068279193aa970aad173a01faeac6ecab150"
     },
     "test-writer": {
       "source": "agents/engineer/skills/test-writer",


### PR DESCRIPTION
## Summary

- 为 `feature-implementor` 增加 implementation plan closeout gate，阻止 `status: Implemented` 与正文计划期状态冲突进入 handoff / delivery。
- 新增 `implementation-plan-closeout-gate` 的 PRD / TRD / IMPLEMENTATION_PLAN，沉淀 issue #44 的产品、技术和实施计划。
- 新增 `eval-010-implementation-plan-closeout-sync`，覆盖 IMPLEMENTATION_PLAN 已完成但正文仍待确认 / 未开始 / 未执行的回归场景。

## Documents

- PRD: `docs/pm/implementation-plan-closeout-gate/PRD.md`
- TRD: `docs/engineer/implementation-plan-closeout-gate/TRD.md`
- Implementation plan: `docs/engineer/implementation-plan-closeout-gate/IMPLEMENTATION_PLAN.md`
- Related issue: Closes #44

## Changes

- 更新 `feature-implementor` PRD、public skill、implementor / reviewer / output conventions。
- 新增 closeout sync eval fixture、metadata 和 durable `comparison.md`。
- 刷新 `skills-lock.json` 中 `feature-implementor` 的 computed hash。

## Testing

- [x] `git diff --check`
- [x] `uv run scripts/check_repository_contract.py`
- [x] `uv run scripts/check_eval_contract.py`
- [x] `uv run scripts/check_eval_artifacts.py`
- [x] `uv run --with pytest pytest agents/test_eval_contract.py`（29 passed）
- [x] Fresh subagent validation PASS，确认 closeout 产物和 eval comparison 已同步完成态

## Notes

- 未提交 runtime transcript、diagnostics、outputs、timing 或 run status。
- `comparison.md` 是本次 fresh subagent validation 的 durable 结论入口。
