### PR TITLE
test: 更新 #81 安全网后 6 个 dispatcher 的 fresh skill eval 结果

### DIFF
--- a/agents/designer/test/designer-agent/evals/workspace/eval-003-engineer-ui-maintenance-handoff/comparison.md
+++ b/agents/designer/test/designer-agent/evals/workspace/eval-003-engineer-ui-maintenance-handoff/comparison.md
@@ -7,7 +7,7 @@
 - Eval: `eval-003-engineer-ui-maintenance-handoff`
 - Test case: engineer-ui-maintenance-handoff
 - Workspace: `workspace/eval-003-engineer-ui-maintenance-handoff`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
 
 ## Test Set / Fixture Version
 
@@ -25,19 +25,19 @@
 
 ## With Skill Behavior
 
-`designer-agent` satisfies the Engineer UI maintenance handoff contract. It treats the Engineer packet as a design-only gap, selects `ui-ux-design` plus `visual-design` for the stated information hierarchy and primary button visual rules, writes only design deliverables under the resolved feature path, and stops before code, tests, shell commands, or implementation task lists.
+`designer-agent` satisfies the Engineer UI maintenance handoff contract. It treats the Engineer packet as a design-only gap, selects `ui-ux-design` plus `visual-design` for the stated information hierarchy and primary button visual rules, writes only design deliverables under the resolved feature path, and stops before code, tests, shell commands, or implementation task lists. For issue #81, even if auto-continue is enabled after closeout, Designer may only hand the completed design deliverables back to `engineer-agent`; Engineer must perform TRD / IMPLEMENTATION_PLAN / code / test work under its own gates.
 
 ## Without Skill Baseline
 
-Without the router skill and Designer README, a generic response could read the request as a frontend implementation planning task because it came from Engineer and mentions UI maintenance. It might return a component checklist or implementation steps, and it may not name the expected `docs/design/customer-portal/profile-settings/` artifacts.
+Fresh without-skill baseline generated in this run on 2026-07-06: without the router skill and Designer README, a generic response could read the request as a frontend implementation planning task because it came from Engineer and mentions UI maintenance. It might return a component checklist, implementation steps, shell/test guidance, or a mixed design-plus-engineering plan, and it may not name the expected `docs/design/customer-portal/profile-settings/` artifacts or the issue #81 rule that auto-continue stops at handoff.
 
 ## Failures
 
-- None found.
+- None found. The issue #81 role-boundary check passed: Designer accepts the Engineer-sourced design gap but hands implementation back to `engineer-agent`.
 
 ## Next Steps
 
-- Keep this eval as regression coverage for Engineer-to-Designer UI maintenance handoffs.
+- Keep this eval as regression coverage for Engineer-to-Designer UI maintenance handoffs and issue #81 auto-continue boundary behavior.
 
 ## Runtime Artifacts Policy
 

--- a/agents/designer/test/designer-agent/evals/workspace/eval-1-route-design-handoff/comparison.md
+++ b/agents/designer/test/designer-agent/evals/workspace/eval-1-route-design-handoff/comparison.md
@@ -7,7 +7,7 @@
 - Eval: `eval-001-route-design-handoff`
 - Test case: route-design-handoff
 - Workspace: `workspace/eval-1-route-design-handoff`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
 
 ## Test Set / Fixture Version
 
@@ -25,19 +25,19 @@
 
 ## With Skill Behavior
 
-`designer-agent` satisfies the design-only route. It accepts confirmed PM/design context, selects the narrow design sequence `ui-ux-design` -> `visual-design` when both UX and visual scope are requested, writes only durable design deliverables, and stops before implementation. Its missing-target rule requires marking unavailable handoff stages as blocked instead of performing Engineer work.
+`designer-agent` satisfies the design-only route. It accepts confirmed PM/design context, selects the narrow design sequence `ui-ux-design` -> `visual-design` when both UX and visual scope are requested, writes only durable design deliverables, and stops before implementation. For issue #81, the inherited safety-net closeout may propose or auto-continue only to the `engineer-agent` handoff point; it does not authorize Designer to invoke Engineer specialists, write React components, or perform implementation work.
 
 ## Without Skill Baseline
 
-Without the router skill and Designer README, a generic response could blend design advice with React implementation because the prompt asks to "顺手" write components. It may describe UI structure and visual style, but it is less likely to enforce the two exact design artifact filenames or stop at an Engineer handoff.
+Fresh without-skill baseline generated in this run on 2026-07-06: without the router skill and Designer README, a generic response could honor the "不要进入实现" clause but still blend design routing with React-oriented next steps because the prompt asks to "顺手" write components. It may describe UI structure and visual style, but it is less likely to enforce the exact `ui-ux-design` -> `visual-design` sequence, the two durable design artifact filenames, or the issue #81 boundary that auto-continue stops at an Engineer handoff.
 
 ## Failures
 
-- None found.
+- None found. The issue #81 role-boundary check passed: Designer stops before code and hands implementation to `engineer-agent`.
 
 ## Next Steps
 
-- Keep this eval as regression coverage for Designer design-only routing and implementation handoff.
+- Keep this eval as regression coverage for Designer design-only routing, implementation handoff, and issue #81 auto-continue boundary behavior.
 
 ## Runtime Artifacts Policy
 

--- a/agents/designer/test/designer-agent/evals/workspace/eval-2-feature-path-design-handoff/comparison.md
+++ b/agents/designer/test/designer-agent/evals/workspace/eval-2-feature-path-design-handoff/comparison.md
@@ -7,7 +7,7 @@
 - Eval: `eval-002-feature-path-design-handoff`
 - Test case: feature-path-design-handoff
 - Workspace: `workspace/eval-2-feature-path-design-handoff`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
 
 ## Test Set / Fixture Version
 
@@ -24,19 +24,19 @@
 
 ## With Skill Behavior
 
-`designer-agent` satisfies the feature-path mirroring contract. Its PM handoff gate requires a stable `feature_path`, and Designer README states that output directories consume the PM/Engineer path rather than inventing synonyms. The with-skill route writes only `ui-ux-spec.md` and `visual-system.md` under the full 4-level path and leaves implementation to `engineer-agent`.
+`designer-agent` satisfies the feature-path mirroring contract. Its PM handoff gate requires a stable `feature_path`, and Designer README states that output directories consume the PM/Engineer path rather than inventing synonyms. The with-skill route writes only `ui-ux-spec.md` and `visual-system.md` under the full 4-level path and leaves implementation to `engineer-agent`. For issue #81, role boundaries take precedence over auto-continue, so Designer may hand off the confirmed design artifacts to `engineer-agent` but must not continue into engineering workflow, implementation steps, tests, or patches.
 
 ## Without Skill Baseline
 
-Without the router skill and Designer README, a generic design answer might preserve the topic but shorten the path to `history-search` or `chat-interface/history-search`, because those are more natural labels. It may also include implementation sequencing or test advice, which would violate the Designer boundary.
+Fresh without-skill baseline generated in this run on 2026-07-06: without the router skill and Designer README, a generic design answer might preserve the topic and even copy the provided PRD/TRD paths, but it has weaker pressure to mirror the full `chat-interface/messages/history/search` path into `docs/design/`. It might shorten the path to `history-search` or `chat-interface/history-search`, and it may include implementation sequencing or test advice instead of stopping at the issue #81 Designer-to-Engineer handoff boundary.
 
 ## Failures
 
-- None found.
+- None found. The issue #81 role-boundary check passed: Designer mirrors the full design path and stops before engineering work.
 
 ## Next Steps
 
-- Keep this eval as regression coverage for multi-level feature-path symmetry across PM, Engineer, and Designer docs.
+- Keep this eval as regression coverage for multi-level feature-path symmetry across PM, Engineer, and Designer docs, including issue #81 handoff-only auto-continue behavior.
 
 ## Runtime Artifacts Policy
 

