### PR TITLE
test: 更新 Batch 4 后 fresh skill eval 结果

### DIFF
--- a/agents/designer/test/designer-agent/evals/workspace/eval-003-engineer-ui-maintenance-handoff/comparison.md
+++ b/agents/designer/test/designer-agent/evals/workspace/eval-003-engineer-ui-maintenance-handoff/comparison.md
@@ -7,41 +7,39 @@
 - Eval: `eval-003-engineer-ui-maintenance-handoff`
 - Test case: engineer-ui-maintenance-handoff
 - Workspace: `workspace/eval-003-engineer-ui-maintenance-handoff`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-06-24 after the issue #35 Engineer UI maintenance handoff update
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: Engineer-sourced design gap for `customer-portal/profile-settings`.
-- Expected output: write only design deliverables and return implementation to Engineer.
-- Validation context: fresh Codex subagent semantic validation plus CLI transcript diagnostics under `tmp/eval-runs/manual-issue35/designer-agent/`. The local Designer eval helper also generated a runtime `comparison.auto.md` skip report because this case has no deterministic outputs.
+- Fixture: Engineer-sourced UI maintenance design gap for `customer-portal/profile-settings`.
+- Context read before applying the skill: `evals.json`, workspace `eval_metadata.json`, `docs/pm/customer-portal/profile-settings/PRD.md`, and `docs/engineer/customer-portal/profile-settings/TRD.md`.
 
 ## Assertions
 
-- PASS `accepts_engineer_design_handoff`: the skill accepts Engineer-sourced UI maintenance / frontend-update design handoffs and treats them as design scope only.
-- PASS `uses_confirmed_feature_path`: the fixture PRD/TRD and metadata all use `customer-portal/profile-settings`, and the skill consumes confirmed `feature_path`.
-- PASS `routes_design_skills`: information hierarchy routes to `ui-ux-design`, and primary button visual rules route to or include `visual-design`.
-- PASS `writes_design_outputs_only`: outputs are limited to `docs/design/{feature_path}/ui-ux-spec.md` and/or `visual-system.md`.
-- PASS `hands_back_to_engineer`: implementation returns to `engineer-agent` after design docs are complete.
+- PASS `accepts_engineer_design_handoff`: the route recognizes an Engineer UI maintenance handoff as design scope, not Engineering implementation.
+- PASS `uses_confirmed_feature_path`: the route uses `customer-portal/profile-settings` and reads same-path PM/Engineer docs.
+- PASS `routes_design_skills`: information hierarchy goes to `ui-ux-design`, and primary button visual rules include `visual-design`.
+- PASS `writes_design_outputs_only`: outputs are limited to `docs/design/customer-portal/profile-settings/ui-ux-spec.md` and/or `visual-system.md`.
+- PASS `hands_back_to_engineer`: implementation returns to `engineer-agent` after design deliverables are complete.
 
-## With Skill
+## With Skill Behavior
 
-- PASS. The with-skill CLI transcript routed to `ui-ux-design` plus `visual-design`, named the two design deliverable paths, avoided code or implementation lists, and handed the result back to Engineer.
+`designer-agent` satisfies the Engineer UI maintenance handoff contract. It treats the Engineer packet as a design-only gap, selects `ui-ux-design` plus `visual-design` for the stated information hierarchy and primary button visual rules, writes only design deliverables under the resolved feature path, and stops before code, tests, shell commands, or implementation task lists.
 
-## Without Skill / Baseline
+## Without Skill Baseline
 
-- Baseline CLI output stayed design-only and mentioned returning to Engineer, but it did not name the expected `docs/design/customer-portal/profile-settings/` deliverables or explicit design-skill routing covered by the skill.
+Without the router skill and Designer README, a generic response could read the request as a frontend implementation planning task because it came from Engineer and mentions UI maintenance. It might return a component checklist or implementation steps, and it may not name the expected `docs/design/customer-portal/profile-settings/` artifacts.
 
 ## Failures
 
-- None found in fresh Codex subagent validation.
+- None found.
 
 ## Next Steps
 
-- Keep this eval as regression coverage for Engineer-sourced UI maintenance handoffs. Re-run fresh subagent validation if `designer-agent` routing, design-only boundaries, or eval fixture docs change.
+- Keep this eval as regression coverage for Engineer-to-Designer UI maintenance handoffs.
 
 ## Runtime Artifacts Policy
 
-- CLI transcript diagnostics were generated under `tmp/eval-runs/manual-issue35/designer-agent/` and are runtime artifacts only.
-- Runtime `comparison.auto.md` from the Designer helper remains under `tmp/eval-runs/...` and should not be committed.
-- Runtime transcripts, verdicts, timing, outputs, and diagnostics should not be committed.
+- No runtime artifacts were created for this validation.
+- Runtime transcripts, verdicts, timing, output directories, diagnostics, and generated with_skill / without_skill files must not be committed.

--- a/agents/designer/test/designer-agent/evals/workspace/eval-1-route-design-handoff/comparison.md
+++ b/agents/designer/test/designer-agent/evals/workspace/eval-1-route-design-handoff/comparison.md
@@ -1,37 +1,45 @@
-# Eval Result: designer-agent-route-design-handoff
+# Eval Result: eval-001-route-design-handoff
 
 ## Evaluation Target
 
+- Agent: `designer`
 - Skill: `designer-agent`
+- Eval: `eval-001-route-design-handoff`
 - Test case: route-design-handoff
-- Test set: dispatcher availability evals
-- Entry: workspace `eval-1-route-design-handoff`
-- Latest result: PASS
+- Workspace: `workspace/eval-1-route-design-handoff`
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: PM-backed design request with implementation temptation
+- Fixture: billing notifications design route with a user request to also write React components.
+- Context read before applying the skill: `evals.json`, workspace `eval_metadata.json`, and `docs/pm/billing-notifications/PRD.md`.
 
-## With Skill
+## Assertions
 
-- Routes UX work to `ui-ux-design` and visual system work to `visual-design`.
-- Uses the durable design output filenames `ui-ux-spec.md` and `visual-system.md`.
-- Stops before React implementation and names `engineer-agent` as the next role.
+- PASS `routes_ux_first`: the route starts with `ui-ux-design` for flow, page structure, IA, wireframes, and interaction states.
+- PASS `routes_visual_followup`: visual styling, component rules, colors, typography, and tone route to `visual-design`.
+- PASS `uses_real_output_filenames`: design outputs are `docs/design/{feature_path}/ui-ux-spec.md` and `docs/design/{feature_path}/visual-system.md`.
+- PASS `stops_before_code`: Designer does not write React components, tests, scripts, or deployment files.
+- PASS `hands_off_to_engineer`: implementation is explicitly handed to `engineer-agent` after design completion.
 
-## Without Skill / Baseline
+## With Skill Behavior
 
-- May mix design advice with component implementation.
-- Less consistently preserves the design-only boundary.
+`designer-agent` satisfies the design-only route. It accepts confirmed PM/design context, selects the narrow design sequence `ui-ux-design` -> `visual-design` when both UX and visual scope are requested, writes only durable design deliverables, and stops before implementation. Its missing-target rule requires marking unavailable handoff stages as blocked instead of performing Engineer work.
+
+## Without Skill Baseline
+
+Without the router skill and Designer README, a generic response could blend design advice with React implementation because the prompt asks to "顺手" write components. It may describe UI structure and visual style, but it is less likely to enforce the two exact design artifact filenames or stop at an Engineer handoff.
 
 ## Failures
 
-- None recorded.
+- None found.
 
 ## Next Steps
 
-- Keep this eval for Designer dispatcher route coverage.
+- Keep this eval as regression coverage for Designer design-only routing and implementation handoff.
 
 ## Runtime Artifacts Policy
 
-- Runtime transcripts, verdicts, timing, and diagnostics should not be committed.
+- No runtime artifacts were created for this validation.
+- Runtime transcripts, verdicts, timing, output directories, diagnostics, and generated with_skill / without_skill files must not be committed.

--- a/agents/designer/test/designer-agent/evals/workspace/eval-2-feature-path-design-handoff/comparison.md
+++ b/agents/designer/test/designer-agent/evals/workspace/eval-2-feature-path-design-handoff/comparison.md
@@ -7,41 +7,38 @@
 - Eval: `eval-002-feature-path-design-handoff`
 - Test case: feature-path-design-handoff
 - Workspace: `workspace/eval-2-feature-path-design-handoff`
-- Latest result: PASS - durable comparison coverage updated on 2026-06-25 for a real 4-level design handoff path; no fresh model transcript or runtime output was generated in this worker pass.
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: 4-level feature path `chat-interface/messages/history/search` with matching PM PRD and Engineer TRD.
-- 4+ fixture path: `chat-interface/messages/history/search`.
-- Expected output: route to the narrowest design skill chain, cite the confirmed feature path, use `docs/design/chat-interface/messages/history/search/` output paths, and stop before implementation.
+- Fixture: confirmed 4-level feature path `chat-interface/messages/history/search` with same-path PM PRD and Engineer TRD.
+- Context read before applying the skill: `evals.json`, workspace `eval_metadata.json`, `docs/pm/chat-interface/messages/history/search/PRD.md`, and `docs/engineer/chat-interface/messages/history/search/TRD.md`.
 
 ## Assertions
 
-- PASS `uses_confirmed_feature_path`: consume `chat-interface/messages/history/search` from the fixture.
-- PASS `mirrors_design_outputs`: use `docs/design/chat-interface/messages/history/search/ui-ux-spec.md` and `docs/design/chat-interface/messages/history/search/visual-system.md`.
-- PASS `no_synonym_top_level`: do not create `docs/design/search/`, `docs/design/history-search/`, `docs/design/chat-history-search/`, or a truncated `docs/design/chat-interface/history-search/` directory.
-- PASS `stops_before_code`: do not emit code, implementation steps, test commands, or patches.
+- PASS `uses_confirmed_feature_path`: the route consumes `chat-interface/messages/history/search` as the only feature path and uses same-path PRD/TRD inputs.
+- PASS `mirrors_design_outputs`: output paths mirror the full path under `docs/design/chat-interface/messages/history/search/`.
+- PASS `no_synonym_top_level`: the route does not create `docs/design/search/`, `docs/design/history-search/`, `docs/design/chat-history-search/`, or truncated parent paths.
+- PASS `stops_before_code`: the route stops at design handoff and does not emit code, engineering implementation steps, test commands, or patches.
 
-## With Skill
+## With Skill Behavior
 
-- Expected with-skill behavior is to consume `feature_path: chat-interface/messages/history/search` from the PM/Engineer handoff, read both same-path source documents, and preserve the full path in design outputs.
-- The output contract writes design artifacts only under `docs/design/{feature_path}/`, so the expected UI/UX and visual deliverables are `docs/design/chat-interface/messages/history/search/ui-ux-spec.md` and `docs/design/chat-interface/messages/history/search/visual-system.md`.
-- The Feature Path Gate blocks synonym or truncated directories when the parent feature is known, satisfying the no `docs/design/search/`, `docs/design/history-search/`, and `docs/design/chat-interface/history-search/` assertion.
-- Designer boundaries forbid code, tests, scripts, deployment config, engineer task lists, and implementation instructions; the route stops at design handoff and names `engineer-agent` as the implementation owner.
+`designer-agent` satisfies the feature-path mirroring contract. Its PM handoff gate requires a stable `feature_path`, and Designer README states that output directories consume the PM/Engineer path rather than inventing synonyms. The with-skill route writes only `ui-ux-spec.md` and `visual-system.md` under the full 4-level path and leaves implementation to `engineer-agent`.
 
-## Without Skill / Baseline
-- Not run in this worker pass.
-- High-level baseline contrast: a generic design response may route the design work but collapse the path to `docs/design/history-search/` or the older 2-level `docs/design/chat-interface/history-search/`, breaking handoff symmetry with PM and Engineer.
+## Without Skill Baseline
+
+Without the router skill and Designer README, a generic design answer might preserve the topic but shorten the path to `history-search` or `chat-interface/history-search`, because those are more natural labels. It may also include implementation sequencing or test advice, which would violate the Designer boundary.
 
 ## Failures
 
-- None in the durable eval definition, fixture, and assertion alignment reviewed on 2026-06-25.
+- None found.
 
 ## Next Steps
 
-- Keep this eval as Designer coverage for 4-level feature-path handoff. Residual risk: this validation is a direct durable comparison update; no model transcript was generated.
+- Keep this eval as regression coverage for multi-level feature-path symmetry across PM, Engineer, and Designer docs.
 
 ## Runtime Artifacts Policy
 
-- Runtime transcripts, verdicts, timing, outputs, and diagnostics should not be committed.
+- No runtime artifacts were created for this validation.
+- Runtime transcripts, verdicts, timing, output directories, diagnostics, and generated with_skill / without_skill files must not be committed.

--- a/agents/devops/test/devops-agent/evals/workspace/eval-1-route-ci-readiness/comparison.md
+++ b/agents/devops/test/devops-agent/evals/workspace/eval-1-route-ci-readiness/comparison.md
@@ -1,37 +1,45 @@
-# Eval Result: devops-agent-route-ci-readiness
+# Eval Result: eval-001-route-ci-readiness
 
 ## Evaluation Target
 
+- Agent: `devops`
 - Skill: `devops-agent`
+- Eval: `eval-001-route-ci-readiness`
 - Test case: route-ci-readiness
-- Test set: dispatcher availability evals
-- Entry: workspace `eval-1-route-ci-readiness`
-- Latest result: PASS
+- Workspace: `workspace/eval-1-route-ci-readiness`
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: existing Docker deployment with missing PR CI
+- Fixture: existing `deploy/docker` path with missing GitHub Actions PR gate and later config/runbook concerns.
+- Context read before applying the skill: `evals.json`, workspace `eval_metadata.json`, and `deploy/docker/README.md`.
 
-## With Skill
+## Assertions
 
-- Routes the immediate CI/CD gap to `cicd-bootstrap`.
-- Carries forward existing `deploy/docker` context.
-- Names `env-config-auditor` and `incident-playbook-writer` as follow-ups without executing them immediately.
+- PASS `routes_primary_to_cicd`: the current missing PR gate routes to `cicd-bootstrap`.
+- PASS `keeps_deployment_context`: the existing `deploy/docker` context is preserved rather than replaced with greenfield deployment planning.
+- PASS `names_followups`: environment coverage remains an `env-config-auditor` follow-up and rollback docs remain an `incident-playbook-writer` follow-up.
+- PASS `does_not_run_all_skills`: the route separates the current primary route from later DevOps checks.
+- PASS `does_not_write_workflow`: route-only work does not create `.github/workflows` files.
 
-## Without Skill / Baseline
+## With Skill Behavior
 
-- May over-expand into deployment rewrites, config audits, and runbook generation at once.
-- Less consistently separates current DevOps route from later hardening.
+`devops-agent` satisfies the CI readiness route. Its PM handoff gate allows equivalent confirmed repo-wide operational context, and this fixture supplies an existing Docker deployment path plus a CI automation gap. The router selects the narrow current owner `cicd-bootstrap`, carries forward `deploy/docker`, and lists config audit and rollback runbook work as explicit follow-ups without executing them.
+
+## Without Skill Baseline
+
+Without the router skill and DevOps README, a generic response might generate a workflow outline immediately or expand into deployment, environment, secrets, and rollback work in one pass. It is less likely to preserve the existing Docker context while making CI/CD the single current route.
 
 ## Failures
 
-- None recorded.
+- None found.
 
 ## Next Steps
 
-- Keep this eval for DevOps dispatcher route coverage.
+- Keep this eval as regression coverage for DevOps primary-route selection and follow-up separation.
 
 ## Runtime Artifacts Policy
 
-- Runtime transcripts, verdicts, timing, and diagnostics should not be committed.
+- No runtime artifacts were created for this validation.
+- Runtime transcripts, verdicts, timing, output directories, diagnostics, and generated with_skill / without_skill files must not be committed.

--- a/agents/engineer/test/engineer-agent/evals/workspace/eval-002-existing-feature-alignment-gate/comparison.md
+++ b/agents/engineer/test/engineer-agent/evals/workspace/eval-002-existing-feature-alignment-gate/comparison.md
@@ -7,42 +7,30 @@
 - Eval: `eval-002-existing-feature-alignment-gate`
 - Test case: existing-feature-alignment-gate
 - Workspace: `workspace/eval-002-existing-feature-alignment-gate`
-- Latest result: PARTIAL - prior skill validation evidence is preserved; without_skill baseline was not generated for this historical comparison.
-- Prior validation note: fresh Codex subagent validation on 2026-06-23
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: Verifies that engineer-agent checks PRD/TRD and any present product decisions before routing small existing-feature behavior changes into implementation.
-- Expected output: 先要求读取 docs/pm/{feature_path}/PRD.md、docs/engineer/{feature_path}/TRD.md，以及存在的 DECISIONS.md 或产品决策记录，对比 archived 行为是否改变既有预期；如果是改变预期，路由回 pm-agent:idea-to-spec 的 existing-project-update，而不是直接进入 feature-implementor。
+- Fixture: small existing-feature behavior change request for Notification Center archived items.
+- Context read before applying the skill: `evals.json` and workspace `eval_metadata.json`.
 
 ## Assertions
 
-- `reads_product_and_engineer_docs`: 先读预期行为文档
-- `classifies_expectation_change`: 识别需求预期变更
-- `routes_to_existing_project_update`: 回到 PM 更新路径
-- `routes_trd_gap_to_trd_gen`: TRD gap 交回 trd-gen
-- `requires_plan_after_alignment`: 对齐后仍需实施计划
-- `does_not_route_directly_to_implementation`: 不得直接进入实现
+- PASS `reads_product_and_engineer_docs`: the route requires same-feature PM PRD, Engineer TRD, and existing product decision records before implementation routing.
+- PASS `classifies_expectation_change`: archived notifications appearing in the active list is treated as a possible approved-expectation change, not as an automatic small code edit.
+- PASS `routes_to_existing_project_update`: expectation conflicts return to `pm-agent:idea-to-spec` through the `existing-project-update` lane.
+- PASS `routes_trd_gap_to_trd_gen`: missing, stale, or incomplete TRD coverage is handed to `engineer-agent:trd-gen` with a TRD gap packet.
+- PASS `requires_plan_after_alignment`: implementation can proceed only after PRD/TRD alignment and still requires a confirmed implementation plan.
+- PASS `does_not_route_directly_to_implementation`: the user's request to skip alignment is not accepted as permission to enter coding or planning directly.
 
-## With Skill
+## With Skill Behavior
 
-Observed behavior:
+`engineer-agent` satisfies the existing-feature alignment gate. Its PM handoff entry gate accepts only an explicit packet or equivalent specialist entry basis, and its routing rules send production behavior changes through PRD/TRD alignment before `feature-implementor`. The directly referenced `feature-implementor` gate confirms that expectation changes go back to PM, TRD gaps go to `trd-gen`, and plan confirmation remains mandatory after alignment.
 
-- Fresh Codex subagent validation on 2026-06-23 read the current skill docs, Engineer README, eval definition, fixture metadata/context, and this comparison; all listed assertions are satisfied.
-  `engineer-agent` enforces the existing-feature PRD/TRD alignment gate before
-  implementation or debugging, routes expectation changes to PM, routes TRD
-  gaps to `trd-gen`, requires a confirmed implementation plan after alignment,
-  and treats user requests to skip PRD alignment as blocker/risk rather than a
-  valid continue reason.
-- 当前 SKILL.md 明确 Existing Feature Alignment Gate：现有功能行为变更、小改动或 bug fix 进入 `feature-implementor` 或 `debugger` 前，必须先识别相关 feature，并读取 `docs/pm/{feature_path}/PRD.md`、`docs/engineer/{feature_path}/TRD.md`，以及存在的 `docs/pm/{feature_path}/DECISIONS.md` 或其他产品决策记录。
-- 对 archived 通知显示到 active 列表这类请求，当前 SKILL.md 不把“小改动”默认视为可直接实现，而是先分类：如果是在改变已批准预期，路由回 `pm-agent:idea-to-spec` 的 `existing-project-update` 路径更新 PRD 或产品决策记录。
-- 如果 PRD 或产品决策稳定但 TRD 缺失、过期、不完整或与请求/代码冲突，当前 SKILL.md 要求构造 TRD gap packet，并交给 `engineer-agent:trd-gen` 补完整 TRD。
-- 只有在 PRD/TRD 对齐后才能进入 `feature-implementor`；进入后仍由 `feature-implementor` 基于确认 TRD 写入 `docs/engineer/{feature_path}/IMPLEMENTATION_PLAN.md`，并等待实现确认后再编码。
+## Without Skill Baseline
 
-## Without Skill / Baseline
-- BLOCKED: No actual without_skill baseline result is recorded for this historical comparison. This file is not treated as a full eval PASS until a baseline result is generated and written here.
-- This comparison records whether the skill-specific protocol, routing, evidence, or artifact expectations are preserved.
+Without the router skill and Engineer README, a generic answer would likely accept the user's "small change" framing and route straight to implementation planning or code changes. It may mention checking docs, but it is less likely to classify the active-versus-archived behavior as a product expectation change or to block direct implementation until PRD/TRD and decision records align.
 
 ## Failures
 
@@ -50,8 +38,9 @@ Observed behavior:
 
 ## Next Steps
 
-- 保持该 eval 覆盖现有功能变更的 PRD/TRD 对齐门禁。
+- Keep this eval as regression coverage for existing-feature PRD/TRD alignment and user attempts to bypass PM updates.
 
 ## Runtime Artifacts Policy
 
-- Runtime transcripts, verdicts, timing, outputs, and diagnostics should not be committed.
+- No runtime artifacts were created for this validation.
+- Runtime transcripts, verdicts, timing, output directories, diagnostics, and generated with_skill / without_skill files must not be committed.

--- a/agents/engineer/test/engineer-agent/evals/workspace/eval-003-nested-feature-alignment-routing/comparison.md
+++ b/agents/engineer/test/engineer-agent/evals/workspace/eval-003-nested-feature-alignment-routing/comparison.md
@@ -7,32 +7,29 @@
 - Eval: `eval-003-nested-feature-alignment-routing`
 - Test case: nested-feature-alignment-routing
 - Workspace: `workspace/eval-003-nested-feature-alignment-routing`
-- Latest result: PARTIAL - prior skill validation evidence is preserved; without_skill baseline was not generated for this historical comparison.
-- Prior validation note: fresh Codex subagent validation on 2026-06-23
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: Nested PRD/TRD pair at `chat-interface/history-search`.
-- Expected output: route-level alignment reads the nested PRD/TRD pair before choosing PM update, TRD gap, debugger, or feature-implementor.
-- Fixture files read: `README.md`, nested PRD/TRD, workspace metadata, and this comparison.
+- Fixture: existing `chat-interface/history-search` PRD/TRD with a small search result ordering change.
+- Context read before applying the skill: `evals.json`, workspace `README.md`, `eval_metadata.json`, `docs/pm/chat-interface/history-search/PRD.md`, and `docs/engineer/chat-interface/history-search/TRD.md`.
 
 ## Assertions
 
-- `resolves_nested_feature_path`: identifies and reads the nested feature path.
-- `does_not_use_sibling_or_parent_only_path`: does not substitute sibling or parent-only docs.
-- `routes_requirement_change_to_pm`: routes expectation changes to PM.
-- `routes_trd_mismatch_to_trd_gen`: routes TRD mismatch to `trd-gen`.
-- `does_not_execute_directly`: performs route-only output.
+- PASS `resolves_nested_feature_path`: the route preserves `chat-interface/history-search` and reads the same-path PRD and TRD.
+- PASS `does_not_use_sibling_or_parent_only_path`: the route does not collapse to `history-search` or parent-only `chat-interface`.
+- PASS `routes_requirement_change_to_pm`: ordering changes that alter approved expectations return to `pm-agent:idea-to-spec` existing-project update.
+- PASS `routes_trd_mismatch_to_trd_gen`: stale, missing, or path-mismatched TRDs go to `engineer-agent:trd-gen`.
+- PASS `does_not_execute_directly`: route-only work does not write plans, code, or tests.
 
-## With Skill
+## With Skill Behavior
 
-- Fresh Codex subagent validation on 2026-06-23 read the current skill docs, Engineer README, eval definition, fixture metadata/context, and this comparison; all listed assertions are satisfied.
-- Expected behavior is defined by the updated `engineer-agent` Existing Feature Alignment Gate.
+`engineer-agent` satisfies the nested feature-path contract. It consumes the same-path PM and Engineer documents, preserves the canonical `feature_path`, and keeps implementation blocked until PRD/TRD expectations align. The directly referenced `trd-gen` and `feature-implementor` gates reinforce that path mismatches and stale TRDs are not fixed by implementation routing.
 
-## Without Skill / Baseline
-- BLOCKED: No actual without_skill baseline result is recorded for this historical comparison. This file is not treated as a full eval PASS until a baseline result is generated and written here.
-- This comparison records the intended regression surface for nested feature routing.
+## Without Skill Baseline
+
+Without the router skill and Engineer README, a generic response could treat "History Search" as a top-level feature or use only the parent chat interface context. It might recommend a direct sorting change because the user calls it small, missing the requirement that child feature docs and `related_prd` stay aligned before routing.
 
 ## Failures
 
@@ -40,8 +37,9 @@
 
 ## Next Steps
 
-- Keep this eval focused on the nested feature_path regression surface covered by the fixture.
+- Keep this eval as regression coverage for nested `feature_path` resolution and same-path PRD/TRD alignment.
 
 ## Runtime Artifacts Policy
 
-- Runtime transcripts, verdicts, timing, outputs, and diagnostics should not be committed.
+- No runtime artifacts were created for this validation.
+- Runtime transcripts, verdicts, timing, output directories, diagnostics, and generated with_skill / without_skill files must not be committed.

--- a/agents/engineer/test/engineer-agent/evals/workspace/eval-004-frontend-ui-routing-contract/comparison.md
+++ b/agents/engineer/test/engineer-agent/evals/workspace/eval-004-frontend-ui-routing-contract/comparison.md
@@ -7,42 +7,41 @@
 - Eval: `eval-004-frontend-ui-routing-contract`
 - Test case: frontend-ui-routing-contract
 - Workspace: `workspace/eval-004-frontend-ui-routing-contract`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-06-24 after the issue #35 frontend UI routing contract update
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: Nested `customer-portal/profile-settings` PRD/TRD with missing design docs.
-- Expected output: route local frontend UI implementation through Engineer, check design deliverables, hand design gaps to Designer, then return to implementation planning.
-- Validation context: fresh Codex subagent semantic validation plus CLI transcript diagnostics under `tmp/eval-runs/manual-issue35/engineer-agent/`.
+- Fixture: frontend UI implementation request for `customer-portal/profile-settings` with same-path PRD/TRD and missing design deliverables.
+- Context read before applying the skill: `evals.json`, workspace `README.md`, `eval_metadata.json`, `docs/pm/customer-portal/profile-settings/PRD.md`, and `docs/engineer/customer-portal/profile-settings/TRD.md`.
 
 ## Assertions
 
-- PASS `routes_frontend_update_to_engineer`: frontend code updates, UI implementation, "改 UI", and design-to-code requests remain Engineer-entry requests.
-- PASS `does_not_route_to_external_ui_skill`: the skill explicitly avoids routing local frontend implementation to external UI reference skills such as `ui-ux-pro-max`.
-- PASS `runs_feature_alignment`: the fixture PRD/TRD share `feature_path: customer-portal/profile-settings`, and the skill requires same-feature PRD/TRD alignment first.
-- PASS `checks_design_deliverables`: the skill checks `docs/design/{feature_path}/ui-ux-spec.md` and/or `visual-system.md` before UI implementation planning.
-- PASS `hands_design_gap_to_designer`: missing, stale, or conflicting design docs are handed to `designer-agent` with feature path, source docs, and design gap.
-- PASS `routes_implementation_after_design`: implementation returns to `feature-implementor` only after design handoff, with the `IMPLEMENTATION_PLAN` confirmation gate preserved.
-- PASS `does_not_execute_directly`: route-only requests do not write code, implementation plans, or run tests.
+- PASS `routes_frontend_update_to_engineer`: frontend code and UI implementation remain Engineering work.
+- PASS `does_not_route_to_external_ui_skill`: the route does not use external `ui-ux-pro-max` for local implementation.
+- PASS `runs_feature_alignment`: the route preserves `customer-portal/profile-settings` and reads same-path PRD/TRD first.
+- PASS `checks_design_deliverables`: the route checks `docs/design/customer-portal/profile-settings/ui-ux-spec.md` and/or `visual-system.md`.
+- PASS `hands_design_gap_to_designer`: missing, stale, or conflicting design inputs are handed to `designer-agent` with the resolved feature path and gap.
+- PASS `routes_implementation_after_design`: implementation returns to `feature-implementor` only after design deliverables are complete and plan confirmation remains in force.
+- PASS `does_not_execute_directly`: the route-only prompt does not authorize code, plan, or test execution.
 
-## With Skill
+## With Skill Behavior
 
-- PASS. The with-skill CLI transcript treated the request as an Engineer routing task, checked the PRD/TRD, detected missing design deliverables, handed the gap to `designer-agent`, and did not recommend `ui-ux-pro-max` or implementation.
+`engineer-agent` satisfies the Batch 4 frontend UI routing contract. It classifies local frontend updates as Engineering, applies the PM handoff and same-path PRD/TRD gate, checks design deliverables for page structure, interaction, visual rules, and information hierarchy, then hands design gaps to `designer-agent` without performing Designer work itself. The route returns to `feature-implementor` only after design handoff completion.
 
-## Without Skill / Baseline
+## Without Skill Baseline
 
-- Baseline CLI output treated the prompt as a direct UI design/change request and offered layout/style directions, without preserving the Engineer PRD/TRD and design-handoff routing contract.
+Without the router skill and Engineer README, a generic response would likely treat the prompt as either a direct UI design task or a direct frontend implementation task. It might provide layout and button style guidance, or suggest coding steps, while missing the repository-specific design deliverable check and the prohibition on external UI reference skills for local implementation routing.
 
 ## Failures
 
-- None found in fresh Codex subagent validation.
+- None found.
 
 ## Next Steps
 
-- Keep this eval as regression coverage for frontend UI routing. Re-run fresh subagent validation if `engineer-agent` routing, Designer handoff, or eval fixture docs change.
+- Keep this eval as regression coverage for frontend UI implementation routing and Designer handoff boundaries.
 
 ## Runtime Artifacts Policy
 
-- CLI transcript diagnostics were generated under `tmp/eval-runs/manual-issue35/engineer-agent/` and are runtime artifacts only.
-- Runtime transcripts, verdicts, timing, outputs, and diagnostics should not be committed.
+- No runtime artifacts were created for this validation.
+- Runtime transcripts, verdicts, timing, output directories, diagnostics, and generated with_skill / without_skill files must not be committed.

--- a/agents/engineer/test/engineer-agent/evals/workspace/eval-1-route-implementation-chain/comparison.md
+++ b/agents/engineer/test/engineer-agent/evals/workspace/eval-1-route-implementation-chain/comparison.md
@@ -7,39 +7,30 @@
 - Eval: `eval-001-route-implementation-chain`
 - Test case: route-implementation-chain
 - Workspace: `workspace/eval-1-route-implementation-chain`
-- Latest result: PARTIAL - prior skill validation evidence is preserved; without_skill baseline was not generated for this historical comparison.
-- Prior validation note: fresh Codex subagent validation on 2026-06-23
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: Verifies that engineer-agent routes a multi-step implementation request through the narrowest engineering chain.
-- Expected output: 工程路由决策，明确先理解仓库，再基于已确认 TRD 编写实现计划、实现、补测试、交付，并说明每一步对应的 specialist skill。
+- Fixture: existing service with an approved billing webhook TRD and a route-only request for implementation, tests, QA E2E handoff, and delivery.
+- Context read before applying the skill: `evals.json`, workspace `README.md`, `eval_metadata.json`, `docs/engineer/billing-webhook/TRD.md`, and `src/billing-webhook.md`.
 
 ## Assertions
 
