### PR TITLE
feat: 为六个 plugin 补充 plugin.json 并加契约校验

### DIFF
--- a/agents/designer/.claude-plugin/plugin.json
+++ b/agents/designer/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "designer-agent",
+  "version": "0.2.0",
+  "description": "Downstream design capability invoked after pm-agent handoff for confirmed UX flows, information architecture, wireframes, reference-pattern analysis, and reference-backed visual system work.",
+  "author": {
+    "name": "Neplich"
+  }
+}

--- a/agents/devops/.claude-plugin/plugin.json
+++ b/agents/devops/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "devops-agent",
+  "version": "0.2.0",
+  "description": "Downstream DevOps capability invoked after pm-agent handoff for confirmed deployment planning, CI/CD automation, environment audits, release readiness, rollback, and runbook preparation.",
+  "author": {
+    "name": "Neplich"
+  }
+}

--- a/agents/engineer/.claude-plugin/plugin.json
+++ b/agents/engineer/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "engineer-agent",
+  "version": "0.2.0",
+  "description": "Downstream engineering capability invoked after pm-agent handoff for confirmed codebase analysis, TRDs, bootstrapping, implementation, tests, debugging, and delivery. Skills remain available for PM-orchestrated execution, not as standalone starting points.",
+  "author": {
+    "name": "Neplich"
+  }
+}

--- a/agents/product_manager/.claude-plugin/plugin.json
+++ b/agents/product_manager/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "pm-agent",
+  "version": "0.2.0",
+  "description": "Public entry dispatcher for product ideas, requirement changes, inherited-project feature catalogs, competitive research, battlecards, bug reports, implementation requests, tests, UI/design, deployment, security, delivery, commits, pushes, PRs, release communication, roadmaps, and GitHub project status. Classifies scope first, then hands off to downstream role agents or PM specialists when ready.",
+  "author": {
+    "name": "Neplich"
+  }
+}

--- a/agents/qa/.claude-plugin/plugin.json
+++ b/agents/qa/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "qa-agent",
+  "version": "0.2.0",
+  "description": "Downstream QA capability invoked after pm-agent handoff for confirmed acceptance, exploratory testing, bug analysis, and regression verification. Requirement or implementation gaps return through the PM-orchestrated handoff path.",
+  "author": {
+    "name": "Neplich"
+  }
+}

--- a/agents/security/.claude-plugin/plugin.json
+++ b/agents/security/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "security-agent",
+  "version": "0.2.0",
+  "description": "Downstream security capability invoked after pm-agent handoff for confirmed AppSec, auth/authz, dependency risk, privacy, and data-flow reviews, with remediation routed through the PM handoff path.",
+  "author": {
+    "name": "Neplich"
+  }
+}

--- a/agents/test_eval_contract.py
+++ b/agents/test_eval_contract.py
@@ -620,6 +620,77 @@ class EvalContractTests(unittest.TestCase):
         rendered = "\n".join(error.render(root) for error in errors)
         self.assertIn("metadata.version must match latest changelog version '0.1.3'", rendered)
 
+    def test_repository_contract_requires_plugin_manifest_name_and_version(self):
+        checker = load_repository_checker_module()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            marketplace = root / ".claude-plugin/marketplace.json"
+            plugin_manifest = root / "agents/engineer/.claude-plugin/plugin.json"
+            skill_doc = root / "agents/engineer/skills/example/SKILL.md"
+            changelog = root / "docs/changelog/changelog-v1.2.3.md"
+            changelog_index = root / "CHANGELOG.md"
+            marketplace.parent.mkdir(parents=True)
+            skill_doc.parent.mkdir(parents=True)
+            changelog.parent.mkdir(parents=True)
+            plugin_manifest.parent.mkdir(parents=True)
+            skill_doc.write_text(
+                "---\n"
+                "name: example\n"
+                "description: Example skill\n"
+                "---\n"
+            )
+            changelog.write_text("# Changelog - v1.2.3\n")
+            changelog_index.write_text(
+                "# Changelog\n\n"
+                "- [v1.2.3](./docs/changelog/changelog-v1.2.3.md)\n"
+            )
+            marketplace.write_text(
+                json.dumps(
+                    {
+                        "name": "dev-agent-skills",
+                        "owner": {"name": "Neplich"},
+                        "metadata": {"version": "1.2.3"},
+                        "plugins": [
+                            {
+                                "name": "engineer-agent",
+                                "source": "./agents/engineer",
+                                "skills": ["./skills/example"],
+                            }
+                        ],
+                    }
+                )
+            )
+
+            errors = []
+            checker.validate_marketplace(root, errors)
+            missing_rendered = "\n".join(error.render(root) for error in errors)
+
+            plugin_manifest.write_text(
+                json.dumps(
+                    {
+                        "name": "wrong-agent",
+                        "version": "1.2.2",
+                    }
+                )
+            )
+            errors = []
+            checker.validate_marketplace(root, errors)
+
+        rendered = "\n".join(error.render(root) for error in errors)
+        self.assertIn(
+            "agents/engineer/.claude-plugin/plugin.json: plugin source must contain .claude-plugin/plugin.json",
+            missing_rendered,
+        )
+        self.assertIn(
+            "name must match marketplace plugins[0].name 'engineer-agent'",
+            rendered,
+        )
+        self.assertIn(
+            "version must match marketplace metadata.version '1.2.3'",
+            rendered,
+        )
+
     def test_repository_contract_same_day_exception_uses_frontmatter_changelog_only(self):
         checker = load_repository_checker_module()
 