--- a/agents/devops/test/devops-agent/evals/workspace/eval-1-route-ci-readiness/comparison.md
+++ b/agents/devops/test/devops-agent/evals/workspace/eval-1-route-ci-readiness/comparison.md
@@ -7,13 +7,13 @@
 - Eval: `eval-001-route-ci-readiness`
 - Test case: route-ci-readiness
 - Workspace: `workspace/eval-1-route-ci-readiness`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
 - Fixture: existing `deploy/docker` path with missing GitHub Actions PR gate and later config/runbook concerns.
-- Context read before applying the skill: `evals.json`, workspace `eval_metadata.json`, and `deploy/docker/README.md`.
+- Context read before applying the skill: `devops-agent/SKILL.md`, `agents/devops/README.md`, `evals.json`, workspace `eval_metadata.json`, `deploy/docker/README.md`, and the `Safety-Net Closeout and Auto-Continue` section in `skill-map.md`.
 
 ## Assertions
 
@@ -27,17 +27,21 @@
 
 `devops-agent` satisfies the CI readiness route. Its PM handoff gate allows equivalent confirmed repo-wide operational context, and this fixture supplies an existing Docker deployment path plus a CI automation gap. The router selects the narrow current owner `cicd-bootstrap`, carries forward `deploy/docker`, and lists config audit and rollback runbook work as explicit follow-ups without executing them.
 
+For the issue #81 safety-net behavior, the routed response remains within the DevOps role boundary: it can recommend `cicd-bootstrap` first, then propose `env-config-auditor` and `incident-playbook-writer` as later DevOps follow-ups, but it does not auto-run those follow-ups, write `.github/workflows`, or cross into another role's actual workflow. If an auto-continue instruction were present, the skill-map rule would only permit continuation through the next-owner proposal and handoff under that owner's own gates.
+
 ## Without Skill Baseline
 
-Without the router skill and DevOps README, a generic response might generate a workflow outline immediately or expand into deployment, environment, secrets, and rollback work in one pass. It is less likely to preserve the existing Docker context while making CI/CD the single current route.
+Fresh without_skill baseline generated on 2026-07-06 without reading or applying `devops-agent/SKILL.md` or `agents/devops/README.md`: a generic response would likely identify GitHub Actions as important, but it may turn the request into an implementation checklist, sketch or create a workflow despite "不要直接写 workflow", and bundle deployment, environment variables, secrets, and rollback documentation into one broad DevOps pass. It is less likely to preserve the existing Docker context while making `cicd-bootstrap` the single current route and treating config audit/runbook work as explicit later checks.
 
 ## Failures
 
 - None found.
+- No issue #81 regression found: safety-net closeout and auto-continue do not weaken the original route/gate behavior or authorize DevOps to execute another role's work.
 
 ## Next Steps
 
 - Keep this eval as regression coverage for DevOps primary-route selection and follow-up separation.
+- Keep issue #81 covered here by checking that follow-up suggestions remain proposals or gated handoffs, not automatic execution of additional DevOps skills or peer-role work.
 
 ## Runtime Artifacts Policy
 

--- a/agents/engineer/test/engineer-agent/evals/workspace/eval-002-existing-feature-alignment-gate/comparison.md
+++ b/agents/engineer/test/engineer-agent/evals/workspace/eval-002-existing-feature-alignment-gate/comparison.md
@@ -7,7 +7,7 @@
 - Eval: `eval-002-existing-feature-alignment-gate`
 - Test case: existing-feature-alignment-gate
 - Workspace: `workspace/eval-002-existing-feature-alignment-gate`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
 
 ## Test Set / Fixture Version
 
@@ -26,15 +26,15 @@
 
 ## With Skill Behavior
 
-`engineer-agent` satisfies the existing-feature alignment gate. Its PM handoff entry gate accepts only an explicit packet or equivalent specialist entry basis, and its routing rules send production behavior changes through PRD/TRD alignment before `feature-implementor`. The directly referenced `feature-implementor` gate confirms that expectation changes go back to PM, TRD gaps go to `trd-gen`, and plan confirmation remains mandatory after alignment.
+`engineer-agent` satisfies the existing-feature alignment gate. Its PM handoff entry gate accepts only an explicit packet or equivalent specialist entry basis, and its routing rules send production behavior changes through PRD/TRD alignment before `feature-implementor`. The directly referenced `feature-implementor` gate confirms that expectation changes go back to PM, TRD gaps go to `trd-gen`, and plan confirmation remains mandatory after alignment. For issue #81, `auto-continue` may carry the handoff proposal back to `pm-agent` when the archived/active behavior conflicts with approved expectations, but it does not let Engineer update PM requirements or proceed around the PRD/TRD gate.
 
 ## Without Skill Baseline
 
-Without the router skill and Engineer README, a generic answer would likely accept the user's "small change" framing and route straight to implementation planning or code changes. It may mention checking docs, but it is less likely to classify the active-versus-archived behavior as a product expectation change or to block direct implementation until PRD/TRD and decision records align.
+Fresh baseline generated on 2026-07-06 without applying `engineer-agent` or the Engineer README: a generic answer would likely accept the user's "small change" framing and route straight to implementation planning or code changes. It may mention checking docs, but it is less likely to classify the active-versus-archived behavior as a product expectation change, block direct implementation until PRD/TRD and decision records align, or constrain auto-continuation to a PM handoff instead of doing PM work inside Engineer.
 
 ## Failures
 
-- None found.
+- None found. Issue #81 did not regress the existing-feature alignment gate or weaken PM-first handling of expectation changes.
 
 ## Next Steps
 

--- a/agents/engineer/test/engineer-agent/evals/workspace/eval-003-nested-feature-alignment-routing/comparison.md
+++ b/agents/engineer/test/engineer-agent/evals/workspace/eval-003-nested-feature-alignment-routing/comparison.md
@@ -7,7 +7,7 @@
 - Eval: `eval-003-nested-feature-alignment-routing`
 - Test case: nested-feature-alignment-routing
 - Workspace: `workspace/eval-003-nested-feature-alignment-routing`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
 
 ## Test Set / Fixture Version
 
@@ -25,15 +25,15 @@
 
 ## With Skill Behavior
 
-`engineer-agent` satisfies the nested feature-path contract. It consumes the same-path PM and Engineer documents, preserves the canonical `feature_path`, and keeps implementation blocked until PRD/TRD expectations align. The directly referenced `trd-gen` and `feature-implementor` gates reinforce that path mismatches and stale TRDs are not fixed by implementation routing.
+`engineer-agent` satisfies the nested feature-path contract. It consumes the same-path PM and Engineer documents, preserves the canonical `feature_path`, and keeps implementation blocked until PRD/TRD expectations align. The directly referenced `trd-gen` and `feature-implementor` gates reinforce that path mismatches and stale TRDs are not fixed by implementation routing. For issue #81, safety-net closeout preserves the same resolved feature path when proposing a PM or `trd-gen` handoff, and `auto-continue` does not authorize route-only prompts to write implementation plans, code, or PM updates.
 
 ## Without Skill Baseline
 
-Without the router skill and Engineer README, a generic response could treat "History Search" as a top-level feature or use only the parent chat interface context. It might recommend a direct sorting change because the user calls it small, missing the requirement that child feature docs and `related_prd` stay aligned before routing.
+Fresh baseline generated on 2026-07-06 without applying `engineer-agent` or the Engineer README: a generic response could treat "History Search" as a top-level feature or use only the parent chat interface context. It might recommend a direct sorting change because the user calls it small, missing the requirement that child feature docs and `related_prd` stay aligned before routing, and it is less likely to keep auto-continued handoff bound to the resolved nested feature path.
 
 ## Failures
 
-- None found.
+- None found. Issue #81 did not regress nested `feature_path` resolution, TRD mismatch routing, or route-only execution boundaries.
 
 ## Next Steps
 