-- `starts_with_codebase_context`: 先建立工程上下文
-- `routes_implementation_to_feature_implementor`: 实现 route
-- `routes_tests_to_test_writer`: 测试 route
-- `routes_qa_e2e_handoff`: 代码完成后 QA E2E 交接
-- `routes_delivery_last`: 交付 route
-- `does_not_execute_directly`: 只做路由不执行
+- PASS `starts_with_codebase_context`: the route starts with `codebase-analyzer` to establish repository structure, stack, constraints, and existing patterns.
+- PASS `routes_implementation_to_feature_implementor`: implementation is routed to `feature-implementor` after confirmed TRD context, with `IMPLEMENTATION_PLAN.md` as the required planning gate.
+- PASS `routes_tests_to_test_writer`: test coverage is a distinct `test-writer` route before delivery.
+- PASS `routes_qa_e2e_handoff`: post-implementation handoff must include PRD, TRD, confirmed `IMPLEMENTATION_PLAN.md`, changed files, verification commands, risks, and `docs/qa/e2e/{feature_path}/`.
+- PASS `routes_delivery_last`: `delivery` remains the last step for commit, push, or PR work.
+- PASS `does_not_execute_directly`: the route-only prompt does not authorize code edits, test runs, or commits.
 
-## With Skill
+## With Skill Behavior
 
-Observed behavior:
+`engineer-agent` satisfies the full route chain. It preserves the PM handoff entry gate, then selects the narrow engineering sequence: `codebase-analyzer` -> `feature-implementor` -> `test-writer` -> QA E2E handoff check -> `delivery`. The skill explicitly points implementation planning to `docs/engineer/{feature_path}/IMPLEMENTATION_PLAN.md`, keeps downstream specialist gates in their owners, and does not perform implementation itself.
 
-- Fresh Codex subagent validation on 2026-06-23 read the current skill docs, Engineer README, eval definition, fixture metadata/context, and this comparison; all listed assertions are satisfied.
-  `engineer-agent` routes the implementation chain through codebase context,
-  confirmed-TRD implementation planning, test coverage, QA E2E handoff package
-  checks, and delivery last, without direct execution.
-- 当前 SKILL.md 支持 route-only 工程链：先用 `codebase-analyzer` 建立仓库结构、技术栈、约束和现有模式上下文；基于已确认 TRD 将实现计划和实现交给 `feature-implementor`，由其写入 `docs/engineer/{feature_path}/IMPLEMENTATION_PLAN.md` 并等待确认后再编码；随后将测试覆盖交给 `test-writer`，最后由 `delivery` 处理 commit、push 或 PR。
-- 当前 SKILL.md 要求实现和自检后检查 QA E2E 文档交接包，且该交接包必须包含 PRD、TRD、已确认 `IMPLEMENTATION_PLAN.md`、变更文件、验证命令、风险和建议的 `docs/qa/e2e/{feature_path}/` 目录。
-- 因用户要求“先做工程路由，不要直接改代码”，当前 SKILL.md 的 dispatcher 职责只选择下游 skill 和执行路径，不会直接修改代码、运行测试或创建提交。
+## Without Skill Baseline
 
-## Without Skill / Baseline
-- BLOCKED: No actual without_skill baseline result is recorded for this historical comparison. This file is not treated as a full eval PASS until a baseline result is generated and written here.
-- This comparison records whether the skill-specific protocol, routing, evidence, or artifact expectations are preserved.
+Without the router skill and Engineer README, a generic response would likely treat the request as a normal implementation checklist, start from the named TRD, and propose coding plus tests directly. It might include delivery at the end, but it is less likely to require codebase context first, preserve the `feature-implementor` plan gate, or include the QA E2E handoff package with confirmed `IMPLEMENTATION_PLAN.md`.
 
 ## Failures
 
@@ -47,8 +38,9 @@ Observed behavior:
 
 ## Next Steps
 
-- 保持该 eval 防止 route-only 请求被直接执行。
+- Keep this eval as regression coverage for route-only implementation chains and QA E2E handoff preservation.
 
 ## Runtime Artifacts Policy
 
-- Runtime transcripts, verdicts, timing, outputs, and diagnostics should not be committed.
+- No runtime artifacts were created for this validation.
+- Runtime transcripts, verdicts, timing, output directories, diagnostics, and generated with_skill / without_skill files must not be committed.

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-001-implement-from-prd-trd/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-001-implement-from-prd-trd/comparison.md
@@ -7,36 +7,29 @@
 - Eval: `eval-001-implement-from-prd-trd`
 - Test case: implement-from-prd-trd
 - Workspace: `workspace/eval-001-implement-from-prd-trd`
-- Latest result: PARTIAL - prior skill validation evidence is preserved; without_skill baseline was not generated for this historical comparison.
-- Prior validation note: fresh Codex subagent validation on 2026-06-23
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: Verifies that feature-implementor handles implement-from-prd-trd by producing an implementation plan, maintaining plan metadata, and waiting for confirmation before coding.
-- Expected output: IMPLEMENTATION_PLAN.md + 文件变更清单 + 实现顺序 + 用户确认门禁，不直接写代码
-- Validation input: current `agents/engineer/skills/feature-implementor/SKILL.md`, Engineer README, `evals.json`, workspace metadata, and this comparison.
+- Fixture files read before skill use: `eval_metadata.json` and the `eval-001-implement-from-prd-trd` item in `evals.json`.
+- Fixture note: this workspace stores metadata only; the PRD/TRD paths are supplied by the eval prompt and expected output.
+- Expected output: produce or update `docs/engineer/notification-center/IMPLEMENTATION_PLAN.md` with file change list, implementation order, plan metadata rules, and a user confirmation gate; do not code directly.
 
 ## Assertions
 
-- `writes_implementation_plan`: 生成实现计划
-- `requires_user_confirmation`: 等待用户确认
-- `does_not_implement_directly`: 不直接实施
-- `maintains_plan_metadata`: 维护实施计划元数据
+- PASS `writes_implementation_plan`: the skill contract requires `docs/engineer/{feature_path}/IMPLEMENTATION_PLAN.md`, file list, order, verification, alignment result, metadata, and split decision before implementation.
+- PASS `requires_user_confirmation`: planner and implementor both stop until the exact implementation plan is presented and confirmed.
+- PASS `does_not_implement_directly`: Phase 2 code work is gated behind plan confirmation.
+- PASS `maintains_plan_metadata`: planner and output conventions require `version`, `last_updated`, `feature_path`, `parent_feature`, `feature_level`, `related_prd`, and `related_trd`, with version/date maintenance rules.
 
-## With Skill
+## With Skill Behavior
 
-Observed behavior:
+Fresh with-skill validation read `agents/engineer/skills/feature-implementor/SKILL.md`, `agents/engineer/README.md`, planner instructions, implementor entry gate, shared coding rules, reviewer instructions, and output conventions. The current skill keeps the PM handoff entry gate intact: direct specialist invocation cannot bypass PM handoff or the equivalent confirmed document chain. Given the eval prompt declares PRD and TRD inputs for `notification-center`, the correct with-skill response is to enter Phase 1 planning, write the durable implementation plan path, include file changes and implementation order, state metadata maintenance requirements, and wait for user confirmation before loading implementor instructions or modifying code.
 
-- Fresh Codex subagent validation on 2026-06-23 read the current skill docs, Engineer README, eval definition, fixture metadata/context, and this comparison; all listed assertions are satisfied.
-- Current `SKILL.md` consumes confirmed PRD/TRD, enters Phase 1 before any code changes, delegates or writes `docs/engineer/{feature_path}/IMPLEMENTATION_PLAN.md`, includes the file change list, implementation order, PRD alignment result, split decision, and blockers, then presents the plan and asks for confirmation.
-- The plan metadata rules require `IMPLEMENTATION_PLAN.md` frontmatter to include `version` and `last_updated`; new plans start from an initial version, substantive body updates change both `version` and `last_updated`, and typo or formatting-only edits may keep `version` unchanged.
-- The skill explicitly says to stop after presenting the plan and not start implementation in the same turn unless the user has already confirmed the exact plan.
-- Phase 2 code work and implementor module loading are gated behind user confirmation of the implementation plan.
+## Without Skill Baseline
 
-## Without Skill / Baseline
-- BLOCKED: No actual without_skill baseline result is recorded for this historical comparison. This file is not treated as a full eval PASS until a baseline result is generated and written here.
-- This comparison records whether the skill-specific protocol, routing, evidence, or artifact expectations are preserved.
+The fresh without-skill baseline was summarized from the eval item and metadata before reading `feature-implementor` or Engineer README. A generic implementation response could treat the prompt as permission to start coding, provide only an informal checklist, or omit frontmatter/version rules. It might still mention a plan because the expected output asks for one, but it would not reliably enforce the durable `IMPLEMENTATION_PLAN.md` gate, exact metadata contract, or Phase 2 confirmation boundary.
 
 ## Failures
 
@@ -44,8 +37,9 @@ Observed behavior:
 
 ## Next Steps
 
-- Keep this eval focused on the confirmed-PRD/TRD plan gate, plan metadata maintenance, and no-direct-code boundary.
+- Keep this eval focused on the confirmed PRD/TRD to implementation-plan gate, metadata maintenance, and no-direct-code boundary.
 
 ## Runtime Artifacts Policy
 
-- Runtime transcripts, verdicts, timing, outputs, and diagnostics should not be committed.
+- This validation did not create runtime artifacts.
+- Runtime transcripts, verdicts, timing files, outputs, diagnostics, run status files, and `comparison.auto.md` must not be committed.

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-002-subagent-division-from-docs/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-002-subagent-division-from-docs/comparison.md
@@ -7,42 +7,32 @@
 - Eval: `eval-002-subagent-division-from-docs`
 - Test case: subagent-division-from-docs
 - Workspace: `workspace/eval-002-subagent-division-from-docs`
-- Latest result: PARTIAL - prior skill validation evidence is preserved; without_skill baseline was not generated for this historical comparison.
-- Prior validation note: fresh Codex subagent validation on 2026-06-23
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: Verifies that feature-implementor preserves main-process context and uses separate implementation and validation sub-agent responsibilities for a complex document-driven coding task.
-- Expected output: 读取源文档并保留主进程上下文，确认 TRD 已就绪，要求通过文档编写 sub-agent 产出 IMPLEMENTATION_PLAN.md，判断任务触发复杂编码分工，给出实现 sub-agent 的写入范围和禁止事项，给出验收 sub-agent 的验收依据和检查范围，并在最终交付契约中包含实现结果、测试情况、验收结论和遗留风险。
-- Fixture files read: `README.md`, PRD, TRD, design spec, `queue-service.ts`, `event-handler.ts`, `queue-service.test.ts`, workspace metadata, and this comparison.
+- Fixture files read before skill use: `README.md`, `eval_metadata.json`, `docs/pm/capture-loop/PRD.md`, `docs/engineer/capture-loop/TRD.md`, `docs/design/capture-loop/ui-ux-spec.md`, `src/capture-loop/queue-service.ts`, `src/capture-loop/event-handler.ts`, and `tests/capture-loop/queue-service.test.ts`.
+- Fixture summary: Capture Loop needs retry scheduling, bounded retries, and test coverage across `queue-service.ts`, `event-handler.ts`, and queue-service tests; the design file states there is no visual UI change.
+- Expected output: preserve main-process context, write `docs/engineer/capture-loop/IMPLEMENTATION_PLAN.md` through a document-writing sub-agent, separate implementation and validation responsibilities for complex work, and include final delivery and QA E2E handoff expectations.
 
 ## Assertions
 
-- `preserves_main_context`: 主进程保留高层上下文
-- `writes_implementation_plan_doc`: 实现计划文档
-- `delegates_implementation_scope`: 实现 sub-agent 范围清晰
-- `delegates_independent_validation`: 验收 sub-agent 独立检查
-- `keeps_simple_path_exception`: 保留简单任务例外
-- `final_summary_contract`: 最终交付说明完整
-- `qa_e2e_handoff_contract`: QA E2E 交接包
+- PASS `preserves_main_context`: the skill keeps PRD/TRD/design docs, repo rules, implementation boundaries, final integration, and delivery risks in the main process.
+- PASS `writes_implementation_plan_doc`: planner requires a fresh document-writing sub-agent when available and forbids rewriting TRD decisions in the implementation plan.
+- PASS `delegates_implementation_scope`: planner and implementor require owned files/modules, source docs, tests, forbidden areas, and no unrelated reverts for implementation delegation.
+- PASS `delegates_independent_validation`: reviewer requires a separate validation sub-agent for complex split work.
+- PASS `keeps_simple_path_exception`: single-file small edits, pure explanation, code reading, or user opt-out can skip complex split only, not planning or confirmation.
+- PASS `final_summary_contract`: implementor and reviewer collect changed files, verification results, open issues, findings, blockers, and residual risks.
+- PASS `qa_e2e_handoff_contract`: closeout requires a QA E2E handoff package when user-facing flows, acceptance paths, permissions, login, data setup, or regression coverage may be affected.
 
-## With Skill
+## With Skill Behavior
 
-Observed behavior:
+Fresh with-skill validation read the public skill, Engineer README, planner, implementor, reviewer, coding rules, and output conventions. The PRD/TRD/design fixtures form an equivalent confirmed document chain, so the PM handoff gate is satisfied without weakening the direct specialist gate. The work is multi-file and spec-heavy, so the skill should keep the main process responsible for context and final judgment, delegate plan writing for `docs/engineer/capture-loop/IMPLEMENTATION_PLAN.md`, then use separate implementation and validation sub-agents after plan confirmation. The implementation scope should cover `src/capture-loop/queue-service.ts`, `src/capture-loop/event-handler.ts`, and `tests/capture-loop/queue-service.test.ts`, with no unrelated module changes.
 
-- Fresh Codex subagent validation on 2026-06-23 read the current skill docs, Engineer README, eval definition, fixture metadata/context, and this comparison; all listed assertions are satisfied.
-- Current `SKILL.md` says the main process keeps PM/design context, repository constraints, implementation boundaries, final integration, and delivery risk while complex coding can be delegated.
-- Phase 1 requires a fresh document-writing sub-agent for `docs/engineer/{feature_path}/IMPLEMENTATION_PLAN.md` when available, and states the plan must not rewrite TRD decisions.
-- The complex coding section requires separate implementation and validation sub-agents for multi-file, multi-module, spec-backed, or context-heavy work. It requires implementation tasks to include owned files/modules, source document references, test expectations, forbidden areas, and a reminder not to revert unrelated user changes.
-- The validation task must use source docs, acceptance criteria, changed files, test evidence, repository rules, coverage, unrelated-change checks, and must return pass/fail, findings, blockers, and residual risks.
-- The skill preserves the simple-path exception for single-file small edits, pure explanation, pure code reading, or user opt-out, while making clear that this only skips complex delegation and never skips implementation planning or confirmation.
-- The handoff section requires implementation result, validation conclusion, tests run, and residual risks when the split was used.
-- The QA E2E documentation handoff section requires PRD, TRD, confirmed implementation plan, PRD alignment result, changed files, verification commands and results, risks, environment assumptions, QA questions, suggested `docs/qa/e2e/{feature_path}/` directory, and likely E2E impact after implementation and self-review.
+## Without Skill Baseline
 
-## Without Skill / Baseline
-- BLOCKED: No actual without_skill baseline result is recorded for this historical comparison. This file is not treated as a full eval PASS until a baseline result is generated and written here.
-- This comparison records whether the skill-specific protocol, routing, evidence, or artifact expectations are preserved.
+The fresh without-skill baseline was summarized before reading skill docs. A generic worker could read the PRD/TRD/source files and propose the same code edits, but it would likely collapse planning, implementation, and validation into one response or one agent. It would not reliably preserve the main-process context contract, require a document-writing sub-agent for the plan, assign a separate validation sub-agent, or produce the QA E2E handoff package after implementation.
 
 ## Failures
 
@@ -50,8 +40,9 @@ Observed behavior:
 
 ## Next Steps
 
-- 保持该 eval 覆盖复杂任务的 implementation/validation 分工。
+- Keep this eval focused on complex spec-backed work where sub-agent splitting is valuable, while preserving the small-task exception.
 
 ## Runtime Artifacts Policy
 
-- Runtime transcripts, verdicts, timing, outputs, and diagnostics should not be committed.
+- This validation did not create runtime artifacts.
+- Runtime transcripts, verdicts, timing files, outputs, diagnostics, run status files, and `comparison.auto.md` must not be committed.

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-003-missing-trd-handoff/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-003-missing-trd-handoff/comparison.md
@@ -7,37 +7,30 @@
 - Eval: `eval-003-missing-trd-handoff`
 - Test case: missing-trd-handoff
 - Workspace: `workspace/eval-003-missing-trd-handoff`
-- Latest result: PARTIAL - prior skill validation evidence is preserved; without_skill baseline was not generated for this historical comparison.
-- Prior validation note: fresh Codex subagent validation on 2026-06-23
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: Verifies that feature-implementor stops before implementation when the Engineer TRD is missing and hands back a complete TRD gap packet to trd-gen.
-- Expected output: 识别缺少已确认 Engineer TRD，停止实现计划和代码实现，明确 handoff 给 engineer-agent:trd-gen 编写 docs/engineer/capture-loop/TRD.md，并列出 TRD gap packet：受影响组件、数据流/API/集成影响、验证命令、发布风险和错误处理策略等缺失技术决策；同时说明发现者负责说明缺口，trd-gen 负责补完整 TRD。
-- Fixture files read: `README.md`, `docs/pm/capture-loop/PRD.md`, workspace metadata, and this comparison. The workspace intentionally has no `docs/engineer/capture-loop/TRD.md`.
+- Fixture files read before skill use: `README.md`, `eval_metadata.json`, and `docs/pm/capture-loop/PRD.md`.
+- Fixture summary: PM scope exists for Capture Loop retry behavior, but `docs/engineer/capture-loop/TRD.md` is intentionally absent.
+- Expected output: stop before `IMPLEMENTATION_PLAN.md` and code, hand off to `engineer-agent:trd-gen`, and provide a complete TRD gap packet.
 
 ## Assertions
 
-- `detects_missing_engineer_trd`: 识别缺失 Engineer TRD
-- `hands_off_to_trd_gen`: 交回 TRD 生成
-- `does_not_write_plan_or_code`: 不进入实现计划或代码
-- `names_required_trd_decisions`: 列出缺失技术决策
-- `keeps_finder_trd_gen_boundary`: 保持发现者和 trd-gen 边界
+- PASS `detects_missing_engineer_trd`: the alignment gate requires `docs/engineer/{feature_path}/TRD.md` before planning.
+- PASS `hands_off_to_trd_gen`: missing, stale, incomplete, path-mismatched, or conflicting TRDs return to `engineer-agent:trd-gen`.
+- PASS `does_not_write_plan_or_code`: planner stops before implementation plan, code, tests, or file-change plan when TRD is missing.
+- PASS `names_required_trd_decisions`: the TRD gap packet must cover technical decisions, components, data/API/integration impacts, validation commands, rollout risks, and error handling/observability/security strategy.
+- PASS `keeps_finder_trd_gen_boundary`: planner states the finder only clarifies gaps and `trd-gen` completes the TRD.
 
-## With Skill
+## With Skill Behavior
 
-Observed behavior:
+Fresh with-skill validation confirmed that the direct specialist gate remains strict: a PRD alone is not an equivalent confirmed document chain. The current skill should resolve `feature_path: capture-loop`, detect the missing mirrored Engineer TRD, and stop before creating `docs/engineer/capture-loop/IMPLEMENTATION_PLAN.md`. It should hand the work to `engineer-agent:trd-gen` with the required TRD gap packet and boundary statement.
 
-- Fresh Codex subagent validation on 2026-06-23 read the current skill docs, Engineer README, eval definition, fixture metadata/context, and this comparison; all listed assertions are satisfied.
-- Current `SKILL.md` requires reading PM and Engineer docs before existing-feature implementation planning and explicitly stops when PRD is stable but TRD is missing, incomplete, or stale.
-- The skill hands back to `engineer-agent:trd-gen` with a TRD gap packet instead of creating `IMPLEMENTATION_PLAN.md`, code, tests, or a file-change implementation plan.
-- The required gap packet covers unresolved technical decisions, affected components/modules, data flow/API/integration impacts, verification commands, release or rollout risks, and error handling, observability, or security strategy when relevant.
-- The skill requires the boundary statement that the finder only clarifies TRD gaps and `engineer-agent:trd-gen` completes or updates the TRD.
+## Without Skill Baseline
 
-## Without Skill / Baseline
-- BLOCKED: No actual without_skill baseline result is recorded for this historical comparison. This file is not treated as a full eval PASS until a baseline result is generated and written here.
-- This comparison records whether the skill-specific protocol, routing, evidence, or artifact expectations are preserved.
+The fresh without-skill baseline was summarized before reading skill docs. Because the prompt explicitly says the TRD is missing and says not to code, a generic response might still block direct implementation. Its likely weakness is an incomplete handoff: it may not name all missing technical decisions, may omit validation and rollout/error strategy, and may not clearly separate the finder role from `engineer-agent:trd-gen`.
 
 ## Failures
 
@@ -45,8 +38,9 @@ Observed behavior:
 
 ## Next Steps
 
-- Keep this eval focused on missing-TRD blocking and complete TRD gap handoff.
+- Keep this eval focused on missing-TRD blocking and full TRD gap handoff.
 
 ## Runtime Artifacts Policy
 
-- Runtime transcripts, verdicts, timing, outputs, and diagnostics should not be committed.
+- This validation did not create runtime artifacts.
+- Runtime transcripts, verdicts, timing files, outputs, diagnostics, run status files, and `comparison.auto.md` must not be committed.

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-004-small-change-plan-gate/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-004-small-change-plan-gate/comparison.md
@@ -7,40 +7,31 @@
 - Eval: `eval-004-small-change-plan-gate`
 - Test case: small-change-plan-gate
 - Workspace: `workspace/eval-004-small-change-plan-gate`
-- Latest result: PARTIAL - prior skill validation evidence is preserved; without_skill baseline was not generated for this historical comparison.
-- Prior validation note: fresh Codex subagent validation on 2026-06-23
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: Verifies that a small single-file implementation still confirms PRD alignment, produces an implementation plan, records the sub-agent split decision, and waits for confirmation.
-- Expected output: 确认 PRD/TRD 已覆盖该文案变更，产出简短 IMPLEMENTATION_PLAN.md，说明无需复杂 sub-agent 拆分，等待用户确认，不直接修改代码。
-- Validation input: current `SKILL.md`, Engineer README, `evals.json`, workspace metadata, and this comparison.
+- Fixture files read before skill use: `eval_metadata.json` and the `eval-004-small-change-plan-gate` item in `evals.json`.
+- Fixture note: this workspace stores metadata only; the prompt declares `docs/pm/settings-label/PRD.md` and `docs/engineer/settings-label/TRD.md` are confirmed.
+- Expected output: produce a short `docs/engineer/settings-label/IMPLEMENTATION_PLAN.md`, record PRD alignment and split decision, wait for user confirmation, and do not edit code.
 
 ## Assertions
 
-- `records_prd_alignment`: 记录 PRD 对齐
-- `writes_plan_for_small_change`: 小改动仍写实施计划
-- `records_split_decision`: 记录拆分判断
-- `waits_for_user_confirmation`: 等待计划确认
-- `blocks_e2e_without_confirmed_plan`: E2E 文档补充依赖确认计划
-- `does_not_modify_code`: 不得直接修改代码
+- PASS `records_prd_alignment`: planner requires an alignment result from PRD/TRD and does not block merely because standalone `DECISIONS.md` is absent.
+- PASS `writes_plan_for_small_change`: planner runs for every implementation task, including small, single-file changes.
+- PASS `records_split_decision`: the plan must state whether the complex implementation/validation split is needed.
+- PASS `waits_for_user_confirmation`: implementation cannot start before exact plan confirmation.
+- PASS `blocks_e2e_without_confirmed_plan`: QA E2E handoff requires a confirmed implementation plan even for small changes.
+- PASS `does_not_modify_code`: no button text or code changes happen during Phase 1 planning.
 
-## With Skill
+## With Skill Behavior
 
-Observed behavior:
+Fresh with-skill validation confirmed that small-change handling was not loosened by the direct specialist gate. The prompt-declared confirmed PRD/TRD chain is sufficient to enter planning, but the task still must create or update `docs/engineer/settings-label/IMPLEMENTATION_PLAN.md`. The plan should record PRD alignment, target file and text change, verification command, and the decision that complex sub-agent split is unnecessary because the change is single-file and low risk. The skill must then wait for user confirmation before code edits or E2E documentation changes.
 
-- Fresh Codex subagent validation on 2026-06-23 read the current skill docs, Engineer README, eval definition, fixture metadata/context, and this comparison; all listed assertions are satisfied.
-- Current `SKILL.md` requires existing-feature changes to read PRD and TRD, plus DECISIONS only when present, so a missing standalone `DECISIONS.md` does not block an otherwise covered PRD/TRD change.
-- The implementation planner is explicitly the first step for every implementation task, including single-file, small, and low-risk changes.
-- The plan must be written to `docs/engineer/{feature_path}/IMPLEMENTATION_PLAN.md`, include the PRD alignment result and implementation/validation sub-agent split decision, then wait for user confirmation.
-- The complex split exception applies to small single-file edits, but the skill says this exception never skips implementation planning or plan confirmation.
-- Phase 2 code work is only after user confirmation, so the skill does not modify the button text or code during planning.
-- The QA E2E documentation handoff section stops if a confirmed implementation plan is missing, and says small, single-file, low-risk, and spec-backed bug-fix changes still require the confirmed implementation plan before the handoff.
+## Without Skill Baseline
 
-## Without Skill / Baseline
-- BLOCKED: No actual without_skill baseline result is recorded for this historical comparison. This file is not treated as a full eval PASS until a baseline result is generated and written here.
-- This comparison records whether the skill-specific protocol, routing, evidence, or artifact expectations are preserved.
+The fresh without-skill baseline was summarized before reading skill docs. A generic worker is likely to treat the requested label change as trivial and either modify the file directly or give a brief implementation note without a durable plan. It may also skip the split decision and omit the rule that E2E documentation updates are blocked until a confirmed implementation plan exists.
 
 ## Failures
 
@@ -48,8 +39,9 @@ Observed behavior:
 
 ## Next Steps
 
-- 保持该 eval 覆盖小改动仍需计划确认。
+- Keep this eval focused on small changes still requiring PRD/TRD alignment, implementation planning, and confirmation.
 
 ## Runtime Artifacts Policy
 
-- Runtime transcripts, verdicts, timing, outputs, and diagnostics should not be committed.
+- This validation did not create runtime artifacts.
+- Runtime transcripts, verdicts, timing files, outputs, diagnostics, run status files, and `comparison.auto.md` must not be committed.

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-005-existing-behavior-change-needs-pm/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-005-existing-behavior-change-needs-pm/comparison.md
@@ -7,40 +7,30 @@
 - Eval: `eval-005-existing-behavior-change-needs-pm`
 - Test case: existing-behavior-change-needs-pm
 - Workspace: `workspace/eval-005-existing-behavior-change-needs-pm`
-- Latest result: PARTIAL - prior skill validation evidence is preserved; without_skill baseline was not generated for this historical comparison.
-- Prior validation note: fresh Codex subagent validation on 2026-06-23
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: Verifies that feature-implementor stops before implementation planning when a small existing-feature change would alter approved PRD/TRD behavior or an existing product decision.
-- Expected output: 识别这是改变已批准预期，停止创建 IMPLEMENTATION_PLAN.md，交回 pm-agent:idea-to-spec existing-project-update 更新 PRD 或产品决策记录，再同步 TRD。
-- Validation input: current `SKILL.md`, Engineer README, `evals.json`, workspace metadata, and this comparison.
+- Fixture files read before skill use: `eval_metadata.json` and the `eval-005-existing-behavior-change-needs-pm` item in `evals.json`.
+- Fixture note: this workspace stores metadata only; the prompt declares PRD/TRD currently require active lists to exclude archived items.
+- Expected output: recognize the requested archived-in-active behavior changes approved expectations, stop before `IMPLEMENTATION_PLAN.md`, return to `pm-agent:idea-to-spec` using `existing-project-update`, then require TRD sync before implementation.
 
 ## Assertions
 
-- `checks_approved_behavior`: 检查已批准预期
-- `stops_before_implementation_plan`: 停止实施计划
-- `hands_off_to_pm_existing_update`: 交回 PM existing-project-update
-- `blocks_e2e_expected_behavior_change`: 预期未对齐时阻断 E2E
-- `does_not_implement_directly`: 不得直接实施
+- PASS `checks_approved_behavior`: the alignment gate classifies expectation changes before planning.
+- PASS `stops_before_implementation_plan`: behavior changes that need PM updates do not create or update `docs/engineer/notifications/IMPLEMENTATION_PLAN.md`.
+- PASS `hands_off_to_pm_existing_update`: approved expectation changes return to `pm-agent:idea-to-spec` with `existing-project-update`.
+- PASS `blocks_e2e_expected_behavior_change`: QA E2E expectations cannot be updated until PRD/product decision update, TRD sync, and implementation plan confirmation.
+- PASS `does_not_implement_directly`: the skill does not code, test, or claim implementation when scope is unaligned.
 
-## With Skill
+## With Skill Behavior
 
-Observed behavior:
+Fresh with-skill validation confirmed the PM handoff gate is still meaningful after direct specialist updates: confirmed PRD/TRD inputs do not permit implementation when the requested behavior contradicts them. The current skill should classify archived items in the active list as an approved-expectation change, stop before planning, route the request to `pm-agent:idea-to-spec` through `existing-project-update`, and require synchronized TRD updates before any `feature-implementor` plan or QA E2E expected behavior update.
 
-- Fresh Codex subagent validation on 2026-06-23 read the current skill docs, Engineer README, eval definition, fixture metadata/context, and this comparison; all listed assertions are satisfied.
-- Current `SKILL.md` requires existing-feature behavior changes to complete the PRD alignment gate before planning, including PRD, TRD, and product decision records when present.
-- If a request changes approved product behavior, the skill stops before implementation planning and hands off to `pm-agent:idea-to-spec` using the `existing-project-update` lane.
-- If PRD/product decisions need updates, the skill does not create `docs/engineer/notifications/IMPLEMENTATION_PLAN.md`, does not update tests, and does not implement code just because the change is small or single-file.
-- After PM alignment, stale or changed technical decisions return through TRD sync before implementation planning.
-- Because QA E2E handoff is only after implementation, self-review, and a confirmed implementation plan, this skill blocks turning the unaligned archived-in-active behavior into a new E2E expected result before PRD/product decision update, TRD sync, and plan confirmation.
-- User requests to skip PRD alignment are recorded as blocker/risk only; they
-  do not permit implementation planning, code changes, or E2E updates.
+## Without Skill Baseline
 
-## Without Skill / Baseline
-- BLOCKED: No actual without_skill baseline result is recorded for this historical comparison. This file is not treated as a full eval PASS until a baseline result is generated and written here.
-- This comparison records whether the skill-specific protocol, routing, evidence, or artifact expectations are preserved.
+The fresh without-skill baseline was summarized before reading skill docs. A generic worker may over-focus on the prompt's "small single-file change" framing and either propose the code/test edit or write a lightweight plan. It would not reliably treat the request as a product expectation change, block `IMPLEMENTATION_PLAN.md`, or require PM update plus later TRD sync before E2E changes.
 
 ## Failures
 
@@ -48,8 +38,9 @@ Observed behavior:
 
 ## Next Steps
 
-- 保持该 eval 覆盖现有行为变更回 PM。
+- Keep this eval focused on stopping small existing-behavior changes that alter approved PM/TRD expectations.
 
 ## Runtime Artifacts Policy
 
