### PR TITLE
feat: 下游安全网收尾与 auto-continue 入口规则

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,10 +48,13 @@ PM Agent → Designer Agent → Engineer Agent → QA Agent → DevOps Agent →
 **PM 唯一入口与下游 gate 指针**
 
 - 用户侧新需求、变更、bug、测试、部署、安全、交付或仓库状态诉求默认先进入 `pm-agent` 分类；下游 role router 和 specialist 只在 PM handoff packet 或等效已确认文档链存在时承接。
+- 用户未显式点名任何 skill 或 agent 时，默认进入 `pm-agent`；用户显式点名某个 skill 或 agent 时，这是受支持的直达路径，但仍必须经过对应入口 gate 的安全网。
 - PM handoff packet 字段定义以 `agents/product_manager/skills/idea-to-spec/_internal/_shared/skill-map.md` 为权威；`AGENTS.md` 不复制字段清单。
+- 下游安全网包含前置与收尾两面：缺少 PM handoff packet、等效已确认文档链或 specialist entry basis 时，温和引导用户经 `pm-agent` 补齐前置；完成当前事项后，主动建议协作链下一步并等待确认，用户已授权 `auto-continue` 时可连续推进直到链路结束或用户喊停。
+- 跨角色收尾与 `auto-continue` 的权威定义在 `agents/product_manager/skills/idea-to-spec/_internal/_shared/skill-map.md` 的 `Safety-Net Closeout and Auto-Continue` 节；`AGENTS.md` 只保留入口契约和指针。
 - SKILL.md frontmatter 的 `visibility: internal` 是声明层标记，Claude Code 与 Codex 都不消费该字段，不隐藏 slash 命令也不阻止显式直调；`pm-agent` 是默认入口，下游标记为 `internal` 仅表示非默认入口。
 - 5 个 role router 只保留入口凭据检查和分流指针；具体执行 gate 的权威副本留在对应 specialist `SKILL.md`，例如 `feature-implementor` 的 PRD/TRD/plan/archive gate、`debugger` 的 expected-behavior gate、QA specialist 的 E2E gate，以及 Designer/DevOps/Security specialist 的 feature-scope gate。
-- 直接调用下游且没有 PM handoff packet 或等效已确认文档链时，不执行下游协议，回到 `pm-agent` 做入口分类；唯一例外是用户直接请求 `project-bootstrap` 且明确要求跳过 PM 并立即 scaffold，此时可进入 `project-bootstrap` 的最小脚手架 override。
+- 直接调用下游且没有 PM handoff packet、等效已确认文档链或 specialist entry basis 时，不执行下游协议，应温和引导用户经 `pm-agent` 补齐前置并完成入口分类；唯一例外是用户直接请求 `project-bootstrap` 且明确要求跳过 PM 并立即 scaffold，此时可进入 `project-bootstrap` 的最小脚手架 override。
 
 **文档依赖**
 

--- a/agents/designer/skills/designer-agent/SKILL.md
+++ b/agents/designer/skills/designer-agent/SKILL.md
@@ -137,3 +137,9 @@ When routing is complete:
 - if relevant, state the follow-up design chain
 - make the design-only stopping point explicit and name `engineer-agent` as the
   next step for implementation
+- after the routed skill or role stage completes, apply the cross-role
+  safety-net closeout defined in
+  `agents/product_manager/skills/idea-to-spec/_internal/_shared/skill-map.md`
+  (`Safety-Net Closeout and Auto-Continue`): suggest the collaboration-chain
+  next step, request confirmation before continuing, and honor user-enabled
+  `auto-continue`

--- a/agents/devops/skills/devops-agent/SKILL.md
+++ b/agents/devops/skills/devops-agent/SKILL.md
@@ -126,3 +126,9 @@ When routing is complete:
 - make it clear whether outputs are expected under `deploy/`,
   repo-native CI/CD paths such as `.github/workflows/`, or durable operational
   docs under `docs/devops/{feature_path}/` or `deploy/`
+- after the routed skill or role stage completes, apply the cross-role
+  safety-net closeout defined in
+  `agents/product_manager/skills/idea-to-spec/_internal/_shared/skill-map.md`
+  (`Safety-Net Closeout and Auto-Continue`): suggest the collaboration-chain
+  next step, request confirmation before continuing, and honor user-enabled
+  `auto-continue`