--- a/agents/engineer/test/engineer-agent/evals/workspace/eval-004-frontend-ui-routing-contract/comparison.md
+++ b/agents/engineer/test/engineer-agent/evals/workspace/eval-004-frontend-ui-routing-contract/comparison.md
@@ -7,7 +7,7 @@
 - Eval: `eval-004-frontend-ui-routing-contract`
 - Test case: frontend-ui-routing-contract
 - Workspace: `workspace/eval-004-frontend-ui-routing-contract`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
 
 ## Test Set / Fixture Version
 
@@ -27,15 +27,15 @@
 
 ## With Skill Behavior
 
-`engineer-agent` satisfies the Batch 4 frontend UI routing contract. It classifies local frontend updates as Engineering, applies the PM handoff and same-path PRD/TRD gate, checks design deliverables for page structure, interaction, visual rules, and information hierarchy, then hands design gaps to `designer-agent` without performing Designer work itself. The route returns to `feature-implementor` only after design handoff completion.
+`engineer-agent` satisfies the frontend UI routing contract. It classifies local frontend updates as Engineering, applies the PM handoff and same-path PRD/TRD gate, checks design deliverables for page structure, interaction, visual rules, and information hierarchy, then hands design gaps to `designer-agent` without performing Designer work itself. The route returns to `feature-implementor` only after design handoff completion. For issue #81, `auto-continue` may move only as far as the Designer handoff when design deliverables are missing; it does not permit Engineer to create design deliverables, call external UI skills, or bypass the later `IMPLEMENTATION_PLAN.md` confirmation gate.
 
 ## Without Skill Baseline
 
-Without the router skill and Engineer README, a generic response would likely treat the prompt as either a direct UI design task or a direct frontend implementation task. It might provide layout and button style guidance, or suggest coding steps, while missing the repository-specific design deliverable check and the prohibition on external UI reference skills for local implementation routing.
+Fresh baseline generated on 2026-07-06 without applying `engineer-agent` or the Engineer README: a generic response would likely treat the prompt as either a direct UI design task or a direct frontend implementation task. It might provide layout and button style guidance, or suggest coding steps, while missing the repository-specific design deliverable check, the prohibition on external UI reference skills for local implementation routing, and the rule that auto-continuation cannot make Engineer perform Designer work.
 
 ## Failures
 
-- None found.
+- None found. Issue #81 did not regress frontend UI routing, Designer handoff boundaries, or implementation-plan gating after design completion.
 
 ## Next Steps
 

--- a/agents/engineer/test/engineer-agent/evals/workspace/eval-1-route-implementation-chain/comparison.md
+++ b/agents/engineer/test/engineer-agent/evals/workspace/eval-1-route-implementation-chain/comparison.md
@@ -7,7 +7,7 @@
 - Eval: `eval-001-route-implementation-chain`
 - Test case: route-implementation-chain
 - Workspace: `workspace/eval-1-route-implementation-chain`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
 
 ## Test Set / Fixture Version
 
@@ -26,15 +26,15 @@
 
 ## With Skill Behavior
 
-`engineer-agent` satisfies the full route chain. It preserves the PM handoff entry gate, then selects the narrow engineering sequence: `codebase-analyzer` -> `feature-implementor` -> `test-writer` -> QA E2E handoff check -> `delivery`. The skill explicitly points implementation planning to `docs/engineer/{feature_path}/IMPLEMENTATION_PLAN.md`, keeps downstream specialist gates in their owners, and does not perform implementation itself.
+`engineer-agent` satisfies the full route chain. It preserves the PM handoff entry gate, then selects the narrow engineering sequence: `codebase-analyzer` -> `feature-implementor` -> `test-writer` -> QA E2E handoff check -> `delivery`. The skill explicitly points implementation planning to `docs/engineer/{feature_path}/IMPLEMENTATION_PLAN.md`, keeps downstream specialist gates in their owners, and does not perform implementation itself. For issue #81, the safety-net closeout can propose the next collaboration owner after the engineering route is complete, but `auto-continue` remains handoff-only across roles and does not authorize Engineer to execute QA work or bypass the implementation-plan gate.
 
 ## Without Skill Baseline
 
-Without the router skill and Engineer README, a generic response would likely treat the request as a normal implementation checklist, start from the named TRD, and propose coding plus tests directly. It might include delivery at the end, but it is less likely to require codebase context first, preserve the `feature-implementor` plan gate, or include the QA E2E handoff package with confirmed `IMPLEMENTATION_PLAN.md`.
+Fresh baseline generated on 2026-07-06 without applying `engineer-agent` or the Engineer README: a generic response would likely treat the request as a normal implementation checklist, start from the named TRD, and propose coding plus tests directly. It might include delivery at the end, but it is less likely to require codebase context first, preserve the `feature-implementor` plan gate, include the QA E2E handoff package with confirmed `IMPLEMENTATION_PLAN.md`, or distinguish auto-continued cross-role handoff from executing another role's workflow.
 
 ## Failures
 
-- None found.
+- None found. Issue #81 did not regress the original route/gate behavior or expand Engineer beyond its role boundary.
 
 ## Next Steps
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-1-route-greenfield-product-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-1-route-greenfield-product-request/comparison.md
@@ -6,7 +6,7 @@
 - Test case: route-greenfield-product-request
 - Test set: PM entry evals for issue #52 / FR-006 scenario 1
 - Entry: workspace `eval-1-route-greenfield-product-request`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
 
 ## Test Set / Fixture Version
 
@@ -14,20 +14,30 @@
 - Fixture: empty-workspace product idea request
 - Expected output: route to `idea-to-spec`, keep the PM-first boundary, name the PM artifacts and downstream handoff points.
 
-## With Skill
+## Assertions
+
+- PASS `route_to_idea_to_spec`: `pm-agent` selects `idea-to-spec` as the narrowest PM route for product discovery, scope shaping, and spec creation.
+- PASS `pm_first_guardrail`: The empty-workspace product idea is kept out of `engineer-agent` and project scaffolding unless the user explicitly bypasses PM.
+- PASS `context_to_collect`: The route names goals, core flows, scope, acceptance criteria, and open questions as the next PM context.
+- PASS `expected_pm_artifacts`: The PM outputs are PRD, BRD, and DECISIONS; TRD remains an Engineer-owned follow-up after requirements stabilize.
+- PASS `handoff_boundary`: Designer or Engineer handoff only happens after PM scope is stable.
+
+## With Skill Behavior
 
 - The `pm-agent` protocol treats empty or near-empty product requests as PM-first and routes the AI chat assistant idea to `idea-to-spec`.
 - It blocks direct engineering bootstrap unless the user explicitly asks to skip PM.
 - It names the context to collect: user goal, core flows, scope, acceptance criteria, open questions, PRD / BRD / DECISIONS output, and later `engineer-agent:trd-gen` after scope is stable.
+- Issue #81 safety-net behavior remains within boundary: closeout can propose Designer or Engineer as the next owner after PM discovery, but `pm-agent` does not execute design or engineering work itself.
 
-## Without Skill / without_skill Baseline
+## Without Skill Baseline
 
-- The baseline read the eval item and fixture before target skill docs. A generic response could recommend scaffolding or implementation planning for the left-right chat UI because the user describes a concrete screen.
+- Fresh without_skill baseline regenerated on 2026-07-06 without applying `pm-agent` or the Product Manager Agent README. A generic response could recommend scaffolding or implementation planning for the left-right chat UI because the user describes a concrete screen.
 - It may mention product clarification, but it is less reliable about the formal PM-first guardrail, the `idea-to-spec` route, and the delayed Designer / Engineer handoff boundary.
 
 ## Failures
 
 - None. All assertions are satisfied by the current `pm-agent` routing and PM-first guardrail.
+- No issue #81 regression found; auto-continue does not bypass the empty-workspace PM-first gate or cross-role handoff boundary.
 
 ## Next Steps
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-10-change-tier-hotfix-fast-lane/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-10-change-tier-hotfix-fast-lane/comparison.md
@@ -6,7 +6,7 @@
 - Test case: change-tier-hotfix-fast-lane
 - Test set: change-tier contract evals for issue #55 / FR-008
 - Entry: workspace `eval-10-change-tier-hotfix-fast-lane`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
 
 ## Test Set / Fixture Version
 