-- Runtime transcripts, verdicts, timing, outputs, and diagnostics should not be committed.
+- This validation did not create runtime artifacts.
+- Runtime transcripts, verdicts, timing files, outputs, diagnostics, run status files, and `comparison.auto.md` must not be committed.

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-006-small-bug-fix-plan-gate/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-006-small-bug-fix-plan-gate/comparison.md
@@ -7,39 +7,30 @@
 - Eval: `eval-006-small-bug-fix-plan-gate`
 - Test case: small-bug-fix-plan-gate
 - Workspace: `workspace/eval-006-small-bug-fix-plan-gate`
-- Latest result: PARTIAL - prior skill validation evidence is preserved; without_skill baseline was not generated for this historical comparison.
-- Prior validation note: fresh Codex subagent validation on 2026-06-23
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: Verifies that a small spec-backed bug fix routed into feature-implementor still writes an implementation plan and waits for confirmation.
-- Expected output: 基于已确认 PRD/TRD 和 debugger 根因，产出或更新 docs/engineer/notifications/IMPLEMENTATION_PLAN.md，记录 PRD 对齐、文件范围、验证命令和无需复杂 sub-agent 拆分，等待用户确认，不直接修复。
-- Validation input: current `SKILL.md`, Engineer README, `evals.json`, workspace metadata, and this comparison.
+- Fixture files read before skill use: `eval_metadata.json` and the `eval-006-small-bug-fix-plan-gate` item in `evals.json`.
+- Fixture note: this workspace stores metadata only; the prompt declares debugger has confirmed the issue is an implementation deviation from approved PRD/TRD, not a requirements change.
+- Expected output: treat the bug fix as spec-backed implementation work, produce or update `docs/engineer/notifications/IMPLEMENTATION_PLAN.md`, record `src/api/notifications.ts` and verification commands, wait for confirmation, and do not fix code yet.
 
 ## Assertions
 
-- `treats_bug_fix_as_spec_backed`: 按 spec-backed bug fix 处理
-- `writes_bug_fix_implementation_plan`: 小 bug fix 仍写实施计划
-- `records_no_complex_split`: 记录轻量分工判断
-- `waits_before_fixing`: 等待确认再修
-- `prepares_e2e_handoff_after_fix`: 修复完成后准备 E2E 交接
+- PASS `treats_bug_fix_as_spec_backed`: the skill allows spec-backed bug fixes after debugger or Engineer routing confirms approved PRD/TRD behavior.
+- PASS `writes_bug_fix_implementation_plan`: even single-file bug fixes require `IMPLEMENTATION_PLAN.md`, file scope, and verification commands.
+- PASS `records_no_complex_split`: the small-fix path can skip complex sub-agent split while still documenting that decision.
+- PASS `waits_before_fixing`: implementor entry gate blocks code and test edits until the exact plan is confirmed.
+- PASS `prepares_e2e_handoff_after_fix`: after implementation and self-review, QA E2E handoff needs PRD/TRD alignment, confirmed plan, changed files, verification commands/results, risks, and suggested feature tree directory.
 
-## With Skill
+## With Skill Behavior
 
-Observed behavior:
+Fresh with-skill validation confirmed that the small bug-fix path still runs through planner. Because the prompt says debugger already established this is a deviation from approved PRD/TRD behavior, the request may enter `feature-implementor`; it must not be sent back to PM just because there is no standalone `DECISIONS.md`. The plan should target `docs/engineer/notifications/IMPLEMENTATION_PLAN.md`, name `src/api/notifications.ts`, record deterministic verification commands, state no complex implementation/validation split is needed, and wait for confirmation before any code change or QA E2E update.
 
-- Fresh Codex subagent validation on 2026-06-23 read the current skill docs, Engineer README, eval definition, fixture metadata/context, and this comparison; all listed assertions are satisfied.
-- Current `SKILL.md` says bug fixes with no spec use `debugger`, but spec-backed bug fixes may enter `feature-implementor` after debugger or Engineer routing confirms the fix is implementation work against approved PRD/TRD behavior.
-- The same section says spec-backed bug fixes still require `IMPLEMENTATION_PLAN.md` and explicit user confirmation before code changes.
-- The planner phase applies to every implementation task, including spec-backed bug-fix changes, and must include file scope, verification commands, PRD alignment result, and implementation/validation split decision.
-- The complex split exception allows a single-file small fix to skip complex implementation/validation sub-agent split, but it never skips the plan or confirmation.
-- Phase 2 only starts after plan confirmation, so the skill does not apply the `src/api/notifications.ts` fix or claim verification before confirmation.
-- After implementation and self-review, the QA E2E handoff package must include PRD/TRD paths, confirmed `IMPLEMENTATION_PLAN.md`, PRD alignment, changed files, verification commands/results, risks, and suggested `docs/qa/e2e/{feature_path}/`; if the confirmed plan is missing, the skill stops before producing that handoff.
+## Without Skill Baseline
 
-## Without Skill / Baseline
-- BLOCKED: No actual without_skill baseline result is recorded for this historical comparison. This file is not treated as a full eval PASS until a baseline result is generated and written here.
-- This comparison records whether the skill-specific protocol, routing, evidence, or artifact expectations are preserved.
+The fresh without-skill baseline was summarized before reading skill docs. A generic worker is likely to honor "but first don't edit code" and produce some repair notes, but it may not create a durable implementation plan, may not distinguish spec-backed bug fix from generic debugging, may skip the split decision, and may omit the post-fix QA E2E handoff constraints.
 
 ## Failures
 
@@ -47,8 +38,9 @@ Observed behavior:
 
 ## Next Steps
 
-- 保持该 eval 覆盖小 bug fix 仍需实施计划。
+- Keep this eval focused on spec-backed bug fixes requiring a plan and confirmation even when the code change is single-file.
 
 ## Runtime Artifacts Policy
 
-- Runtime transcripts, verdicts, timing, outputs, and diagnostics should not be committed.
+- This validation did not create runtime artifacts.
+- Runtime transcripts, verdicts, timing files, outputs, diagnostics, run status files, and `comparison.auto.md` must not be committed.

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-007-missing-nested-trd-handoff/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-007-missing-nested-trd-handoff/comparison.md
@@ -7,40 +7,39 @@
 - Eval: `eval-007-missing-nested-trd-handoff`
 - Test case: missing-nested-trd-handoff
 - Workspace: `workspace/eval-007-missing-nested-trd-handoff`
-- Latest result: PARTIAL - prior skill validation evidence is preserved; without_skill baseline was not generated for this historical comparison.
-- Prior validation note: fresh Codex subagent validation on 2026-06-23
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: Nested PRD exists at `docs/pm/chat-interface/history-search/PRD.md`; mirrored Engineer TRD is intentionally absent.
-- Expected output: `feature-implementor` stops before `IMPLEMENTATION_PLAN.md` and hands back to `engineer-agent:trd-gen` with feature path metadata.
-- Fixture files read: `README.md`, `docs/pm/chat-interface/history-search/PRD.md`, workspace metadata, and this comparison.
+- Fixture files read before skill use: `README.md`, `eval_metadata.json`, and `docs/pm/chat-interface/history-search/PRD.md`.
+- Fixture summary: the PRD declares `feature_path: chat-interface/history-search`, `parent_feature: chat-interface`, and `feature_level: 2`; the mirrored `docs/engineer/chat-interface/history-search/TRD.md` is intentionally absent.
+- Expected output: stop before implementation planning, hand off to `engineer-agent:trd-gen`, and include nested feature path metadata and expected PRD/TRD paths.
 
 ## Assertions
 
-- `detects_missing_mirrored_trd`: detects the missing nested TRD path.
-- `hands_off_to_trd_gen_with_feature_path`: hands off with feature path metadata.
-- `does_not_write_plan_or_code`: does not write plan, code, tests, or file-change steps.
-- `keeps_pm_trd_boundary`: distinguishes missing PRD from missing TRD ownership.
+- PASS `detects_missing_mirrored_trd`: the feature path gate requires the mirrored TRD at `docs/engineer/chat-interface/history-search/TRD.md`.
+- PASS `hands_off_to_trd_gen_with_feature_path`: the TRD gap packet includes `feature_path`, `parent_feature`, `feature_level`, PRD path, and expected TRD path.
+- PASS `does_not_write_plan_or_code`: no `IMPLEMENTATION_PLAN.md`, code, tests, or file-change plan are written.
+- PASS `keeps_pm_trd_boundary`: missing PRD returns to PM, while the current missing TRD returns to `trd-gen`; feature-implementor does not invent TRD decisions.
 
-## With Skill
+## With Skill Behavior
 
-- Fresh Codex subagent validation on 2026-06-23 read the current skill docs, Engineer README, eval definition, fixture metadata/context, and this comparison; all listed assertions are satisfied.
-- Expected behavior is defined by the updated `feature-implementor` PRD alignment gate and planner feature path gate.
+Fresh with-skill validation confirmed the nested feature path gate. The current skill reads canonical `feature_path` metadata before planning, so it should not look only for `docs/engineer/history-search/TRD.md`, a parent `docs/engineer/chat-interface/TRD.md`, or a flattened fallback. It must block planning for `docs/engineer/chat-interface/history-search/IMPLEMENTATION_PLAN.md`, route to `engineer-agent:trd-gen`, and carry the nested feature metadata and expected mirrored TRD path.
 
-## Without Skill / Baseline
-- BLOCKED: No actual without_skill baseline result is recorded for this historical comparison. This file is not treated as a full eval PASS until a baseline result is generated and written here.
-- This comparison records the intended regression surface for missing nested TRD blocking.
+## Without Skill Baseline
+
+The fresh without-skill baseline was summarized before reading skill docs. A generic worker may notice the prompt says the nested TRD is missing, but it could still look for a flattened or parent TRD path, provide an incomplete handoff, or blur the PM/TRD boundary by suggesting that feature-implementor fill in technical decisions.
 
 ## Failures
 
-- None found.
+- None.
 
 ## Next Steps
 
-- Keep this eval focused on the nested feature_path regression surface covered by the fixture.
+- Keep this eval focused on mirrored nested `feature_path` TRD requirements.
 
 ## Runtime Artifacts Policy
 
-- Runtime transcripts, verdicts, timing, outputs, and diagnostics should not be committed.
+- This validation did not create runtime artifacts.
+- Runtime transcripts, verdicts, timing files, outputs, diagnostics, run status files, and `comparison.auto.md` must not be committed.

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-008-feature-path-mismatch-blocked/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-008-feature-path-mismatch-blocked/comparison.md
@@ -7,40 +7,39 @@
 - Eval: `eval-008-feature-path-mismatch-blocked`
 - Test case: feature-path-mismatch-blocked
 - Workspace: `workspace/eval-008-feature-path-mismatch-blocked`
-- Latest result: PARTIAL - prior skill validation evidence is preserved; without_skill baseline was not generated for this historical comparison.
-- Prior validation note: fresh Codex subagent validation on 2026-06-23
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: Nested PRD has `feature_path: chat-interface/history-search`; TRD fixture describes only `chat-interface` and points `related_prd` at the parent path.
-- Expected output: `feature-implementor` blocks `IMPLEMENTATION_PLAN.md` and hands off to `engineer-agent:trd-gen`.
-- Fixture files read: `README.md`, `docs/pm/chat-interface/history-search/PRD.md`, `docs/engineer/chat-interface/TRD.md`, workspace metadata, and this comparison.
+- Fixture files read before skill use: `README.md`, `eval_metadata.json`, `docs/pm/chat-interface/history-search/PRD.md`, and `docs/engineer/chat-interface/TRD.md`.
+- Fixture summary: the PRD declares `feature_path: chat-interface/history-search`; the TRD declares parent `feature_path: chat-interface` and `related_prd: docs/pm/chat-interface/PRD.md`.
+- Expected output: detect PRD/TRD metadata and related PRD mismatch, block implementation planning, and hand back to `engineer-agent:trd-gen`.
 
 ## Assertions
 
-- `detects_prd_trd_path_mismatch`: identifies mismatched PRD and TRD feature paths.
-- `checks_related_prd`: validates `related_prd` before planning.
-- `blocks_implementation_plan`: does not create or update the implementation plan.
-- `hands_off_to_trd_gen`: sends the mismatch to `trd-gen`.
+- PASS `detects_prd_trd_path_mismatch`: the skill requires matching PRD/TRD `feature_path`, `parent_feature`, and `feature_level`.
+- PASS `checks_related_prd`: output conventions and planner require TRD `related_prd` to point to `docs/pm/{feature_path}/PRD.md`.
+- PASS `blocks_implementation_plan`: mismatched TRD blocks `docs/engineer/chat-interface/history-search/IMPLEMENTATION_PLAN.md`, code, and tests.
+- PASS `hands_off_to_trd_gen`: stale, incomplete, path-mismatched, or conflicting TRDs return to `engineer-agent:trd-gen`.
 
-## With Skill
+## With Skill Behavior
 
-- Fresh Codex subagent validation on 2026-06-23 read the current skill docs, Engineer README, eval definition, fixture metadata/context, and this comparison; all listed assertions are satisfied.
-- Expected behavior is defined by the updated `feature-implementor` PRD alignment gate and planner feature path gate.
+Fresh with-skill validation confirmed that Batch 3's direct specialist gate is not diluted by a parent TRD. The current skill should compare the nested PRD with the supplied parent TRD, explicitly report `chat-interface/history-search` versus `chat-interface`, detect that `related_prd` points to `docs/pm/chat-interface/PRD.md` instead of the nested PRD, and stop before writing any plan. The correct handoff is to `engineer-agent:trd-gen` to create or correct the mirrored nested TRD.
 
-## Without Skill / Baseline
-- BLOCKED: No actual without_skill baseline result is recorded for this historical comparison. This file is not treated as a full eval PASS until a baseline result is generated and written here.
-- This comparison records the intended regression surface for PRD/TRD path mismatch blocking.
+## Without Skill Baseline
+
+The fresh without-skill baseline was summarized before reading skill docs. A generic response could accept the parent Chat Interface TRD as close enough and proceed with a plan, or mention mismatch without validating `related_prd`. It would not reliably enforce the mirrored feature path and related-PRD gates before planning.
 
 ## Failures
 
-- None found.
+- None.
 
 ## Next Steps
 
-- Keep this eval focused on the nested feature_path regression surface covered by the fixture.
+- Keep this eval focused on blocking parent/child feature path mismatches before implementation planning.
 
 ## Runtime Artifacts Policy
 
-- Runtime transcripts, verdicts, timing, outputs, and diagnostics should not be committed.
+- This validation did not create runtime artifacts.
+- Runtime transcripts, verdicts, timing files, outputs, diagnostics, run status files, and `comparison.auto.md` must not be committed.

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-009-ui-design-handoff-gate/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-009-ui-design-handoff-gate/comparison.md
@@ -7,41 +7,41 @@
 - Eval: `eval-009-ui-design-handoff-gate`
 - Test case: ui-design-handoff-gate
 - Workspace: `workspace/eval-009-ui-design-handoff-gate`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-06-24 after the issue #35 UI design handoff gate update
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: Confirmed PRD/TRD for a frontend UI change with missing design docs.
-- Expected output: block implementation planning and hand design work back through Engineer to Designer.
-- Validation context: fresh Codex subagent semantic validation plus CLI transcript diagnostics under `tmp/eval-runs/manual-issue35/feature-implementor/`.
+- Fixture files read before skill use: `README.md`, `eval_metadata.json`, `docs/pm/customer-portal/profile-settings/PRD.md`, and `docs/engineer/customer-portal/profile-settings/TRD.md`.
+- Fixture summary: PM/TRD documents exist for `customer-portal/profile-settings`, but same-feature `docs/design/customer-portal/profile-settings/ui-ux-spec.md` and `visual-system.md` are intentionally missing.
+- Expected output: identify a frontend UI/visual change, block implementation planning, hand design work back through Engineer to Designer, and preserve the plan gate after design docs are supplied.
 
 ## Assertions
 
-- PASS `detects_ui_design_change`: frontend UI, visual, component, usability, and information hierarchy changes enter the UI Design Handoff Gate.
-- PASS `checks_design_docs`: the skill checks same-feature `docs/design/{feature_path}/ui-ux-spec.md` and `visual-system.md`.
-- PASS `blocks_plan_when_design_missing`: the fixture has no design docs, so the skill stops before `IMPLEMENTATION_PLAN.md` or implementation.
-- PASS `hands_off_to_designer`: missing design decisions are handed back through `engineer-agent` to `designer-agent`.
-- PASS `preserves_plan_gate_after_design`: after Designer returns, implementation still requires an `IMPLEMENTATION_PLAN.md` and user confirmation.
-- PASS `does_not_implement_directly`: no code, tests, or fix steps are allowed before the design and plan gates are satisfied.
+- PASS `detects_ui_design_change`: information hierarchy and primary button styling are frontend UI/visual changes.
+- PASS `checks_design_docs`: the skill checks same-feature `ui-ux-spec.md` and `visual-system.md`.
+- PASS `blocks_plan_when_design_missing`: missing design deliverables block `docs/engineer/customer-portal/profile-settings/IMPLEMENTATION_PLAN.md`.
+- PASS `hands_off_to_designer`: the gap is handed through `engineer-agent` to `designer-agent`.
+- PASS `preserves_plan_gate_after_design`: after Designer resolves the gap, feature-implementor must still write a plan and wait for confirmation.
+- PASS `does_not_implement_directly`: no frontend code, tests, or verification are performed before design and plan gates.
 
-## With Skill
+## With Skill Behavior
 
-- PASS. The with-skill CLI transcript recognized the UI/visual change, checked for missing design deliverables, stopped before planning, and sent the gap through Engineer to Designer.
+Fresh with-skill validation confirmed the UI Design Handoff Gate. The current skill enters the gate for frontend UI, interaction, visual, component, usability, or information hierarchy changes. Since the fixture lacks the same-feature design docs, the skill must stop before planning and hand the missing design deliverables back through Engineer to Designer. Once design docs exist and cover the change, the implementation still returns to `feature-implementor` for `IMPLEMENTATION_PLAN.md` and user confirmation before coding.
 
-## Without Skill / Baseline
+## Without Skill Baseline
 
-- Baseline CLI output treated the request as a direct frontend implementation task and proposed changing layout, hierarchy, and button styling without checking design docs or blocking on Designer handoff.
+The fresh without-skill baseline was summarized before reading skill docs. A generic frontend implementation response is likely to propose layout, hierarchy, and button style changes directly from PRD/TRD or start a code plan. It would not reliably require same-feature UI/UX and visual-system documents, block the implementation plan, or preserve the Designer handoff before coding.
 
 ## Failures
 
-- None found in fresh Codex subagent validation.
+- None.
 
 ## Next Steps
 
-- Keep this eval as regression coverage for UI design handoff gating. Re-run fresh subagent validation if `feature-implementor` planning gates, design inputs, or eval fixture docs change.
+- Keep this eval as regression coverage for UI design handoff gating.
 
 ## Runtime Artifacts Policy
 
-- CLI transcript diagnostics were generated under `tmp/eval-runs/manual-issue35/feature-implementor/` and are runtime artifacts only.
-- Runtime transcripts, verdicts, timing, outputs, and diagnostics should not be committed.
+- This validation did not create runtime artifacts.
+- Runtime transcripts, verdicts, timing files, outputs, diagnostics, run status files, and `comparison.auto.md` must not be committed.

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-010-implementation-plan-closeout-sync/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-010-implementation-plan-closeout-sync/comparison.md
@@ -7,40 +7,41 @@
 - Eval: `eval-010-implementation-plan-closeout-sync`
 - Test case: implementation-plan-closeout-sync
 - Workspace: `workspace/eval-010-implementation-plan-closeout-sync`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-06-24; with-skill run `019ef5f3-bf60-7922-bcc0-2a296cd3be0b` passed, without_skill baseline run `019ef5f3-e0e2-7ef3-adb9-5f89535a79f3` passed, and deterministic checks passed
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: Confirmed PRD/TRD plus an `IMPLEMENTATION_PLAN.md` whose frontmatter is implemented while the body still contains planning-state text.
-- Run set: actual with-skill subagent validation plus actual without_skill baseline subagent validation against the same prompt and fixture.
-- Expected output: block QA handoff or delivery until the implementation plan closeout state, implementation result, deterministic checks, and eval evidence are synchronized.
+- Fixture files read before skill use: `README.md`, `eval_metadata.json`, `docs/pm/sample-feature/PRD.md`, `docs/engineer/sample-feature/TRD.md`, and `docs/engineer/sample-feature/IMPLEMENTATION_PLAN.md`.
+- Fixture summary: the implementation plan frontmatter says `status: Implemented`, but the body still says the plan awaits confirmation, code/skill edits are not started, eval execution is pending, and model eval has not run.
+- Expected output: block QA handoff and delivery until closeout state, implementation result, deterministic checks, eval evidence, and runtime artifact policy are synchronized.
 
 ## Assertions
 
-- PASS `detects_closeout_state_conflict`: the updated skill and reviewer instructions identify conflict between `status: Implemented` and unresolved pending/not-started/not-executed body state.
-- PASS `blocks_handoff_until_plan_updated`: the closeout gate runs before QA handoff or delivery and blocks when the durable plan is stale.
-- PASS `requires_implementation_result_update`: output conventions require implementation result, status table, completed files, checks, risks, and next owner.
-- PASS `records_deterministic_checks`: output conventions require actual deterministic commands and results, or skipped/blocked reasons.
-- PASS `records_eval_evidence`: output conventions require durable `comparison.md` references for executed evals, or skipped/blocked reasons.
-- PASS `keeps_runtime_artifacts_out_of_git`: skill and output conventions keep transcripts, diagnostics, outputs, timing, run status, and `comparison.auto.md` out of git.
+- PASS `detects_closeout_state_conflict`: reviewer and output conventions detect implemented frontmatter with unresolved planning-state text.
+- PASS `blocks_handoff_until_plan_updated`: closeout must be updated before QA E2E handoff, delivery, PR creation, or issue closeout.
+- PASS `requires_implementation_result_update`: closeout records final status, changed files, completed checks, remaining risks, and next owner.
+- PASS `records_deterministic_checks`: actual deterministic commands and results, or skipped/blocked reasons, must be recorded.
+- PASS `records_eval_evidence`: executed skill eval or fresh subagent validation must cite durable `comparison.md`; skipped or blocked evals need explicit reasons.
+- PASS `keeps_runtime_artifacts_out_of_git`: runtime transcripts, diagnostics, outputs, timing, run status, and `comparison.auto.md` stay out of git.
 
-## With Skill
+## With Skill Behavior
 
-- PASS. Subagent `019ef5f3-bf60-7922-bcc0-2a296cd3be0b` used `feature-implementor` and confirmed the PRD/TRD, `SKILL.md`, implementor/reviewer/output conventions, eval definition, and fixture satisfy the closeout-gate plan. The candidate output blocked QA handoff, delivery, PR creation, and issue closeout until the durable `IMPLEMENTATION_PLAN.md` closeout state, deterministic checks, eval evidence, and runtime artifact policy are synchronized.
+Fresh with-skill validation read reviewer and output conventions in addition to the public skill and Engineer README. The skill should detect the contradiction between `status: Implemented` and unresolved pending/not-started/not-executed body state, block any handoff or delivery, and require the durable `IMPLEMENTATION_PLAN.md` to be synchronized with implementation result, deterministic checks, eval/comparison evidence, residual risks, and runtime artifact policy.
 
-## Without Skill / Baseline
+## Without Skill Baseline
 
-- PASS. Subagent `019ef5f3-e0e2-7ef3-adb9-5f89535a79f3` ran the same prompt and fixture without reading or using `feature-implementor` or its internal instructions. The baseline response still detected the stale `IMPLEMENTATION_PLAN.md` closeout state, blocked QA handoff and delivery, required implementation-result, deterministic-check, eval-evidence, and runtime-artifact updates, and satisfied all six assertions. Baseline weakness: it could not confirm the `feature-implementor`-specific closeout templates, wording, or ordering beyond the prompt, fixture, and repository-level eval constraints.
+The fresh without-skill baseline was summarized before reading skill docs. Because the prompt explicitly highlights the stale closeout state, a generic reviewer would likely detect the conflict and block delivery. Its weakness is that it would not reliably apply `feature-implementor`-specific closeout ordering, exact runtime artifact exclusions, durable `comparison.md` citation expectations, or archive/closeout consistency rules from reviewer and output conventions.
 
 ## Failures
 
-- None in the skill/eval contract after closeout synchronization. Both actual with-skill and without_skill baseline runs passed; the remaining distinction is that the with-skill run also validates the `feature-implementor`-specific closeout contract.
+- None.
 
 ## Next Steps
 
-- Keep this eval as regression coverage for stale `IMPLEMENTATION_PLAN.md` closeout state. Re-run both with-skill and without_skill baseline validation if `feature-implementor` closeout behavior, implementation plan output conventions, or eval fixture docs change.
+- Keep this eval focused on stale implementation-plan closeout state blocking delivery and QA handoff.
 
 ## Runtime Artifacts Policy
 
-- Runtime transcripts, verdicts, timing, outputs, diagnostics, run status files, and `comparison.auto.md` should not be committed.
+- This validation did not create runtime artifacts.
+- Runtime transcripts, verdicts, timing files, outputs, diagnostics, run status files, and `comparison.auto.md` must not be committed.

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-011-four-level-feature-path-plan-gate/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-011-four-level-feature-path-plan-gate/comparison.md
@@ -7,45 +7,41 @@
 - Eval: `eval-011-four-level-feature-path-plan-gate`
 - Test case: four-level-feature-path-plan-gate
 - Workspace: `workspace/eval-011-four-level-feature-path-plan-gate`
-- Latest result: PASS - durable comparison coverage added on 2026-06-25 for a real 4-level PRD/TRD -> IMPLEMENTATION_PLAN gate; no fresh model transcript or runtime output was generated in this worker pass.
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: matching 4-level PRD and TRD at `chat-interface/messages/history/search`, plus source and test files that give the implementation plan a concrete file scope.
-- 4+ fixture path: `chat-interface/messages/history/search`.
-- Expected output: confirm PRD/TRD path alignment, write `docs/engineer/chat-interface/messages/history/search/IMPLEMENTATION_PLAN.md`, record feature metadata, file scope, and validation commands, then wait for user confirmation before coding.
+- Fixture files read before skill use: `README.md`, `eval_metadata.json`, `docs/pm/chat-interface/messages/history/search/PRD.md`, `docs/engineer/chat-interface/messages/history/search/TRD.md`, `src/chat-interface/messages/history/search-service.ts`, and `tests/chat-interface/messages/history/search-service.test.ts`.
+- Fixture summary: PRD and TRD both declare `feature_path: chat-interface/messages/history/search`, `parent_feature: chat-interface/messages/history`, and `feature_level: 4`; fixture source/test files give concrete scope for message-history search.
+- Expected output: create or update `docs/engineer/chat-interface/messages/history/search/IMPLEMENTATION_PLAN.md`, preserve feature metadata, include file scope and deterministic checks, and wait for user confirmation before coding.
 
 ## Assertions
 
-- PASS `reads_matching_four_level_docs`: reads the matching PRD and TRD and confirms both declare `feature_path: chat-interface/messages/history/search`.
-- PASS `writes_four_level_plan_path`: targets `docs/engineer/chat-interface/messages/history/search/IMPLEMENTATION_PLAN.md`, not a top-level or 2-level fallback.
-- PASS `preserves_feature_metadata`: requires plan frontmatter with `feature_path`, `parent_feature`, `feature_level`, `related_prd`, and `related_trd`.
-- PASS `includes_scope_and_checks`: includes source/test file scope and deterministic validation commands.
-- PASS `waits_for_user_confirmation`: waits for plan confirmation before coding.
-- PASS `does_not_implement_directly`: does not modify code, tests, or claim verification.
+- PASS `reads_matching_four_level_docs`: PRD/TRD paths and frontmatter match at four levels.
+- PASS `writes_four_level_plan_path`: the planned output path mirrors the full feature path, not a flattened or parent path.
+- PASS `preserves_feature_metadata`: plan frontmatter requires `feature_path`, `parent_feature`, `feature_level`, `related_prd`, and `related_trd`.
+- PASS `includes_scope_and_checks`: the plan includes `search-service.ts`, `search-service.test.ts`, and deterministic validation commands.
+- PASS `waits_for_user_confirmation`: coding starts only after the exact plan is confirmed.
+- PASS `does_not_implement_directly`: no source/test edits or verification claims happen during planning.
 
-## With Skill
+## With Skill Behavior
 
-- Expected with-skill behavior is to treat the confirmed PRD/TRD pair as sufficient to enter the implementation planning gate.
-- The plan path must mirror the full feature path: `docs/engineer/chat-interface/messages/history/search/IMPLEMENTATION_PLAN.md`.
-- The plan must preserve `feature_path: chat-interface/messages/history/search`, `feature: search`, `parent_feature: chat-interface/messages/history`, `feature_level: 4`, `related_prd: docs/pm/chat-interface/messages/history/search/PRD.md`, and `related_trd: docs/engineer/chat-interface/messages/history/search/TRD.md`.
-- The plan should name the concrete fixture scope, including `src/chat-interface/messages/history/search-service.ts` and `tests/chat-interface/messages/history/search-service.test.ts`, and wait for user confirmation before editing.
+Fresh with-skill validation confirmed that the feature path gate supports deep feature trees. The current skill should accept the matching PRD/TRD pair, keep the direct specialist gate satisfied by the equivalent confirmed document chain, target `docs/engineer/chat-interface/messages/history/search/IMPLEMENTATION_PLAN.md`, preserve `feature_path: chat-interface/messages/history/search`, `parent_feature: chat-interface/messages/history`, `feature_level: 4`, `related_prd`, and `related_trd`, list source/test scope, and wait for confirmation.
 
-## Without Skill / Baseline
+## Without Skill Baseline
 
-- Not run in this worker pass.
-- High-level baseline contrast: a generic implementation response may skip the implementation-plan gate, write directly to code, or collapse the target plan path to `docs/engineer/history-search/IMPLEMENTATION_PLAN.md` or `docs/engineer/chat-interface/history-search/IMPLEMENTATION_PLAN.md`.
+The fresh without-skill baseline was summarized before reading skill docs. A generic implementation planner might plan the code changes from the PRD/TRD, but it could collapse the path to `docs/engineer/history-search/IMPLEMENTATION_PLAN.md`, `docs/engineer/chat-interface/history-search/IMPLEMENTATION_PLAN.md`, or `docs/engineer/chat-interface/IMPLEMENTATION_PLAN.md`. It would not reliably enforce four-level metadata preservation or the exact confirmation gate.
 
 ## Failures
 
-- None in the durable eval definition, fixture, and assertion alignment reviewed on 2026-06-25.
+- None.
 
 ## Next Steps
 
-- Keep this eval as feature-implementor coverage for successful 4-level PRD/TRD alignment entering the IMPLEMENTATION_PLAN gate.
-- If model eval workflow is run later, compare transcript behavior against this durable expectation and keep runtime artifacts out of git.
+- Keep this eval focused on successful four-level PRD/TRD alignment entering the mirrored plan gate.
 
 ## Runtime Artifacts Policy
 
-- Runtime transcripts, verdicts, timing, outputs, diagnostics, run status files, and `comparison.auto.md` should not be committed.
+- This validation did not create runtime artifacts.
+- Runtime transcripts, verdicts, timing files, outputs, diagnostics, run status files, and `comparison.auto.md` must not be committed.

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-012-implementation-plan-archive-preflight/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-012-implementation-plan-archive-preflight/comparison.md
@@ -7,57 +7,30 @@
 - Eval: `eval-012-implementation-plan-archive-preflight`
 - Test case: implementation-plan-archive-preflight
 - Workspace: `workspace/eval-012-implementation-plan-archive-preflight`
