### PR TITLE
fix: 无 profile 时允许 feature-catalog 轻量扫描出草案

### DIFF
--- a/agents/product_manager/skills/feature-catalog/SKILL.md
+++ b/agents/product_manager/skills/feature-catalog/SKILL.md
@@ -43,11 +43,15 @@ Detailed execution guidance lives in `_internal/INSTRUCTIONS.md`.
 - Code scan results: routes, pages, API endpoints, services, data models,
   background jobs, tests
 
-If no Project Profile or `feature_inventory` is available yet, request an
-explicit handoff to `engineer-agent:codebase-analyzer` to generate one. If
-that skill is unavailable in the current environment, degrade to a lightweight
-read-only scan of README, routes, and API entry points, and mark every entry
-derived this way as `confidence: low`.
+If a Project Profile or `feature_inventory` already exists, reuse it as the
+primary evidence source. If none is available yet, do not block on a handoff:
+run a lightweight read-only scan directly (README, routes, pages, API entry
+points, services, workspace or module manifests) and produce the draft catalog
+from that evidence, marking entries derived only from this scan as
+`confidence: low`. Recommend running `engineer-agent:codebase-analyzer` first —
+as a suggestion, not a blocker — only when the repository is clearly beyond a
+lightweight scan, for example many services or modules, an unfamiliar stack, or
+evidence conflicts the scan cannot resolve.
 
 ## Protocol
 
@@ -61,7 +65,8 @@ Before proposing any name, read what already exists:
    fallback: treat `docs/pm/{feature}/PRD.md` as `feature_path={feature}`,
    `parent_feature=N/A`, `feature_level=1`.
 2. Read README and any feature-level docs for business vocabulary.
-3. Load the Project Profile and its `feature_inventory` entries.
+3. Load the Project Profile and its `feature_inventory` entries when present;
+   otherwise collect evidence through the lightweight scan described above.
 
 Existing feature paths — explicit or derived through the legacy fallback —
 are authoritative: evidence that maps to an existing feature must reuse its

--- a/agents/product_manager/skills/feature-catalog/_internal/INSTRUCTIONS.md
+++ b/agents/product_manager/skills/feature-catalog/_internal/INSTRUCTIONS.md
@@ -21,9 +21,13 @@ features, decide blocked states, and format the catalog and handoff outputs.
    scheduled jobs, and test names.
 
 Never re-run a deep codebase scan yourself when a Project Profile is
-available; consume it. When neither a profile nor `codebase-analyzer` is
-available, keep the fallback scan read-only and shallow (entry points, not
-implementations) and cap every resulting entry at `confidence: low`.
+available; consume it. When no profile exists, run the lightweight scan
+directly and draft from it — do not block on a `codebase-analyzer` handoff.
+Keep the scan read-only and shallow (entry points, not implementations) and
+cap every entry derived only from it at `confidence: low`. Suggest running
+`codebase-analyzer` first only when the repository clearly exceeds a shallow
+scan (many services or modules, unfamiliar stack, unresolvable evidence
+conflicts), and phrase it as a recommendation, not a blocker.
 
 ## 2. Merging evidence into candidate features
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -14,7 +14,7 @@
     "feature-catalog": {
       "source": "agents/product_manager/skills/feature-catalog",
       "sourceType": "local",
-      "computedHash": "da7c80e2380d14de38b335892e9de864f9cc50b378395f46bcce4ca06527dac7"
+      "computedHash": "8c829787b7fae02db2fae6ee24526e6c0a1f08548eea3b0680d2c97e168b597b"
     },
     "competitive-brief": {
       "source": "agents/product_manager/skills/competitive-brief",


### PR DESCRIPTION
## 背景

PR #67 第三轮 Codex review 的一条 P2 在合并前未及修复，本 PR 补上。

问题：`feature-catalog` 在没有 Project Profile 时强制 handoff 给 `codebase-analyzer`（marketplace 中该 skill 总是已注册），普通接手场景会在产出目录草案前被中断，与本 skill 自己的 no-docs / monorepo eval fixture 期望（直接检查 README/routes/workspaces 后出草案或问范围问题）冲突。

## 修改内容

- `SKILL.md` Inputs 段：有 profile 必须复用；无 profile 不阻塞——直接做轻量只读扫描（README、routes、pages、API 入口、services、workspace/module 清单）出草案，仅此来源的条目 `confidence: low`；仅当仓库明显超出轻量扫描能力（多服务/模块、陌生技术栈、证据冲突无法解决）时建议先跑 analyzer，且为建议非阻断
- Step 1 第 3 条同步为「profile 存在时加载，否则用轻量扫描收集证据」
- `_internal/INSTRUCTIONS.md` 证据优先级段同步同一口径
- `skills-lock.json` 重算 feature-catalog hash

## 验证

三个契约脚本 PASS；CI 同款 pytest 85 passed, 3 subtests passed。

🤖 Generated with [Claude Code](https://claude.com/claude-code)