@@ -14,20 +14,28 @@
 - Fixture: README link fix that does not change approved behavior and has local verification evidence
 - Expected output: classify as `hotfix`, allow fast lane after classification, and preserve scope / source / verification evidence.
 
-## With Skill
+## Assertions
+
+- PASS `classify_hotfix`: The README link fix is a `hotfix` because it does not change approved expectations and can be covered by one verification record.
+- PASS `allow_fast_lane`: `hotfix` plus delivery / status work may use the fast lane only after classification.
+- PASS `preserve_evidence`: Scope, source evidence, and verification evidence remain required.
+
+## With Skill Behavior
 
 - The `pm-agent` change-tier rule classifies unchanged-expectation lightweight fixes as `hotfix`.
 - It allows `hotfix` plus `delivery` / `status` requests to use the fast lane only after scope, source evidence, and verification status are confirmed.
 - It keeps verification evidence requirements intact rather than treating fast lane as no-evidence delivery.
+- Issue #81 safety-net behavior remains within boundary: fast lane affects delivery routing after classification, while auto-continue still cannot skip evidence or execute another role's work.
 
-## Without Skill / without_skill Baseline
+## Without Skill Baseline
 
-- The baseline read the eval item and fixture before target skill docs. A generic response could accept fast lane but omit the structured evidence requirement.
+- Fresh without_skill baseline regenerated on 2026-07-06 without applying `pm-agent` or the Product Manager Agent README. A generic response could accept fast lane but omit the structured evidence requirement.
 - It may not distinguish classification-before-fast-lane from immediate delivery.
 
 ## Failures
 
 - None. The current `pm-agent` change-tier rule satisfies all hotfix fast-lane assertions.
+- No issue #81 regression found; auto-continue does not weaken fast-lane evidence requirements.
 
 ## Next Steps
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-11-change-tier-standard-full-gate/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-11-change-tier-standard-full-gate/comparison.md
@@ -6,7 +6,7 @@
 - Test case: change-tier-standard-full-gate
 - Test set: change-tier contract evals for issue #55 / FR-008
 - Entry: workspace `eval-11-change-tier-standard-full-gate`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
 
 ## Test Set / Fixture Version
 
@@ -14,20 +14,28 @@
 - Fixture: refund approval behavior change mislabeled as small hotfix
 - Expected output: classify as `existing_update`, reject `hotfix`, set `standard` or higher, and require PRD/TRD expectation alignment.
 
-## With Skill
+## Assertions
+
+- PASS `classify_standard`: The behavior change is `standard` or higher, not `hotfix`.
+- PASS `require_prd_trd_alignment`: PRD/TRD or equivalent product expectation alignment is required before downstream implementation.
+- PASS `request_type_existing_update`: The request is `existing_update` because it changes approved business behavior.
+
+## With Skill Behavior
 
 - The `pm-agent` change-tier rule rejects `hotfix` when approved product behavior changes.
 - Changing refund approval from automatic approval to admin secondary confirmation is an `existing_update` and at least `standard`.
 - The request stays on the PM path for PRD/TRD or equivalent expectation alignment before downstream implementation.
+- Issue #81 safety-net behavior remains within boundary: closeout may recommend the next PM or Engineer-alignment step, but auto-continue cannot reclassify the behavior change as hotfix or skip gates.
 
-## Without Skill / without_skill Baseline
+## Without Skill Baseline
 
-- The baseline read the eval item and fixture before target skill docs. A generic response could accept the user's "small" framing and skip expectation alignment.
+- Fresh without_skill baseline regenerated on 2026-07-06 without applying `pm-agent` or the Product Manager Agent README. A generic response could accept the user's "small" framing and skip expectation alignment.
 - It may hand off implementation before confirming changed business behavior and downstream document impact.
 
 ## Failures
 
 - None. The current change-tier rule satisfies all standard full-gate assertions.
+- No issue #81 regression found; auto-continue respects the full PRD/TRD alignment gate for expectation changes.
 
 ## Next Steps
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-12-change-tier-hotfix-abuse-blocked/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-12-change-tier-hotfix-abuse-blocked/comparison.md
@@ -6,7 +6,7 @@
 - Test case: change-tier-hotfix-abuse-blocked
 - Test set: change-tier contract evals for issue #55 / FR-008
 - Entry: workspace `eval-12-change-tier-hotfix-abuse-blocked`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
 
 ## Test Set / Fixture Version
 
@@ -14,20 +14,28 @@
 - Fixture: membership trial duration change mislabeled as hotfix to skip PM
 - Expected output: reject hotfix abuse, identify expectation / business-rule change, and block or return to PM for scope confirmation.
 
-## With Skill
+## Assertions
+
+- PASS `reject_hotfix_abuse`: The route explicitly rejects treating the request as `hotfix`.
+- PASS `expectation_change_standard`: The trial-duration change is a business-rule expectation change and must be `standard` or higher.
+- PASS `block_or_return_pm`: The request is blocked or returned to PM for scope and expectation confirmation, not handed directly to implementation.
+
+## With Skill Behavior
 
 - The `pm-agent` protocol explicitly says new requirements, expectation changes, and unclear scope stay on the PM path and must not be routed as `hotfix`.
 - Changing trial duration from 7 days to 30 days is a business-rule expectation change, so the request is `standard` or higher.
 - It blocks direct implementation and returns to PM expectation and scope confirmation.
+- Issue #81 safety-net behavior remains within boundary: auto-continue cannot turn an attempted PM bypass into implementation permission.
 
-## Without Skill / without_skill Baseline
+## Without Skill Baseline
 
-- The baseline read the eval item and fixture before target skill docs. A generic response could follow the user's hotfix framing and start the value change.
+- Fresh without_skill baseline regenerated on 2026-07-06 without applying `pm-agent` or the Product Manager Agent README. A generic response could follow the user's hotfix framing and start the value change.
 - It may not catch that the request is trying to use `hotfix` as an escape hatch from PM alignment.
 
 ## Failures
 
 - None. The current `pm-agent` protocol satisfies all hotfix-abuse assertions.
+- No issue #81 regression found; role-boundary priority keeps expectation changes on the PM path.
 
 ## Next Steps
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-13-change-tier-hotfix-e2e-direct-path/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-13-change-tier-hotfix-e2e-direct-path/comparison.md
@@ -6,7 +6,7 @@
 - Test case: change-tier-hotfix-e2e-direct-path
 - Test set: change-tier contract evals for issue #55 / FR-008
 - Entry: workspace `eval-13-change-tier-hotfix-e2e-direct-path`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
 
 ## Test Set / Fixture Version
 
@@ -14,20 +14,28 @@
 - Fixture: login empty-state copy hotfix with QA/E2E scope question
 - Expected output: limit hotfix QA/E2E to directly affected path, still record verification evidence and blocked checks, and avoid full-suite requirement unless risk escalates.
 
-## With Skill
+## Assertions
+
+- PASS `hotfix_direct_path_only`: Hotfix QA/E2E coverage can focus on the directly affected login empty-state path.
+- PASS `evidence_still_required`: Verification evidence, result, and blocked checks remain required.
+- PASS `no_full_suite_required`: A full E2E suite is not required unless risk or scope escalates to `standard` / `major`.
+
+## With Skill Behavior
 
 - The repository change-tier contract allows hotfix QA/E2E coverage to focus on the directly affected path.
 - The `pm-agent` routing still requires verification evidence, results, and any blocked checks to be recorded.
 - It does not require the full E2E suite unless risk or scope upgrades the work to `standard` / `major`.
+- Issue #81 safety-net behavior remains within boundary: closeout may propose QA verification next, but auto-continue cannot skip evidence or make PM perform QA execution.
 
-## Without Skill / without_skill Baseline
+## Without Skill Baseline
 