-- Latest result: PASS - fresh Codex subagent validation confirmed the archive preflight gate blocks direct overwrite of an unarchived active plan.
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: Confirmed PRD/TRD plus an existing completed `IMPLEMENTATION_PLAN.md` on `feature_path: payment-refund` that has not been archived.
-- Run set: with-skill fresh subagent validation and a separate fresh without_skill baseline run against the same prompt and fixture.
-- Expected output: block direct overwrite of the active plan; report the existing plan path, status, and scope; ask the user to archive-then-create, continue updating, or supersede with a reason.
+- Fixture files read before skill use: `README.md`, `eval_metadata.json`, `docs/pm/payment-refund/PRD.md`, `docs/engineer/payment-refund/TRD.md`, and `docs/engineer/payment-refund/IMPLEMENTATION_PLAN.md`.
+- Fixture summary: PRD/TRD now cover partial refunds, but an existing active `IMPLEMENTATION_PLAN.md` for `implementation_scope: full-refund-flow` has `status: Implemented` and has not been archived.
+- Expected output: run archive preflight, block direct overwrite, report existing plan path/status/scope, and ask the user to choose archive-then-create, continue-update, or supersede-with-reason.
 
 ## Assertions
 
-- PASS `runs_pre_plan_archive_scan`: with-skill behavior scans the existing active plan and `implementation-plans/archive/` before writing a new plan.
-- PASS `blocks_direct_overwrite`: with-skill behavior blocks overwriting or replacing the active `IMPLEMENTATION_PLAN.md` while the handling decision is unresolved.
-- PASS `offers_three_handling_options`: with-skill behavior asks the user to choose archive-then-create, continue-updating, or supersede-with-reason.
-- PASS `keeps_active_entry_fixed`: with-skill behavior keeps the active plan entry at `docs/engineer/payment-refund/IMPLEMENTATION_PLAN.md`.
-- PASS `does_not_implement_directly`: with-skill behavior does not modify code or claim implementation completed.
+- PASS `runs_pre_plan_archive_scan`: the skill scans active `IMPLEMENTATION_PLAN.md` and `implementation-plans/archive/` before a new plan.
+- PASS `blocks_direct_overwrite`: unresolved active-plan handling blocks overwriting or replacing the active entry.
+- PASS `offers_three_handling_options`: the user must choose archive completed plan then create, continue updating, or archive as `Superseded` with reason then create.
+- PASS `keeps_active_entry_fixed`: active entry stays `docs/engineer/payment-refund/IMPLEMENTATION_PLAN.md`; history goes under `implementation-plans/archive/`.
+- PASS `does_not_implement_directly`: no code, implementation, or verification is performed before plan handling and confirmation.
 
-## With Skill
+## With Skill Behavior
 
-Fresh Codex subagent validation applied `feature-implementor` and read the Agent
-README, public skill doc, planner, reviewer, output conventions, eval definition,
-and fixture.
+Fresh with-skill validation confirmed the Plan And Archive Gate. The current skill should first confirm the PRD/TRD feature path, then scan `docs/engineer/payment-refund/IMPLEMENTATION_PLAN.md` and the archive directory. Because the fixture has an unarchived active plan with completed full-refund scope and no recorded handling decision for the new partial-refund scope, the skill must stop before writing a new plan, report the existing plan path, `status: Implemented`, and `implementation_scope: full-refund-flow`, and ask for one of the three allowed handling decisions.
 
-The subagent concluded that `feature-implementor` should first confirm PRD/TRD
-alignment, then run the pre-plan archive scan. The fixture contains
-`docs/engineer/payment-refund/IMPLEMENTATION_PLAN.md` with
-`status: Implemented`, `implementation_scope: full-refund-flow`, and no archive
-record. Therefore the skill must not create or overwrite a new active plan for
-the partial-refund scope. It must report the old plan path, status, and scope,
-then ask the user to choose one of the three allowed handling paths.
+## Without Skill Baseline
 
-With-skill assertion verdicts were all PASS. There were no blocking findings.
-
-## Without Skill / Baseline
-
-A separate fresh Codex subagent generated a without_skill baseline without
-reading or applying `feature-implementor` or the Engineer Agent README.
-
-The baseline would likely read the PRD/TRD and notice the existing
-`IMPLEMENTATION_PLAN.md`, but without the archive gate it would probably draft
-or prepare a replacement plan instead of formally blocking. Baseline behavior
-was assessed as:
-
-- PARTIAL `runs_pre_plan_archive_scan`: likely notices active plan, but does not reliably scan archive.
-- PARTIAL `blocks_direct_overwrite`: likely avoids coding, but may still draft a replacement active plan.
-- FAIL `offers_three_handling_options`: does not reliably require the exact three archive/update/supersede choices.
-- PARTIAL `keeps_active_entry_fixed`: may use the active path, but does not reliably state archive-only history handling.
-- PASS `does_not_implement_directly`: prompt already asks not to code.
-
-The baseline gap confirms the new skill rule adds behavior that generic
-implementation planning does not reliably provide.
+The fresh without-skill baseline was summarized before reading skill docs. A generic planner would likely notice the existing active plan but might draft a replacement or update it directly for partial refunds. It would not reliably scan the archive directory, require the exact three handling options, keep the active entry fixed as the only live plan, or block all writes until the handling decision is explicit.
 
 ## Failures
 
@@ -65,9 +38,9 @@ implementation planning does not reliably provide.
 
 ## Next Steps
 
-- Keep this eval in the `feature-implementor` regression set.
-- If archive metadata rules change, update the fixture and re-run fresh with-skill and without_skill validation.
+- Keep this eval focused on archive preflight blocking direct overwrite of an unarchived active plan.
 
 ## Runtime Artifacts Policy
 
-- Runtime transcripts, verdicts, timing, outputs, diagnostics, run status files, and `comparison.auto.md` should not be committed.
+- This validation did not create runtime artifacts.
+- Runtime transcripts, verdicts, timing files, outputs, diagnostics, run status files, and `comparison.auto.md` must not be committed.

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-013-implementation-plan-archive-allows-next-plan/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-013-implementation-plan-archive-allows-next-plan/comparison.md
@@ -7,59 +7,30 @@
 - Eval: `eval-013-implementation-plan-archive-allows-next-plan`
 - Test case: implementation-plan-archive-allows-next-plan
 - Workspace: `workspace/eval-013-implementation-plan-archive-allows-next-plan`
-- Latest result: PASS - fresh Codex subagent validation confirmed an archived prior plan allows a new active plan when linkage metadata is required.
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: Confirmed PRD/TRD plus an archived prior plan at `implementation-plans/archive/IMPLEMENTATION_PLAN-full-refund-flow.md` and no current active `IMPLEMENTATION_PLAN.md` on `feature_path: payment-refund`.
-- Run set: with-skill fresh subagent validation and a separate fresh without_skill baseline run against the same prompt and fixture.
-- Expected output: allow creating a new active plan; require the new plan to record `previous_plan_archive`; keep the active entry fixed; wait for confirmation before coding.
+- Fixture files read before skill use: `README.md`, `eval_metadata.json`, `docs/pm/payment-refund/PRD.md`, `docs/engineer/payment-refund/TRD.md`, and `docs/engineer/payment-refund/implementation-plans/archive/IMPLEMENTATION_PLAN-full-refund-flow.md`.
+- Fixture summary: the prior full-refund plan is archived with `status: "Archived"`, `implementation_scope: full-refund-flow`, `archived_at`, `archive_approved_by`, and `source_plan`; no active `docs/engineer/payment-refund/IMPLEMENTATION_PLAN.md` exists.
+- Expected output: allow a new active plan for partial refunds, require `previous_plan_archive`, keep the active entry fixed, and wait for confirmation before coding.
 
 ## Assertions
 
-- PASS `detects_prior_plan_archived`: with-skill behavior recognizes the prior plan is already archived and no active plan blocks creation.
-- PASS `allows_new_active_plan`: with-skill behavior proceeds to write a new `docs/engineer/payment-refund/IMPLEMENTATION_PLAN.md` for the partial refund scope.
-- PASS `records_previous_plan_archive`: with-skill behavior requires the new plan frontmatter to record `previous_plan_archive` pointing to the archived plan.
-- PASS `keeps_active_entry_fixed`: with-skill behavior keeps the active plan entry at `docs/engineer/payment-refund/IMPLEMENTATION_PLAN.md`.
-- PASS `waits_for_user_confirmation`: with-skill behavior waits for confirmation before coding and does not modify code directly.
+- PASS `detects_prior_plan_archived`: the skill recognizes the archived prior plan and no active-plan blocker.
+- PASS `allows_new_active_plan`: planning may create a new `docs/engineer/payment-refund/IMPLEMENTATION_PLAN.md` for the partial-refund scope.
+- PASS `records_previous_plan_archive`: the new plan frontmatter must point `previous_plan_archive` to the archived full-refund plan.
+- PASS `keeps_active_entry_fixed`: the new active plan path remains `docs/engineer/payment-refund/IMPLEMENTATION_PLAN.md`, not an archive path.
+- PASS `waits_for_user_confirmation`: coding waits until the new active plan is confirmed.
 
-## With Skill
+## With Skill Behavior
 
-Fresh Codex subagent validation applied `feature-implementor` and read the Agent
-README, public skill doc, planner, reviewer, output conventions, eval definition,
-and fixture.
+Fresh with-skill validation confirmed the archived-plan positive path. The current skill should scan the active plan path and archive directory, find no active plan, identify the archived full-refund plan as valid historical context, and proceed to write a new active plan for partial refunds. The plan must record `previous_plan_archive: docs/engineer/payment-refund/implementation-plans/archive/IMPLEMENTATION_PLAN-full-refund-flow.md`, keep the live entry at `docs/engineer/payment-refund/IMPLEMENTATION_PLAN.md`, and wait for user confirmation before implementation.
 
-The subagent concluded that `feature-implementor` should confirm PRD/TRD
-alignment, then run the archive scan. The fixture has no active
-`docs/engineer/payment-refund/IMPLEMENTATION_PLAN.md`; the prior plan is already
-archived at
-`docs/engineer/payment-refund/implementation-plans/archive/IMPLEMENTATION_PLAN-full-refund-flow.md`
-with `status: "Archived"`, `implementation_scope`, `archived_at`,
-`archive_approved_by`, and `source_plan`. Therefore the skill may create a new
-active plan for the partial-refund scope, but the new plan frontmatter must
-record `previous_plan_archive` pointing to the archived plan, and the skill must
-wait for user confirmation before coding.
+## Without Skill Baseline
 
-With-skill assertion verdicts were all PASS. There were no blocking findings.
-
-## Without Skill / Baseline
-
-A separate fresh Codex subagent generated a without_skill baseline without
-reading or applying `feature-implementor` or the Engineer Agent README.
-
-The baseline would likely recognize the archived prior plan and allow a new
-active implementation plan, but it would not reliably require exact linkage
-metadata. Baseline behavior was assessed as:
-
-- PASS `detects_prior_plan_archived`: prompt and fixture clearly show the archived prior plan.
-- PASS `allows_new_active_plan`: baseline likely allows a new active plan because no active plan exists.
-- FAIL `records_previous_plan_archive`: baseline does not reliably require the exact `previous_plan_archive` frontmatter field.
-- PARTIAL `keeps_active_entry_fixed`: baseline may use the active path, but does not reliably forbid writing the new plan into archive.
-- PARTIAL `waits_for_user_confirmation`: baseline avoids coding because prompt asks not to code, but may not clearly require plan confirmation before implementation.
-
-The baseline gap confirms the new skill rule is needed for stable archived-plan
-linkage and active-entry discipline.
+The fresh without-skill baseline was summarized before reading skill docs. A generic planner would likely allow a new plan because the prompt says no active plan exists, but it would not reliably require exact `previous_plan_archive` linkage metadata, validate that the archive is on the same feature path, or explicitly forbid writing the new plan inside the archive directory.
 
 ## Failures
 
@@ -67,9 +38,9 @@ linkage and active-entry discipline.
 
 ## Next Steps
 
-- Keep this eval in the `feature-implementor` regression set.
-- If active/archive linkage metadata changes, update the fixture and re-run fresh with-skill and without_skill validation.
+- Keep this eval focused on allowing a new active plan only after proper archival and linkage metadata.
 
 ## Runtime Artifacts Policy
 
-- Runtime transcripts, verdicts, timing, outputs, diagnostics, run status files, and `comparison.auto.md` should not be committed.
+- This validation did not create runtime artifacts.
+- Runtime transcripts, verdicts, timing files, outputs, diagnostics, run status files, and `comparison.auto.md` must not be committed.

--- a/agents/product_manager/test/feature-catalog/evals/workspace/eval-001-legacy-project-catalog/comparison.md
+++ b/agents/product_manager/test/feature-catalog/evals/workspace/eval-001-legacy-project-catalog/comparison.md
@@ -7,40 +7,43 @@
 - Eval: `eval-001-legacy-project-catalog`
 - Test case: legacy-project-catalog
 - Workspace: `workspace/eval-001-legacy-project-catalog`
-- Latest result: BLOCKED - 本条是新增 skill 的首个 eval 定义，本轮只提交了 eval 定义与 fixture，尚未执行模型 transcript 生成和 fresh Codex subagent validation；`without_skill` baseline 也尚未生成。模型 eval 由维护者在 PR 上决定触发。
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: 初版（本次随 skill 一起提交）——无 PM 文档的 Node.js 老项目，含登录认证、订单、订单状态通知后台任务、订单模型和测试
-- Expected output: 显式标记待确认的功能目录草案，条目带 suggested_feature_path、分类证据、置信度、open questions 和关联代码路径，以维护者确认 feature_path 收尾，不生成正式文档或 PRD
+- Fixture: Node.js commerce backend with no PM docs and code evidence for auth, orders, notifications, model, and tests
+- Expected output: pending-confirmation feature catalog draft with evidence, confidence, open questions, related code paths, and a maintainer confirmation gate; no formal catalog or PRD before confirmation.
 
 ## Assertions
 
-- `draft_before_formal_docs`: 草案先行，不落正式文档
-- `evidence_and_confidence`: 条目带分类证据和置信度
-- `business_capability_naming`: 按业务能力命名
-- `open_questions_present`: 不确定项记录待确认问题
-- `confirmation_gate`: 以确认门禁收尾
+- `draft_before_formal_docs`: draft first, no formal PM docs before confirmation
+- `evidence_and_confidence`: candidate entries include evidence categories and confidence
+- `business_capability_naming`: business capability names, not copied code directory names
+- `open_questions_present`: unresolved ownership or boundary questions are explicit
+- `confirmation_gate`: output stops by asking maintainers to confirm feature paths
 
 ## With Skill
 
-- 尚未运行。首次 fresh subagent validation 执行后在此记录 with-skill 行为摘要。
+- The `feature-catalog` protocol first scans existing PM docs, then README and shallow code entry points when no Project Profile exists.
+- For this fixture it can produce a visible pending-confirmation draft with candidates such as login/authentication, order management, and order status notifications, backed by `src/routes/auth.js`, `src/routes/orders.js`, `src/services/order-service.js`, `src/services/notification-job.js`, `src/models/order.js`, and `test/orders.test.js`.
+- Because the evidence comes from a lightweight fallback scan, confidence is conservative and open questions remain for maintainer confirmation.
+- It stops at the confirmation gate and does not write `docs/pm/FEATURE_CATALOG.md` or any `docs/pm/{feature_path}/PRD.md`.
 
-## Without Skill / Baseline
+## Without Skill / without_skill Baseline
 
-- BLOCKED: 尚未生成本 eval 的 `without_skill` baseline。按 Fresh Sub-Agent 门禁，首次执行时必须基于同一份 prompt 和 fixture 重新生成新的 baseline，不得复用历史 baseline。
-- 在 baseline 与 with-skill 结果生成并被评审前，本文件不构成 eval PASS 结论。
+- The baseline read the eval item and fixture before target skill docs. A generic project scan could list routes and services, but may copy code directory names directly into feature names.
+- It may generate a polished catalog or PRD immediately, omit confidence and open questions, or skip the explicit maintainer confirmation gate.
 
 ## Failures
 
-- 无（尚未执行）。
+- None. The current `feature-catalog` public and internal protocol satisfies the draft, evidence, naming, uncertainty, and confirmation assertions.
 
 ## Next Steps
 
-- 维护者在 PR 上决定是否触发模型 eval workflow / fresh Codex subagent validation。
-- 执行后更新本文件的 Latest result、With Skill 和 Without Skill / Baseline 小节。
+- Keep this eval as coverage for inherited projects with no PM documentation.
+- Re-run fresh validation if shallow-scan confidence rules or confirmation-gate behavior changes.
 
 ## Runtime Artifacts Policy
 
-- 运行期 transcripts、verdicts、outputs、timing 和 diagnostics 写入隔离 scratch workspace（如 `tmp/eval-runs/...`），不提交到 git；长期提交的结果只有本 `comparison.md`。
+- No runtime artifacts were created or committed. Transcripts, verdicts, outputs, timing, and diagnostics must remain outside git; the durable result is this `comparison.md`.

--- a/agents/product_manager/test/feature-catalog/evals/workspace/eval-002-child-feature-under-parent-prd/comparison.md
+++ b/agents/product_manager/test/feature-catalog/evals/workspace/eval-002-child-feature-under-parent-prd/comparison.md
@@ -7,40 +7,43 @@
 - Eval: `eval-002-child-feature-under-parent-prd`
 - Test case: child-feature-under-parent-prd
 - Workspace: `workspace/eval-002-child-feature-under-parent-prd`
-- Latest result: BLOCKED - 本条是新增 skill 的首个 eval 定义，本轮只提交了 eval 定义与 fixture，尚未执行模型 transcript 生成和 fresh Codex subagent validation；`without_skill` baseline 也尚未生成。模型 eval 由维护者在 PR 上决定触发。
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: 初版（本次随 skill 一起提交）——已有 `docs/pm/order-management/PRD.md` 父 PRD，代码新增 `src/orders/refund/` 退款模块与测试
-- Expected output: 复用父 feature_path，退款作为 order-management 下子功能提案，parent_feature/feature_level 一致，说明确认后 prd-gen / trd-gen 链路，handoff packet 字段完整
+- Fixture: existing `docs/pm/order-management/PRD.md` parent PRD plus new refund API/service/test code
+- Expected output: reuse parent `order-management`, propose refund as a child feature, include consistent metadata and handoff packet fields, and avoid generating PRD/TRD content directly.
 
 ## Assertions
 
-- `parent_prd_context_read`: 先读父 PRD 并复用其 feature_path
-- `child_nested_under_parent`: 子功能嵌套在父路径下
-- `feature_level_metadata`: 父子元数据一致
-- `handoff_packet_fields`: handoff packet 字段完整
-- `no_bulk_prd`: 不越界生成 PRD/TRD
+- `parent_prd_context_read`: read parent PRD and reuse its `feature_path`
+- `child_nested_under_parent`: suggest refund under `order-management`
+- `feature_level_metadata`: `parent_feature` and `feature_level` match the nested path
+- `handoff_packet_fields`: handoff packet includes feature path fields and `{source, reason}` evidence
+- `no_bulk_prd`: no direct PRD/TRD generation
 
 ## With Skill
 
-- 尚未运行。首次 fresh subagent validation 执行后在此记录 with-skill 行为摘要。
+- The `feature-catalog` protocol makes existing PRD feature paths authoritative. The fixture PRD confirms `feature_path: order-management`, `parent_feature: N/A`, and `feature_level: 1`.
+- The refund evidence belongs under the parent order-management capability, so the expected suggestion is `order-management/refund` or equivalent lower-kebab child path with `parent_feature: order-management` and `feature_level: 2`.
+- The handoff packet must include `feature_path`, `feature`, `parent_feature`, `feature_level`, and `feature_path_evidence` as `{source, reason}` entries derived from the confirmed catalog, plus `source_catalog`.
+- The protocol sends confirmed requirements work to `prd-gen` via `pm-agent:idea-to-spec`, and only after PM docs are confirmed does it hand off to `engineer-agent:trd-gen`.
 
-## Without Skill / Baseline
+## Without Skill / without_skill Baseline
 
-- BLOCKED: 尚未生成本 eval 的 `without_skill` baseline。按 Fresh Sub-Agent 门禁，首次执行时必须基于同一份 prompt 和 fixture 重新生成新的 baseline，不得复用历史 baseline。
-- 在 baseline 与 with-skill 结果生成并被评审前，本文件不构成 eval PASS 结论。
+- The baseline read the eval item and fixture before target skill docs. A generic scan could notice `src/orders/refund/`, but might propose a new top-level `refund` feature or inline route/service/test objects directly into `feature_path_evidence`.
+- It may also start writing a refund PRD or TRD instead of stopping at feature path confirmation and handoff.
 
 ## Failures
 
-- 无（尚未执行）。
+- None. The current `feature-catalog` protocol satisfies parent reuse, child nesting, metadata, handoff packet, and no-PRD/TRD assertions.
 
 ## Next Steps
 
-- 维护者在 PR 上决定是否触发模型 eval workflow / fresh Codex subagent validation。
-- 执行后更新本文件的 Latest result、With Skill 和 Without Skill / Baseline 小节。
+- Keep this eval as coverage for child features under an existing parent PRD.
+- Re-run fresh validation if feature-path evidence or catalog-to-spec handoff rules change.
 
 ## Runtime Artifacts Policy
 
-- 运行期 transcripts、verdicts、outputs、timing 和 diagnostics 写入隔离 scratch workspace（如 `tmp/eval-runs/...`），不提交到 git；长期提交的结果只有本 `comparison.md`。
+- No runtime artifacts were created or committed. Transcripts, verdicts, outputs, timing, and diagnostics must remain outside git; the durable result is this `comparison.md`.

--- a/agents/product_manager/test/feature-catalog/evals/workspace/eval-003-monorepo-scope-clarification/comparison.md
+++ b/agents/product_manager/test/feature-catalog/evals/workspace/eval-003-monorepo-scope-clarification/comparison.md
@@ -7,39 +7,42 @@
 - Eval: `eval-003-monorepo-scope-clarification`
 - Test case: monorepo-scope-clarification
 - Workspace: `workspace/eval-003-monorepo-scope-clarification`
-- Latest result: BLOCKED - 本条是新增 skill 的首个 eval 定义，本轮只提交了 eval 定义与 fixture，尚未执行模型 transcript 生成和 fresh Codex subagent validation；`without_skill` baseline 也尚未生成。模型 eval 由维护者在 PR 上决定触发。
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: 初版（本次随 skill 一起提交）——pnpm monorepo，含 `apps/web`、`apps/admin`、`services/api` 三个独立 workspace，无 PM 文档
-- Expected output: 识别多 workspace 且范围未指定，blocked 并只问一个最小范围澄清问题；不产出确认版功能目录，不写正式文档，不猜测并列顶层 feature_path 结论
+- Fixture: pnpm monorepo with independently deployed `apps/web`, `apps/admin`, and `services/api`, with no PM docs
+- Expected output: blocked on scope, ask exactly one minimal scope clarification question, and avoid confirmed catalog or guessed parallel top-level feature paths.
 
 ## Assertions
 
-- `blocked_on_scope`: 识别范围不清并 blocked
-- `minimal_clarification`: 只问最小澄清问题
-- `no_fabricated_catalog`: 不伪造确认版目录
-- `no_parallel_top_level`: 不猜测并列顶层路径
+- `blocked_on_scope`: identify multiple workspaces and unresolved scope
+- `minimal_clarification`: ask one smallest clarification question
+- `no_fabricated_catalog`: do not fabricate a confirmed catalog or PRD
+- `no_parallel_top_level`: do not guess each workspace as a settled top-level feature path
 
 ## With Skill
 
-- 尚未运行。首次 fresh subagent validation 执行后在此记录 with-skill 行为摘要。
+- The `feature-catalog` edge-case rule treats undetermined monorepo scope as `blocked`.
+- The fixture clearly exposes three independently deployed surfaces: `apps/web`, `apps/admin`, and `services/api`.
+- The correct with-skill behavior is to ask one minimal question, such as whether to catalog `apps/web`, `apps/admin`, `services/api`, or all of them, and stop.
+- It does not create `docs/pm/FEATURE_CATALOG.md`, generate PRDs, or present guessed top-level feature paths as confirmed conclusions.
 
-## Without Skill / Baseline
+## Without Skill / without_skill Baseline
 
-- BLOCKED: 尚未生成本 eval 的 `without_skill` baseline。按 Fresh Sub-Agent 门禁，首次执行时必须基于同一份 prompt 和 fixture 重新生成新的 baseline，不得复用历史 baseline。
-- 在 baseline 与 with-skill 结果生成并被评审前，本文件不构成 eval PASS 结论。
+- The baseline read the eval item and fixture before target skill docs. A generic response could eagerly inventory all packages and produce a catalog despite unresolved scope.
+- It may ask several discovery questions or treat each workspace name as a confirmed top-level feature path.
 
 ## Failures
 
-- 无（尚未执行）。
+- None. The current `feature-catalog` protocol satisfies the blocked, single-question, no-fabrication, and no-parallel-top-level assertions.
 
 ## Next Steps
 
-- 维护者在 PR 上决定是否触发模型 eval workflow / fresh Codex subagent validation。
-- 执行后更新本文件的 Latest result、With Skill 和 Without Skill / Baseline 小节。
+- Keep this eval as coverage for monorepo scope clarification.
+- Re-run fresh validation if monorepo scope or blocked-state rules change.
 
 ## Runtime Artifacts Policy
 
-- 运行期 transcripts、verdicts、outputs、timing 和 diagnostics 写入隔离 scratch workspace（如 `tmp/eval-runs/...`），不提交到 git；长期提交的结果只有本 `comparison.md`。
+- No runtime artifacts were created or committed. Transcripts, verdicts, outputs, timing, and diagnostics must remain outside git; the durable result is this `comparison.md`.

--- a/agents/product_manager/test/idea-to-spec/workspace/iteration-1/eval-1-existing-project-feature/comparison.md
+++ b/agents/product_manager/test/idea-to-spec/workspace/iteration-1/eval-1-existing-project-feature/comparison.md
@@ -7,46 +7,43 @@
 - Eval: `eval-001-existing-project-feature-design`
 - Test case: existing-project-feature-design
 - Workspace: `workspace/iteration-1/eval-1-existing-project-feature`
-- Latest result: PARTIAL - prior skill validation evidence is preserved; without_skill baseline was not generated for this historical comparison.
-- Prior validation note: fresh Codex subagent validation on 2026-06-23 after the feature_path doc-schema update
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: Verifies that idea-to-spec handles existing-project-feature-design and produces the expected role-specific artifact.
-- Expected output: 先给出项目上下文摘要，然后按单决策点推进设计；在关键点提供 2-3 个方案和 trade-off；按 section 逐段确认；把已确认内容沉淀到 docs/pm/{feature_path}/DECISIONS.md 与相关 PM 文档。
-- Validation context: fresh Codex subagent semantic validation on 2026-06-23 after `prd-schema.md`, `brd-schema.md`, `test-spec-schema.md`, and `trd-schema.md` added explicit `feature_path` metadata requirements.
+- Fixture: existing web app with partial docs, app catalog TRD, and working app-tags PM draft / DECISIONS docs
+- Expected output: start with context summary, advance one decision point, present 2-3 options and trade-offs, progress by section, and use `DECISIONS.md` / feature docs as durable memory.
 
 ## Assertions
 
-- `assertion_1`: 先做上下文检测
-- `assertion_2`: 单决策点推进
-- `assertion_3`: 关键点有选项比较
-- `section`: 按 section 推进
-- `assertion_5`: 文档作为记忆源
+- `assertion_1`: context detection first
+- `assertion_2`: one decision point at a time
+- `assertion_3`: key trade-offs include 2-3 options
+- `section`: section-based confirmation
+- `assertion_5`: durable memory through `DECISIONS.md` or feature docs
 
 ## With Skill
 
-Observed behavior:
+- `idea-to-spec` requires Phase 0 workspace and document context detection before formal design, then selects `existing-project-feature` for an existing repo adding app tags.
+- The non-negotiable protocol requires one decision point per turn, 2-3 options with trade-offs when choices matter, and section-based progression.
+- The fixture has an existing app catalog TRD plus `docs/pm/app-tags/DECISIONS.md` and `design.md`; with skill, those documents are treated as durable memory rather than ignored or overwritten.
+- New or updated formal PM docs must preserve `feature_path=app-tags`, `feature=app-tags`, `parent_feature=N/A`, and `feature_level=1`.
 
-- The current `idea-to-spec` skill requires Phase 0 workspace/doc detection before formal design, then selects `existing-project-feature` for an existing repo adding a new capability.
-- The skill contract requires one decision point per turn, 2-3 option trade-offs for meaningful design choices, section-based confirmation, and durable PM memory through `DECISIONS.md` / feature docs.
-- The fixture is an existing web app with partial docs and an app-tags PM workspace, so the expected first-turn behavior is context summary, confirmation gate, and incremental PM design rather than final artifact generation.
-- The feature_path schema update is compatible with this eval: `app-tags` is a valid level-1 `feature_path`, and any new or updated formal PM document for the feature must now carry `feature_path`, `feature`, `parent_feature`, and `feature_level`.
+## Without Skill / without_skill Baseline
 
-## Without Skill / Baseline
-- BLOCKED: No actual without_skill baseline result is recorded for this historical comparison. This file is not treated as a full eval PASS until a baseline result is generated and written here.
-- Without the skill contract, the likely risk is jumping straight to a complete solution or implementation plan before context detection, confirmation, and PM document memory are established.
+- The baseline read the eval item and fixture before target skill docs. A generic PM response could jump straight to a full design or implementation plan before context detection and confirmation.
+- It may not enforce one decision per turn, section confirmation, or durable decision logging in `DECISIONS.md`.
 
 ## Failures
 
-- None found in this fresh Codex subagent validation after the feature_path doc-schema update.
-- No transcript, verdict, output, or diagnostics artifact was generated in this worker pass.
+- None. The current `idea-to-spec` protocol satisfies all first-turn and durable-memory assertions.
 
 ## Next Steps
 
-- Keep deterministic checks focused on first-turn protocol. Add separate multi-turn or seeded artifact eval coverage if final `DECISIONS.md` / PRD generation needs automated verification against the feature_path frontmatter contract.
+- Keep this eval focused on first-turn PM design discipline.
+- Add a separate multi-turn artifact eval only if final PRD / DECISIONS generation needs automated content validation.
 
 ## Runtime Artifacts Policy
 
-- No runtime artifacts were created in this worker pass. Runtime transcripts, verdicts, timing, outputs, and diagnostics should not be committed.
+- No runtime artifacts were created or committed. Transcripts, verdicts, timing, outputs, and diagnostics must remain outside git.

--- a/agents/product_manager/test/idea-to-spec/workspace/iteration-1/eval-2-existing-project-update/comparison.md
+++ b/agents/product_manager/test/idea-to-spec/workspace/iteration-1/eval-2-existing-project-update/comparison.md
@@ -7,45 +7,42 @@
 - Eval: `eval-002-existing-project-update`
 - Test case: existing-project-update
 - Workspace: `workspace/iteration-1/eval-2-existing-project-update`
-- Latest result: PARTIAL - prior skill validation evidence is preserved; without_skill baseline was not generated for this historical comparison.
-- Prior validation note: fresh Codex subagent validation on 2026-06-23 after the feature_path doc-schema update
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: Verifies that idea-to-spec handles existing-project-update and produces the expected role-specific artifact.
-- Expected output: 识别为 existing-project-update；先总结 delta 和影响范围；优先走 change-impactor / iteration 思路而不是整份重写；明确受影响文档和后续迭代路径。
-- Validation context: fresh Codex subagent semantic validation on 2026-06-23 after `prd-schema.md`, `brd-schema.md`, `test-spec-schema.md`, and `trd-schema.md` added explicit `feature_path` metadata requirements.
+- Fixture: approved notification-center PRD, DECISIONS, and Engineer TRD covering a polling baseline and event-driven migration direction
+- Expected output: recognize `existing-project-update`, summarize delta and blast radius first, prefer `change-impactor` / iteration over full regeneration, and name affected docs.
 
 ## Assertions
 
