### PR TITLE
fix: marketplace 条目改用 strict:true 消除 plugin.json manifest 冲突

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "pm-agent",
       "description": "Public entry dispatcher for product ideas, requirement changes, inherited-project feature catalogs, competitive research, battlecards, bug reports, implementation requests, tests, UI/design, deployment, security, delivery, commits, pushes, PRs, release communication, roadmaps, and GitHub project status. Classifies scope first, then hands off to downstream role agents or PM specialists when ready.",
       "source": "./agents/product_manager",
-      "strict": false,
+      "strict": true,
       "skills": [
         "./skills/pm-agent",
         "./skills/idea-to-spec",
@@ -29,7 +29,7 @@
       "name": "engineer-agent",
       "description": "Downstream engineering capability invoked after pm-agent handoff for confirmed codebase analysis, TRDs, bootstrapping, implementation, tests, debugging, and delivery. Skills remain available for PM-orchestrated execution, not as standalone starting points.",
       "source": "./agents/engineer",
-      "strict": false,
+      "strict": true,
       "skills": [
         "./skills/engineer-agent",
         "./skills/codebase-analyzer",
@@ -45,7 +45,7 @@
       "name": "qa-agent",
       "description": "Downstream QA capability invoked after pm-agent handoff for confirmed acceptance, exploratory testing, bug analysis, and regression verification. Requirement or implementation gaps return through the PM-orchestrated handoff path.",
       "source": "./agents/qa",
-      "strict": false,
+      "strict": true,
       "skills": [
         "./skills/qa-agent",
         "./skills/exploratory-tester",
@@ -58,7 +58,7 @@
       "name": "devops-agent",
       "description": "Downstream DevOps capability invoked after pm-agent handoff for confirmed deployment planning, CI/CD automation, environment audits, release readiness, rollback, and runbook preparation.",
       "source": "./agents/devops",
-      "strict": false,
+      "strict": true,
       "skills": [
         "./skills/devops-agent",
         "./skills/deployment-planner",
@@ -71,7 +71,7 @@
       "name": "designer-agent",
       "description": "Downstream design capability invoked after pm-agent handoff for confirmed UX flows, information architecture, wireframes, reference-pattern analysis, and reference-backed visual system work.",
       "source": "./agents/designer",
-      "strict": false,
+      "strict": true,
       "skills": [
         "./skills/designer-agent",
         "./skills/ui-ux-design",
@@ -82,7 +82,7 @@
       "name": "security-agent",
       "description": "Downstream security capability invoked after pm-agent handoff for confirmed AppSec, auth/authz, dependency risk, privacy, and data-flow reviews, with remediation routed through the PM handoff path.",
       "source": "./agents/security",
-      "strict": false,
+      "strict": true,
       "skills": [
         "./skills/security-agent",
         "./skills/appsec-checklist",


### PR DESCRIPTION
## 背景

Closes #91（P0，v0.2.1 回归）。

v0.2.1 起 `/plugin marketplace update` + `/reload-plugins` 时 6 个插件全部报 `conflicting manifests: both plugin.json and marketplace entry specify components`，插件无法加载。

## 根因

#79（PR #83）为每个 agent 新增 `.claude-plugin/plugin.json`，但 `marketplace.json` 的 6 个条目仍是 `strict: false` + 显式 `skills` 数组 → plugin.json（经 `skills/` 自动发现）与 marketplace 条目两处都声明 components → 冲突。

`strict` 默认 true 表示 plugin.json 为 component 权威；`strict: false` 让 marketplace 当完整 manifest（前提是无 plugin.json）。

## 改动

- `.claude-plugin/marketplace.json` 6 个条目 `"strict": false` → `"strict": true`（plugin.json 权威，官方推荐）。
- 保留 `skills` 数组（`validate_marketplace` 强制其为数组、`skills-lock` 校验依赖它，不能删）。

## 验证

- `check_repository_contract.py` → PASS；`marketplace.json` JSON 解析 → OK
- ⚠️ Claude Code 实际加载需合并后由维护者 `/plugin marketplace update` + `/reload-plugins` 确认无冲突报错（CI 不加载插件，属已知盲区，见 #91 后续建议）

## 变更分级

`change_tier`: hotfix。

🤖 Generated with [Claude Code](https://claude.com/claude-code)