-- The baseline read the eval item and fixture before target skill docs. A generic response could either skip QA entirely because the change is "just copy" or require a full suite without considering hotfix scope.
+- Fresh without_skill baseline regenerated on 2026-07-06 without applying `pm-agent` or the Product Manager Agent README. A generic response could either skip QA entirely because the change is "just copy" or require a full suite without considering hotfix scope.
 - It is less reliable about preserving evidence while narrowing coverage to the direct login empty-state path.
 
 ## Failures
 
 - None. The current change-tier and QA gate language satisfies all hotfix E2E assertions.
+- No issue #81 regression found; auto-continue preserves the direct-path QA evidence gate for hotfix work.
 
 ## Next Steps
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-2-route-bugfix-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-2-route-bugfix-request/comparison.md
@@ -6,7 +6,7 @@
 - Test case: route-bugfix-request
 - Test set: PM entry evals for issue #52 / FR-006 scenario 2
 - Entry: workspace `eval-2-route-bugfix-request`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
 
 ## Test Set / Fixture Version
 
@@ -14,20 +14,28 @@
 - Fixture: login bug report before expected behavior has been checked
 - Expected output: classify as `bug_report`, confirm approved PRD / TRD expected behavior first, then hand off to Engineer/debugger only after implementation deviation is established.
 
-## With Skill
+## Assertions
+
+- PASS `request_type_bug_report`: The request is classified as `bug_report` rather than immediate repair work.
+- PASS `expectation_first`: The route requires approved PRD / TRD or equivalent expected behavior before implementation diagnosis.
+- PASS `debugger_handoff_after_confirmation`: Engineer/debugger handoff is allowed only after the bug is confirmed as an implementation deviation.
+
+## With Skill Behavior
 
 - The `pm-agent` classification protocol explicitly maps bug reports to `bug_report`.
 - It requires comparing the reported token-expiry spinner against approved PRD / TRD or equivalent product expectations before diagnosing implementation.
 - It only allows Engineer/debugger handoff after expected behavior is confirmed and the issue is an implementation deviation.
+- Issue #81 safety-net behavior remains within boundary: closeout may recommend Engineer/debugger as the next owner after expectation confirmation, but does not run debugging or repair inside PM.
 
-## Without Skill / without_skill Baseline
+## Without Skill Baseline
 
-- The baseline read the eval item and fixture before target skill docs. A generic response could jump straight into debugging the token expiry behavior from logs.
+- Fresh without_skill baseline regenerated on 2026-07-06 without applying `pm-agent` or the Product Manager Agent README. A generic response could jump straight into debugging the token expiry behavior from logs.
 - It may ask for reproduction details, but is less consistent about product expectation alignment before debugger handoff.
 
 ## Failures
 
 - None. The current `pm-agent` protocol satisfies the bug classification and expectation-first assertions.
+- No issue #81 regression found; auto-continue does not bypass expected-behavior confirmation or execute Engineer/debugger work from the PM role.
 
 ## Next Steps
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-3-route-test-writing-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-3-route-test-writing-request/comparison.md
@@ -6,7 +6,7 @@
 - Test case: route-test-writing-request
 - Test set: PM entry evals for issue #52 / FR-006 scenario 3
 - Entry: workspace `eval-3-route-test-writing-request`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
 
 ## Test Set / Fixture Version
 
@@ -14,20 +14,28 @@
 - Fixture: test-writing request without confirmed test basis
 - Expected output: classify as `validation`, name PRD / TRD / IMPLEMENTATION_PLAN or existing acceptance evidence, then hand off QA or Engineer/test-writer only after expectations are stable.
 
-## With Skill
+## Assertions
+
+- PASS `request_type_validation`: The request is classified as `validation` / test verification work.
+- PASS `test_basis_first`: The route requires PRD, TRD, confirmed implementation plan, or existing acceptance evidence as the test basis.
+- PASS `qa_or_test_writer_handoff`: QA or Engineer/test-writer handoff waits until expectations and source documents are stable.
+
+## With Skill Behavior
 
 - The `pm-agent` classification protocol maps test-writing and validation requests to `validation`.
 - It requires a stable test basis from PRD, TRD, confirmed implementation plan, or existing acceptance record.
 - It allows QA or Engineer/test-writer handoff only after source documents and expected behavior are named.
+- Issue #81 safety-net behavior remains within boundary: closeout can propose QA or Engineer/test-writer next, but does not write tests from the PM role.
 
-## Without Skill / without_skill Baseline
+## Without Skill Baseline
 
-- The baseline read the eval item and fixture before target skill docs. A generic response could begin writing refund-flow tests from the user request alone.
+- Fresh without_skill baseline regenerated on 2026-07-06 without applying `pm-agent` or the Product Manager Agent README. A generic response could begin writing refund-flow tests from the user request alone.
 - It may ask about scenarios, but is less reliable about requiring durable PM / Engineer source evidence before test coverage.
 
 ## Failures
 
 - None. The current `pm-agent` protocol satisfies the validation and test-basis assertions.
+- No issue #81 regression found; auto-continue does not bypass the test-basis gate or start QA / test-writer execution inside PM.
 
 ## Next Steps
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-4-route-ui-update-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-4-route-ui-update-request/comparison.md
@@ -6,7 +6,7 @@
 - Test case: route-ui-update-request
 - Test set: PM entry evals for issue #52 / FR-006 scenario 4
 - Entry: workspace `eval-4-route-ui-update-request`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
 
 ## Test Set / Fixture Version
 
@@ -14,20 +14,28 @@
 - Fixture: frontend UI update request with ambiguous PM / Designer / Engineer ownership
 - Expected output: classify as `design` or `existing_update`, decide whether PM expectation update, Designer artifact, or Engineer implementation is needed, and delay implementation until alignment is complete.
 
-## With Skill
+## Assertions
+
+- PASS `request_type_design_or_update`: The request is classified as `design` or `existing_update`, not direct frontend implementation.
+- PASS `pm_designer_engineer_decision`: The route separates PM expectation updates, Designer deliverables, and Engineer implementation readiness.
+- PASS `implementation_waits_for_alignment`: Frontend implementation waits for PM / TRD / design alignment before Engineer handoff.
+
+## With Skill Behavior
 
 - The `pm-agent` protocol distinguishes UI / UX design artifacts from frontend implementation.
 - It requires checking whether the settings page layout change alters product expectations before picking Designer or Engineer.
 - It routes design artifacts to Designer and waits for PM / TRD / design alignment before Engineer frontend implementation.
+- Issue #81 safety-net behavior remains within boundary: closeout may suggest Designer or Engineer next, but PM does not create design deliverables or implement UI changes.
 
-## Without Skill / without_skill Baseline
+## Without Skill Baseline
 
-- The baseline read the eval item and fixture before target skill docs. A generic response could treat the UI request as direct frontend work.
+- Fresh without_skill baseline regenerated on 2026-07-06 without applying `pm-agent` or the Product Manager Agent README. A generic response could treat the UI request as direct frontend work.
 - It may mention design review, but is less consistent about separating PM expectation changes, design deliverables, and implementation readiness.
 
 ## Failures
 
 - None. The current `pm-agent` protocol satisfies the UI routing assertions.
+- No issue #81 regression found; auto-continue respects the PM -> Designer -> Engineer boundary and cannot skip alignment gates.
 
 ## Next Steps
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-5-route-deployment-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-5-route-deployment-request/comparison.md
@@ -6,7 +6,7 @@
 - Test case: route-deployment-request
 - Test set: PM entry evals for issue #52 / FR-006 scenario 5
 - Entry: workspace `eval-5-route-deployment-request`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
 
 ## Test Set / Fixture Version
 
@@ -14,20 +14,28 @@
 - Fixture: repo-wide CI and release-readiness request
 - Expected output: classify as `deployment`, allow repo-wide `N/A` feature fields, and prepare DevOps handoff with operational scope.
 