--- a/agents/engineer/skills/engineer-agent/SKILL.md
+++ b/agents/engineer/skills/engineer-agent/SKILL.md
@@ -245,3 +245,9 @@ When routing is complete:
 - if relevant, state the follow-up engineering chain
 - carry forward the resolved context so the downstream skill starts with the
   right implementation target
+- after the routed skill or role stage completes, apply the cross-role
+  safety-net closeout defined in
+  `agents/product_manager/skills/idea-to-spec/_internal/_shared/skill-map.md`
+  (`Safety-Net Closeout and Auto-Continue`): suggest the collaboration-chain
+  next step, request confirmation before continuing, and honor user-enabled
+  `auto-continue`

--- a/agents/product_manager/skills/idea-to-spec/_internal/_shared/skill-map.md
+++ b/agents/product_manager/skills/idea-to-spec/_internal/_shared/skill-map.md
@@ -294,6 +294,14 @@ workflow, or blocked handoff report.
   chain without step-by-step confirmation until the chain ends, a blocker is
   reached, a required target is unavailable, or the user tells the agent to
   stop.
+- Role boundaries and role-only gates take precedence over auto-continue.
+  Auto-continue never authorizes the current role to execute another role's
+  workflow, call that role's specialists, or bypass a hard stop. Across roles,
+  auto-continue only automates the next-owner proposal and handoff; the next
+  owner agent performs the actual work under its own gates. Roles with hard
+  stopping points, such as Designer stopping at design deliverables and handing
+  implementation to `engineer-agent`, may auto-continue only up to that handoff
+  point.
 - If a user directly invokes a downstream role, dispatcher, or specialist but
   the required upstream PM handoff packet, confirmed document chain, or
   specialist entry basis is missing, softly guide the request back through

--- a/agents/product_manager/skills/idea-to-spec/_internal/_shared/skill-map.md
+++ b/agents/product_manager/skills/idea-to-spec/_internal/_shared/skill-map.md
@@ -274,7 +274,34 @@ If the target agent or skill is unavailable, state the missing stage, name the
 plugin or capability needed, mark the handoff blocked in `blockers_risks`, and
 do not perform that downstream role's responsibilities yourself.
 
-## 8. Phase and Situation Routing
+## 8. Safety-Net Closeout and Auto-Continue
+
+This is the cross-role public behavior shared by the six dispatchers. It
+applies after the current role finishes its scoped task, selected specialist
+workflow, or blocked handoff report.
+
+- Use the existing Downstream Owner Map and the collaboration chain
+  `PM -> Designer -> Engineer -> QA -> DevOps -> Security` to identify the
+  most likely next owner. Do not create a parallel owner map or new chain.
+- At closeout, proactively tell the user what the recommended next step is,
+  why that owner is next, and what artifact or action that owner should
+  produce.
+- Unless the user has already authorized automatic continuation, ask for user
+  confirmation before continuing into the next role or skill. One role
+  completion normally produces one next-step proposal.
+- If the user authorizes auto-continue with wording such as "后面自动继续",
+  "auto", or an equivalent instruction, continue through the collaboration
+  chain without step-by-step confirmation until the chain ends, a blocker is
+  reached, a required target is unavailable, or the user tells the agent to
+  stop.
+- If a user directly invokes a downstream role, dispatcher, or specialist but
+  the required upstream PM handoff packet, confirmed document chain, or
+  specialist entry basis is missing, softly guide the request back through
+  `pm-agent` to fill the prerequisite context. This is a safety-net guidance
+  path, not a silent refusal and not permission to execute downstream work
+  without the missing basis.
+
+## 9. Phase and Situation Routing
 
 | Phase / Situation | Primary internal skill | Alternative / follow-up |
 | --- | --- | --- |
@@ -288,7 +315,7 @@ do not perform that downstream role's responsibilities yourself.
 | Full end-to-end pipeline requested | `flow` | Narrower gen / validator steps if the user backs off |
 | Diff only | `version-differ` | `trace-check` if the issue is coverage rather than versioning |
 
-## 9. Existing-Project Update Rules
+## 10. Existing-Project Update Rules
 
 - Run `change-impactor` first when the user asks to update an existing feature,
   requirement, rollout policy, or integration and the blast radius is unclear.
@@ -303,7 +330,7 @@ do not perform that downstream role's responsibilities yourself.
   - the current artifact is too incomplete to safely iterate
   - the user explicitly prefers regeneration
 
