### PR TITLE
docs: 修正 release 归档口径

### DIFF
--- a/docs/changelog/changelog-v0.1.1.md
+++ b/docs/changelog/changelog-v0.1.1.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- 将 `trd-gen` 从 PM 内部能力迁移为 Engineer Agent 的公开 skill，并注册到 marketplace；PRD 确认后由 Engineer 负责产出 `docs/engineer/{feature}/TRD.md`。([#19](https://github.com/Neplich/dev-agent-skills/pull/19))
+- 将 `trd-gen` 从 PM 内部能力迁移为 Engineer Agent 的公开 skill，并注册到 marketplace；PRD 确认后由 Engineer 负责产出 `docs/engineer/{feature_path}/TRD.md`。([#19](https://github.com/Neplich/dev-agent-skills/pull/19))
 - 增加 Engineer Agent 复杂编码任务分工规则，明确主进程、实现 sub-agent 和验收 sub-agent 的职责边界。([#16](https://github.com/Neplich/dev-agent-skills/pull/16))
 - 增加 `feature-implementor` 文档驱动实现 eval fixture，并补充缺失 TRD 时不得直接实施的负向 eval。([#16](https://github.com/Neplich/dev-agent-skills/pull/16), [#19](https://github.com/Neplich/dev-agent-skills/pull/19))
 

--- a/docs/changelog/changelog-v0.1.2.md
+++ b/docs/changelog/changelog-v0.1.2.md
@@ -4,14 +4,14 @@
 
 ### Added
 
-- 增加 QA E2E 功能树持久化规范，统一 `docs/qa/e2e/{一级功能}/{二级功能}/{三级功能}/` 下的 `TEST_SUITE.md`、`FLOW_INDEX.md`、`cases/`、`scripts/`、`results/` 和 `_reports/` 目录结构。([#25](https://github.com/Neplich/dev-agent-skills/pull/25))
+- 增加 QA E2E 功能树持久化规范，统一 `docs/qa/e2e/{feature_path}/` 下的 `TEST_SUITE.md`、`FLOW_INDEX.md`、`cases/`、`scripts/`、`results/` 和 `_reports/` 目录结构。([#25](https://github.com/Neplich/dev-agent-skills/pull/25))
 - 增加 QA E2E 本地账号引用与测试报告 reference，明确 `.qa/e2e/accounts.local.json` 的本地凭据存储方式，避免明文账号、密码、token 或 session 进入测试文档。([#25](https://github.com/Neplich/dev-agent-skills/pull/25))
 - 增加 `docs/pm/qa-e2e-case-memory/PRD.md`、`docs/engineer/qa-e2e-case-memory/TRD.md` 和 `docs/engineer/qa-e2e-case-memory/IMPLEMENTATION_PLAN.md`，沉淀 QA E2E 用例记忆能力的产品、技术和实施计划。([#25](https://github.com/Neplich/dev-agent-skills/pull/25))
 - 增加 `debugger` 最小 failing-test eval workspace，让 bug 复现证据可以由真实 fixture 和测试命令给出。([#22](https://github.com/Neplich/dev-agent-skills/pull/22))
 
 ### Changed
 
-- 调整 `feature-implementor` 实施流程，要求所有实现任务先产出或更新 `docs/engineer/{feature}/IMPLEMENTATION_PLAN.md`，并在用户确认后再修改代码；小功能、单文件变更和轻量 bug fix 也不能跳过实施计划。([#22](https://github.com/Neplich/dev-agent-skills/pull/22))
+- 调整 `feature-implementor` 实施流程，要求所有实现任务先产出或更新 `docs/engineer/{feature_path}/IMPLEMENTATION_PLAN.md`，并在用户确认后再修改代码；小功能、单文件变更和轻量 bug fix 也不能跳过实施计划。([#22](https://github.com/Neplich/dev-agent-skills/pull/22))
 - 调整 `engineer-agent`、`feature-implementor`、`debugger` 和 `trd-gen` 的现有功能变更路径，在进入实现或修复前先对齐 PRD/TRD 预期；需求变化回 PM，TRD 缺口回 `trd-gen`。([#22](https://github.com/Neplich/dev-agent-skills/pull/22))
 - 调整 `debugger` 流程，在根因分析后先汇报 bug 分析并询问是否产出 repair plan，修复计划确认前不直接修改代码。([#22](https://github.com/Neplich/dev-agent-skills/pull/22))
 - 调整 eval metadata 与 runner 边界，运行期 transcript、subagent verdict、diagnostics 和 scratch eval run 不再作为 durable eval output 提交。([#24](https://github.com/Neplich/dev-agent-skills/pull/24))

--- a/docs/changelog/changelog-v0.1.4.md
+++ b/docs/changelog/changelog-v0.1.4.md
@@ -18,4 +18,4 @@
 - 调整 `changelog-generator` 的 docs/test/ci/build/style 前缀处理策略，避免 skill marketplace 中的重要文档、eval 或发布流程变化被无条件跳过。([#41](https://github.com/Neplich/dev-agent-skills/pull/41))
 - 固化前端 UI 更新路由，要求 Engineer 完成 PRD/TRD 对齐后检查设计交付物，设计缺失或过期时回接 Designer。([#43](https://github.com/Neplich/dev-agent-skills/pull/43))
 - 补齐 `feature-implementor` 实施计划收尾门禁，防止 `status: Implemented` 与正文计划状态冲突进入 handoff / delivery。([#45](https://github.com/Neplich/dev-agent-skills/pull/45))
-- 规范 eval baseline 证据契约，阻止完整 PASS 搭配 diagnostic-only、blocked 或 skipped baseline 说明，并回填历史 comparison 证据状态。([#47](https://github.com/Neplich/dev-agent-skills/pull/47))
+- 规范 eval baseline 证据契约，明确 baseline 是 `without_skill` 对照输入；deterministic checker 不再根据 baseline 自由文本判断 PASS、PARTIAL 或 BLOCKED，baseline output 与 baseline-only assertion 只作为报告证据。([#47](https://github.com/Neplich/dev-agent-skills/pull/47))


### PR DESCRIPTION
## Summary

- 按当前 `feature_path` 口径，将历史 changelog 中的 `{feature}` 路径改为 `{feature_path}`。
- 将 QA E2E 归档路径从固定三级目录改为 `docs/qa/e2e/{feature_path}/`。
- 按最新 eval baseline 契约，修正 v0.1.4 changelog 中的 baseline 描述。
- 已同步更新 GitHub Releases：v0.1.1、v0.1.2、v0.1.4。

## Verification

- [x] `git diff --check`
- [x] `uv run scripts/check_repository_contract.py`
- [x] `uv run scripts/check_eval_contract.py`
- [x] `uv run scripts/check_eval_artifacts.py`
- [x] `uv run --with pytest pytest agents/test_eval_contract.py`（31 passed）
- [x] GitHub Release 正文精确旧口径检索无命中