-## With Skill
+## Assertions
+
+- PASS `request_type_deployment`: CI and release-readiness work is classified as `deployment`.
+- PASS `repo_wide_scope_allowed`: Confirmed repository-level non-feature work can use `N/A` feature fields and empty `feature_path_evidence`.
+- PASS `devops_handoff_packet`: DevOps handoff requires operational goal, environment, release scope, rollback needs, and risks.
+
+## With Skill Behavior
 
 - The `pm-agent` protocol maps CI and release-readiness work to `deployment`.
 - It allows confirmed non-feature repo-wide work to use `feature_path: N/A`, related feature fields as `N/A`, and `feature_path_evidence: []`.
 - It requires operational goal, environment, release scope, rollback needs, and risks before DevOps handoff.
+- Issue #81 safety-net behavior remains within boundary: closeout may recommend DevOps as next owner, but PM does not create CI, deployment config, or release-readiness artifacts itself.
 
-## Without Skill / without_skill Baseline
+## Without Skill Baseline
 
-- The baseline read the eval item and fixture before target skill docs. A generic response could jump directly into CI configuration.
+- Fresh without_skill baseline regenerated on 2026-07-06 without applying `pm-agent` or the Product Manager Agent README. A generic response could jump directly into CI configuration.
 - It may not preserve the repo-wide non-feature scope rule or the complete DevOps handoff context.
 
 ## Failures
 
 - None. The current `pm-agent` protocol satisfies deployment classification and repo-wide scope assertions.
+- No issue #81 regression found; auto-continue does not bypass the DevOps handoff packet or execute DevOps work from PM.
 
 ## Next Steps
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-6-route-security-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-6-route-security-request/comparison.md
@@ -6,7 +6,7 @@
 - Test case: route-security-request
 - Test set: PM entry evals for issue #52 / FR-006 scenario 6
 - Entry: workspace `eval-6-route-security-request`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
 
 ## Test Set / Fixture Version
 
@@ -14,20 +14,28 @@
 - Fixture: authorization, dependency, and secrets-risk review request
 - Expected output: classify as `security`, capture risk scope, and hand off Security with scope and required output.
 
-## With Skill
+## Assertions
+
+- PASS `request_type_security`: Authz, dependency, and secrets-risk review is classified as `security`.
+- PASS `security_scope_first`: The route requires risk surface, assets, permissions, data flow, and remediation expectations.
+- PASS `security_handoff`: Security receives a bounded handoff with scope and required output.
+
+## With Skill Behavior
 
 - The `pm-agent` protocol maps authorization, dependency risk, secrets, privacy, upload, webhook, login, and data-flow risk requests to `security`.
 - It requires recording risk surface, assets, permissions, data flow, and remediation expectations.
 - It hands off to Security with a bounded review packet instead of doing the security specialist work itself.
+- Issue #81 safety-net behavior remains within boundary: closeout may recommend Security next, but PM does not run AppSec, dependency, or privacy review work itself.
 
-## Without Skill / without_skill Baseline
+## Without Skill Baseline
 
-- The baseline read the eval item and fixture before target skill docs. A generic response could start a broad security checklist immediately.
+- Fresh without_skill baseline regenerated on 2026-07-06 without applying `pm-agent` or the Product Manager Agent README. A generic response could start a broad security checklist immediately.
 - It may miss the PM-side scope packet and required output definition for Security.
 
 ## Failures
 
 - None. The current `pm-agent` protocol satisfies security classification and handoff assertions.
+- No issue #81 regression found; auto-continue does not bypass Security scope capture or perform downstream security specialist work.
 
 ## Next Steps
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-7-direct-downstream-without-handoff/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-7-direct-downstream-without-handoff/comparison.md
@@ -6,7 +6,7 @@
 - Test case: direct-downstream-without-handoff
 - Test set: PM entry evals for issue #52 / FR-006 scenario 7
 - Entry: workspace `eval-7-direct-downstream-without-handoff`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
 
 ## Test Set / Fixture Version
 
@@ -14,20 +14,28 @@
 - Fixture: direct downstream role-router request without PM handoff context
 - Expected output: reject direct downstream execution, return to `pm-agent`, and require PM handoff packet or equivalent confirmed docs.
 
-## With Skill
+## Assertions
+
+- PASS `reject_direct_downstream`: The request cannot directly enter `engineer-agent`, code modification, or downstream execution.
+- PASS `return_to_pm_agent`: The route returns to `pm-agent` for request type, scope, feature path, and handoff readiness classification.
+- PASS `require_handoff_or_docs`: Downstream role routers require a PM handoff packet or equivalent confirmed source documents.
+
+## With Skill Behavior
 
 - The `pm-agent` and downstream execution contract reject starting Engineer implementation without PM classification and source context.
 - It returns the request to `pm-agent` for request type, scope, feature path, and handoff readiness classification.
 - It requires PM handoff packet or equivalent confirmed PRD / TRD / design / test / deployment / security docs before downstream execution.
+- Issue #81 safety-net behavior remains within boundary: direct downstream invocation without prerequisite context is guided back to PM; auto-continue does not turn this into permission to execute Engineer work.
 
-## Without Skill / without_skill Baseline
+## Without Skill Baseline
 
-- The baseline read the eval item and fixture before target skill docs. A generic response could honor the user's "directly use engineer-agent" instruction and start implementation planning.
+- Fresh without_skill baseline regenerated on 2026-07-06 without applying `pm-agent` or the Product Manager Agent README. A generic response could honor the user's "directly use engineer-agent" instruction and start implementation planning.
 - It is less reliable about enforcing the PM handoff entry gate when the user explicitly asks to skip PM docs.
 
 ## Failures
 
 - None. The current PM entry gate satisfies all direct-downstream defense assertions.
+- No issue #81 regression found; the safety-net guidance path returns missing-basis requests to PM and does not authorize downstream work.
 
 ## Next Steps
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-8-direct-specialist-bypass-gate/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-8-direct-specialist-bypass-gate/comparison.md
@@ -6,7 +6,7 @@
 - Test case: direct-specialist-bypass-gate
 - Test set: PM entry evals for issue #52 / FR-006 scenario 8
 - Entry: workspace `eval-8-direct-specialist-bypass-gate`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
 
 ## Test Set / Fixture Version
 
@@ -14,20 +14,28 @@
 - Fixture: direct internal specialist invocation without PRD, TRD, implementation plan, or PM handoff packet
 - Expected output: specialist entry gate blocks plan/code/test implementation and returns to `pm-agent` classification.
 
-## With Skill
+## Assertions
+
+- PASS `specialist_gate_runs`: Direct invocation of an internal specialist still triggers the PM handoff entry gate.
+- PASS `requires_handoff_or_docs`: The gate requires PM handoff packet or equivalent confirmed PRD / TRD and current implementation scope; an implementation plan is not treated as the upstream entry prerequisite.
+- PASS `blocks_implementation`: The route blocks plan creation, code, and tests, then returns to `pm-agent` classification.
+
+## With Skill Behavior
 
 - The PM handoff entry gate applies even when an internal specialist is directly invoked.
 - It requires a PM handoff packet or equivalent confirmed PRD / TRD and current implementation scope before `feature-implementor` planning can proceed.
 - It blocks creating an implementation plan, writing code, or writing tests until the request returns to `pm-agent` classification.
+- Issue #81 safety-net behavior remains within boundary: auto-continue cannot bypass the specialist entry gate or let PM execute `feature-implementor` planning.
 
-## Without Skill / without_skill Baseline
+## Without Skill Baseline
 
-- The baseline read the eval item and fixture before target skill docs. A generic response could treat the explicit specialist invocation as permission to start planning.
+- Fresh without_skill baseline regenerated on 2026-07-06 without applying `pm-agent` or the Product Manager Agent README. A generic response could treat the explicit specialist invocation as permission to start planning.
 - It may incorrectly treat the missing implementation plan as something to create immediately instead of a downstream step after confirmed PM / TRD context.
 
 ## Failures
 
 - None. The current gate language satisfies all direct-specialist bypass assertions.