-## 10. Lifecycle Coverage Matrix
+## 11. Lifecycle Coverage Matrix
 
 | Document Type | Generator | Validator | Iteration |
 | --- | --- | --- | --- |
@@ -314,7 +341,7 @@ do not perform that downstream role's responsibilities yourself.
 | ADR | `engineer-agent:trd-gen` | `adr-validator` | hand off to `engineer-agent:trd-gen` for revisions |
 | TEST_SPEC | `tspecs-gen` | `tspecs-validator` | `tspecs-iteration` |
 
-## 11. Shared References
+## 12. Shared References
 
 - Schema source root:
   `_internal/_shared/doc-schemas/`

--- a/agents/product_manager/skills/pm-agent/SKILL.md
+++ b/agents/product_manager/skills/pm-agent/SKILL.md
@@ -289,3 +289,9 @@ When routing is complete:
   permission to proceed
 - preserve settled PM context so the downstream skill does not need to reopen
   route decisions
+- after the routed skill or role stage completes, apply the cross-role
+  safety-net closeout defined in
+  `agents/product_manager/skills/idea-to-spec/_internal/_shared/skill-map.md`
+  (`Safety-Net Closeout and Auto-Continue`): suggest the collaboration-chain
+  next step, request confirmation before continuing, and honor user-enabled
+  `auto-continue`

--- a/agents/qa/skills/qa-agent/SKILL.md
+++ b/agents/qa/skills/qa-agent/SKILL.md
@@ -127,3 +127,9 @@ When routing is complete:
   unclear `feature_path`, PRD/TRD alignment, or confirmed
   `IMPLEMENTATION_PLAN.md`, report the blocker and next owner instead of
   creating or executing TC
+- after the routed skill or role stage completes, apply the cross-role
+  safety-net closeout defined in
+  `agents/product_manager/skills/idea-to-spec/_internal/_shared/skill-map.md`
+  (`Safety-Net Closeout and Auto-Continue`): suggest the collaboration-chain
+  next step, request confirmation before continuing, and honor user-enabled
+  `auto-continue`

--- a/agents/security/skills/security-agent/SKILL.md
+++ b/agents/security/skills/security-agent/SKILL.md
@@ -120,3 +120,9 @@ When routing is complete:
   implementation patch
 - for feature-scoped work, state the expected report path under
   `docs/security/{feature_path}/...`
