### PR TITLE
docs: release-notes-generator 补 release 标题惯例与市场感知升级说明

### DIFF
--- a/agents/product_manager/skills/release-notes-generator/reference/github-release-workflow.md
+++ b/agents/product_manager/skills/release-notes-generator/reference/github-release-workflow.md
@@ -139,10 +139,10 @@ publishedAt = null
 
 ## Draft Release Updates
 
-After editing release notes, update the draft body:
+After editing release notes, update the draft body. Always pass `--title "{TITLE}"` here too (per the GitHub Release Name rule), so a draft created before this rule or outside this workflow is not published with the bare-tag name:
 
 ```bash
-gh release edit {THIS_TAG} --notes-file {NOTES_FILE}
+gh release edit {THIS_TAG} --title "{TITLE}" --notes-file {NOTES_FILE}
 ```
 
 Re-check:
@@ -164,7 +164,7 @@ Only publish after:
 Publish:
 
 ```bash
-gh release edit {THIS_TAG} --notes-file {NOTES_FILE} --target main --verify-tag
+gh release edit {THIS_TAG} --title "{TITLE}" --notes-file {NOTES_FILE} --target main --verify-tag
 gh release edit {THIS_TAG} --draft=false --latest
 ```
 

--- a/agents/product_manager/skills/release-notes-generator/reference/github-release-workflow.md
+++ b/agents/product_manager/skills/release-notes-generator/reference/github-release-workflow.md
@@ -114,6 +114,8 @@ git show --no-patch --format='%H%n%D%n%s' {THIS_TAG}
 
 Create a draft release when the user asks for a release but says not to publish:
 
+Set `{TITLE}` from the GitHub Release Name rule in `reference/release-outline.md`; do not use only the bare tag.
+
 ```bash
 gh release create {THIS_TAG} \
   --draft \

--- a/agents/product_manager/skills/release-notes-generator/reference/release-outline.md
+++ b/agents/product_manager/skills/release-notes-generator/reference/release-outline.md
@@ -4,6 +4,16 @@ Use the repository's existing release outline before introducing a new structure
 
 Use `THIS_TAG` for the full release tag, for example `v1.2.0`. Use `VERSION` only when a normalized version without one leading `v` is required.
 
+## GitHub Release Name
+
+For this repository, the GitHub release `name` and `gh release --title` value must be `v{VERSION} - {概括性简述}`. The summary should cover about 3 key release items, align with the body highlights, and never be only the bare tag.
+
+Example:
+
+```text
+v0.2.0 - PM 唯一入口、变更分级契约与实施计划归档门禁
+```
+
 For this repository, match the `v0.1.1` release outline:
 
 ```markdown
@@ -74,7 +84,7 @@ Fetch and follow instructions from {INSTALL_URL}
 - Keep each highlight to one short paragraph unless an upgrade action needs more detail.
 - Include upgrade commands only when they are stable and useful for the release audience.
 - If a release has breaking changes, place them near the top and add concrete migration steps.
-- If there are no breaking changes, say `无破坏性变更。已有安装可以继续使用。`
+- If there are no breaking changes in a skill or plugin marketplace repository, say `无破坏性变更。已有安装可以继续使用；建议按使用环境执行下面的升级方式。`
 
 ## Change Detail Rules
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -34,7 +34,7 @@
     "release-notes-generator": {
       "source": "agents/product_manager/skills/release-notes-generator",
       "sourceType": "local",
-      "computedHash": "2fa7b97cf6b9a8b8de39346928f3c7b79d8d2ae4f9b4a40daeab342da45d201f"
+      "computedHash": "bcfc5eefab74cc13c2f1b0b3725046025251050ba710df9f8b7765887fd756fe"
     },
     "roadmap-generator": {
       "source": "agents/product_manager/skills/roadmap-generator",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -34,7 +34,7 @@
     "release-notes-generator": {
       "source": "agents/product_manager/skills/release-notes-generator",
       "sourceType": "local",
-      "computedHash": "bcfc5eefab74cc13c2f1b0b3725046025251050ba710df9f8b7765887fd756fe"
+      "computedHash": "4fbcdd07a103773d9bccdc24ca85e3d1a03c0131eab45bf7298c1accedba71c1"
     },
     "roadmap-generator": {
       "source": "agents/product_manager/skills/roadmap-generator",


### PR DESCRIPTION
## 背景

Closes #90。发 v0.2.1 时用 `release-notes-generator` 发现两处内容缺口，产出不符合仓库惯例需人工修正。

## 改动（仅 release-notes-generator reference）

- `reference/release-outline.md`：新增 `## GitHub Release Name` 规则——`name` / `gh release --title` 必须为 `v{VERSION} - {概括性简述}`（约 3 项、与正文 highlights 对齐、不用裸 tag），并给示例。
- `reference/release-outline.md`：无破坏性变更文案改为维护者确认版本 `无破坏性变更。已有安装可以继续使用；建议按使用环境执行下面的升级方式。`（针对 skill/plugin 市场）。
- `reference/github-release-workflow.md`：`{TITLE}` 使用处指向 release name 规则。
- `skills-lock.json`：刷新 release-notes-generator hash。

## 验证

- `repository-contract` / `doc-contract` / `eval-contract` → PASS

## 备注

本次为 release-notes-generator 的 reference 文档措辞修订，不改变其路由/eval 行为；该 skill eval 现状为 PARTIAL，未触发 fresh 复验（如需可另行确认）。

## 变更分级

`change_tier`: standard。

🤖 Generated with [Claude Code](https://claude.com/claude-code)