### PR TITLE
docs: 补充 PR 合并确认规则

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,7 @@ PM Agent → Designer Agent → Engineer Agent → QA Agent → DevOps Agent →
 - Branch、tag、release、bypass 和仓库设置权限默认只授予唯一管理员；需要维护者或机器人时再显式添加。
 - 维护变更不得直接在 `main` 上进行；开始修改前先创建工作分支，完成后通过 PR 合入。
 - PR 创建后的更新默认追加新 commit 并普通 push；除非用户明确要求整理提交历史，否则不要 amend、rebase 或 force push。
+- 创建 PR 后不要直接合并；必须等待维护者明确确认“可以合并”后再执行 merge / squash / rebase 合并操作。
 - 当前仓库仍处于早期维护阶段，暂不新增 Release CI；发布前使用手动 release checklist：确认 `.claude-plugin/marketplace.json` 的 `metadata.version` 已更新为目标版本且不带 `v` 前缀，确认 `docs/changelog/changelog-v{version}.md` 存在并已被根 `CHANGELOG.md` 索引，tag 使用 `v` 前缀 SemVer，PR 必跑 CI 全部通过，必要时手动触发 eval workflow 并记录结果；每次使用 tag 发版时，按 skill 维度汇总 skill eval 后的 `comparison.md` 最新结论。不要自动创建 GitHub Release，不要自动上传 marketplace package，也不要配置 release bot bypass tag ruleset。
 
 ### 新增 Agent


### PR DESCRIPTION
## Summary

- 在 `AGENTS.md` 的仓库治理规则中补充 PR 创建后不得直接合并的约束。
- 明确必须等待维护者确认可以合并后，才执行 merge / squash / rebase 合并操作。

## Testing

- [x] 人工检查变更范围，仅修改 `AGENTS.md` 一条仓库治理规则。