### PR TITLE
docs: 回滚旧 changelog 口径更新

### DIFF
--- a/docs/changelog/changelog-v0.1.1.md
+++ b/docs/changelog/changelog-v0.1.1.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- 将 `trd-gen` 从 PM 内部能力迁移为 Engineer Agent 的公开 skill，并注册到 marketplace；PRD 确认后由 Engineer 负责产出 `docs/engineer/{feature_path}/TRD.md`。([#19](https://github.com/Neplich/dev-agent-skills/pull/19))
+- 将 `trd-gen` 从 PM 内部能力迁移为 Engineer Agent 的公开 skill，并注册到 marketplace；PRD 确认后由 Engineer 负责产出 `docs/engineer/{feature}/TRD.md`。([#19](https://github.com/Neplich/dev-agent-skills/pull/19))
 - 增加 Engineer Agent 复杂编码任务分工规则，明确主进程、实现 sub-agent 和验收 sub-agent 的职责边界。([#16](https://github.com/Neplich/dev-agent-skills/pull/16))
 - 增加 `feature-implementor` 文档驱动实现 eval fixture，并补充缺失 TRD 时不得直接实施的负向 eval。([#16](https://github.com/Neplich/dev-agent-skills/pull/16), [#19](https://github.com/Neplich/dev-agent-skills/pull/19))
 

--- a/docs/changelog/changelog-v0.1.2.md
+++ b/docs/changelog/changelog-v0.1.2.md
@@ -4,14 +4,14 @@
 
 ### Added
 
-- 增加 QA E2E 功能树持久化规范，统一 `docs/qa/e2e/{feature_path}/` 下的 `TEST_SUITE.md`、`FLOW_INDEX.md`、`cases/`、`scripts/`、`results/` 和 `_reports/` 目录结构。([#25](https://github.com/Neplich/dev-agent-skills/pull/25))
+- 增加 QA E2E 功能树持久化规范，统一 `docs/qa/e2e/{一级功能}/{二级功能}/{三级功能}/` 下的 `TEST_SUITE.md`、`FLOW_INDEX.md`、`cases/`、`scripts/`、`results/` 和 `_reports/` 目录结构。([#25](https://github.com/Neplich/dev-agent-skills/pull/25))
 - 增加 QA E2E 本地账号引用与测试报告 reference，明确 `.qa/e2e/accounts.local.json` 的本地凭据存储方式，避免明文账号、密码、token 或 session 进入测试文档。([#25](https://github.com/Neplich/dev-agent-skills/pull/25))
 - 增加 `docs/pm/qa-e2e-case-memory/PRD.md`、`docs/engineer/qa-e2e-case-memory/TRD.md` 和 `docs/engineer/qa-e2e-case-memory/IMPLEMENTATION_PLAN.md`，沉淀 QA E2E 用例记忆能力的产品、技术和实施计划。([#25](https://github.com/Neplich/dev-agent-skills/pull/25))
 - 增加 `debugger` 最小 failing-test eval workspace，让 bug 复现证据可以由真实 fixture 和测试命令给出。([#22](https://github.com/Neplich/dev-agent-skills/pull/22))
 
 ### Changed
 
-- 调整 `feature-implementor` 实施流程，要求所有实现任务先产出或更新 `docs/engineer/{feature_path}/IMPLEMENTATION_PLAN.md`，并在用户确认后再修改代码；小功能、单文件变更和轻量 bug fix 也不能跳过实施计划。([#22](https://github.com/Neplich/dev-agent-skills/pull/22))
+- 调整 `feature-implementor` 实施流程，要求所有实现任务先产出或更新 `docs/engineer/{feature}/IMPLEMENTATION_PLAN.md`，并在用户确认后再修改代码；小功能、单文件变更和轻量 bug fix 也不能跳过实施计划。([#22](https://github.com/Neplich/dev-agent-skills/pull/22))
 - 调整 `engineer-agent`、`feature-implementor`、`debugger` 和 `trd-gen` 的现有功能变更路径，在进入实现或修复前先对齐 PRD/TRD 预期；需求变化回 PM，TRD 缺口回 `trd-gen`。([#22](https://github.com/Neplich/dev-agent-skills/pull/22))
 - 调整 `debugger` 流程，在根因分析后先汇报 bug 分析并询问是否产出 repair plan，修复计划确认前不直接修改代码。([#22](https://github.com/Neplich/dev-agent-skills/pull/22))
 - 调整 eval metadata 与 runner 边界，运行期 transcript、subagent verdict、diagnostics 和 scratch eval run 不再作为 durable eval output 提交。([#24](https://github.com/Neplich/dev-agent-skills/pull/24))


### PR DESCRIPTION
## Summary

- 回滚 `changelog-v0.1.1.md` 和 `changelog-v0.1.2.md` 的口径更新，旧版本 changelog 保留发布当时的历史存档描述。
- 保留最新 `changelog-v0.1.4.md` 的 baseline 口径修正。
- 不调整已发布 GitHub Release 正文。

## Verification

- [x] `git diff --check`
- [x] `uv run scripts/check_repository_contract.py`
- [x] `uv run scripts/check_eval_contract.py`
- [x] `uv run scripts/check_eval_artifacts.py`
- [x] `uv run --with pytest pytest agents/test_eval_contract.py`（31 passed）