-- `update`: 识别 update 场景
-- `delta_blast_radius`: 先做 delta 与 blast radius 分析
-- `assertion_3`: 优先迭代而非重写
-- `assertion_4`: 文档路径明确
+- `update`: recognize existing update
+- `delta_blast_radius`: start with delta and blast radius
+- `assertion_3`: prefer iteration over rewrite
+- `assertion_4`: name affected feature docs or document types
 
 ## With Skill
 
-Observed behavior:
+- `idea-to-spec` selects `existing-project-update` when approved behavior, rollout, or scope changes.
+- The shared skill map requires `change-impactor` first when blast radius is unclear, then targeted iteration rather than full regeneration.
+- The fixture docs establish the affected paths: `docs/pm/notification-center/PRD.md`, `docs/pm/notification-center/DECISIONS.md`, and `docs/engineer/notification-center/TRD.md`.
+- The current docs preserve the hybrid event-driven transition and rejected permanent polling-only option, so the update path can describe delta, impacted docs, and revision order without reopening unrelated decisions.
 
-- The current `idea-to-spec` and shared skill-map route approved behavior changes to `existing-project-update`.
-- The required behavior is to summarize the requested delta and blast radius first, then prefer `change-impactor` / targeted iteration over full regeneration.
-- The fixture contains approved notification-center `DECISIONS.md`, `PRD.md`, and Engineer `TRD.md`; the durable docs now preserve the hybrid event-driven transition and explicitly reject permanent polling-only delivery, satisfying the update and decision-history expectations.
-- The feature_path schema update is compatible with this eval: legacy single-level `notification-center` docs remain readable as a level-1 feature, while any updated formal docs or handoff should preserve `feature_path=notification-center`, `feature=notification-center`, `parent_feature=N/A`, and `feature_level=1`.
+## Without Skill / without_skill Baseline
 
-## Without Skill / Baseline
-- BLOCKED: No actual without_skill baseline result is recorded for this historical comparison. This file is not treated as a full eval PASS until a baseline result is generated and written here.
-- Without the skill contract, the likely risk is treating the request as a new design or rewriting documents without retiring the prior polling decision.
+- The baseline read the eval item and fixture before target skill docs. A generic response could treat the request as a net-new design or rewrite the PRD/TRD wholesale.
+- It may miss the decision-history requirement to revise or retire the prior polling decision instead of silently replacing it.
 
 ## Failures
 
-- None found in this fresh Codex subagent validation after the feature_path doc-schema update.
-- No transcript, verdict, output, or diagnostics artifact was generated in this worker pass.
+- None. The current `idea-to-spec` and `change-impactor` routing satisfy all update assertions.
 
 ## Next Steps
 
-- 后续可继续强化旧决策退役/修订断言，并在产生新版 PRD/TRD/Test Spec 时校验 feature_path frontmatter。
+- Keep this eval as existing-project update coverage.
+- Re-run fresh validation if change impact, iteration ordering, or document-memory rules change.
 
 ## Runtime Artifacts Policy
 
-- No runtime artifacts were created in this worker pass. Runtime transcripts, verdicts, timing, outputs, and diagnostics should not be committed.
+- No runtime artifacts were created or committed. Transcripts, verdicts, timing, outputs, and diagnostics must remain outside git.

--- a/agents/product_manager/test/idea-to-spec/workspace/iteration-1/eval-3-greenfield-discovery/comparison.md
+++ b/agents/product_manager/test/idea-to-spec/workspace/iteration-1/eval-3-greenfield-discovery/comparison.md
@@ -7,44 +7,41 @@
 - Eval: `eval-003-greenfield-discovery`
 - Test case: greenfield-discovery
 - Workspace: `workspace/iteration-1/eval-3-greenfield-discovery`
-- Latest result: PARTIAL - prior skill validation evidence is preserved; without_skill baseline was not generated for this historical comparison.
-- Prior validation note: fresh Codex subagent validation on 2026-06-23 after the feature_path doc-schema update
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: Verifies that idea-to-spec handles greenfield-discovery and produces the expected role-specific artifact.
-- Expected output: 保持在 greenfield-discovery；不直接产出整份 PRD；通过单决策点问题和关键方案比较逐步收敛；在方向稳定后再建议下一步文档化。
-- Validation context: fresh Codex subagent semantic validation on 2026-06-23 after `prd-schema.md`, `brd-schema.md`, `test-spec-schema.md`, and `trd-schema.md` added explicit `feature_path` metadata requirements.
+- Fixture: vague team knowledge Q&A idea with minimal notes and no formal docs or technical stack
+- Expected output: stay in `greenfield-discovery`, avoid full PRD/TRD generation, use one-decision discovery, and recommend document generation only after direction stabilizes.
 
 ## Assertions
 
-- `assertion_1`: 不直接生成完整文档
-- `assertion_2`: 使用探索式协议
-- `assertion_3`: 方向稳定后再建议文档化
+- `assertion_1`: no complete document on the first turn
+- `assertion_2`: use exploratory single-decision protocol
+- `assertion_3`: recommend documentation after the direction stabilizes
 
 ## With Skill
 
-Observed behavior:
+- `idea-to-spec` maps vague ideas and near-empty workspaces to `greenfield-discovery`.
+- Its non-negotiable protocol blocks immediate full PRD/TRD generation and advances one decision point at a time.
+- It keeps the feature path unresolved until problem, users, scope, constraints, and assumptions are stable enough to document.
+- It can recommend future PRD / DECISIONS documentation, but only after the discovery direction is confirmed.
 
-- The current `idea-to-spec` skill keeps vague product ideas in `greenfield-discovery`.
-- The skill contract blocks immediate full PRD/TRD generation, requires one decision point per turn, and recommends downstream document generation only after problem, users, scope, constraints, and assumptions are stable.
-- The fixture is intentionally thin and has no formal docs, matching the assertion that discovery should narrow the idea before durable document creation.
-- The feature_path schema update does not weaken this eval: early discovery may keep the target feature path unresolved, but the skill must resolve or clarify a valid multi-level `feature_path` before writing formal feature-scoped docs.
+## Without Skill / without_skill Baseline
 
-## Without Skill / Baseline
-- BLOCKED: No actual without_skill baseline result is recorded for this historical comparison. This file is not treated as a full eval PASS until a baseline result is generated and written here.
-- Without the skill contract, the likely risk is producing a premature PRD or implementation plan from a vague idea.
+- The baseline read the eval item and fixture before target skill docs. A generic PM response could produce a premature PRD outline or implementation plan from the vague idea.
+- It may ask several broad questions at once rather than using a single focused decision point.
 
 ## Failures
 
-- None found in this fresh Codex subagent validation after the feature_path doc-schema update.
-- No transcript, verdict, output, or diagnostics artifact was generated in this worker pass.
+- None. The current `idea-to-spec` protocol satisfies all greenfield discovery assertions.
 
 ## Next Steps
 
-- 保留确认纪律断言；如后续扩展到文档落地，应增加 feature_path 解析和 frontmatter 校验。
+- Keep this eval as first-turn discovery discipline coverage.
+- Re-run fresh validation if greenfield lane selection or document timing changes.
 
 ## Runtime Artifacts Policy
 
-- No runtime artifacts were created in this worker pass. Runtime transcripts, verdicts, timing, outputs, and diagnostics should not be committed.
+- No runtime artifacts were created or committed. Transcripts, verdicts, timing, outputs, and diagnostics must remain outside git.

--- a/agents/product_manager/test/idea-to-spec/workspace/iteration-2/eval-4-greenfield-bootstrap-routing/comparison.md
+++ b/agents/product_manager/test/idea-to-spec/workspace/iteration-2/eval-4-greenfield-bootstrap-routing/comparison.md
@@ -7,46 +7,42 @@
 - Eval: `eval-004-greenfield-bootstrap-routing`
 - Test case: greenfield-bootstrap-routing
 - Workspace: `workspace/iteration-2/eval-4-greenfield-bootstrap-routing`
-- Latest result: PARTIAL - prior skill validation evidence is preserved; without_skill baseline was not generated for this historical comparison.
-- Prior validation note: fresh Codex subagent validation on 2026-06-23 after the feature_path doc-schema update
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: Verifies that idea-to-spec handles greenfield-bootstrap-routing and produces the expected role-specific artifact.
-- Expected output: 先输出空工作区 context summary；识别为 PM-first 的 greenfield-discovery 或 greenfield-bootstrap 路径；保持在 PM/idea-to-spec 路径里，不直接运行脚手架；明确下一步是需求澄清、PRD/DECISIONS 文档化或等价的 PM 动作，而不是工程实现。
-- Validation context: fresh Codex subagent semantic validation on 2026-06-23 after `prd-schema.md`, `brd-schema.md`, `test-spec-schema.md`, and `trd-schema.md` added explicit `feature_path` metadata requirements.
+- Fixture: empty-workspace AI chat assistant request; `eval_metadata.json` lists `PRD.md` as execution cleanup for stale runtime output
+- Expected output: Phase 0 empty-workspace context summary, PM-first `greenfield-discovery` or `greenfield-bootstrap`, no code scaffold, and PM documentation next step.
 
 ## Assertions
 
-- `assertion_1`: 先做空工作区检测
-- `pm_first_lane`: 识别为 PM-first lane
-- `pm_first`: 保持 PM-first，不直接工程化
-- `assertion_4`: 给出文档化下一步
+- `assertion_1`: empty workspace / docs context first
+- `pm_first_lane`: PM-first lane selection
+- `pm_first`: no direct engineering scaffold
+- `assertion_4`: document-oriented next step
 
 ## With Skill
 
-Observed behavior:
+- `idea-to-spec` requires Phase 0 context detection and keeps empty product requests in PM lanes unless the user explicitly opts out.
+- Because the user asks for PRD shaping rather than code, the correct lane is `greenfield-bootstrap` or a `greenfield-discovery` first step that may load `project-init` for durable docs.
+- `project-init` creates documentation scaffolding only when appropriate and records API / ADR needs as Engineer handoff, not immediate code scaffolding.
+- The stale `PRD.md` listed in `execution_cleanup` does not weaken the expected behavior; fresh validation treats cleanup metadata as a signal not to reuse prior runtime output as the answer.
 
-- The current `idea-to-spec` skill requires Phase 0 context summary for empty or near-empty product requests, with tech stack and existing docs marked as TBD/none.
-- The PM-first guardrail keeps this request in `greenfield-discovery` or `greenfield-bootstrap`, recommends PRD/DECISIONS/project-init style document work, and does not run scaffolding commands.
-- The fixture README says the workspace is intentionally empty except eval metadata. The stale root `PRD.md` remains only as an `execution_cleanup` target, so it does not change the expected PM-first routing.
-- The feature_path schema update reinforces the PM-first lane: before `project-init` or PRD skeleton output becomes formal, the flow must establish a valid multi-level `feature_path` and include the required feature metadata fields.
+## Without Skill / without_skill Baseline
 
-## Without Skill / Baseline
-- BLOCKED: No actual without_skill baseline result is recorded for this historical comparison. This file is not treated as a full eval PASS until a baseline result is generated and written here.
-- Without the skill contract, the likely risk is starting `npm create`, `create-next-app`, or another engineering bootstrap before PM requirements are settled.
+- The baseline read the eval item and fixture before target skill docs. A generic response could run or recommend `create-next-app`, `npm create vite`, or another scaffold because the layout is concrete.
+- It could also accept stale `PRD.md` content without first stating empty-workspace context or PM-first routing.
 
 ## Failures
 
-- None found in this fresh Codex subagent validation after the feature_path doc-schema update.
-- No transcript, verdict, output, or diagnostics artifact was generated in this worker pass.
+- None. The current `idea-to-spec` and `project-init` contract satisfies all greenfield bootstrap routing assertions.
 
 ## Next Steps
 
-- fixture 中 `PRD.md` 属于 cleanup 目标，不应视为本轮新产物。
-- 后续若将该 fixture 扩展为真实 PRD 产物校验，应断言输出使用 `docs/pm/{feature_path}/PRD.md` 而不是根目录 `PRD.md`。
+- Keep this eval as PM-first coverage for empty-workspace app requests.
+- Re-run fresh validation if project-init or stale runtime cleanup behavior changes.
 
 ## Runtime Artifacts Policy
 
-- No runtime artifacts were created in this worker pass. Runtime transcripts, verdicts, timing, outputs, and diagnostics should not be committed.
+- No runtime artifacts were created or committed. Transcripts, verdicts, timing, outputs, and diagnostics must remain outside git.

--- a/agents/product_manager/test/idea-to-spec/workspace/iteration-2/eval-5-pm-agent-direct-delegation/comparison.md
+++ b/agents/product_manager/test/idea-to-spec/workspace/iteration-2/eval-5-pm-agent-direct-delegation/comparison.md
@@ -3,48 +3,45 @@
 ## Evaluation Target
 
 - Agent: `product_manager`
-- Skill: `idea-to-spec`
+- Skill: `pm-agent` -> `idea-to-spec`
 - Eval: `eval-005-pm-agent-direct-delegation`
 - Test case: pm-agent-direct-delegation
 - Workspace: `workspace/iteration-2/eval-5-pm-agent-direct-delegation`
-- Latest result: PARTIAL - prior skill validation evidence is preserved; without_skill baseline was not generated for this historical comparison.
-- Prior validation note: fresh Codex subagent validation on 2026-06-23 after the feature_path doc-schema update
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: Verifies that idea-to-spec handles pm-agent-direct-delegation and produces the expected role-specific artifact.
-- Expected output: 通过 pm-agent 入口先识别为 PM-first 的新产品需求，再直接继续进入 idea-to-spec 的上下文摘要与需求收敛流程；不会停在'推荐技能'或'是否需要我帮你唤起'这类 dispatcher 元回答。
-- Validation context: fresh Codex subagent semantic validation on 2026-06-23 after `prd-schema.md`, `brd-schema.md`, `test-spec-schema.md`, and `trd-schema.md` added explicit `feature_path` metadata requirements.
+- Fixture: `/pm-agent` entry command for a greenfield AI chat assistant idea
+- Expected output: route through PM entry, immediately continue into `idea-to-spec` requirement shaping, and avoid dispatcher-only meta-answer.
 
 ## Assertions
 
-- `dispatcher`: 入口 dispatcher 直接下钻
-- `skill`: 不反问是否调用子 skill
-- `pm`: 进入 PM 流程
+- `dispatcher`: dispatcher directly drills into `idea-to-spec`
+- `skill`: no "do you want me to invoke" handoff question
+- `pm`: same response continues product positioning, MVP, scope, or requirement shaping
 
 ## With Skill
 
-Observed behavior:
+- `pm-agent` treats the request as a PM-first new product idea and selects `idea-to-spec`.
+- The downstream execution contract says the dispatcher must immediately continue with the selected PM skill in the same response.
+- It must not stop at a meta-routing answer, ask whether to invoke `idea-to-spec`, or tell the user to run a manual sub-skill command.
+- The expected next behavior is `idea-to-spec` Phase 0 context summary and requirement-shaping prompt for the left-history / right-chat product.
 
-- The current `pm-agent` downstream contract requires direct continuation into the selected downstream PM skill in the same response.
-- For this greenfield PM request, `pm-agent` must route to `idea-to-spec`, preserve PM-first context, and continue into Phase 0 / requirement shaping instead of stopping at a dispatcher-only explanation.
-- The fixture explicitly validates that the entry command `/pm-agent` does not ask whether to invoke `idea-to-spec` or require manual sub-skill execution.
-- The feature_path schema update does not change dispatcher expectations, but once the delegated `idea-to-spec` flow reaches durable document output, it must apply the same feature path gate and handoff fields.
+## Without Skill / without_skill Baseline
 
-## Without Skill / Baseline
-- BLOCKED: No actual without_skill baseline result is recorded for this historical comparison. This file is not treated as a full eval PASS until a baseline result is generated and written here.
-- Without the dispatcher contract, the likely risk is a meta-routing response that recommends `idea-to-spec` but does not actually begin PM requirement shaping.
+- The baseline read the eval item and fixture before target skill docs. A generic dispatcher could only recommend `idea-to-spec` and wait for user confirmation.
+- It may not continue into product positioning, MVP scope, or requirement questions in the same turn.
 
 ## Failures
 
-- None found in this fresh Codex subagent validation after the feature_path doc-schema update.
-- No transcript, verdict, output, or diagnostics artifact was generated in this worker pass.
+- None. The current `pm-agent` downstream execution contract and `idea-to-spec` entry behavior satisfy all delegation assertions.
 
 ## Next Steps
 
-- 保留该 eval 防止 dispatcher 只做元回答；后续产物型扩展应覆盖 delegated flow 中的 feature_path handoff。
+- Keep this eval as coverage for PM dispatcher direct delegation.
+- Re-run fresh validation if `pm-agent` routing output behavior changes.
 
 ## Runtime Artifacts Policy
 
-- No runtime artifacts were created in this worker pass. Runtime transcripts, verdicts, timing, outputs, and diagnostics should not be committed.
+- No runtime artifacts were created or committed. Transcripts, verdicts, timing, outputs, and diagnostics must remain outside git.

--- a/agents/product_manager/test/idea-to-spec/workspace/iteration-3/eval-6-nested-feature-path/comparison.md
+++ b/agents/product_manager/test/idea-to-spec/workspace/iteration-3/eval-6-nested-feature-path/comparison.md
@@ -7,45 +7,42 @@
 - Eval: `eval-006-nested-feature-path`
 - Test case: nested-feature-path
 - Workspace: `workspace/iteration-3/eval-6-nested-feature-path`
-- Latest result: PASS - durable comparison coverage updated on 2026-06-25 for a real 4-level `feature_path`; no fresh model transcript or runtime output was generated in this worker pass.
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: Existing approved parent PRDs at `docs/pm/chat-interface/PRD.md`, `docs/pm/chat-interface/messages/PRD.md`, and `docs/pm/chat-interface/messages/history/PRD.md`.
-- 4+ fixture path: `chat-interface/messages/history/search`.
-- Expected output: scan existing PM PRDs, resolve `feature_path=chat-interface/messages/history/search`, avoid `docs/pm/history-search/PRD.md`, `docs/pm/search/PRD.md`, and `docs/pm/chat-interface/history-search/PRD.md`, and include feature path fields in the handoff packet.
-- Validation context: current durable fixture and eval contract review on 2026-06-25 after the 4-level coverage gap was identified.
+- Fixture: approved PM PRDs for `chat-interface`, `chat-interface/messages`, and `chat-interface/messages/history`
+- Expected output: scan existing PRDs, resolve search under `chat-interface/messages/history/search`, avoid parallel / truncated paths, and include feature path fields in the handoff packet.
 
 ## Assertions
 
-- PASS `scan_existing_prds`: first turn scans existing PM PRDs before choosing a target folder.
-- PASS `nested_feature_path`: child feature resolves under the existing 4-level parent feature tree.
-- PASS `no_parallel_top_level`: does not choose a parallel top-level or truncated child directory.
-- PASS `handoff_fields`: handoff packet includes `feature_path`, `feature`, `parent_feature`, `feature_level`, and `feature_path_evidence`.
+- `scan_existing_prds`: scan or read existing PM PRDs first
+- `nested_feature_path`: resolve to `chat-interface/messages/history/search`
+- `no_parallel_top_level`: do not choose `docs/pm/history-search/PRD.md` or `docs/pm/chat-interface/history-search/PRD.md`
+- `handoff_fields`: include `feature_path`, `feature`, `parent_feature`, `feature_level`, and `feature_path_evidence`
 
 ## With Skill
 
-- Expected with-skill behavior is to scan `docs/pm/**/PRD.md`, find the existing message history parent at `docs/pm/chat-interface/messages/history/PRD.md`, and keep the new search capability under that parent.
-- The target PM artifact is `docs/pm/chat-interface/messages/history/search/PRD.md` with `feature_path: chat-interface/messages/history/search`, `feature: search`, `parent_feature: chat-interface/messages/history`, and `feature_level: 4`.
-- The handoff packet must preserve `feature_path`, `feature`, `parent_feature`, `feature_level`, and `feature_path_evidence` so Engineer, Designer, QA, DevOps, and Security can mirror the same path.
-- The skill contract blocks `docs/pm/search/PRD.md`, `docs/pm/history-search/PRD.md`, and `docs/pm/chat-interface/history-search/PRD.md` because those paths drop confirmed ancestry.
+- `idea-to-spec` requires scanning `docs/pm/**/PRD.md` before choosing or writing a feature folder.
+- The fixture establishes an approved parent chain: `chat-interface` -> `chat-interface/messages` -> `chat-interface/messages/history`.
+- Message history search is a child under the confirmed history feature, so the correct `feature_path` is `chat-interface/messages/history/search`, with `feature=search`, `parent_feature=chat-interface/messages/history`, and `feature_level=4`.
+- The handoff packet must include the feature path fields and `{source, reason}` evidence from the existing PRDs.
 
-## Without Skill / Baseline
-- Not run in this worker pass.
-- High-level baseline contrast: a generic PM response may scan only the display name and create `docs/pm/history-search/PRD.md` or reuse the older 2-level `docs/pm/chat-interface/history-search/PRD.md`, losing the confirmed `messages/history` ancestry and producing an incomplete handoff packet.
+## Without Skill / without_skill Baseline
+
+- The baseline read the eval item and fixture before target skill docs. A generic response could choose the shorter display-name path `docs/pm/history-search/PRD.md` or reuse the older two-level `docs/pm/chat-interface/history-search/PRD.md`.
+- It may also omit `parent_feature`, `feature_level`, or structured `feature_path_evidence`.
 
 ## Failures
 
-- None in the durable eval definition, fixture, and assertion alignment reviewed on 2026-06-25.
-- No transcript, verdict, output, or diagnostics artifact was generated in this worker pass.
+- None. The current `idea-to-spec` feature document memory rules satisfy all nested feature path assertions.
 
 ## Next Steps
 
-- Keep this eval as issue #37 PM coverage for 4-level `feature_path` routing.
-- If model eval workflow is run later, compare transcript behavior against this durable expectation and keep runtime artifacts out of git.
-- Future PM eval additions should preserve the no-parallel-top-level assertion for 4+ paths.
+- Keep this eval as issue #37 coverage for multi-level PM feature ownership.
+- Re-run fresh validation if feature path inheritance or handoff fields change.
 
 ## Runtime Artifacts Policy
 
-- No runtime artifacts were created in this worker pass. Runtime transcripts, verdicts, timing, outputs, and diagnostics should not be committed.
+- No runtime artifacts were created or committed. Transcripts, verdicts, timing, outputs, and diagnostics must remain outside git.

--- a/agents/product_manager/test/idea-to-spec/workspace/iteration-3/eval-7-api-adr-engineer-handoff/comparison.md
+++ b/agents/product_manager/test/idea-to-spec/workspace/iteration-3/eval-7-api-adr-engineer-handoff/comparison.md
@@ -7,43 +7,42 @@
 - Eval: `eval-007-api-adr-engineer-handoff`
 - Test case: api-adr-engineer-handoff
 - Workspace: `workspace/iteration-3/eval-7-api-adr-engineer-handoff`
-- Latest result: PARTIAL - prior skill validation evidence is preserved; without_skill baseline was not generated for this historical comparison.
-- Prior validation note: fresh Codex subagent validation on 2026-06-23 after API / ADR ownership migration and PM deprecated stub cleanup
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: Confirmed PM PRD at `docs/pm/chat-interface/history-search/PRD.md`.
-- Expected output: PM does not generate Engineer API or ADR docs directly; it hands a feature path packet to `engineer-agent:trd-gen`.
+- Fixture: confirmed PM PRD at `docs/pm/chat-interface/history-search/PRD.md`
+- Expected output: PM does not generate Engineer API or ADR docs directly; it hands a feature path packet to `engineer-agent:trd-gen` and mirrors output paths under `docs/engineer/chat-interface/history-search/`.
 
 ## Assertions
 
-- `does_not_use_pm_api_adr_generators`: PM does not directly generate API or ADR docs.
-- `routes_to_trd_gen`: next owner is `engineer-agent:trd-gen`.
-- `engineer_paths_mirror_feature_path`: Engineer output paths mirror `chat-interface/history-search`.
-- `handoff_contains_feature_path_evidence`: handoff packet includes feature path fields, PRD path, and API / ADR context.
+- `does_not_use_pm_api_adr_generators`: API and ADR are Engineer-owned
+- `routes_to_trd_gen`: next owner is `engineer-agent:trd-gen`
+- `engineer_paths_mirror_feature_path`: Engineer outputs mirror `chat-interface/history-search`
+- `handoff_contains_feature_path_evidence`: handoff packet includes feature path fields, PRD path, and API / ADR context
 
 ## With Skill
 
-Observed behavior:
+- The shared `idea-to-spec` skill map routes API and ADR generation to `engineer-agent:trd-gen`; PM internal API / ADR resources are not used to create Engineer-owned documents.
+- The confirmed PRD provides `feature_path=chat-interface/history-search`, `parent_feature=chat-interface`, and `feature_level=2`.
+- The required Engineer-owned outputs are under `docs/engineer/chat-interface/history-search/`, including `API.md` and `ADR-*.md`, not `docs/engineer/history-search/`.
+- The handoff packet carries `feature_path`, `parent_feature`, `feature_level`, PRD source path, API goals, and search-index decision background.
 
-- The current `idea-to-spec` skill routes stable technical planning, API documentation, and ADR creation or revision to `engineer-agent:trd-gen` after PRD confirmation.
-- PM keeps ownership of product requirements and decision context only. The historical PM internal `api-gen`, `adr-gen`, `api-iteration`, and `adr-iteration` resources are deprecated handoff stubs and must not write Engineer-owned documents.
-- The handoff packet carries `feature_path=chat-interface/history-search`, `parent_feature=chat-interface`, `feature_level=2`, the PRD path, API goals, and the search-index decision background.
-- API and ADR outputs are expected under `docs/engineer/chat-interface/history-search/`, preventing a parallel `docs/engineer/history-search/` directory.
+## Without Skill / without_skill Baseline
 
-## Without Skill / Baseline
-- BLOCKED: No actual without_skill baseline result is recorded for this historical comparison. This file is not treated as a full eval PASS until a baseline result is generated and written here.
-- Without the ownership gate, PM could directly use the historical internal API / ADR generators and write Engineer docs using only the terminal feature name.
+- The baseline read the eval item and fixture before target skill docs. A generic PM response could directly draft API and ADR documents from the PRD.
+- It may also choose a terminal-only Engineer path such as `docs/engineer/history-search/`, losing the confirmed feature-path mirror.
 
 ## Failures
 
-- None found in this fresh Codex subagent validation.
+- None. The current `idea-to-spec` ownership and handoff rules satisfy all API / ADR assertions.
 
 ## Next Steps
 
-- Keep this eval as PM coverage for API / ADR Engineer handoff and feature path mirroring.
+- Keep this eval as PM coverage for Engineer-owned API / ADR handoff and path mirroring.
+- Re-run fresh validation if API / ADR ownership or Engineer handoff paths change.
 
 ## Runtime Artifacts Policy
 
-- Runtime transcripts, verdicts, timing, outputs, and diagnostics should not be committed.
+- No runtime artifacts were created or committed. Transcripts, verdicts, timing, outputs, and diagnostics must remain outside git.

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-1-route-greenfield-product-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-1-route-greenfield-product-request/comparison.md
@@ -6,33 +6,34 @@
 - Test case: route-greenfield-product-request
 - Test set: PM entry evals for issue #52 / FR-006 scenario 1
 - Entry: workspace `eval-1-route-greenfield-product-request`
-- Latest result: PASS (deterministic Batch 2 route coverage)
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
 - Fixture: empty-workspace product idea request
+- Expected output: route to `idea-to-spec`, keep the PM-first boundary, name the PM artifacts and downstream handoff points.
 
 ## With Skill
 
-- Routes the empty-workspace product idea to `idea-to-spec`.
-- Preserves the PM-first boundary before design or engineering execution.
-- Names the expected PM documents and downstream handoff points.
+- The `pm-agent` protocol treats empty or near-empty product requests as PM-first and routes the AI chat assistant idea to `idea-to-spec`.
+- It blocks direct engineering bootstrap unless the user explicitly asks to skip PM.
+- It names the context to collect: user goal, core flows, scope, acceptance criteria, open questions, PRD / BRD / DECISIONS output, and later `engineer-agent:trd-gen` after scope is stable.
 
-## Without Skill / Baseline
+## Without Skill / without_skill Baseline
 
-- May jump directly to project scaffolding or implementation planning.
-- Less consistently separates PM discovery from engineering execution.
+- The baseline read the eval item and fixture before target skill docs. A generic response could recommend scaffolding or implementation planning for the left-right chat UI because the user describes a concrete screen.
+- It may mention product clarification, but it is less reliable about the formal PM-first guardrail, the `idea-to-spec` route, and the delayed Designer / Engineer handoff boundary.
 
 ## Failures
 
-- None recorded.
+- None. All assertions are satisfied by the current `pm-agent` routing and PM-first guardrail.
 
 ## Next Steps
 
-- Re-run with fresh Codex subagent validation in the post-merge centralized
-  skill-eval pass.
+- Keep this eval as PM entry coverage for empty-workspace product ideas.
+- Re-run fresh validation only when `pm-agent`, `idea-to-spec`, or PM handoff rules change.
 
 ## Runtime Artifacts Policy
 
-- Runtime transcripts, verdicts, timing, and diagnostics should not be committed.
+- No runtime artifacts were created or committed. Transcripts, verdicts, timing, outputs, and diagnostics must remain outside git.

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-10-change-tier-hotfix-fast-lane/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-10-change-tier-hotfix-fast-lane/comparison.md
@@ -6,38 +6,34 @@
 - Test case: change-tier-hotfix-fast-lane
 - Test set: change-tier contract evals for issue #55 / FR-008
 - Entry: workspace `eval-10-change-tier-hotfix-fast-lane`
-- Latest result: PARTIAL - deterministic Batch 4 definition and pytest coverage
-  exist, but fresh centralized subagent validation is deferred to the
-  post-merge skill-eval pass.
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: already-scoped README link fix with verification evidence
+- Fixture: README link fix that does not change approved behavior and has local verification evidence
+- Expected output: classify as `hotfix`, allow fast lane after classification, and preserve scope / source / verification evidence.
 
 ## With Skill
 
-- Classifies the request as `hotfix` because it does not change approved
-  behavior and can be covered by direct evidence.
-- Allows the fast lane only after classification.
-- Keeps scope, source evidence, and verification evidence requirements.
+- The `pm-agent` change-tier rule classifies unchanged-expectation lightweight fixes as `hotfix`.
+- It allows `hotfix` plus `delivery` / `status` requests to use the fast lane only after scope, source evidence, and verification status are confirmed.
+- It keeps verification evidence requirements intact rather than treating fast lane as no-evidence delivery.
 
-## Without Skill / Baseline
+## Without Skill / without_skill Baseline
 
-- May skip `change_tier` classification.
-- May treat the fast lane as permission to omit verification evidence.
+- The baseline read the eval item and fixture before target skill docs. A generic response could accept fast lane but omit the structured evidence requirement.
+- It may not distinguish classification-before-fast-lane from immediate delivery.
 
-## Failures / Coverage Gaps
+## Failures
 
-- Fresh Codex subagent validation has not run for this scenario in this PR.
-- A new without-skill baseline will be generated in the post-merge centralized
-  skill-eval pass.
+- None. The current `pm-agent` change-tier rule satisfies all hotfix fast-lane assertions.
 
 ## Next Steps
 
-- Run fresh with-skill and without-skill validation in the centralized eval
-  phase after Batch 4 merges.
+- Keep this eval as coverage for valid hotfix fast-lane handling.
+- Re-run fresh validation if change-tier definitions or fast-lane evidence requirements change.
 
 ## Runtime Artifacts Policy
 