+- after the routed skill or role stage completes, apply the cross-role
+  safety-net closeout defined in
+  `agents/product_manager/skills/idea-to-spec/_internal/_shared/skill-map.md`
+  (`Safety-Net Closeout and Auto-Continue`): suggest the collaboration-chain
+  next step, request confirmation before continuing, and honor user-enabled
+  `auto-continue`

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -4,12 +4,12 @@
     "pm-agent": {
       "source": "agents/product_manager/skills/pm-agent",
       "sourceType": "local",
-      "computedHash": "5cc3464ec14ced41c6aaecb4c88a19ed6d6038db48c6632b1ddcf3c29fd070de"
+      "computedHash": "d90905d9a4342ad6a6398ee203ba6aa58c5612493a81a5d02baaf677cdf76f29"
     },
     "idea-to-spec": {
       "source": "agents/product_manager/skills/idea-to-spec",
       "sourceType": "local",
-      "computedHash": "b1f3c0c82499b851ce5b52c2f113975a42bafa7b4c3c96cdb39cfd68e85c8c05"
+      "computedHash": "ce75bf2e403aaa05eb5590417d9fd4cad1421a0c1f42969364382f5f452a7cb3"
     },
     "feature-catalog": {
       "source": "agents/product_manager/skills/feature-catalog",
@@ -49,7 +49,7 @@
     "engineer-agent": {
       "source": "agents/engineer/skills/engineer-agent",
       "sourceType": "local",
-      "computedHash": "f4330ace47ca79e1878a9426c284721725fe60046218984105c00f6d942c7714"
+      "computedHash": "2563d9894f1dea013a361377b0e3dadf25a8125a1cb0d4f910ba7dc91b97a290"
     },
     "codebase-analyzer": {
       "source": "agents/engineer/skills/codebase-analyzer",
@@ -89,7 +89,7 @@
     "qa-agent": {
       "source": "agents/qa/skills/qa-agent",
       "sourceType": "local",
-      "computedHash": "bcedde8e7ee8e9fd23e91c8afe2213effbcc1f98663d3b55cb03230cc4556125"
+      "computedHash": "da8e090f4d177603e98e401cbe2ab16ea22561ec87bd9c557b760668cc555b67"
     },
     "exploratory-tester": {
       "source": "agents/qa/skills/exploratory-tester",
@@ -114,7 +114,7 @@
     "devops-agent": {
       "source": "agents/devops/skills/devops-agent",
       "sourceType": "local",
-      "computedHash": "7eb35834cf3cae44a720829f4502e9789ecb37441b1a686bed8da0ed8516d244"
+      "computedHash": "12ba9d852dc41727b7870c16f5ff6d9c2f9c32571602a3d30b0be485594d6a5f"
     },
     "deployment-planner": {
       "source": "agents/devops/skills/deployment-planner",
@@ -139,7 +139,7 @@
     "designer-agent": {
       "source": "agents/designer/skills/designer-agent",
       "sourceType": "local",
-      "computedHash": "1a18eb2ebd8dd1f1c159136fa779f88a3d462676e92b8979f158fb96ef8b1843"
+      "computedHash": "ac7536619f2d61c1805dc508ef383a17fee14c476777e235c159c7099f66cce8"
     },
     "ui-ux-design": {
       "source": "agents/designer/skills/ui-ux-design",
@@ -154,7 +154,7 @@
     "security-agent": {
       "source": "agents/security/skills/security-agent",
       "sourceType": "local",
-      "computedHash": "ec97d5d20e53517a881333ee08b5fc78e592e86719fc713e7da09290729bf139"
+      "computedHash": "4818332850624f39467a1ed67e5129e03ee7cc1e1238bc1a4b32a530f074bbf6"
     },
     "appsec-checklist": {
       "source": "agents/security/skills/appsec-checklist",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -9,7 +9,7 @@
     "idea-to-spec": {
       "source": "agents/product_manager/skills/idea-to-spec",
       "sourceType": "local",
-      "computedHash": "ce75bf2e403aaa05eb5590417d9fd4cad1421a0c1f42969364382f5f452a7cb3"
+      "computedHash": "72f8885625c4262ea0ddb471f14791e60fe71f47c586297234f90aa65add93e8"
     },
     "feature-catalog": {
       "source": "agents/product_manager/skills/feature-catalog",


### PR DESCRIPTION
## 背景

Closes #81。

按已确认的入口 + 安全网产品规则落地：
- 用户未显式点名 skill/agent → 默认 `pm-agent`；显式点名 → 受支持的直达路径，但套安全网。
- 安全网两面：缺前置 → 经 `pm-agent` 软引导补齐；完成后 → 主动建议协作链下一步并等确认，用户可开启 `auto-continue` 连续推进。

排查发现大部分基础设施已存在（router 的 Entry Gate / Escalation / Output Behavior、skill-map 的 Downstream Owner Map），本 PR 只补真正缺失的「收尾建议下一步 + auto-continue」交互，并把入口契约讲清楚。

## 改动（DRY：权威定义单一副本 + 指针引用）

- `skill-map.md`：新增 `Safety-Net Closeout and Auto-Continue` 节，作为跨角色收尾行为的**唯一权威定义**（前向建议+确认、auto-continue 开关、前置软引导），复用既有协作链与 Downstream Owner Map，未新造映射。
- `AGENTS.md`：在「PM 唯一入口与下游 gate 指针」补入口+安全网契约，旧的硬回退措辞软化为「引导补齐前置」，保留 `project-bootstrap` override，权威细节指向 skill-map。
- 6 个 dispatcher（pm-agent + 5 role router）的 `Output Behavior`：各加一条短指针，引用 skill-map 权威节，不复制正文。
- `skills-lock.json`：刷新受影响 dispatcher 的 hash。

不在本 PR：34 个 SKILL.md frontmatter（description/visibility 未动）；#80 触发词、#77 合约校验。

## 验证

- `check_repository_contract.py` / `check_eval_contract.py` / `check_eval_artifacts.py` → PASS
- `unittest agents.test_eval_contract` → 51 tests OK
- 小节重编号无失效外部引用

## 变更分级

`change_tier`: standard（跨角色行为契约 + 6 dispatcher 文档）。

## 备注

本 PR 改动路由/收尾行为，合并前后建议按仓库规则对受影响 dispatcher skill 运行 eval（待确认）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)