+- No issue #81 regression found; the role-boundary priority blocks direct specialist execution without upstream basis.
 
 ## Next Steps
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-9-missing-handoff-target-unavailable/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-9-missing-handoff-target-unavailable/comparison.md
@@ -6,7 +6,7 @@
 - Test case: missing-handoff-target-unavailable
 - Test set: PM entry evals for issue #52 / #62 missing target coverage
 - Entry: workspace `eval-9-missing-handoff-target-unavailable`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
 
 ## Test Set / Fixture Version
 
@@ -14,20 +14,28 @@
 - Fixture: confirmed design handoff with missing `designer-agent`
 - Expected output: mark handoff blocked, name missing capability, and do not perform Designer responsibilities inside PM.
 
-## With Skill
+## Assertions
+
+- PASS `detect_missing_target`: The route detects that `designer-agent` or the required design capability is unavailable.
+- PASS `mark_handoff_blocked`: The handoff stage is marked `blocked` with the missing plugin / capability named.
+- PASS `do_not_perform_missing_role`: PM does not produce Designer visual specifications or design deliverables itself.
+
+## With Skill Behavior
 
 - The `pm-agent` missing handoff target rule detects unavailable downstream agents or skills.
 - It names the missing `designer-agent` capability, marks that handoff stage as `blocked`, and records the blocker.
 - It does not substitute for Designer by producing visual specifications or design deliverables.
+- Issue #81 safety-net behavior remains within boundary: auto-continue stops at the unavailable target blocker instead of letting PM perform Designer responsibilities.
 
-## Without Skill / without_skill Baseline
+## Without Skill Baseline
 
-- The baseline read the eval item and fixture before target skill docs. A generic response could proceed by drafting a design spec despite the missing Designer capability.
+- Fresh without_skill baseline regenerated on 2026-07-06 without applying `pm-agent` or the Product Manager Agent README. A generic response could proceed by drafting a design spec despite the missing Designer capability.
 - It may mention installation but is less reliable about marking the handoff stage blocked and stopping at PM classification.
 
 ## Failures
 
 - None. The current missing-target rule satisfies all assertions.
+- No issue #81 regression found; unavailable handoff targets remain hard blockers for auto-continue.
 
 ## Next Steps
 

--- a/agents/qa/test/qa-agent/evals/workspace/eval-1-route-mixed-qa-request/comparison.md
+++ b/agents/qa/test/qa-agent/evals/workspace/eval-1-route-mixed-qa-request/comparison.md
@@ -7,13 +7,14 @@
 - Eval: `eval-001-route-mixed-qa-request`
 - Test case: route-mixed-qa-request
 - Workspace: `workspace/eval-1-route-mixed-qa-request`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
 - Fixture: login refresh implementation with PM acceptance question and intermittent CI failure evidence.
 - Context read before applying the skill: `evals.json`, workspace `eval_metadata.json`, `docs/pm/login-refresh/PRD.md`, `docs/engineer/login-refresh/TRD.md`, `docs/qa/e2e/auth/login/login-refresh/TEST_SUITE.md`, `FLOW_INDEX.md`, `implementation/changes.md`, and `ci/login-intermittent-failure.log`.
+- #81 context read: `Safety-Net Closeout and Auto-Continue` from `agents/product_manager/skills/idea-to-spec/_internal/_shared/skill-map.md`.
 
 ## Assertions
 
@@ -30,17 +31,20 @@
 
 `qa-agent` satisfies the mixed QA routing contract. It chooses the narrowest current evidence route, preserves the intermittent CI failure as risk or follow-up rather than a parallel execution path, and carries the required QA memory, environment, credential, report, and PRD/TRD/plan gates into the selected specialist. Because the fixture does not include a confirmed implementation plan, the route can still be selected, but E2E acceptance creation or execution would be blocked until `engineer-agent:feature-implementor` supplies the confirmed plan.
 
+#81 closeout behavior is safe for this case: after routing, `qa-agent` may propose the next collaboration-chain owner, but `auto-continue` cannot make QA perform engineering fixes, bypass E2E gates, or execute another role's workflow.
+
 ## Without Skill Baseline
 
-Without the router skill, QA README, and QA E2E references, a generic response would likely either start running tests immediately or split the work into both acceptance testing and bug analysis. It might assume a localhost port or browser path, miss the durable E2E memory read set, omit credential/report references, or classify the intermittent CI log as a confirmed bug too early.
+Fresh baseline generated on 2026-07-06 without reading or applying `qa-agent` skill instructions or the QA Agent README: a generic response would likely either start running tests immediately or split the work into both acceptance testing and bug analysis. It might assume a localhost port or browser path, miss the durable E2E memory read set, omit credential/report references, or classify the intermittent CI log as a confirmed bug too early.
 
 ## Failures
 
 - None found. The missing implementation plan is an expected gate condition for acceptance execution, not a router failure.
+- No #81 regression found: original single-route selection and gate behavior remain intact, and `auto-continue` does not cross the QA role boundary.
 
 ## Next Steps
 
-- Keep this eval as regression coverage for mixed QA requests, single-route selection, and E2E gate preservation.
+- Keep this eval as regression coverage for mixed QA requests, single-route selection, E2E gate preservation, and #81 closeout boundary behavior.
 
 ## Runtime Artifacts Policy
 

--- a/agents/qa/test/qa-agent/evals/workspace/eval-2-empty-qa-directory-expands-cases/comparison.md
+++ b/agents/qa/test/qa-agent/evals/workspace/eval-2-empty-qa-directory-expands-cases/comparison.md
@@ -7,13 +7,14 @@
 - Eval: `eval-002-empty-qa-directory-expands-cases`
 - Test case: empty-qa-directory-expands-cases
 - Workspace: `workspace/eval-2-empty-qa-directory-expands-cases`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
 - Fixture: existing empty E2E function tree for profile settings plus source files and QA environment notes.
 - Context read before applying the skill: `evals.json`, workspace `eval_metadata.json`, `docs/qa/e2e/account/profile-settings/profile-form/TEST_SUITE.md`, `FLOW_INDEX.md`, `environment/qa-env.md`, `src/routes/profile-settings.md`, `src/pages/ProfileSettingsPage.tsx`, and `src/components/ProfileSettingsForm.tsx`.
+- #81 context read: `Safety-Net Closeout and Auto-Continue` from `agents/product_manager/skills/idea-to-spec/_internal/_shared/skill-map.md`.
 
 ## Assertions
 
@@ -29,17 +30,20 @@
 
 `qa-agent` satisfies the empty-directory E2E route. It treats the existing function tree as durable memory, but not as executable coverage, and points to `exploratory-tester` as the narrow route for discovering flows and creating cases. It preserves credential hygiene, per-TC case/script persistence, subagent execution, and platform-version blocking. The fixture's `TEST_SUITE.md` states the platform version is missing, so execution is intentionally blocked until the version is provided; case expansion can still be routed as the preparatory QA work.
 
+#81 closeout behavior is safe for this case: after preparatory QA routing, `qa-agent` may propose the next owner or handoff, but `auto-continue` cannot skip the platform-version gate, execute blocked E2E work, or perform implementation fixes outside the QA role.
+
 ## Without Skill Baseline
 
-Without the router skill, QA README, and QA references, a generic response might either mark the existing QA directory as sufficient coverage or jump straight to browser execution from source files. It is less likely to create durable per-TC case/script files, preserve function-tree report paths, block missing platform version correctly, or avoid writing credentials into scripts.
+Fresh baseline generated on 2026-07-06 without reading or applying `qa-agent` skill instructions or the QA Agent README: a generic response might either mark the existing QA directory as sufficient coverage or jump straight to browser execution from source files. It is less likely to create durable per-TC case/script files, preserve function-tree report paths, block missing platform version correctly, or avoid writing credentials into scripts.
 
 ## Failures
 
 - None found. Missing platform version is the expected execution blocker for this fixture.
+- No #81 regression found: original empty-directory expansion, E2E persistence, and version gates remain intact, and `auto-continue` does not authorize blocked execution.
 
 ## Next Steps
 