-- Runtime transcripts, verdicts, timing, and diagnostics should not be committed.
+- No runtime artifacts were created or committed. Transcripts, verdicts, timing, outputs, and diagnostics must remain outside git.

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-11-change-tier-standard-full-gate/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-11-change-tier-standard-full-gate/comparison.md
@@ -6,37 +6,34 @@
 - Test case: change-tier-standard-full-gate
 - Test set: change-tier contract evals for issue #55 / FR-008
 - Entry: workspace `eval-11-change-tier-standard-full-gate`
-- Latest result: PARTIAL - deterministic Batch 4 definition and pytest coverage
-  exist, but fresh centralized subagent validation is deferred to the
-  post-merge skill-eval pass.
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: refund approval behavior change mislabeled as small
+- Fixture: refund approval behavior change mislabeled as small hotfix
+- Expected output: classify as `existing_update`, reject `hotfix`, set `standard` or higher, and require PRD/TRD expectation alignment.
 
 ## With Skill
 
-- Classifies the request as `existing_update`.
-- Rejects `hotfix` because the approved business behavior changes.
-- Keeps PRD/TRD or equivalent expectation alignment before downstream handoff.
+- The `pm-agent` change-tier rule rejects `hotfix` when approved product behavior changes.
+- Changing refund approval from automatic approval to admin secondary confirmation is an `existing_update` and at least `standard`.
+- The request stays on the PM path for PRD/TRD or equivalent expectation alignment before downstream implementation.
 
-## Without Skill / Baseline
+## Without Skill / without_skill Baseline
 
-- May accept the user's "small" framing and skip expectation alignment.
-- May hand off implementation before product behavior is confirmed.
+- The baseline read the eval item and fixture before target skill docs. A generic response could accept the user's "small" framing and skip expectation alignment.
+- It may hand off implementation before confirming changed business behavior and downstream document impact.
 
-## Failures / Coverage Gaps
+## Failures
 
-- Fresh Codex subagent validation has not run for this scenario in this PR.
-- A new without-skill baseline will be generated in the post-merge centralized
-  skill-eval pass.
+- None. The current change-tier rule satisfies all standard full-gate assertions.
 
 ## Next Steps
 
-- Run fresh with-skill and without-skill validation in the centralized eval
-  phase after Batch 4 merges.
+- Keep this eval as coverage for behavior changes mislabeled as hotfix.
+- Re-run fresh validation if change-tier or existing-update gates change.
 
 ## Runtime Artifacts Policy
 
-- Runtime transcripts, verdicts, timing, and diagnostics should not be committed.
+- No runtime artifacts were created or committed. Transcripts, verdicts, timing, outputs, and diagnostics must remain outside git.

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-12-change-tier-hotfix-abuse-blocked/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-12-change-tier-hotfix-abuse-blocked/comparison.md
@@ -6,40 +6,34 @@
 - Test case: change-tier-hotfix-abuse-blocked
 - Test set: change-tier contract evals for issue #55 / FR-008
 - Entry: workspace `eval-12-change-tier-hotfix-abuse-blocked`
-- Latest result: PARTIAL - deterministic Batch 4 definition and pytest coverage
-  exist, but fresh centralized subagent validation is deferred to the
-  post-merge skill-eval pass.
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: membership trial duration change mislabeled as hotfix
+- Fixture: membership trial duration change mislabeled as hotfix to skip PM
+- Expected output: reject hotfix abuse, identify expectation / business-rule change, and block or return to PM for scope confirmation.
 
 ## With Skill
 
-- Rejects the user's requested `hotfix` label.
-- Classifies the expectation change as `standard` or higher, or blocks until PM
-  expectation alignment completes.
-- Does not hand off implementation before scope and product behavior are
-  confirmed.
+- The `pm-agent` protocol explicitly says new requirements, expectation changes, and unclear scope stay on the PM path and must not be routed as `hotfix`.
+- Changing trial duration from 7 days to 30 days is a business-rule expectation change, so the request is `standard` or higher.
+- It blocks direct implementation and returns to PM expectation and scope confirmation.
 
-## Without Skill / Baseline
+## Without Skill / without_skill Baseline
 
-- May follow the user's `hotfix` framing and skip PM alignment.
-- May send implementation downstream without confirming the changed business
-  expectation.
+- The baseline read the eval item and fixture before target skill docs. A generic response could follow the user's hotfix framing and start the value change.
+- It may not catch that the request is trying to use `hotfix` as an escape hatch from PM alignment.
 
-## Failures / Coverage Gaps
+## Failures
 
-- Fresh Codex subagent validation has not run for this scenario in this PR.
-- A new without-skill baseline will be generated in the post-merge centralized
-  skill-eval pass.
+- None. The current `pm-agent` protocol satisfies all hotfix-abuse assertions.
 
 ## Next Steps
 
-- Run fresh with-skill and without-skill validation in the centralized eval
-  phase after Batch 4 merges.
+- Keep this eval as coverage for attempts to misuse `hotfix`.
+- Re-run fresh validation if change-tier abuse handling changes.
 
 ## Runtime Artifacts Policy
 
-- Runtime transcripts, verdicts, timing, and diagnostics should not be committed.
+- No runtime artifacts were created or committed. Transcripts, verdicts, timing, outputs, and diagnostics must remain outside git.

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-13-change-tier-hotfix-e2e-direct-path/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-13-change-tier-hotfix-e2e-direct-path/comparison.md
@@ -6,38 +6,34 @@
 - Test case: change-tier-hotfix-e2e-direct-path
 - Test set: change-tier contract evals for issue #55 / FR-008
 - Entry: workspace `eval-13-change-tier-hotfix-e2e-direct-path`
-- Latest result: PARTIAL - deterministic Batch 4 definition and pytest coverage
-  exist, but fresh centralized subagent validation is deferred to the
-  post-merge skill-eval pass.
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: narrow login empty-state copy hotfix
+- Fixture: login empty-state copy hotfix with QA/E2E scope question
+- Expected output: limit hotfix QA/E2E to directly affected path, still record verification evidence and blocked checks, and avoid full-suite requirement unless risk escalates.
 
 ## With Skill
 
-- Allows hotfix QA/E2E scope to focus on the directly affected path.
-- Still requires verification evidence, result recording, and blocked-check
-  disclosure.
-- Avoids forcing a full E2E suite unless risk or scope escalates.
+- The repository change-tier contract allows hotfix QA/E2E coverage to focus on the directly affected path.
+- The `pm-agent` routing still requires verification evidence, results, and any blocked checks to be recorded.
+- It does not require the full E2E suite unless risk or scope upgrades the work to `standard` / `major`.
 
-## Without Skill / Baseline
+## Without Skill / without_skill Baseline
 
-- May treat `hotfix` as no-QA-needed.
-- May require a full E2E suite even when the change is safely direct-path only.
+- The baseline read the eval item and fixture before target skill docs. A generic response could either skip QA entirely because the change is "just copy" or require a full suite without considering hotfix scope.
+- It is less reliable about preserving evidence while narrowing coverage to the direct login empty-state path.
 
-## Failures / Coverage Gaps
+## Failures
 
-- Fresh Codex subagent validation has not run for this scenario in this PR.
-- A new without-skill baseline will be generated in the post-merge centralized
-  skill-eval pass.
+- None. The current change-tier and QA gate language satisfies all hotfix E2E assertions.
 
 ## Next Steps
 
-- Run fresh with-skill and without-skill validation in the centralized eval
-  phase after Batch 4 merges.
+- Keep this eval as coverage for hotfix QA/E2E scoping.
+- Re-run fresh validation if QA E2E gates or change-tier rules change.
 
 ## Runtime Artifacts Policy
 
-- Runtime transcripts, verdicts, timing, and diagnostics should not be committed.
+- No runtime artifacts were created or committed. Transcripts, verdicts, timing, outputs, and diagnostics must remain outside git.

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-2-route-bugfix-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-2-route-bugfix-request/comparison.md
@@ -6,35 +6,34 @@
 - Test case: route-bugfix-request
 - Test set: PM entry evals for issue #52 / FR-006 scenario 2
 - Entry: workspace `eval-2-route-bugfix-request`
-- Latest result: PASS (deterministic Batch 2 route coverage)
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: bug-fix request without confirmed product expectation
+- Fixture: login bug report before expected behavior has been checked
+- Expected output: classify as `bug_report`, confirm approved PRD / TRD expected behavior first, then hand off to Engineer/debugger only after implementation deviation is established.
 
 ## With Skill
 
-- Classifies the request as `bug_report`.
-- Keeps the request in PM long enough to confirm expected behavior from
-  approved PRD / TRD or equivalent source docs.
-- Allows Engineer/debugger handoff only after the report is confirmed as an
-  implementation deviation.
+- The `pm-agent` classification protocol explicitly maps bug reports to `bug_report`.
+- It requires comparing the reported token-expiry spinner against approved PRD / TRD or equivalent product expectations before diagnosing implementation.
+- It only allows Engineer/debugger handoff after expected behavior is confirmed and the issue is an implementation deviation.
 
-## Without Skill / Baseline
+## Without Skill / without_skill Baseline
 
-- May jump directly into debugging from the error log.
-- Less consistently checks product expectation before diagnosing code.
+- The baseline read the eval item and fixture before target skill docs. A generic response could jump straight into debugging the token expiry behavior from logs.
+- It may ask for reproduction details, but is less consistent about product expectation alignment before debugger handoff.
 
 ## Failures
 
-- None recorded in deterministic coverage.
+- None. The current `pm-agent` protocol satisfies the bug classification and expectation-first assertions.
 
 ## Next Steps
 
-- Re-run with fresh Codex subagent validation in the post-merge centralized
-  skill-eval pass.
+- Keep this eval as PM entry coverage for bug reports.
+- Re-run fresh validation if bug handling or debugger handoff gates change.
 
 ## Runtime Artifacts Policy
 
-- Runtime transcripts, verdicts, timing, and diagnostics should not be committed.
+- No runtime artifacts were created or committed. Transcripts, verdicts, timing, outputs, and diagnostics must remain outside git.

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-3-route-test-writing-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-3-route-test-writing-request/comparison.md
@@ -6,36 +6,34 @@
 - Test case: route-test-writing-request
 - Test set: PM entry evals for issue #52 / FR-006 scenario 3
 - Entry: workspace `eval-3-route-test-writing-request`
-- Latest result: PASS (deterministic Batch 2 route coverage)
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
 - Fixture: test-writing request without confirmed test basis
+- Expected output: classify as `validation`, name PRD / TRD / IMPLEMENTATION_PLAN or existing acceptance evidence, then hand off QA or Engineer/test-writer only after expectations are stable.
 
 ## With Skill
 
-- Classifies the request as `validation`.
-- Requires a stable test basis from PRD, TRD, implementation plan, or existing
-  acceptance evidence.
-- Hands off to QA or Engineer/test-writer only after expectations and source
-  documents are named.
+- The `pm-agent` classification protocol maps test-writing and validation requests to `validation`.
+- It requires a stable test basis from PRD, TRD, confirmed implementation plan, or existing acceptance record.
+- It allows QA or Engineer/test-writer handoff only after source documents and expected behavior are named.
 
-## Without Skill / Baseline
+## Without Skill / without_skill Baseline
 
-- May start writing tests from the user request alone.
-- Less consistently names the PRD / TRD / implementation-plan evidence needed
-  for durable coverage.
+- The baseline read the eval item and fixture before target skill docs. A generic response could begin writing refund-flow tests from the user request alone.
+- It may ask about scenarios, but is less reliable about requiring durable PM / Engineer source evidence before test coverage.
 
 ## Failures
 
-- None recorded in deterministic coverage.
+- None. The current `pm-agent` protocol satisfies the validation and test-basis assertions.
 
 ## Next Steps
 
-- Re-run with fresh Codex subagent validation in the post-merge centralized
-  skill-eval pass.
+- Keep this eval as PM entry coverage for test-writing requests.
+- Re-run fresh validation if QA or Engineer/test-writer handoff criteria change.
 
 ## Runtime Artifacts Policy
 
-- Runtime transcripts, verdicts, timing, and diagnostics should not be committed.
+- No runtime artifacts were created or committed. Transcripts, verdicts, timing, outputs, and diagnostics must remain outside git.

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-4-route-ui-update-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-4-route-ui-update-request/comparison.md
@@ -6,36 +6,34 @@
 - Test case: route-ui-update-request
 - Test set: PM entry evals for issue #52 / FR-006 scenario 4
 - Entry: workspace `eval-4-route-ui-update-request`
-- Latest result: PASS (deterministic Batch 2 route coverage)
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: frontend UI update request with ambiguous PM / Designer / Engineer
-  ownership
+- Fixture: frontend UI update request with ambiguous PM / Designer / Engineer ownership
+- Expected output: classify as `design` or `existing_update`, decide whether PM expectation update, Designer artifact, or Engineer implementation is needed, and delay implementation until alignment is complete.
 
 ## With Skill
 
-- Classifies the request as `design` or `existing_update`.
-- Checks whether product expectations changed before selecting a downstream
-  owner.
-- Sends design artifacts to Designer and waits for PM / TRD / design alignment
-  before Engineer frontend implementation.
+- The `pm-agent` protocol distinguishes UI / UX design artifacts from frontend implementation.
+- It requires checking whether the settings page layout change alters product expectations before picking Designer or Engineer.
+- It routes design artifacts to Designer and waits for PM / TRD / design alignment before Engineer frontend implementation.
 
-## Without Skill / Baseline
+## Without Skill / without_skill Baseline
 
-- May treat UI wording as direct frontend implementation.
-- Less consistently separates design artifact needs from code execution.
+- The baseline read the eval item and fixture before target skill docs. A generic response could treat the UI request as direct frontend work.
+- It may mention design review, but is less consistent about separating PM expectation changes, design deliverables, and implementation readiness.
 
 ## Failures
 
-- None recorded in deterministic coverage.
+- None. The current `pm-agent` protocol satisfies the UI routing assertions.
 
 ## Next Steps
 
-- Re-run with fresh Codex subagent validation in the post-merge centralized
-  skill-eval pass.
+- Keep this eval as PM entry coverage for UI update routing.
+- Re-run fresh validation if Designer or Engineer handoff boundaries change.
 
 ## Runtime Artifacts Policy
 
-- Runtime transcripts, verdicts, timing, and diagnostics should not be committed.
+- No runtime artifacts were created or committed. Transcripts, verdicts, timing, outputs, and diagnostics must remain outside git.

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-5-route-deployment-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-5-route-deployment-request/comparison.md
@@ -6,36 +6,34 @@
 - Test case: route-deployment-request
 - Test set: PM entry evals for issue #52 / FR-006 scenario 5
 - Entry: workspace `eval-5-route-deployment-request`
-- Latest result: PASS (deterministic Batch 2 route coverage)
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
 - Fixture: repo-wide CI and release-readiness request
+- Expected output: classify as `deployment`, allow repo-wide `N/A` feature fields, and prepare DevOps handoff with operational scope.
 
 ## With Skill
 
-- Classifies the request as `deployment`.
-- Allows confirmed non-feature repo-wide work to use `N/A` feature-scope fields
-  and empty `feature_path_evidence`.
-- Records operational goal, environment, release scope, rollback needs, and
-  risks before DevOps handoff.
+- The `pm-agent` protocol maps CI and release-readiness work to `deployment`.
+- It allows confirmed non-feature repo-wide work to use `feature_path: N/A`, related feature fields as `N/A`, and `feature_path_evidence: []`.
+- It requires operational goal, environment, release scope, rollback needs, and risks before DevOps handoff.
 
-## Without Skill / Baseline
+## Without Skill / without_skill Baseline
 
-- May jump directly into CI implementation without recording operational scope.
-- Less consistently distinguishes repo-wide deployment work from feature-scoped
-  DevOps outputs.
+- The baseline read the eval item and fixture before target skill docs. A generic response could jump directly into CI configuration.
+- It may not preserve the repo-wide non-feature scope rule or the complete DevOps handoff context.
 
 ## Failures
 
-- None recorded in deterministic coverage.
+- None. The current `pm-agent` protocol satisfies deployment classification and repo-wide scope assertions.
 
 ## Next Steps
 
-- Re-run with fresh Codex subagent validation in the post-merge centralized
-  skill-eval pass.
+- Keep this eval as PM entry coverage for deployment and CI routing.
+- Re-run fresh validation if repo-wide feature-scope handling changes.
 
 ## Runtime Artifacts Policy
 
-- Runtime transcripts, verdicts, timing, and diagnostics should not be committed.
+- No runtime artifacts were created or committed. Transcripts, verdicts, timing, outputs, and diagnostics must remain outside git.

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-6-route-security-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-6-route-security-request/comparison.md
@@ -6,35 +6,34 @@
 - Test case: route-security-request
 - Test set: PM entry evals for issue #52 / FR-006 scenario 6
 - Entry: workspace `eval-6-route-security-request`
-- Latest result: PASS (deterministic Batch 2 route coverage)
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: authorization, dependency, and secret-risk review request
+- Fixture: authorization, dependency, and secrets-risk review request
+- Expected output: classify as `security`, capture risk scope, and hand off Security with scope and required output.
 
 ## With Skill
 
-- Classifies the request as `security`.
-- Records risk surface, assets, permissions, data flow, and remediation
-  expectations.
-- Hands off to Security with scope and required output.
+- The `pm-agent` protocol maps authorization, dependency risk, secrets, privacy, upload, webhook, login, and data-flow risk requests to `security`.
+- It requires recording risk surface, assets, permissions, data flow, and remediation expectations.
+- It hands off to Security with a bounded review packet instead of doing the security specialist work itself.
 
-## Without Skill / Baseline
+## Without Skill / without_skill Baseline
 
-- May start a security checklist without PM-side classification.
-- Less consistently names assets, permissions, and data-flow scope before
-  handoff.
+- The baseline read the eval item and fixture before target skill docs. A generic response could start a broad security checklist immediately.
+- It may miss the PM-side scope packet and required output definition for Security.
 
 ## Failures
 
-- None recorded in deterministic coverage.
+- None. The current `pm-agent` protocol satisfies security classification and handoff assertions.
 
 ## Next Steps
 
-- Re-run with fresh Codex subagent validation in the post-merge centralized
-  skill-eval pass.
+- Keep this eval as PM entry coverage for security routing.
+- Re-run fresh validation if Security handoff fields change.
 
 ## Runtime Artifacts Policy
 
-- Runtime transcripts, verdicts, timing, and diagnostics should not be committed.
+- No runtime artifacts were created or committed. Transcripts, verdicts, timing, outputs, and diagnostics must remain outside git.

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-7-direct-downstream-without-handoff/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-7-direct-downstream-without-handoff/comparison.md
@@ -6,39 +6,34 @@
 - Test case: direct-downstream-without-handoff
 - Test set: PM entry evals for issue #52 / FR-006 scenario 7
 - Entry: workspace `eval-7-direct-downstream-without-handoff`
-- Latest result: PARTIAL - deterministic Batch 4 gate coverage exists, but fresh
-  Codex subagent validation and a newly generated without-skill baseline are
-  deferred to the post-merge centralized skill-eval pass.
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
 - Fixture: direct downstream role-router request without PM handoff context
+- Expected output: reject direct downstream execution, return to `pm-agent`, and require PM handoff packet or equivalent confirmed docs.
 
 ## With Skill
 
-- Rejects direct downstream execution without a PM handoff packet or equivalent
-  confirmed source documents.
-- Returns the request to `pm-agent` for request type, scope, feature path, and
-  handoff readiness classification.
-- Avoids starting implementation, tests, delivery, or other role execution.
+- The `pm-agent` and downstream execution contract reject starting Engineer implementation without PM classification and source context.
+- It returns the request to `pm-agent` for request type, scope, feature path, and handoff readiness classification.
+- It requires PM handoff packet or equivalent confirmed PRD / TRD / design / test / deployment / security docs before downstream execution.
 
-## Without Skill / Baseline
+## Without Skill / without_skill Baseline
 
-- May treat the named downstream role as direct execution permission.
-- May begin implementation before source documents or scope are confirmed.
+- The baseline read the eval item and fixture before target skill docs. A generic response could honor the user's "directly use engineer-agent" instruction and start implementation planning.
+- It is less reliable about enforcing the PM handoff entry gate when the user explicitly asks to skip PM docs.
 
-## Failures / Coverage Gaps
+## Failures
 
-- Fresh Codex subagent validation has not run for this scenario in this PR.
-- A new without-skill baseline will be generated in the post-merge centralized
-  skill-eval pass.
+- None. The current PM entry gate satisfies all direct-downstream defense assertions.
 
 ## Next Steps
 
-- Run fresh with-skill and without-skill validation in the centralized eval
-  phase after Batch 4 merges.
+- Keep this eval as PM entry coverage for direct role-router bypass attempts.
+- Re-run fresh validation if downstream role-router entry gates change.
 
 ## Runtime Artifacts Policy
 
-- Runtime transcripts, verdicts, timing, and diagnostics should not be committed.
+- No runtime artifacts were created or committed. Transcripts, verdicts, timing, outputs, and diagnostics must remain outside git.

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-8-direct-specialist-bypass-gate/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-8-direct-specialist-bypass-gate/comparison.md
@@ -6,43 +6,34 @@
 - Test case: direct-specialist-bypass-gate
 - Test set: PM entry evals for issue #52 / FR-006 scenario 8
 - Entry: workspace `eval-8-direct-specialist-bypass-gate`
-- Latest result: PARTIAL - deterministic Batch 4 specialist-gate coverage exists,
-  but fresh Codex subagent validation and a newly generated without-skill
-  baseline are deferred to the post-merge centralized skill-eval pass.
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: direct internal specialist request without PRD/TRD, implementation
-  scope, or handoff
+- Fixture: direct internal specialist invocation without PRD, TRD, implementation plan, or PM handoff packet
+- Expected output: specialist entry gate blocks plan/code/test implementation and returns to `pm-agent` classification.
 
 ## With Skill
 
-- Enforces the specialist PM handoff entry gate even when the user names the
-  internal specialist directly.
-- Requires a PM handoff packet or equivalent confirmed PRD/TRD plus current
-  implementation scope. Existing `IMPLEMENTATION_PLAN.md` is not required for
-  first-time `feature-implementor` planning, because this specialist creates
-  that plan.
-- Blocks planning, code changes, and test implementation, then returns the
-  request to `pm-agent` classification.
+- The PM handoff entry gate applies even when an internal specialist is directly invoked.
+- It requires a PM handoff packet or equivalent confirmed PRD / TRD and current implementation scope before `feature-implementor` planning can proceed.
+- It blocks creating an implementation plan, writing code, or writing tests until the request returns to `pm-agent` classification.
 
-## Without Skill / Baseline
+## Without Skill / without_skill Baseline
 
-- May assume direct specialist invocation is permission to plan or implement.
-- May skip PM classification and source document checks.
+- The baseline read the eval item and fixture before target skill docs. A generic response could treat the explicit specialist invocation as permission to start planning.
+- It may incorrectly treat the missing implementation plan as something to create immediately instead of a downstream step after confirmed PM / TRD context.
 
-## Failures / Coverage Gaps
+## Failures
 
-- Fresh Codex subagent validation has not run for this scenario in this PR.
-- A new without-skill baseline will be generated in the post-merge centralized
-  skill-eval pass.
+- None. The current gate language satisfies all direct-specialist bypass assertions.
 
 ## Next Steps
 
-- Run fresh with-skill and without-skill validation in the centralized eval
-  phase after Batch 4 merges.
+- Keep this eval as coverage for internal specialist bypass attempts.
+- Re-run fresh validation if specialist entry prerequisites change.
 
 ## Runtime Artifacts Policy
 
-- Runtime transcripts, verdicts, timing, and diagnostics should not be committed.
+- No runtime artifacts were created or committed. Transcripts, verdicts, timing, outputs, and diagnostics must remain outside git.

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-9-missing-handoff-target-unavailable/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-9-missing-handoff-target-unavailable/comparison.md
@@ -6,38 +6,34 @@
 - Test case: missing-handoff-target-unavailable
 - Test set: PM entry evals for issue #52 / #62 missing target coverage
 - Entry: workspace `eval-9-missing-handoff-target-unavailable`
-- Latest result: PARTIAL - deterministic Batch 4 definition and pytest coverage
-  exist, but fresh centralized subagent validation is deferred to the
-  post-merge skill-eval pass.
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
 - Fixture: confirmed design handoff with missing `designer-agent`
+- Expected output: mark handoff blocked, name missing capability, and do not perform Designer responsibilities inside PM.
 
 ## With Skill
 
-- Detects that the target handoff capability is not installed or unavailable.
-- Marks the handoff stage as `blocked` and names the missing plugin or
-  capability.
-- Does not perform the missing Designer responsibility inside PM.
+- The `pm-agent` missing handoff target rule detects unavailable downstream agents or skills.
+- It names the missing `designer-agent` capability, marks that handoff stage as `blocked`, and records the blocker.
+- It does not substitute for Designer by producing visual specifications or design deliverables.
 
-## Without Skill / Baseline
+## Without Skill / without_skill Baseline
 
-- May continue by inventing the missing downstream role's output.
-- May fail to identify the installation or availability blocker.
+- The baseline read the eval item and fixture before target skill docs. A generic response could proceed by drafting a design spec despite the missing Designer capability.
+- It may mention installation but is less reliable about marking the handoff stage blocked and stopping at PM classification.
 
-## Failures / Coverage Gaps
+## Failures
 
-- Fresh Codex subagent validation has not run for this scenario in this PR.
-- A new without-skill baseline will be generated in the post-merge centralized
-  skill-eval pass.
+- None. The current missing-target rule satisfies all assertions.
 
 ## Next Steps
 
-- Run fresh with-skill and without-skill validation in the centralized eval
-  phase after Batch 4 merges.
+- Keep this eval as coverage for unavailable cross-agent handoff targets.
+- Re-run fresh validation if plugin availability handling changes.
 
 ## Runtime Artifacts Policy
 
-- Runtime transcripts, verdicts, timing, and diagnostics should not be committed.
+- No runtime artifacts were created or committed. Transcripts, verdicts, timing, outputs, and diagnostics must remain outside git.

--- a/agents/qa/test/bug-analyzer/evals/workspace/eval-1-analyze-test-failure/comparison.md
+++ b/agents/qa/test/bug-analyzer/evals/workspace/eval-1-analyze-test-failure/comparison.md
@@ -2,32 +2,47 @@
 
 ## Evaluation Target
 
+- Agent: `qa`
 - Skill: `bug-analyzer`
+- Eval: `eval-001-analyze-test-failure`
 - Test case: analyze-test-failure
-- Test set: QA availability evals
-- Entry: workspace `eval-1-analyze-test-failure`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-06-04
-- Validation method: direct fresh subagent review of current `SKILL.md`, QA README, eval assertions, and fixture evidence
+- Workspace: `workspace/eval-1-analyze-test-failure`
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
+- Validation method: fresh Codex subagent review; baseline was derived before reading `bug-analyzer` or QA README, then with-skill behavior was checked against `SKILL.md`, `agents/qa/README.md`, direct shared references, eval assertions, and fixture evidence.
 
-## With Skill
+## Test Set / Fixture Version
 
-- PASS: The skill requires intake of failing scenario, runtime evidence, and environment/build context before classification. The fixture provides `POST /api/login 500`, Chromium console output, missing trace status, branch, commit, and local acceptance harness context.
-- PASS: The skill separates evidence status from confidence, using `confirmed and reproducible`, `confirmed but environment-sensitive`, and `suspected / needs more evidence` without collapsing severity into certainty.
-- PASS: The skill requires severity rationale, confidence statement, reproduction steps, expected/actual behavior, evidence references, and implementation or release impact in the defect artifact.
-- PASS: The skill defaults to durable local Markdown output and only creates a GitHub issue when repo workflow or user request requires it.
-- PASS: For confirmed E2E reproductions that should become reusable regression coverage, the skill requires cases under `docs/qa/e2e/{feature_path}/cases/TC-NNN-<short-slug>.md`, matching scripts under `scripts/`, and a defect artifact reference.
-- PASS: For existing-feature changes or bug-fix acceptance coverage, the skill requires PRD/TRD expectation alignment and a confirmed `docs/engineer/{feature_path}/IMPLEMENTATION_PLAN.md`; unclear paths or expectations keep reusable E2E coverage blocked.
+- Schema: `evals.json` v1.0
+- Prompt: 分析测试失败：登录表单提交后返回 500 错误，生成 Bug 报告
+- Fixture context: `logs/test-failure.log` and `environment/build.md`
+- Evidence present: `POST /api/login 500`, login-form test name, Chromium console error, trace unavailable, branch `login-refresh`, commit `fixture-only`, and local acceptance harness environment.
 
-## Baseline
+## Without Skill Baseline
 
-- Tends to jump from the 500 error directly to a generic bug report.
-- Provides weaker evidence handling and less explicit uncertainty.
+- A generic QA response would likely turn the HTTP 500 into a confirmed bug report immediately, with weaker separation between reproducibility, evidence completeness, and severity.
+- It might omit explicit gaps such as missing stack trace, screenshot, network payload, trace file, release channel, and repeated reproduction proof.
+- It could choose GitHub issue creation by default instead of first selecting the repo-appropriate durable Markdown artifact.
+- It would be less likely to gate reusable E2E regression coverage behind `docs/qa/e2e/{feature_path}/cases/TC-NNN-<short-slug>.md`, matching `scripts/`, PRD/TRD alignment, and a confirmed implementation plan when the TC becomes acceptance coverage.
+
+## With Skill Behavior
+
+- PASS: `bug-analyzer` accepts the test failure log plus build context as enough QA evidence for a defect intake, while still recording missing trace and supporting artifacts as evidence gaps.
+- PASS: The skill requires failing scenario, source evidence, console/network/test output, and environment/build context before classification.
+- PASS: The classification vocabulary separates evidence status from confidence: `confirmed and reproducible`, `confirmed but environment-sensitive`, and `suspected / needs more evidence` are distinct from severity.
+- PASS: The report contract includes severity rationale, confidence statement, reproduction steps, expected/actual behavior, evidence references, and implementation or release impact.
+- PASS: Durable output defaults to a local Markdown artifact unless repo workflow or the user explicitly requires GitHub issue tracking.
+- PASS: Confirmed E2E reproduction that should become reusable regression coverage must use `docs/qa/e2e/{feature_path}/cases/TC-NNN-<short-slug>.md` plus matching `scripts/TC-NNN-<short-slug>.spec.md`; acceptance-style TC creation or update requires same-path PRD/TRD expectation alignment and a confirmed `docs/engineer/{feature_path}/IMPLEMENTATION_PLAN.md`.
 
 ## Failures
 
-- None identified against the current eval assertions.
+- None identified. The current skill contract satisfies all eval assertions for evidence intake, classification, severity/confidence separation, durable output choice, reusable E2E path rules, and impact framing.
 
 ## Next Steps
 
-- Runtime transcripts, verdicts, timing, and diagnostics should not be committed.
-- Residual risk: This validation is a direct skill-read judgment, not a generated model transcript run.
+- No fixture or skill change is required from this eval.
+- If a real report is produced later, keep the current missing artifacts visible instead of inflating confidence.
+
+## Runtime Artifact Policy
+
+- No runtime artifacts were created for this validation.
+- Do not commit transcripts, verdicts, timing files, diagnostics, `with_skill/`, `without_skill/`, `outputs/`, or `comparison.auto.md`.

--- a/agents/qa/test/bug-analyzer/evals/workspace/eval-2-thin-evidence-suspected-bug/comparison.md
+++ b/agents/qa/test/bug-analyzer/evals/workspace/eval-2-thin-evidence-suspected-bug/comparison.md
@@ -2,30 +2,44 @@
 
 ## Evaluation Target
 
+- Agent: `qa`
 - Skill: `bug-analyzer`
+- Eval: `eval-002-thin-evidence-suspected-bug`
 - Test case: thin-evidence-suspected-bug
