### PR TITLE
chore: 准备 v0.2.2 发版

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "PM-first agent skill marketplace with one public pm-agent entry and downstream PM-orchestrated engineering, QA, DevOps, design, and security capabilities",
-    "version": "0.2.1"
+    "version": "0.2.2"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 仓库级发布变更记录按版本归档到 `docs/changelog/`。
 
+- [v0.2.2](./docs/changelog/changelog-v0.2.2.md)
 - [v0.2.1](./docs/changelog/changelog-v0.2.1.md)
 - [v0.2.0](./docs/changelog/changelog-v0.2.0.md)
 - [v0.1.4](./docs/changelog/changelog-v0.1.4.md)

--- a/agents/designer/.claude-plugin/plugin.json
+++ b/agents/designer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "designer-agent",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Downstream design capability invoked after pm-agent handoff for confirmed UX flows, information architecture, wireframes, reference-pattern analysis, and reference-backed visual system work.",
   "author": {
     "name": "Neplich"

--- a/agents/devops/.claude-plugin/plugin.json
+++ b/agents/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops-agent",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Downstream DevOps capability invoked after pm-agent handoff for confirmed deployment planning, CI/CD automation, environment audits, release readiness, rollback, and runbook preparation.",
   "author": {
     "name": "Neplich"

--- a/agents/engineer/.claude-plugin/plugin.json
+++ b/agents/engineer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "engineer-agent",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Downstream engineering capability invoked after pm-agent handoff for confirmed codebase analysis, TRDs, bootstrapping, implementation, tests, debugging, and delivery. Skills remain available for PM-orchestrated execution, not as standalone starting points.",
   "author": {
     "name": "Neplich"

--- a/agents/product_manager/.claude-plugin/plugin.json
+++ b/agents/product_manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pm-agent",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Public entry dispatcher for product ideas, requirement changes, inherited-project feature catalogs, competitive research, battlecards, bug reports, implementation requests, tests, UI/design, deployment, security, delivery, commits, pushes, PRs, release communication, roadmaps, and GitHub project status. Classifies scope first, then hands off to downstream role agents or PM specialists when ready.",
   "author": {
     "name": "Neplich"

--- a/agents/qa/.claude-plugin/plugin.json
+++ b/agents/qa/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qa-agent",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Downstream QA capability invoked after pm-agent handoff for confirmed acceptance, exploratory testing, bug analysis, and regression verification. Requirement or implementation gaps return through the PM-orchestrated handoff path.",
   "author": {
     "name": "Neplich"

--- a/agents/security/.claude-plugin/plugin.json
+++ b/agents/security/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "security-agent",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Downstream security capability invoked after pm-agent handoff for confirmed AppSec, auth/authz, dependency risk, privacy, and data-flow reviews, with remediation routed through the PM handoff path.",
   "author": {
     "name": "Neplich"

--- a/docs/changelog/changelog-v0.2.2.md
+++ b/docs/changelog/changelog-v0.2.2.md
@@ -1,0 +1,34 @@
+---
+feature: release-changelog
+version: 0.2.2
+date: 2026-07-06
+last_updated: 2026-07-06
+---
+
+# Changelog - v0.2.2
+
+## [v0.2.2] - 2026-07-06
+
+修复 v0.2.1 的插件加载回归：v0.2.1 引入 per-plugin `plugin.json` 后，marketplace 条目仍为 `strict: false` 且显式列出 `skills`，导致 Claude Code `/reload-plugins` 报 `conflicting manifests`，6 个插件无法加载。v0.2.1 的其它内容随本版本继续可用。
+
+### Fixed
+
+- **插件 manifest 冲突（v0.2.1 回归）**：将 `.claude-plugin/marketplace.json` 6 个条目的 `strict: false` 改为 `strict: true`，让 `plugin.json` 成为 component 权威（官方推荐），消除 `plugin.json` 与 marketplace 条目双重声明 components 导致的 `conflicting manifests` 加载错误；保留 `skills` 数组以满足 `validate_marketplace` 与 `skills-lock` 校验。([#92](https://github.com/Neplich/dev-agent-skills/pull/92))
+
+### Changed
+
+- **`release-notes-generator` skill 补齐 release 标题惯例与市场感知升级说明**：`reference/release-outline.md` 新增 GitHub release `name` / `--title` 规则 `v{VERSION} - {概括性简述}`（约 3 项、与正文 highlights 对齐、不用裸 tag），并把无破坏性变更文案修正为 `无破坏性变更。已有安装可以继续使用；建议按使用环境执行下面的升级方式。`；`reference/github-release-workflow.md` 的创建、更新与发布（`gh release edit`）流程均补 `--title "{TITLE}"`，确保标题规则贯穿 edit/publish 而不仅创建。([#93](https://github.com/Neplich/dev-agent-skills/pull/93))
+
+## Skill Eval 汇总（v0.2.2 发版前）
+
+v0.2.2 的改动仅涉及 marketplace 条目配置（#92）与 `release-notes-generator` 的 reference 文档（#93），**不改变任何 dispatcher 的路由 / 安全网行为**，因此未新增 skill eval 运行；各 skill 最新 `comparison.md` 结论沿用 v0.2.1（6 个 dispatcher 于 2026-07-06 完成 #81 安全网 fresh Codex subagent validation，其余沿用 v0.2.0 Batch 4 2026-07-05 结果）。
+
+### 汇总统计
+
+| 结论 | 数量 | Skills |
+| --- | --- | --- |
+| **PASS** | 14 | pm-agent, idea-to-spec, feature-catalog, roadmap-generator, engineer-agent, feature-implementor, qa-agent, bug-analyzer, exploratory-tester, regression-suite, spec-based-tester, devops-agent, designer-agent, security-agent |
+| **PARTIAL** | 21 | changelog-generator, competitive-brief, competitive-intelligence, github-reader, release-notes-generator, codebase-analyzer, debugger, delivery, project-bootstrap, test-writer, trd-gen, cicd-bootstrap, deployment-planner, env-config-auditor, incident-playbook-writer, ui-ux-design, visual-design, appsec-checklist, authz-reviewer, dependency-risk-auditor, privacy-surface-mapper |
+| **BLOCKED** | 0 | — |
+
+各 skill 逐项结论见 [changelog-v0.2.1.md](./changelog-v0.2.1.md) 的 `Skill Eval 汇总`。PARTIAL 原因仍集中在 without_skill baseline 未生成（历史 eval 在 Fresh Sub-Agent 门禁收紧前执行），下一版本应对 PARTIAL skill 补跑 fresh Codex subagent validation。


### PR DESCRIPTION
## 发版准备 v0.2.2（hotfix）

修复 v0.2.1 的插件加载回归（#91），并纳入 release-notes-generator 惯例补齐（#90）。

### 改动
- `marketplace.json` `metadata.version` `0.2.1 → 0.2.2`
- 6 个 `plugin.json` `version` `0.2.1 → 0.2.2`
- 新增 `docs/changelog/changelog-v0.2.2.md`（含按 skill eval 汇总）
- 根 `CHANGELOG.md` 增加 `v0.2.2` 索引

### v0.2.2 内容
- **Fixed**：marketplace `strict:true` 消除 plugin.json manifest 冲突（#92 / 修 #91）
- **Changed**：release-notes-generator 补 release 标题惯例与升级说明（#93 / 修 #90）

### eval
v0.2.2 改动不涉及 dispatcher 路由行为，未新增 eval 运行；结论沿用 v0.2.1（14 PASS / 21 PARTIAL / 0 BLOCKED），详见 changelog。

### 待维护者确认（不在本 PR 自动执行）
- ⚠️ **合并前建议先验证 #91 修复**：`/plugin marketplace update dev-agent-skills` + `/reload-plugins` 确认无 conflicting manifests
- 合并本 PR（需明确「可以合并」）
- 合并后打 tag `v0.2.2` + 发布 Release（release notes 草稿已产出）

🤖 Generated with [Claude Code](https://claude.com/claude-code)