-- Keep this eval as regression coverage for empty E2E function-tree expansion and version-gated execution.
+- Keep this eval as regression coverage for empty E2E function-tree expansion, version-gated execution, and #81 closeout boundary behavior.
 
 ## Runtime Artifacts Policy
 

--- a/agents/qa/test/qa-agent/evals/workspace/eval-3-feature-path-missing-plan-blocked/comparison.md
+++ b/agents/qa/test/qa-agent/evals/workspace/eval-3-feature-path-missing-plan-blocked/comparison.md
@@ -7,13 +7,14 @@
 - Eval: `eval-003-feature-path-missing-plan-blocked`
 - Test case: feature-path-missing-plan-blocked
 - Workspace: `workspace/eval-3-feature-path-missing-plan-blocked`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
 - Fixture: same-path PRD/TRD and QA E2E function tree for `account/profile/preferences`, with no confirmed implementation plan.
 - Context read before applying the skill: `evals.json`, workspace `eval_metadata.json`, `docs/pm/account/profile/preferences/PRD.md`, `docs/engineer/account/profile/preferences/TRD.md`, `docs/qa/e2e/account/profile/preferences/TEST_SUITE.md`, and `FLOW_INDEX.md`.
+- #81 context read: `Safety-Net Closeout and Auto-Continue` from `agents/product_manager/skills/idea-to-spec/_internal/_shared/skill-map.md`.
 
 ## Assertions
 
@@ -26,17 +27,20 @@
 
 `qa-agent` satisfies the expected blocked behavior. Its router output requires same-path PRD/TRD and confirmed implementation plan gates for code-complete E2E acceptance updates. The directly referenced QA specialist gates confirm that a missing implementation plan blocks creating, updating, or executing acceptance TC and sends the next action to `engineer-agent:feature-implementor`.
 
+#81 closeout behavior is safe for this case: `auto-continue` may carry the handoff proposal to `engineer-agent:feature-implementor`, but QA must stop at the missing-plan blocker and must not create the plan, mutate E2E cases, or execute acceptance TC itself.
+
 ## Without Skill Baseline
 
-Without the router skill, QA README, and QA E2E gate references, a generic response could proceed from the existing PRD/TRD and QA directory into test-case creation or execution. It might treat the empty QA tree as enough context and miss that the confirmed `IMPLEMENTATION_PLAN.md` is mandatory for code-complete acceptance work.
+Fresh baseline generated on 2026-07-06 without reading or applying `qa-agent` skill instructions or the QA Agent README: a generic response could proceed from the existing PRD/TRD and QA directory into test-case creation or execution. It might treat the empty QA tree as enough context and miss that the confirmed `IMPLEMENTATION_PLAN.md` is mandatory for code-complete acceptance work.
 
 ## Failures
 
 - None found. The blocked route is the expected pass condition for this eval.
+- No #81 regression found: original missing-plan hard stop remains intact, and `auto-continue` only permits handoff to the next owner rather than QA crossing into Engineer work.
 
 ## Next Steps
 
-- Keep this eval as regression coverage for missing implementation-plan blocking before E2E acceptance mutation or execution.
+- Keep this eval as regression coverage for missing implementation-plan blocking before E2E acceptance mutation or execution, plus #81 closeout boundary behavior.
 
 ## Runtime Artifacts Policy
 

--- a/agents/security/test/security-agent/evals/workspace/eval-1-route-auth-release-risk/comparison.md
+++ b/agents/security/test/security-agent/evals/workspace/eval-1-route-auth-release-risk/comparison.md
@@ -7,13 +7,13 @@
 - Eval: `eval-001-route-auth-release-risk`
 - Test case: route-auth-release-risk
 - Workspace: `workspace/eval-1-route-auth-release-risk`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
 - Fixture: auth-centered release security request with dependency-risk concern.
-- Context read before applying the skill: `evals.json`, workspace `eval_metadata.json`, `docs/security/auth-model.md`, and `package.json`.
+- Context read before applying the skill: `security-agent/SKILL.md`, Security Agent `README.md`, `evals.json`, workspace `eval_metadata.json`, `docs/security/auth-model.md`, `package.json`, and the `Safety-Net Closeout and Auto-Continue` section in `skill-map.md`.
 
 ## Assertions
 
@@ -25,19 +25,21 @@
 
 ## With Skill Behavior
 
-`security-agent` satisfies the release-risk route. Its router chooses the narrowest security outcome, so the auth/admin risk gets `authz-reviewer` as the current route while dependency audit remains a named follow-up. The skill preserves Security as an evidence-backed risk review role and explicitly hands remediation to Engineer or DevOps when findings require changes.
+`security-agent` satisfies the release-risk route. Its router chooses the narrowest security outcome, so the auth/admin risk gets `authz-reviewer` as the current route while dependency audit remains a named `dependency-risk-auditor` follow-up. The selected downstream context is authentication flow, role and permission matrix, sensitive routes, test evidence, and the dependency manifest.
+
+The skill preserves Security as an evidence-backed risk review role and explicitly hands remediation to `engineer-agent` or `devops-agent` when findings require code, dependency, or deployment changes. The #81 safety-net closeout is compatible with this route: the prompt asks for routing only and does not authorize auto-continue, so Security stops at the route and handoff proposal. If auto-continue were enabled later, it would automate only the next-owner handoff and would not let Security execute another role's workflow or bypass that role's gate.
 
 ## Without Skill Baseline
 
-Without the router skill and Security README, a generic response could blend auth review, dependency audit, and fix recommendations into one broad release checklist. It may also suggest code changes directly instead of keeping Security output as structured risk evidence with remediation handoff.
+Fresh without_skill baseline generated on 2026-07-06 without reading or applying `security-agent/SKILL.md` or the Security Agent README: a generic response could blend auth review, dependency audit, and fix recommendations into one broad release checklist. It may choose a broad security review as the primary route instead of the narrower auth route, bury the dependency concern in the same checklist, and suggest direct code or package changes instead of keeping Security output as structured risk evidence with remediation handoff.
 
 ## Failures
 
-- None found.
+- None found. No #81 regression was observed: the original narrow routing and remediation handoff remain intact, and auto-continue does not expand the Security role boundary.
 
 ## Next Steps
 
-- Keep this eval as regression coverage for Security narrow-route selection and remediation handoff.
+- Keep this eval as regression coverage for Security narrow-route selection, remediation handoff, and #81 auto-continue boundary behavior.
 
 ## Runtime Artifacts Policy
 


### PR DESCRIPTION
## 背景

#81（安全网收尾 + auto-continue + 角色边界优先，PR #85）改动了 6 个 dispatcher 的路由/收尾行为。按 AGENTS.md eval 门禁，对受影响 skill 执行 fresh Codex subagent 验证并更新 durable `comparison.md`。

## 执行

对 6 个 dispatcher 全部 eval case 逐个执行 fresh Codex subagent 验证（遵守 Fresh Sub-Agent 门禁：**重新生成 without_skill baseline**，不复用历史）：
- pm-agent（13）、engineer-agent（4）、qa-agent（3）、designer-agent（3）、devops-agent（1）、security-agent（1）= **25 个 case**

## 结果

- **全部 25 个 case PASS**，`Latest result` 更新为 `... fresh Codex subagent validation completed on 2026-07-06`。
- 原有路由/gate 行为无回归；`auto-continue` 在各角色均只推进到「建议 / 交接」，不越界执行下一角色实际工作。
- 硬边界在 auto-continue 下仍成立：Designer 停在设计交回 `engineer-agent`；QA 不越界改工程 / 不绕 E2E gate；Security 不代做 Engineer/DevOps 工作。
- pm-agent 的 `eval-7 直达下游无 handoff`、`eval-8 specialist bypass`、`eval-9 missing target` 均 PASS，验证安全网入口行为。

## 产物策略

- 仅提交 25 个 durable `comparison.md`；运行期草稿写入 gitignored `tmp/eval-runs/`，未提交。
- `check_eval_contract` / `check_eval_artifacts` → PASS（无 tracked 运行期产物）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)