-- Test set: QA availability evals
-- Entry: workspace `eval-2-thin-evidence-suspected-bug`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-06-04
-- Validation method: direct fresh subagent review of current `SKILL.md`, QA README, eval assertions, and fixture evidence
+- Workspace: `workspace/eval-2-thin-evidence-suspected-bug`
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
+- Validation method: fresh Codex subagent review; baseline was derived before reading `bug-analyzer` or QA README, then with-skill behavior was checked against `SKILL.md`, `agents/qa/README.md`, direct shared references, eval assertions, and fixture evidence.
 
-## With Skill
+## Test Set / Fixture Version
 
-- PASS: The skill explicitly classifies weak reports as `suspected / needs more evidence` and warns against treating every failure as a confirmed bug.
-- PASS: The customer note lacks exact failing scenario, reproduction steps, environment/version, console output, network output, screenshots, trace, and build context; the skill requires these gaps to be recorded instead of guessed.
-- PASS: The required report structure covers classification, evidence status, confidence statement, missing evidence through explicit gaps, and next evidence needed to confirm or rule out the defect.
-- PASS: The skill keeps suspected reports honest, asks for additional proof, avoids overstating reproducibility, and defaults to a local investigation note or evidence request rather than a confirmed bug artifact or GitHub issue.
+- Schema: `evals.json` v1.0
+- Prompt: 用户只提供一句反馈：偶尔点击保存后页面好像没反应，没有截图、日志、复现步骤、环境信息或版本号。请分析是否能生成 Bug 报告。
+- Fixture context: `feedback/customer-note.md`
+- Evidence present: one customer note describing intermittent save non-response, with no screenshot or exact steps.
 
-## Baseline
+## Without Skill Baseline
 
-- More likely to convert the thin report into a full bug prematurely.
-- Gives less attention to missing evidence and confidence level.
+- A generic response could prematurely write a confirmed bug report from the customer note.
+- It might fail to separate an observed customer complaint from a reproducible failing scenario.
+- It would likely omit a structured missing-evidence list and could recommend issue creation before confidence is high enough.
+
+## With Skill Behavior
+
+- PASS: `bug-analyzer` explicitly classifies thin reports as `suspected / needs more evidence`; it must not label this fixture `confirmed and reproducible` or `confirmed but environment-sensitive`.
+- PASS: The skill requires missing evidence to be stated rather than guessed, including exact failing scenario, reproduction steps, environment/version, console output, network output, screenshot, trace, and build context.
+- PASS: The report structure covers classification, evidence status, confidence statement, missing evidence, and recommended next evidence.
+- PASS: The output boundary is an investigation note or evidence request. It avoids creating a confirmed bug artifact or GitHub issue from this fixture.
 
 ## Failures
 
-- None identified against the current eval assertions.
+- None identified. The current skill contract satisfies all eval assertions for thin-evidence handling, evidence gaps, structured output, and persistence boundaries.
 
 ## Next Steps
 
-- Runtime transcripts, verdicts, timing, and diagnostics should not be committed.
-- Residual risk: This validation is a direct skill-read judgment, not a generated model transcript run.
+- No fixture or skill change is required from this eval.
+- If this scenario is handled in production, collect steps, version, environment, console/network output, screenshot or trace before escalating.
+
+## Runtime Artifact Policy
+
+- No runtime artifacts were created for this validation.
+- Do not commit transcripts, verdicts, timing files, diagnostics, `with_skill/`, `without_skill/`, `outputs/`, or `comparison.auto.md`.

--- a/agents/qa/test/exploratory-tester/evals/workspace/eval-1-explore-web-app/comparison.md
+++ b/agents/qa/test/exploratory-tester/evals/workspace/eval-1-explore-web-app/comparison.md
@@ -7,46 +7,41 @@
 - Eval: `eval-001-explore-web-app`
 - Test case: explore-web-app
 - Workspace: `workspace/eval-1-explore-web-app`
-- Latest result: PARTIAL - prior skill validation evidence is preserved; without_skill baseline was not generated for this historical comparison.
-- Prior validation note: fresh Codex subagent validation completed on 2026-06-04
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
+- Validation method: fresh Codex subagent review; baseline was derived before reading `exploratory-tester` or QA README, then with-skill behavior was checked against `SKILL.md`, `agents/qa/README.md`, direct shared references, eval assertions, and fixture evidence.
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: Verifies that exploratory-tester handles explore-web-app and produces the expected role-specific artifact.
 - Expected output: 探索测试报告，包含发现的问题列表和复现路径
+- Fixture context: search-refresh PRD, `SearchPanel`, `FilterPills`, `ResultsList`, QA environment note, `TEST_SUITE.md`, `FLOW_INDEX.md`, and `cases/TC-001-filter-results.md`.
+- Scenario and version: `feature-update`, platform version `v0.9.0-dev`.
 
-## Assertions
+## Without Skill Baseline
 
-- `assertion_1`: 探索章程
-- `assertion_2`: 探索记忆沉淀
-- `assertion_3`: 范围与时限
-- `assertion_4`: 证据分层
-- `assertion_5`: 探索方法
-- `assertion_6`: 可交接产物
-- `deduplicates_existing_flows`: 不重复创建同义 TC
+- A generic exploratory answer would likely begin browser probing or list ad hoc checks without first building a charter from PM context, changed surface, known risks, and environment constraints.
+- It could skip the existing `docs/qa/e2e/search/results/filtering/` memory and create a duplicate filter-results TC instead of updating `TC-001-filter-results`.
+- It might not separate observed defects, suspicious unconfirmed signals, and gaps not explored.
+- It could ignore that browser execution depends on `QA_BASE_URL`, and it would be less likely to state repo harness > Chrome plugin / browser connector > Playwright fallback as the execution-entry order.
 
-## With Skill
+## With Skill Behavior
 
-Observed behavior:
-
-- 当前 skill 要求先读 QA 记忆、PM 上下文、changed surface、风险和环境说明，再产出包含 surface、timebox、heuristics、escalation signals 的 exploration charter；fixture 提供 search-refresh PRD、SearchPanel/FilterPills/ResultsList 改动面和 QA_BASE_URL 阻塞规则，能满足 charter、上下文驱动范围、证据分层和可交接报告 assertions。
-- 当前 skill 明确把 `docs/qa/e2e/{feature_path}/` 作为 durable QA memory，要求先读取 `TEST_SUITE.md`、`FLOW_INDEX.md`、`cases/*.md`、`scripts/*.spec.md`、历史结果和报告。fixture 中已有 `docs/qa/e2e/search/results/filtering/TEST_SUITE.md`、`FLOW_INDEX.md` 和 `cases/TC-001-filter-results.md`，且这些文件明确要求同一 filter-results flow 增量更新既有 TC，不创建同义重复 TC；skill 的 deduplication 规则与 fixture 预期一致。
-- 当前 skill 要求如果读取源码或配置来推导覆盖面，需要更新 `FLOW_INDEX.md` 记录读取文件、原因和覆盖影响；如果识别出可复用 E2E 场景，需要写入单独 case，并在需要可重复执行时写对应 script。一次性观察保留在探索报告，不沉淀为重复 TC。
-- 当前 skill 要求 E2E 执行入口按 repo harness > Chrome plugin / browser connector > Playwright fallback 选择，并默认由 subagent 执行 E2E TC；本 eval 未要求真实执行，`QA_BASE_URL` 缺失时应报告 browser execution blocked，同时仍产出 charter 和 evidence plan。
-
-## Without Skill / Baseline
-- BLOCKED: No actual without_skill baseline result is recorded for this historical comparison. This file is not treated as a full eval PASS until a baseline result is generated and written here.
-- This comparison records whether the skill-specific protocol, routing, evidence, or artifact expectations are preserved.
+- PASS: `exploratory-tester` requires a charter before interaction, including surface, timebox source, heuristics, and escalation signals. The fixture supplies the changed search surfaces and keyboard-focus risk needed for that charter.
+- PASS: Existing QA memory is primary. The skill requires reading `TEST_SUITE.md`, `FLOW_INDEX.md`, `cases/*.md`, `scripts/*.spec.md`, prior `results/`, and `_reports/`; absent scripts/results/reports must be recorded instead of silently skipped.
+- PASS: The fixture's existing `TC-001-filter-results` covers the filter-results flow. The skill requires updating the existing TC, script, or `FLOW_INDEX.md` when the same flow is found, and keeps one-off observations in the exploratory report.
+- PASS: For existing-feature exploration, reusable TC creation/update/execution remains gated by same-path PRD/TRD expectation alignment and a confirmed `IMPLEMENTATION_PLAN.md`; fixture-level browser execution is also blocked unless `QA_BASE_URL` is present.
+- PASS: The report contract separates observed issues, suspicious but unconfirmed signals, gaps not explored, exploration path covered, evidence used, and recommended next actions.
 
 ## Failures
 
-- None. Fresh Codex subagent validation found the current `SKILL.md` satisfies all eval assertions, including QA memory reuse, durable function-tree updates, and duplicate TC avoidance.
+- None identified. The current skill contract satisfies all eval assertions for chartering, QA memory reuse, scope/timebox discipline, evidence layering, chartered exploration, handoff-ready output, and duplicate TC avoidance.
 
 ## Next Steps
 
-- 无需修改 fixture。Residual risk: this validation is static against the skill contract and fixture files; no browser session, repo harness, or model transcript was executed.
+- No fixture or skill change is required from this eval.
+- A real execution should record any missing `scripts/`, prior `results/`, `_reports/`, `QA_BASE_URL`, TRD, or implementation-plan gates as blocked before browser or E2E execution.
 
-## Runtime Artifacts Policy
+## Runtime Artifact Policy
 
-- Runtime transcripts, verdicts, timing, outputs, and diagnostics should not be committed.
+- No runtime artifacts were created for this validation.
+- Do not commit transcripts, verdicts, timing files, diagnostics, `with_skill/`, `without_skill/`, `outputs/`, or `comparison.auto.md`.

--- a/agents/qa/test/exploratory-tester/evals/workspace/eval-2-explore-with-custom-duration/comparison.md
+++ b/agents/qa/test/exploratory-tester/evals/workspace/eval-2-explore-with-custom-duration/comparison.md
@@ -7,46 +7,43 @@
 - Eval: `eval-002-explore-with-custom-duration`
 - Test case: explore-with-custom-duration
 - Workspace: `workspace/eval-2-explore-with-custom-duration`
-- Latest result: PARTIAL - prior skill validation evidence is preserved; without_skill baseline was not generated for this historical comparison.
-- Prior validation note: fresh Codex subagent validation completed on 2026-06-04
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
+- Validation method: fresh Codex subagent review; baseline was derived before reading `exploratory-tester` or QA README, then with-skill behavior was checked against `SKILL.md`, `agents/qa/README.md`, direct shared references, eval assertions, and fixture evidence.
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: Verifies that exploratory-tester handles explore-with-custom-duration and produces the expected role-specific artifact.
 - Expected output: 5 分钟探索测试报告
+- Fixture context: settings-panel PRD, `SettingsPanel`, `EmailPreferenceForm`, shared toast notifications, QA environment note, `TEST_SUITE.md`, and `FLOW_INDEX.md`.
+- Target and timebox: `https://qa.example.test/settings`, 5 minutes.
+- Scenario and version: `feature-update`, platform version missing.
 
-## Assertions
+## Without Skill Baseline
 
-- `assertion_1`: 上下文驱动范围
-- `assertion_2`: 独立探索确认
-- `version_entry_and_subagent`: 版本、执行入口与 subagent
-- `assertion_3`: 异常分层
-- `assertion_4`: 证据输出
-- `assertion_5`: 风险交接
+- A generic exploratory answer might honor the 5-minute phrase but skip the function-tree QA memory and platform-version gate.
+- It could start browser automation against the URL before confirming reachability, execution entry, platform version, or subagent delegation.
+- It might create a new save/cancel TC without first updating `FLOW_INDEX.md` or checking for existing equivalent cases.
+- It would be less likely to keep console/network anomalies as unconfirmed signals unless reproduction evidence is strong enough.
 
-## With Skill
+## With Skill Behavior
 
-Observed behavior:
-
-- 当前 skill 要求 timebox 来自上下文而非固定默认值；fixture 中用户指定 5 分钟、目标 URL 为 `https://qa.example.test/settings`，并提供 SettingsPanel、EmailPreferenceForm 和 toast 风险，因此 skill 能建立包含 URL、时长、changed surface、可用环境信息和未验证前提的探索章程。
-- 当前 skill 要求 standalone exploratory 或 E2E 请求先确认 function-tree scope 和 scenario；E2E 执行前必须确认 platform version，缺失时 blocked，不能写入 `unknown`。fixture 中 `TEST_SUITE.md` 明确 scenario 为 `feature-update` 且 platform version missing，所以符合预期的 skill 行为是阻塞执行 TC，并保留 charter 和 evidence plan。
-- 当前 skill 要求先读取 `docs/qa/e2e/account/settings/email-preferences/TEST_SUITE.md`、`FLOW_INDEX.md`、既有 cases、scripts、历史 results 和 reports；fixture 当前没有 active TC，若扩充覆盖应先更新 `FLOW_INDEX.md`，再按单独 TC 文件和对应 script 沉淀可复用流程，避免重复 save/cancel 语义用例。
-- 当前 skill 要求 E2E 执行入口按 repo harness > Chrome plugin / browser connector > Playwright fallback 选择并说明原因，实际执行 TC 默认由 subagent 执行。由于 fixture 平台版本缺失且目标环境可达性未确认，正确结果是 blocked before execution，而不是绕过版本门禁启动浏览器或 Playwright。
-- 当前 skill 要求报告分开记录 observed issues、suspicious but unconfirmed signals、gaps not explored，并包含实际执行路径、evidence references、risk notes 和 recommended next actions；这满足异常分层、证据输出和风险交接 assertions。
-
-## Without Skill / Baseline
-- BLOCKED: No actual without_skill baseline result is recorded for this historical comparison. This file is not treated as a full eval PASS until a baseline result is generated and written here.
-- This comparison records whether the skill-specific protocol, routing, evidence, or artifact expectations are preserved.
+- PASS: `exploratory-tester` uses the user-provided 5-minute timebox exactly and builds the charter from URL, changed surface, environment note, and toast-risk context.
+- PASS: The skill requires reading `TEST_SUITE.md`, `FLOW_INDEX.md`, `cases/*.md`, `scripts/*.spec.md`, prior `results/`, and `_reports/`; absent cases/scripts/results/reports are recorded as gaps.
+- PASS: The fixture explicitly lacks a platform version. The correct with-skill result is blocked before E2E execution, never an `unknown` archive path.
+- PASS: Execution-entry precedence is repo harness > Chrome plugin / browser connector > Playwright fallback, and executable E2E TC are delegated to subagents by default while the main agent owns scope and summary.
+- PASS: Because this is an existing-feature exploration, reusable TC creation/update/execution also remains blocked until same-path PRD/TRD expectation alignment and a confirmed implementation plan are available.
+- PASS: The report must separate observed issues, suspicious but unconfirmed signals, gaps not explored, evidence references, risk notes, and recommended next actions.
 
 ## Failures
 
-- None. Fresh Codex subagent validation found the current `SKILL.md` satisfies all eval assertions, including platform-version blocking, execution-entry precedence, subagent default, and function-tree QA memory reuse.
+- None identified. The current skill contract satisfies all eval assertions for context-driven scope, E2E memory confirmation, platform-version blocking, execution-entry precedence, subagent default, anomaly layering, evidence output, and risk handoff.
 
 ## Next Steps
 
-- 保持该 eval 覆盖用户指定时长、版本门禁、执行入口选择、subagent 默认执行和证据分层行为。Residual risk: this validation is static against the skill contract and fixture files; no browser session, repo harness, or model transcript was executed.
+- No fixture or skill change is required from this eval.
+- A real execution should ask for platform version before any E2E run and keep URL reachability, TRD, implementation-plan, and missing TC/script gaps visible.
 
-## Runtime Artifacts Policy
+## Runtime Artifact Policy
 
-- Runtime transcripts, verdicts, timing, outputs, and diagnostics should not be committed.
+- No runtime artifacts were created for this validation.
+- Do not commit transcripts, verdicts, timing files, diagnostics, `with_skill/`, `without_skill/`, `outputs/`, or `comparison.auto.md`.

--- a/agents/qa/test/qa-agent/evals/workspace/eval-1-route-mixed-qa-request/comparison.md
+++ b/agents/qa/test/qa-agent/evals/workspace/eval-1-route-mixed-qa-request/comparison.md
@@ -7,50 +7,42 @@
 - Eval: `eval-001-route-mixed-qa-request`
 - Test case: route-mixed-qa-request
 - Workspace: `workspace/eval-1-route-mixed-qa-request`
-- Latest result: PARTIAL - prior skill validation evidence is preserved; without_skill baseline was not generated for this historical comparison.
-- Prior validation note: fresh Codex subagent validation completed on 2026-06-04
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: Verifies that qa-agent handles route-mixed-qa-request and produces the expected role-specific artifact.
-- Expected output: QA 路由决策，明确选择最窄的下游 QA skill、选择理由、需要读取的上下文和预期 evidence artifact
+- Fixture: login refresh implementation with PM acceptance question and intermittent CI failure evidence.
+- Context read before applying the skill: `evals.json`, workspace `eval_metadata.json`, `docs/pm/login-refresh/PRD.md`, `docs/engineer/login-refresh/TRD.md`, `docs/qa/e2e/auth/login/login-refresh/TEST_SUITE.md`, `FLOW_INDEX.md`, `implementation/changes.md`, and `ci/login-intermittent-failure.log`.
 
 ## Assertions
 
-- `assertion_1`: 路由选择
-- `assertion_2`: 上下文传递
-- `qa`: QA 用例记忆
-- `e2e_execution_protocol`: E2E 执行协议
-- `credential_and_report_refs`: 账号与报告 reference
-- `alignment_and_plan_gate`: PRD/TRD 与实施计划门禁
-- `assertion_4`: 结构化产物
-- `assertion_5`: 边界控制
+- PASS `assertion_1`: the primary QA route is `spec-based-tester` because PM asks whether an implementation can enter documented acceptance; the intermittent CI failure remains a risk note or possible `bug-analyzer` follow-up.
+- PASS `assertion_2`: downstream context includes PM/spec, TRD, implementation changes, CI failure log, environment constraints, and test commands.
+- PASS `qa`: E2E work reads the function-tree memory set under `docs/qa/e2e/{feature_path}/`, including suite, flow index, cases, scripts, prior results, and reports.
+- PASS `e2e_execution_protocol`: E2E routing requires scenario and platform version, blocks missing versions instead of writing `unknown`, selects repo harness > Chrome plugin / browser connector > Playwright fallback, and delegates TC execution to subagents.
+- PASS `credential_and_report_refs`: credential storage uses `references/e2e-credential-store.md` and `.qa/e2e/accounts.local.json`; summary reporting uses `references/e2e-test-report.md`.
+- PASS `alignment_and_plan_gate`: existing-feature and code-complete E2E updates require same-path PRD, TRD, product decisions when present, and confirmed `IMPLEMENTATION_PLAN.md`; gaps return to PM, `trd-gen`, or `feature-implementor`.
+- PASS `assertion_4`: expected artifacts include route decision, execution path, evidence references, risk notes, blockers, and handoff notes.
+- PASS `assertion_5`: only one primary QA route is selected; the intermittent failure is not promoted to a confirmed bug without stronger evidence.
 
-## With Skill
+## With Skill Behavior
 
-Observed behavior:
+`qa-agent` satisfies the mixed QA routing contract. It chooses the narrowest current evidence route, preserves the intermittent CI failure as risk or follow-up rather than a parallel execution path, and carries the required QA memory, environment, credential, report, and PRD/TRD/plan gates into the selected specialist. Because the fixture does not include a confirmed implementation plan, the route can still be selected, but E2E acceptance creation or execution would be blocked until `engineer-agent:feature-implementor` supplies the confirmed plan.
 
-- PASS - fresh Codex subagent validation completed on 2026-06-04.
-- `qa-agent` requires routing before execution and selecting one narrow downstream QA skill. For this fixture, the main route is `spec-based-tester` because PM asks whether the implemented login refresh can enter documented acceptance. The intermittent CI failure remains a risk note or potential `bug-analyzer` follow-up, not a confirmed bug and not a second simultaneously executed route.
-- The skill requires carrying PM/spec context, implementation changes, CI failure information, environment notes, and test commands into the downstream route. The fixture provides `docs/pm/login-refresh/PRD.md`, `docs/engineer/login-refresh/TRD.md`, `implementation/changes.md`, `ci/login-intermittent-failure.log`, and the TRD command/environment constraints, including not assuming a fixed localhost port.
-- The E2E protocol is satisfied: the skill uses `docs/qa/e2e/{feature_path}/` with `TEST_SUITE.md`, `FLOW_INDEX.md`, `cases/`, `scripts/`, prior `results/`, and `_reports/`; it requires `feature-update` or `release`, blocks missing platform version instead of using `unknown`, selects execution by repo harness > Chrome plugin / browser connector > Playwright fallback, and runs E2E TC through subagents by default.
-- Credential and report references are covered by explicit skill-relative links to `references/e2e-credential-store.md` and `references/e2e-test-report.md` under the qa-agent skill directory. The skill requires local `.qa/e2e/accounts.local.json` storage and committed docs referencing account IDs only.
-- The PRD/TRD and plan gate is covered for this existing-feature change: the skill requires same-`feature_path` PRD/TRD expectation alignment and a confirmed `docs/engineer/{feature_path}/IMPLEMENTATION_PLAN.md` before creating, updating, or executing acceptance TC. If alignment, environment, credentials, feature path, or the implementation plan are missing, the output must report `blocked` and the next owner.
-- The expected artifact shape is explicit: route decision, execution path, evidence artifact, E2E scenario/scope/version status, subagent plan, selected execution entry, evidence references, risk notes, and blocker or handoff notes.
+## Without Skill Baseline
 
-## Without Skill / Baseline
-- BLOCKED: No actual without_skill baseline result is recorded for this historical comparison. This file is not treated as a full eval PASS until a baseline result is generated and written here.
-- This comparison records whether the skill-specific protocol, routing, evidence, or artifact expectations are preserved.
+Without the router skill, QA README, and QA E2E references, a generic response would likely either start running tests immediately or split the work into both acceptance testing and bug analysis. It might assume a localhost port or browser path, miss the durable E2E memory read set, omit credential/report references, or classify the intermittent CI log as a confirmed bug too early.
 
 ## Failures
 
-- None.
+- None found. The missing implementation plan is an expected gate condition for acceptance execution, not a router failure.
 
 ## Next Steps
 
-- No skill or fixture change is required for this eval.
+- Keep this eval as regression coverage for mixed QA requests, single-route selection, and E2E gate preservation.
 
 ## Runtime Artifacts Policy
 
-- Runtime transcripts, verdicts, timing, outputs, and diagnostics should not be committed.
+- No runtime artifacts were created for this validation.
+- Runtime transcripts, verdicts, timing, output directories, diagnostics, and generated with_skill / without_skill files must not be committed.

--- a/agents/qa/test/qa-agent/evals/workspace/eval-2-empty-qa-directory-expands-cases/comparison.md
+++ b/agents/qa/test/qa-agent/evals/workspace/eval-2-empty-qa-directory-expands-cases/comparison.md
@@ -1,4 +1,4 @@
-# Eval Result: qa-agent-empty-qa-directory-expands-cases
+# Eval Result: eval-002-empty-qa-directory-expands-cases
 
 ## Evaluation Target
 
@@ -7,50 +7,41 @@
 - Eval: `eval-002-empty-qa-directory-expands-cases`
 - Test case: empty-qa-directory-expands-cases
 - Workspace: `workspace/eval-2-empty-qa-directory-expands-cases`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-06-04
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: Verifies that qa-agent handles an existing but empty E2E function-tree directory by routing to targeted file exploration, durable case creation, and case-based execution when exploration is already authorized.
-- Expected output: QA 路由决策与执行协议，明确空 E2E 功能树目录需要触发目标文件探索、更新 TEST_SUITE.md 和 FLOW_INDEX.md、创建独立 TC 与 script 文件，并要求后续验证基于这些用例执行
+- Fixture: existing empty E2E function tree for profile settings plus source files and QA environment notes.
+- Context read before applying the skill: `evals.json`, workspace `eval_metadata.json`, `docs/qa/e2e/account/profile-settings/profile-form/TEST_SUITE.md`, `FLOW_INDEX.md`, `environment/qa-env.md`, `src/routes/profile-settings.md`, `src/pages/ProfileSettingsPage.tsx`, and `src/components/ProfileSettingsForm.tsx`.
 
 ## Assertions
 
-- `assertion_1`: 空目录识别
-- `assertion_2`: 授权后主动探索
-- `assertion_3`: 探索记录沉淀
-- `e2e`: E2E 用例创建
-- `assertion_5`: 用例驱动执行
-- `version_and_subagent_gate`: 版本与 subagent 门禁
-- `assertion_6`: 路由边界
+- PASS `assertion_1`: the route recognizes that the QA function tree exists but has no executable TC and must not be treated as existing coverage.
+- PASS `assertion_2`: because the user confirmed a feature-update and authorized exploration, the downstream route should inspect target files and environment notes instead of asking whether exploration is allowed.
+- PASS `assertion_3`: exploration must update `TEST_SUITE.md` and `FLOW_INDEX.md` with files explored, discovered route/form/commands, coverage meaning, and assumptions.
+- PASS `e2e`: each new E2E case must be stored as `cases/TC-NNN-<short-slug>.md` with a matching `scripts/TC-NNN-<short-slug>.spec.md`, without plaintext secrets.
+- PASS `assertion_5`: validation is TC-driven, feature-update scope stays on the changed feature and direct impacts, and execution entry follows repo harness > Chrome plugin / browser connector > Playwright fallback.
+- PASS `version_and_subagent_gate`: platform version is required before execution; missing version blocks execution and reports go to `_reports/{platform-version}/test-reports-{test-time}.md` only after a real version is known.
+- PASS `assertion_6`: the router selects one narrow QA route, with `exploratory-tester` as the best fit for expanding empty E2E coverage before execution.
 
-## With Skill
+## With Skill Behavior
 
-- PASS - fresh Codex subagent validation completed on 2026-06-04.
-- `qa-agent` requires downstream QA to read the target function-tree `TEST_SUITE.md`, `FLOW_INDEX.md`, `cases/*.md`, `scripts/*.spec.md`, prior `results/`, and `_reports/` before exploring. This satisfies the empty-directory assertion because the fixture path is `docs/qa/e2e/account/profile-settings/profile-form/` and no reusable TC exists there.
-- Because the prompt already confirms `feature-update`, a new feature update, and authorization to explore, the skill routes the downstream worker to targeted project-file exploration rather than asking again. The relevant fixture files are `src/routes/profile-settings.md`, `src/pages/ProfileSettingsPage.tsx`, `src/components/ProfileSettingsForm.tsx`, and `environment/qa-env.md`.
-- Missing coverage is handled durably: the skill requires adding or updating `cases/`, `scripts/`, and `FLOW_INDEX.md` in the same function-tree directory and avoiding duplicate synonym TC. This covers independent `cases/TC-NNN-<short-slug>.md` files and matching `scripts/TC-NNN-<short-slug>.spec.md` snippets.
-- The credential rule is satisfied because the skill requires committed QA docs to reference account IDs only and to follow `e2e-credential-store.md` for `.qa/e2e/accounts.local.json`; this matches the fixture credential ref `platform.profile-settings.qa_user` and forbids plaintext secrets in TC, scripts, results, or reports.
-- The execution protocol is satisfied: `feature-update` covers the changed feature and direct impact paths only, execution entry order is repo harness > Chrome plugin / browser connector > Playwright fallback, and every E2E TC is executed through a subagent by default while the main agent owns scope confirmation and the final report.
-- The platform version gate is satisfied. The fixture explicitly marks platform version missing, and the skill requires `blocked` until the version is provided, never `unknown`; final reporting must follow `e2e-test-report.md` at the feature `_reports/{platform-version}/test-reports-{test-time}.md` path once execution is unblocked.
-- The route boundary is satisfied because the skill selects one narrow QA route and keeps QA focused on evidence, case creation, execution protocol, blockers, and handoff instead of implementing fixes.
+`qa-agent` satisfies the empty-directory E2E route. It treats the existing function tree as durable memory, but not as executable coverage, and points to `exploratory-tester` as the narrow route for discovering flows and creating cases. It preserves credential hygiene, per-TC case/script persistence, subagent execution, and platform-version blocking. The fixture's `TEST_SUITE.md` states the platform version is missing, so execution is intentionally blocked until the version is provided; case expansion can still be routed as the preparatory QA work.
 
-## Baseline
+## Without Skill Baseline
 
-- Often skips durable test-case memory or creates a one-off checklist.
-- Less consistently writes reusable case files before execution.
-- Does not consistently name the Chrome plugin / browser connector execution
-  path when browser E2E validation is required.
+Without the router skill, QA README, and QA references, a generic response might either mark the existing QA directory as sufficient coverage or jump straight to browser execution from source files. It is less likely to create durable per-TC case/script files, preserve function-tree report paths, block missing platform version correctly, or avoid writing credentials into scripts.
 
 ## Failures
 
-- None.
+- None found. Missing platform version is the expected execution blocker for this fixture.
 
 ## Next Steps
 
-- No skill or fixture change is required for this eval.
+- Keep this eval as regression coverage for empty E2E function-tree expansion and version-gated execution.
 
 ## Runtime Artifacts Policy
 
-- Runtime transcripts, verdicts, timing, outputs, and diagnostics should not be committed.
+- No runtime artifacts were created for this validation.
+- Runtime transcripts, verdicts, timing, output directories, diagnostics, and generated with_skill / without_skill files must not be committed.

--- a/agents/qa/test/qa-agent/evals/workspace/eval-3-feature-path-missing-plan-blocked/comparison.md
+++ b/agents/qa/test/qa-agent/evals/workspace/eval-3-feature-path-missing-plan-blocked/comparison.md
@@ -7,41 +7,38 @@
 - Eval: `eval-003-feature-path-missing-plan-blocked`
 - Test case: feature-path-missing-plan-blocked
 - Workspace: `workspace/eval-3-feature-path-missing-plan-blocked`
-- Latest result: PARTIAL - prior skill validation evidence is preserved; without_skill baseline was not generated for this historical comparison.
-- Prior validation note: fresh Codex subagent validation on 2026-06-23
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: Same-path PRD and TRD for `account/profile/preferences`, an existing QA E2E function-tree directory, and no `docs/engineer/account/profile/preferences/IMPLEMENTATION_PLAN.md`.
-- Expected output: QA route decision that blocks E2E acceptance TC creation/update/execution because the confirmed implementation plan is missing.
+- Fixture: same-path PRD/TRD and QA E2E function tree for `account/profile/preferences`, with no confirmed implementation plan.
+- Context read before applying the skill: `evals.json`, workspace `eval_metadata.json`, `docs/pm/account/profile/preferences/PRD.md`, `docs/engineer/account/profile/preferences/TRD.md`, `docs/qa/e2e/account/profile/preferences/TEST_SUITE.md`, and `FLOW_INDEX.md`.
 
 ## Assertions
 
-- `reads_same_feature_path`: use `account/profile/preferences` as the confirmed feature path and read matching PRD/TRD plus QA function-tree memory.
-- `blocks_missing_plan`: mark the request blocked and return the missing implementation plan to `engineer-agent:feature-implementor`.
-- `no_e2e_mutation_or_execution`: do not create, update, or execute acceptance TC without the plan.
-- `keeps_single_route`: choose one narrow QA route and do not enter implementation.
+- PASS `reads_same_feature_path`: the route preserves `account/profile/preferences`, reads same-path PRD/TRD, and keeps the QA E2E function tree under the same path.
+- PASS `blocks_missing_plan`: missing `docs/engineer/account/profile/preferences/IMPLEMENTATION_PLAN.md` is a blocker, with next owner `engineer-agent:feature-implementor`.
+- PASS `no_e2e_mutation_or_execution`: no E2E acceptance TC is created, updated, or executed without the confirmed implementation plan.
+- PASS `keeps_single_route`: the router keeps one narrow QA route and treats the missing plan as the blocker instead of invoking multiple QA skills or entering implementation repair.
 