@@ -671,10 +742,12 @@ class EvalContractTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             marketplace = root / ".claude-plugin/marketplace.json"
+            plugin_manifest = root / "agents/engineer/.claude-plugin/plugin.json"
             skill_doc = root / "agents/engineer/skills/example/SKILL.md"
             changelog_dir = root / "docs/changelog"
             changelog_index = root / "CHANGELOG.md"
             marketplace.parent.mkdir(parents=True)
+            plugin_manifest.parent.mkdir(parents=True)
             skill_doc.parent.mkdir(parents=True)
             changelog_dir.mkdir(parents=True)
             skill_doc.write_text(
@@ -682,6 +755,14 @@ class EvalContractTests(unittest.TestCase):
                 "name: example\n"
                 "description: Example skill\n"
                 "---\n"
+            )
+            plugin_manifest.write_text(
+                json.dumps(
+                    {
+                        "name": "engineer-agent",
+                        "version": "1.2.3-rc.10",
+                    }
+                )
             )
             (changelog_dir / "changelog-v1.2.3-rc.2.md").write_text(
                 "# Changelog - v1.2.3-rc.2\n"

--- a/scripts/check_repository_contract.py
+++ b/scripts/check_repository_contract.py
@@ -368,6 +368,48 @@ def validate_root_changelog_entry(
         )
 
 
+def validate_plugin_manifest(
+    manifest_path: Path,
+    marketplace_path: Path,
+    plugin_index: int,
+    plugin_name: Any,
+    metadata_version: Any,
+    errors: list[ContractError],
+) -> None:
+    if not manifest_path.exists():
+        add_error(
+            errors,
+            manifest_path,
+            "plugin source must contain .claude-plugin/plugin.json",
+        )
+        return
+
+    payload = load_json(manifest_path, errors)
+    if not isinstance(payload, dict):
+        add_error(errors, manifest_path, "top-level payload must be an object")
+        return
+
+    if not isinstance(plugin_name, str) or not plugin_name.strip():
+        add_error(
+            errors,
+            marketplace_path,
+            f"plugins[{plugin_index}].name must be a non-empty string",
+        )
+    elif payload.get("name") != plugin_name:
+        add_error(
+            errors,
+            manifest_path,
+            f"name must match marketplace plugins[{plugin_index}].name {plugin_name!r}",
+        )
+
+    if isinstance(metadata_version, str) and payload.get("version") != metadata_version:
+        add_error(
+            errors,
+            manifest_path,
+            f"version must match marketplace metadata.version {metadata_version!r}",
+        )
+
+
 def validate_marketplace(root: Path, errors: list[ContractError]) -> None:
     path = root / ".claude-plugin" / "marketplace.json"
     payload = load_json(path, errors)
@@ -380,6 +422,7 @@ def validate_marketplace(root: Path, errors: list[ContractError]) -> None:
         add_error(errors, path, "plugins must be an array")
         return
 
+    metadata_version: Any = None
     metadata = payload.get("metadata")
     if not isinstance(metadata, dict):
         add_error(errors, path, "metadata must be an object")
@@ -421,6 +464,15 @@ def validate_marketplace(root: Path, errors: list[ContractError]) -> None:
         if not source_path.exists():
             add_error(errors, root / source, f"plugins[{index}].source does not exist")
             continue
+
+        validate_plugin_manifest(
+            source_path / ".claude-plugin" / "plugin.json",
+            path,
+            index,
+            plugin.get("name"),
+            metadata_version,
+            errors,
+        )
 
         skills = plugin.get("skills")
         if not isinstance(skills, list):


### PR DESCRIPTION
## 背景

Closes #79。

按 Claude Code 官方标准，marketplace 中每个 plugin 的 source 根目录都应包含 `.claude-plugin/plugin.json`。此前六个 agent 目录全部缺失，仓库只依赖 `marketplace.json` 的内联定义，偏离文档要求的标准结构，是最可能在未来版本被收紧而失效的合规缺口。

## 改动

- 新增 6 个 `agents/*/.claude-plugin/plugin.json`，`name` / `version` / `description` / `author` 与 `marketplace.json` 对应条目及 `metadata.version`、`owner` 对齐。
- 在 `scripts/check_repository_contract.py` 增加确定性校验：每个 plugin source 必须存在 `.claude-plugin/plugin.json`，且其 `name` 与 marketplace plugin name 一致、`version` 与 `metadata.version` 一致。
- 在 `agents/test_eval_contract.py` 补充缺失与不一致两类失败场景的单测。

## 验证

- `uv run scripts/check_repository_contract.py` → PASS
- `uv run python -m json.tool .claude-plugin/marketplace.json > /dev/null` → PASS
- `uv run python -m unittest agents.test_eval_contract` → PASS

## 变更分级

`change_tier`: standard（触及 marketplace 契约面与校验脚本）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)