-## With Skill
+## With Skill Behavior
 
-- PASS. Current `qa-agent` instructions consume a confirmed same-path `feature_path` before E2E acceptance work. The fixture provides matching `docs/pm/account/profile/preferences/PRD.md`, `docs/engineer/account/profile/preferences/TRD.md`, and QA function-tree memory under `docs/qa/e2e/account/profile/preferences/`.
-- PASS. The QA Feature Path Gate requires `docs/engineer/{feature_path}/IMPLEMENTATION_PLAN.md` for existing-feature changes, bug fixes, or code-complete E2E documentation updates before creating, updating, or executing acceptance TC. The fixture intentionally omits `docs/engineer/account/profile/preferences/IMPLEMENTATION_PLAN.md`, so the correct route result is `blocked`.
-- PASS. The skill separates owners: missing or mismatched TRD returns to `engineer-agent:trd-gen`, while a missing or mismatched implementation plan returns to `engineer-agent:feature-implementor`. This fixture omits the implementation plan, so the next owner is `engineer-agent:feature-implementor` rather than QA execution.
-- PASS. The route remains a single narrow QA route and stops before TC mutation, TC execution, or implementation repair. The QA directory being present is treated as memory to read, not sufficient authorization to run acceptance.
+`qa-agent` satisfies the expected blocked behavior. Its router output requires same-path PRD/TRD and confirmed implementation plan gates for code-complete E2E acceptance updates. The directly referenced QA specialist gates confirm that a missing implementation plan blocks creating, updating, or executing acceptance TC and sends the next action to `engineer-agent:feature-implementor`.
 
-## Without Skill / Baseline
-- BLOCKED: No actual without_skill baseline result is recorded for this historical comparison. This file is not treated as a full eval PASS until a baseline result is generated and written here.
-- A generic answer may treat the QA directory as sufficient context and start creating or executing TC without the implementation-plan gate.
+## Without Skill Baseline
+
+Without the router skill, QA README, and QA E2E gate references, a generic response could proceed from the existing PRD/TRD and QA directory into test-case creation or execution. It might treat the empty QA tree as enough context and miss that the confirmed `IMPLEMENTATION_PLAN.md` is mandatory for code-complete acceptance work.
 
 ## Failures
 
-- None.
+- None found. The blocked route is the expected pass condition for this eval.
 
 ## Next Steps
 
-- No skill or fixture change is required for this eval. Residual risk: this validation is a direct skill-read judgment against current docs and fixture files; no model transcript was generated.
+- Keep this eval as regression coverage for missing implementation-plan blocking before E2E acceptance mutation or execution.
 
 ## Runtime Artifacts Policy
 
-- Runtime transcripts, verdicts, timing, outputs, and diagnostics should not be committed.
+- No runtime artifacts were created for this validation.
+- Runtime transcripts, verdicts, timing, output directories, diagnostics, and generated with_skill / without_skill files must not be committed.

--- a/agents/qa/test/regression-suite/evals/workspace/eval-1-verify-bug-fix/comparison.md
+++ b/agents/qa/test/regression-suite/evals/workspace/eval-1-verify-bug-fix/comparison.md
@@ -2,35 +2,48 @@
 
 ## Evaluation Target
 
+- Agent: `qa`
 - Skill: `regression-suite`
+- Eval: `eval-001-verify-bug-fix`
 - Test case: verify-bug-fix
-- Test set: QA availability evals
-- Entry: workspace `eval-1-verify-bug-fix`
-- Latest result: PASS - fresh Codex subagent validation on 2026-06-23 after QA owner split fix
+- Workspace: `workspace/eval-1-verify-bug-fix`
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
+- Validation method: fresh Codex subagent review; baseline was derived before reading `regression-suite` or QA README, then with-skill behavior was checked against `SKILL.md`, `agents/qa/README.md`, direct shared references, eval assertions, and fixture evidence.
 
-## With Skill
+## Test Set / Fixture Version
 
-- Reuses the original bug report, fix notes, and QA environment context.
-- Verifies the fix path and adjacent regression risk instead of checking only the happy path.
-- Produces a clear pass/fail/blocked regression conclusion.
-- Reads the function-tree E2E suite, flow index, case file, script snippet, prior results, and reports when available before execution.
-- Keeps `feature-update` scoped to the fixed flow, direct impact paths, shared components, adjacent flows, and related state branches; reserves all active E2E TC coverage for `release`.
-- Requires same-`feature_path` PRD/TRD expectation alignment and a confirmed `docs/engineer/{feature_path}/IMPLEMENTATION_PLAN.md` before updating or executing acceptance TC for existing-feature changes or bug fixes.
-- Routes PRD/path ambiguity to `pm-agent:idea-to-spec`, TRD gaps to `engineer-agent:trd-gen`, and missing or mismatched implementation plans to `engineer-agent:feature-implementor`.
-- Treats a missing platform version as `blocked`, avoids `unknown`, and appends E2E results under `results/TC-NNN-<short-slug>/{platform-version}/` without overwriting history.
-- Separates run status from evidence confidence and includes a release recommendation.
+- Schema: `evals.json` v1.0
+- Prompt: 验证 Bug #001 的修复，执行回归测试
+- Fixture context: `BUG-001.md`, `PR-001.md`, QA environment note, `TEST_SUITE.md`, `FLOW_INDEX.md`, `cases/TC-001-login-session.md`, and `scripts/TC-001-login-session.spec.md`.
+- Scenario and version: `feature-update`, platform version `v1.2.0-fix.1`.
 
-## Baseline
+## Without Skill Baseline
 
-- More likely to verify only the direct symptom.
-- Provides weaker linkage back to original bug evidence.
-- More likely to over-expand a local `feature-update` regression into release-wide coverage or skip durable E2E case memory.
+- A generic regression answer would likely run or recommend `npm test -- login-regression` and stop at the original happy path.
+- It might not preserve the original failure, expected behavior, fix context, adjacent invalid-credential and locked-account risks, and evidence confidence as separate report fields.
+- It could over-expand a local `feature-update` into release-wide coverage or skip the existing function-tree E2E memory.
+- It would be less likely to block acceptance TC execution when same-path PRD/TRD or confirmed implementation-plan evidence is missing.
+
+## With Skill Behavior
+
+- PASS: `regression-suite` requires the original bug report, failing evidence, fix context, expected behavior, and scoped regression target before execution. The fixture provides original login 500 behavior, expected session creation, fix summary, adjacent serialization risks, and QA environment notes.
+- PASS: The skill reuses existing QA memory under `docs/qa/e2e/auth/login/session-start/`, including suite, flow index, case file, script, prior results, and reports when available.
+- PASS: The verification scope covers original failure recheck, expected fixed behavior, and adjacent invalid-credential and locked-account branches because they share response serialization.
+- PASS: `feature-update` scope stays limited to the fixed flow, direct impact paths, shared components, adjacent flows, and related state branches; full active E2E coverage is reserved for `release`.
+- PASS: Platform version `v1.2.0-fix.1` is available, so any actual result archive would append under `results/TC-001-login-session/v1.2.0-fix.1/` and would not overwrite history.
+- PASS: Because this is a bug-fix regression, the skill requires a visible same-path PRD/TRD/confirmed `IMPLEMENTATION_PLAN.md` gate before executing or updating acceptance TC. The fixture does not include those documents, so the correct with-skill execution result is blocked at that gate rather than release-ready.
+- PASS: The report contract keeps run status (`pass`, `fail`, `blocked`) separate from evidence confidence and includes release recommendation. With the missing alignment/plan evidence in this fixture, recommendation should be `blocked` or `needs more verification`, not `safe to release`.
 
 ## Failures
 
-- None. Current `regression-suite` instructions satisfy all eval assertions for evidence reuse, QA case reuse, fix verification, adjacent regression scope, PRD/TRD and implementation-plan gate, owner routing, platform-version archive rules, and release recommendation.
+- None identified. The current skill contract satisfies all eval assertions for original-context reuse, QA case reuse, fix verification, adjacent-risk scope, alignment and version archive gates, release recommendation, and status/confidence separation.
 
 ## Next Steps
 
-- Keep this eval for regression evidence reuse.
-- Runtime transcripts, verdicts, timing, and diagnostics should not be committed.
+- No fixture or skill change is required from this eval.
+- A real run should provide or confirm same-path PRD, TRD, and implementation-plan evidence before executing or archiving the E2E regression result.
+
+## Runtime Artifact Policy
+
+- No runtime artifacts were created for this validation.
+- Do not commit transcripts, verdicts, timing files, diagnostics, `with_skill/`, `without_skill/`, `outputs/`, or `comparison.auto.md`.

--- a/agents/qa/test/regression-suite/evals/workspace/eval-2-blocked-without-original-bug-context/comparison.md
+++ b/agents/qa/test/regression-suite/evals/workspace/eval-2-blocked-without-original-bug-context/comparison.md
@@ -2,33 +2,45 @@
 
 ## Evaluation Target
 
+- Agent: `qa`
 - Skill: `regression-suite`
+- Eval: `eval-002-blocked-without-original-bug-context`
 - Test case: blocked-without-original-bug-context
-- Test set: QA availability evals
-- Entry: workspace `eval-2-blocked-without-original-bug-context`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-06-04
+- Workspace: `workspace/eval-2-blocked-without-original-bug-context`
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
+- Validation method: fresh Codex subagent review; baseline was derived before reading `regression-suite` or QA README, then with-skill behavior was checked against `SKILL.md`, `agents/qa/README.md`, direct shared references, eval assertions, and fixture evidence.
 
-## With Skill
+## Test Set / Fixture Version
 
-- Detects that original bug, fix, and environment evidence are missing.
-- Returns a blocked regression verdict instead of inventing a verification result.
-- Lists the minimum evidence needed to proceed.
-- Marks original failure recheck, fixed behavior, adjacent regression checks, platform version confirmation, and PRD/TRD alignment as `blocked` or not executed when evidence is missing.
-- Includes original failure recheck, fixed behavior, adjacent regression checks, release recommendation, and evidence confidence in the blocked report.
-- Keeps the release recommendation at needs more verification or blocked; it does not infer release readiness from absent failures.
-- Requires the platform version and release environment before archiving results, avoids `unknown`, and does not treat a local feature-update check as a release-wide E2E conclusion.
+- Schema: `evals.json` v1.0
+- Prompt: 复测上周修过的支付按钮问题，但仓库里找不到原始 bug 报告、失败证据、修复 PR 或可用测试环境。请给出回归验证结论。
+- Fixture context: `notes/missing-context.md`
+- Evidence present: explicit note that original bug report, failing evidence, fix PR, test command, and QA environment are unavailable.
 
-## Baseline
+## Without Skill Baseline
 
-- More likely to provide speculative verification steps as if validation were possible.
-- Does not consistently preserve blocked status.
-- More likely to omit the missing platform version, original bug evidence, fix context, and environment as explicit blockers.
+- A generic regression response might provide speculative retest steps and a soft recommendation instead of an explicit blocked conclusion.
+- It could treat "no evidence of failure" as enough for progress, omitting original failure recheck and fixed-behavior status.
+- It would be less likely to block platform-version archive paths and might not distinguish local feature-update checks from release-wide E2E conclusions.
+
+## With Skill Behavior
+
+- PASS: `regression-suite` requires original failure evidence, fix context, expected behavior, and a scoped regression target. The fixture lacks all of these, so the correct result is blocked.
+- PASS: Original failure recheck, fixed behavior, adjacent regression checks, platform version confirmation, and PRD/TRD/implementation-plan alignment must be `blocked` or `not executed`, never `pass`.
+- PASS: The blocked report still includes original failure recheck, fixed behavior, adjacent regression checks, release recommendation, and evidence confidence.
+- PASS: Release recommendation must be `blocked` or `needs more verification`; absent failures do not imply release readiness.
+- PASS: The skill requires platform version and environment before archiving results, avoids `unknown`, and does not treat an unscoped local retest as a release-wide E2E result.
 
 ## Failures
 
-- None. Current `regression-suite` instructions satisfy all eval assertions for missing original evidence, blocked status, structured blocked output, release boundary, and avoiding `unknown` or unscoped release conclusions.
+- None identified. The current skill contract satisfies all eval assertions for missing original evidence, blocked status, structured blocked output, release boundary, and avoiding `unknown` or unscoped release conclusions.
 
 ## Next Steps
 
-- Keep this eval for blocked regression handling.
-- Runtime transcripts, verdicts, timing, and diagnostics should not be committed.
+- No fixture or skill change is required from this eval.
+- To unblock a real run, provide the original bug report, failing evidence, fix PR or implementation notes, expected behavior, QA environment, scenario, and platform version.
+
+## Runtime Artifact Policy
+
+- No runtime artifacts were created for this validation.
+- Do not commit transcripts, verdicts, timing files, diagnostics, `with_skill/`, `without_skill/`, `outputs/`, or `comparison.auto.md`.

--- a/agents/qa/test/spec-based-tester/evals/workspace/eval-1-test-from-spec/comparison.md
+++ b/agents/qa/test/spec-based-tester/evals/workspace/eval-1-test-from-spec/comparison.md
@@ -7,51 +7,43 @@
 - Eval: `eval-001-test-from-spec`
 - Test case: test-from-spec
 - Workspace: `workspace/eval-1-test-from-spec`
-- Latest result: PARTIAL - prior skill validation evidence is preserved; without_skill baseline was not generated for this historical comparison.
-- Prior validation note: fresh Codex subagent validation completed on 2026-06-04
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
+- Validation method: fresh Codex subagent review; baseline was derived before reading `spec-based-tester` or QA README, then with-skill behavior was checked against `SKILL.md`, `agents/qa/README.md`, direct shared references, eval assertions, and fixture evidence.
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: Verifies that spec-based-tester handles test-from-spec and produces the expected role-specific artifact.
 - Expected output: 测试报告，包含通过/失败统计和失败用例详情
 - Fixture context: `docs/test-spec.md`, `docs/prd.md`, `docs/trd.md`, `docs/qa/e2e/commerce/checkout/discount-code/TEST_SUITE.md`, `FLOW_INDEX.md`, `cases/TC-001-discount-code.md`, and `package.json`.
+- Scenario and version: `feature-update`, platform version `v0.3.0-dev`.
 
-## Assertions
+## Without Skill Baseline
 
-- `assertion_1`: 上下文基线
-- `assertion_2`: 独立用例复用
-- `assertion_3`: 执行路径选择
-- `assertion_4`: 结果分级
-- `assertion_5`: 结构化证据
-- `e2e`: E2E 单文件约束
-- `assertion_7`: 交接边界
+- A generic spec-test answer would likely run the obvious `npm test` command or summarize expected checks without first recording scope, environment assumptions, unknowns, and blocked checks.
+- It might not reuse the existing `docs/qa/e2e/commerce/checkout/discount-code/` function-tree memory before considering new cases.
+- It could treat missing scripts, previous results, or reports as irrelevant instead of recording them as absent.
+- It would be more likely to turn blocked or assumed observations into bugs without confirmed reproducible evidence.
 
-## With Skill
+## With Skill Behavior
 
-Observed behavior:
-
-- PASS. 当前 `spec-based-tester` 要求执行前读取 PM/spec、TRD、实现上下文、仓库指令和现有 QA 功能树，并记录 scope、环境假设、unknowns、blocked checks。
-- PASS. 当 PM 未提供具体 E2E 用例时，skill 要求先读取 `docs/qa/e2e/{feature_path}/TEST_SUITE.md`、`FLOW_INDEX.md`、`cases/*.md`、`scripts/*.spec.md`、历史 `results/` 和 `_reports/`；fixture 已有 `commerce/checkout/discount-code` 功能树和 `TC-001-discount-code`，所以应优先复用现有 TC，不回退到旧的单层 QA 目录。
-- PASS. 执行路径规则明确为 repo acceptance/e2e/integration/manual QA harness 优先，其次 Chrome plugin / browser connector，最后才是 standalone Playwright fallback；fixture 的 TRD 和 TEST_SUITE 均指向 `npm test -- checkout-discount` 作为 repo harness。
-- PASS. Evidence contract 要求 requirement matrix 使用 `pass`、`fail`、`blocked` 或 `assumed`，并明确不把 blocked 或 assumed 项误写成 confirmed defect。
-- PASS. 输出要求包含 scoped validation summary、requirement matrix、execution path、evidence references、risk notes、blocked items 和 handoff notes。
-- PASS. Shared QA directory contract 要求 E2E TC 单文件存放到 `cases/TC-NNN-<short-slug>.md`，并维护 `FLOW_INDEX.md`、`TEST_SUITE.md` 和 matching `scripts/TC-NNN-<short-slug>.spec.md`；fixture 当前已有 case，若后续补充脚本或新增 TC，skill 会按该目录契约处理。
-- PASS. E2E 运行前必须确认 `feature-update` 或 `release` 场景和 platform version；缺失版本时 blocked，不写 `unknown`。结果归档和主报告路径按 `e2e-test-report.md` reference 写入 `results/TC-NNN-<short-slug>/{platform-version}/` 和对应 `_reports/{platform-version}/test-reports-{test-time}.md`。
-- PASS. Bug handoff 只允许 confirmed reproducible failure with evidence；blocked、assumed、flaky 或证据不足的观察不会升级为 bug-analyzer handoff。
-
-## Without Skill / Baseline
-- BLOCKED: No actual without_skill baseline result is recorded for this historical comparison. This file is not treated as a full eval PASS until a baseline result is generated and written here.
-- This comparison records whether the skill-specific protocol, routing, evidence, or artifact expectations are preserved.
+- PASS: `spec-based-tester` requires reading the test spec, PRD, TRD, repository instructions, implementation context when available, and existing QA memory before execution.
+- PASS: The fixture has an existing `TC-001-discount-code` in the function-tree QA directory, so the skill reuses that TC as the primary scope and does not fall back to a legacy single-level QA directory.
+- PASS: Missing `scripts/*.spec.md`, prior `results/`, and `_reports/` must be recorded as absent or blocked rather than skipped; any future E2E script must use `scripts/TC-NNN-<short-slug>.spec.md`.
+- PASS: The narrowest execution path is the repo harness `npm test -- checkout-discount`, referenced by both TRD and `TEST_SUITE.md`; Chrome plugin / browser connector and standalone Playwright are lower-priority fallbacks.
+- PASS: Requirement matrix statuses are limited to `pass`, `fail`, `blocked`, or `assumed`, with evidence references and notes for each requirement.
+- PASS: E2E execution requires scenario and platform version. This fixture has `feature-update` and `v0.3.0-dev`, so archive/report paths are versioned and never use `unknown`.
+- PASS: Handoff to `bug-analyzer` is allowed only for confirmed reproducible failures with evidence; blocked, assumed, flaky, or thin-evidence items remain in the QA report.
 
 ## Failures
 
-- None.
+- None identified. The current skill contract satisfies all eval assertions for context baseline, E2E memory reuse, execution-path choice, result grading, structured evidence, single-file E2E constraints, versioned report archive, and bug handoff boundary.
 
 ## Next Steps
 
-- 无运行期文件需要生成。Eval fixture 中 `TC-001-discount-code` 当前没有 matching script 文件；本次评测判断的是当前 skill 协议是否满足 assertions，实际执行或新增脚本时应按 skill 的 `scripts/TC-NNN-<short-slug>.spec.md` 契约补齐。
+- No fixture or skill change is required from this eval.
+- If this eval is later executed as real E2E, add or confirm a matching script file before script-based replay, and keep absent historical results/reports visible in the preflight.
 
-## Runtime Artifacts Policy
+## Runtime Artifact Policy
 
-- Runtime transcripts, verdicts, timing, outputs, and diagnostics should not be committed.
+- No runtime artifacts were created for this validation.
+- Do not commit transcripts, verdicts, timing files, diagnostics, `with_skill/`, `without_skill/`, `outputs/`, or `comparison.auto.md`.

--- a/agents/qa/test/spec-based-tester/evals/workspace/eval-2-boundary-test-generation/comparison.md
+++ b/agents/qa/test/spec-based-tester/evals/workspace/eval-2-boundary-test-generation/comparison.md
@@ -7,50 +7,44 @@
 - Eval: `eval-002-boundary-test-generation`
 - Test case: boundary-test-generation
 - Workspace: `workspace/eval-2-boundary-test-generation`
-- Latest result: PARTIAL - prior skill validation evidence is preserved; without_skill baseline was not generated for this historical comparison.
-- Prior validation note: fresh Codex subagent validation on 2026-06-23 after QA owner split fix
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
+- Validation method: fresh Codex subagent review; baseline was derived before reading `spec-based-tester` or QA README, then with-skill behavior was checked against `SKILL.md`, `agents/qa/README.md`, direct shared references, eval assertions, and fixture evidence.
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: Verifies that spec-based-tester handles boundary-test-generation and produces the expected role-specific artifact.
 - Expected output: 结构化边界验证报告，包含 requirement matrix、execution path、evidence references、risk notes 和 handoff decision
 - Fixture context: `docs/pm/login-refresh/PRD.md`, `docs/engineer/login-refresh/TRD.md`, `implementation/changes.md`, `docs/qa/e2e/auth/login/login-form/TEST_SUITE.md`, `FLOW_INDEX.md`, `cases/TC-001-login-boundaries.md`, `scripts/TC-001-login-boundaries.spec.md`, and `package.json`.
+- Scenario and version: `feature-update`, platform version `v1.2.0-rc.1`.
 
-## Assertions
+## Without Skill Baseline
 
-- `assertion_1`: 范围与假设
-- `assertion_2`: 用例目录优先
-- `assertion_3`: 边界执行
-- `assertion_4`: 证据与分层
-- `assertion_5`: 硬性结构
-- `assertion_6`: 风险与交接
-- `alignment_plan_gate`: PRD/TRD 和实施计划门禁
+- A generic boundary-test answer would likely enumerate empty values, long strings, special characters, invalid email, and locked-account checks, then run `npm test` without a formal preflight.
+- It might skip existing QA memory and recreate cases from the prompt.
+- It could treat missing browser URL or missing confirmed implementation plan as a minor caveat instead of a blocked gate.
+- It would be more likely to hand off assumed failures to bug analysis without confirmed reproducible evidence.
 
-## With Skill
+## With Skill Behavior
 
-Observed behavior:
-
-- PASS. 当前 `spec-based-tester` 要求先读取 PRD、TRD、实现上下文、仓库测试命令和既有 QA 功能树，记录边界范围、环境假设、未知依赖和 blocked 条件后再执行。
-- PASS. Skill 明确在功能树存在时优先读取 `docs/qa/e2e/auth/login/login-form/TEST_SUITE.md`、`FLOW_INDEX.md`、`cases/*.md`、`scripts/*.spec.md`、历史 `results/` 和 `_reports/`；fixture 已提供 `TC-001-login-boundaries` 和 matching script，当前 TC 覆盖空值、超长字符串、特殊字符、非法邮箱和锁定账号状态。
-- PASS. 执行路径选择要求用最窄且能证明要求的 repo harness；fixture 的 TRD、TEST_SUITE 和 script 都指向 `npm test -- login-boundaries`，Chrome plugin / browser connector 只在 repo harness 无法覆盖可见断言时使用，Playwright 仅为 fallback。
-- PASS. 报告协议要求 requirement matrix 逐项标记 `pass`、`fail`、`blocked` 或 `assumed`，并为每项保留 evidence references，避免把 blocked 或 assumed 项升级成缺陷。
-- PASS. Expected outcome 和 evidence contract 要求输出 validation summary、requirement matrix、execution path、evidence references、risk notes、blocked items、release/implementation risks 和 handoff notes，覆盖 eval 的硬性结构。
-- PASS. Bug-analyzer handoff 仅允许 confirmed reproducible failure with evidence；缺失环境、证据不足、不稳定观察和假设必须保留为 blocked 或 assumed。
-- PASS. 对现有功能变更、bug fix 或代码完成后的 E2E 文档更新，skill 要求先确认同一 `feature_path` 下 PRD/TRD 预期对齐并有已确认的 `docs/engineer/{feature_path}/IMPLEMENTATION_PLAN.md`；预期变化或 PRD/path 不清回 `pm-agent:idea-to-spec`，TRD gap 回 `engineer-agent:trd-gen`，缺 implementation plan 回 `engineer-agent:feature-implementor`，文档缺失、平台版本缺失或实施计划缺失时 blocked。本 fixture 没有提供 `IMPLEMENTATION_PLAN.md`，因此真实执行时应 blocked，而不是伪造边界验证结果。
-
-## Without Skill / Baseline
-- BLOCKED: No actual without_skill baseline result is recorded for this historical comparison. This file is not treated as a full eval PASS until a baseline result is generated and written here.
-- This comparison records whether the skill-specific protocol, routing, evidence, or artifact expectations are preserved.
+- PASS: `spec-based-tester` requires PRD, TRD, implementation context, repository test commands, and QA function-tree files before execution.
+- PASS: Existing QA memory at `docs/qa/e2e/auth/login/login-form/` is primary. The provided `TC-001-login-boundaries` and matching script cover empty values, overlong input, special characters, invalid email format, and locked-account state.
+- PASS: The narrowest execution path is the repo harness `npm test -- login-boundaries`, referenced by TRD, `TEST_SUITE.md`, and the script. Chrome plugin / browser connector is only for visible assertions the harness cannot cover; standalone Playwright remains fallback.
+- PASS: The validation report must include requirement matrix, execution path, evidence references, risk notes, blocked items, and handoff decision, with each boundary marked `pass`, `fail`, `blocked`, or `assumed`.
+- PASS: Platform version `v1.2.0-rc.1` is present, so versioned result/archive paths are available and must not use `unknown`.
+- PASS: The direct hotfix or feature-update boundary is tight: validate changed login form behavior and direct impact paths, not release-wide E2E coverage.
+- PASS: The alignment-plan gate is enforced. Because the fixture does not include `docs/engineer/login-refresh/IMPLEMENTATION_PLAN.md`, real execution or E2E documentation update should be blocked and routed to `engineer-agent:feature-implementor` rather than fabricating boundary validation results.
+- PASS: Handoff to `bug-analyzer` is allowed only for confirmed reproducible failures with evidence; missing environment, blocked checks, assumptions, and unstable observations stay in the QA report.
 
 ## Failures
 
-- None.
+- None identified. The current skill contract satisfies all eval assertions for scope and assumptions, function-tree priority, boundary execution, evidence/status layering, required report structure, risk handoff, alignment-plan gate, and direct feature-update scope.
 
 ## Next Steps
 
-- 保持缺失浏览器环境、缺失平台版本或缺失已确认实施计划时不伪造执行结果；按 skill 规则记录 blocked，并按 PRD/path、TRD、implementation plan 三类缺口交给对应 owner。
+- No fixture or skill change is required from this eval.
+- A real run should provide the confirmed implementation plan before executing or archiving E2E boundary evidence; browser-only checks also require a deployed app URL such as `QA_BASE_URL`.
 
-## Runtime Artifacts Policy
+## Runtime Artifact Policy
 
-- Runtime transcripts, verdicts, timing, outputs, and diagnostics should not be committed.
+- No runtime artifacts were created for this validation.
+- Do not commit transcripts, verdicts, timing files, diagnostics, `with_skill/`, `without_skill/`, `outputs/`, or `comparison.auto.md`.

--- a/agents/security/test/security-agent/evals/workspace/eval-1-route-auth-release-risk/comparison.md
+++ b/agents/security/test/security-agent/evals/workspace/eval-1-route-auth-release-risk/comparison.md
@@ -1,37 +1,45 @@
-# Eval Result: security-agent-route-auth-release-risk
+# Eval Result: eval-001-route-auth-release-risk
 
 ## Evaluation Target
 
+- Agent: `security`
 - Skill: `security-agent`
+- Eval: `eval-001-route-auth-release-risk`
 - Test case: route-auth-release-risk
-- Test set: dispatcher availability evals
-- Entry: workspace `eval-1-route-auth-release-risk`
-- Latest result: PASS
+- Workspace: `workspace/eval-1-route-auth-release-risk`
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: auth-centered release security request
+- Fixture: auth-centered release security request with dependency-risk concern.
+- Context read before applying the skill: `evals.json`, workspace `eval_metadata.json`, `docs/security/auth-model.md`, and `package.json`.
 
-## With Skill
+## Assertions
 
-- Routes the admin authorization risk to `authz-reviewer`.
-- Keeps dependency risk as a `dependency-risk-auditor` follow-up.
-- Preserves security review as evidence and risk reporting, not direct remediation.
+- PASS `routes_primary_to_authz`: login, roles, admin access, and authorization bypass risk route to `authz-reviewer`.
+- PASS `names_dependency_followup`: dependency vulnerability concerns are preserved as a `dependency-risk-auditor` follow-up.
+- PASS `collects_security_context`: downstream context includes auth flows, roles/permissions, sensitive routes, test evidence, and dependency manifest.
+- PASS `structured_risk_output`: expected output is a structured review, risk matrix, evidence, and remediation guidance.
+- PASS `hands_off_remediation`: fixes are handed to `engineer-agent` or `devops-agent`, not implemented by Security.
 
-## Without Skill / Baseline
+## With Skill Behavior
 
-- May blend auth review, dependency audit, and implementation advice.
-- Less consistently hands remediation back to engineering or DevOps owners.
+`security-agent` satisfies the release-risk route. Its router chooses the narrowest security outcome, so the auth/admin risk gets `authz-reviewer` as the current route while dependency audit remains a named follow-up. The skill preserves Security as an evidence-backed risk review role and explicitly hands remediation to Engineer or DevOps when findings require changes.
+
+## Without Skill Baseline
+
+Without the router skill and Security README, a generic response could blend auth review, dependency audit, and fix recommendations into one broad release checklist. It may also suggest code changes directly instead of keeping Security output as structured risk evidence with remediation handoff.
 
 ## Failures
 
-- None recorded.
+- None found.
 
 ## Next Steps
 
-- Keep this eval for Security dispatcher route coverage.
+- Keep this eval as regression coverage for Security narrow-route selection and remediation handoff.
 
 ## Runtime Artifacts Policy
 
-- Runtime transcripts, verdicts, timing, and diagnostics should not be committed.
+- No runtime artifacts were created for this validation.
+- Runtime transcripts, verdicts, timing, output directories, diagnostics, and generated with_skill / without_skill files must not be committed.


### PR DESCRIPTION
## Summary

- Batch 4 合并后集中执行 fresh Codex subagent validation，并更新 56 个 durable `comparison.md`。
- 覆盖范围：`pm-agent`、`feature-catalog`、`idea-to-spec`、5 个下游 role router、`feature-implementor`、QA specialists。
- 所有目标 comparison 均记录 with-skill behavior、without_skill baseline、failures、next steps 和 runtime artifact policy；未提交 runtime artifacts。

## Validation Scope

- PM 侧：23 个 comparison
- Role routers：12 个 comparison
- `feature-implementor`：13 个 comparison
- QA specialists：8 个 comparison

## Testing

- `git diff --check` -> PASS
- `uv run scripts/check_repository_contract.py` -> PASS
- `uv run scripts/check_eval_contract.py` -> PASS
- `uv run scripts/check_eval_artifacts.py` -> PASS
- `uv run --with pytest pytest agents/product_manager/test/idea-to-spec agents/product_manager/test/pm-agent agents/qa/test/test_qa_run_eval.py agents/designer/test/test_designer_run_eval.py agents/devops/test/test_devops_run_eval.py agents/test_eval_contract.py` -> 97 passed

## Notes

- This follows up on #74 after #52 and #61 were closed.
- Release prep should wait until this PR passes CI and review, then the maintainer can decide whether to proceed with the optional release step.

@codex review
