### PR TITLE
fix: pm-agent 入口描述改为场景句式并收窄 specialist 触发面

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "pm-agent",
-      "description": "Public entry dispatcher for product ideas, requirement changes, inherited-project feature catalogs, competitive research, battlecards, bug reports, implementation requests, tests, UI/design, deployment, security, delivery, commits, pushes, PRs, release communication, roadmaps, and GitHub project status. Classifies scope first, then hands off to downstream role agents or PM specialists when ready.",
+      "description": "Default entry plugin for new user requests. Use when the user describes product ideas, feature requests, requirement changes, bugs, build/test/deploy/review/status requests, feature catalogs, competitive research, release communication, roadmaps, or GitHub project status. Classifies scope first, then routes to PM specialists or hands off to downstream role agents.",
       "source": "./agents/product_manager",
       "strict": true,
       "skills": [

--- a/agents/designer/skills/ui-ux-design/SKILL.md
+++ b/agents/designer/skills/ui-ux-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ui-ux-design
-description: "Internal design specialist invoked by designer-agent after pm-agent handoff to produce UX flows, page structures, journey maps, and ASCII prototypes from confirmed PM/design scope."
+description: "Internal design specialist—not a direct entry point. Invoked by designer-agent after pm-agent handoff to produce UX flows, page structures, journey maps, and ASCII prototypes from confirmed PM/design scope."
 visibility: internal
 ---
 

--- a/agents/designer/skills/visual-design/SKILL.md
+++ b/agents/designer/skills/visual-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: visual-design
-description: "Internal design specialist invoked by designer-agent after pm-agent handoff to define visual systems, aesthetic direction, color, typography, components, copy tone, and reference-backed UI quality rules."
+description: "Internal design specialist—not a direct entry point. Invoked by designer-agent after pm-agent handoff to define visual systems, aesthetic direction, color, typography, components, copy tone, and reference-backed UI quality rules."
 visibility: internal
 ---
 

--- a/agents/designer/test/designer-agent/evals/workspace/eval-003-engineer-ui-maintenance-handoff/comparison.md
+++ b/agents/designer/test/designer-agent/evals/workspace/eval-003-engineer-ui-maintenance-handoff/comparison.md
@@ -7,39 +7,73 @@
 - Eval: `eval-003-engineer-ui-maintenance-handoff`
 - Test case: engineer-ui-maintenance-handoff
 - Workspace: `workspace/eval-003-engineer-ui-maintenance-handoff`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
+- Review context: PR #98 trigger description routing review
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-08
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
 - Fixture: Engineer-sourced UI maintenance design gap for `customer-portal/profile-settings`.
-- Context read before applying the skill: `evals.json`, workspace `eval_metadata.json`, `docs/pm/customer-portal/profile-settings/PRD.md`, and `docs/engineer/customer-portal/profile-settings/TRD.md`.
+- Prompt source: `agents/designer/test/designer-agent/evals/evals.json` and workspace `eval_metadata.json`.
+- Fixture documents:
+  - `docs/pm/customer-portal/profile-settings/PRD.md`
+  - `docs/engineer/customer-portal/profile-settings/TRD.md`
+- Fixture document status: both approved, both dated 2026-06-24, both confirming `feature_path: customer-portal/profile-settings`
 
 ## Assertions
 
-- PASS `accepts_engineer_design_handoff`: the route recognizes an Engineer UI maintenance handoff as design scope, not Engineering implementation.
-- PASS `uses_confirmed_feature_path`: the route uses `customer-portal/profile-settings` and reads same-path PM/Engineer docs.
-- PASS `routes_design_skills`: information hierarchy goes to `ui-ux-design`, and primary button visual rules include `visual-design`.
-- PASS `writes_design_outputs_only`: outputs are limited to `docs/design/customer-portal/profile-settings/ui-ux-spec.md` and/or `visual-system.md`.
-- PASS `hands_back_to_engineer`: implementation returns to `engineer-agent` after design deliverables are complete.
+| Assertion | Result | Notes |
+| --- | --- | --- |
+| `accepts_engineer_design_handoff` | PASS | The with-skill route treats the request as an Engineer UI maintenance design gap, not an engineering implementation request. |
+| `uses_confirmed_feature_path` | PASS | The route preserves `customer-portal/profile-settings` and uses the approved PRD/TRD fixture documents as the design basis. |
+| `routes_design_skills` | PASS | The route selects `ui-ux-design` for information hierarchy and page structure, and selects `visual-design` for the primary button visual rule. |
+| `writes_design_outputs_only` | PASS | The route limits outputs to `docs/design/customer-portal/profile-settings/ui-ux-spec.md` and `docs/design/customer-portal/profile-settings/visual-system.md`; it does not produce code, tests, shell commands, deployment config, or engineering implementation lists. |
+| `hands_back_to_engineer` | PASS | The route stops after design handoff and names `engineer-agent` as the next owner for TRD / IMPLEMENTATION_PLAN / code / test continuation. |
 
 ## With Skill Behavior
 
-`designer-agent` satisfies the Engineer UI maintenance handoff contract. It treats the Engineer packet as a design-only gap, selects `ui-ux-design` plus `visual-design` for the stated information hierarchy and primary button visual rules, writes only design deliverables under the resolved feature path, and stops before code, tests, shell commands, or implementation task lists. For issue #81, even if auto-continue is enabled after closeout, Designer may only hand the completed design deliverables back to `engineer-agent`; Engineer must perform TRD / IMPLEMENTATION_PLAN / code / test work under its own gates.
+The with-skill run read and applied `AGENTS.md`, `agents/designer/README.md`, `agents/designer/skills/designer-agent/SKILL.md`, the eval definition, `eval_metadata.json`, the PRD/TRD fixture documents, and the directly referenced PM shared handoff / closeout contract in `agents/product_manager/skills/idea-to-spec/_internal/_shared/skill-map.md`.
+
+Observed behavior:
+
+- Entry gate is satisfied by equivalent confirmed PM/Engineer documents: the PRD and TRD are approved, share the same stable `feature_path`, and identify the missing UI/UX and visual guidance as the current blocker.
+- The request is accepted as Designer scope because `designer-agent` explicitly supports Engineer UI maintenance and frontend-update design handoffs.
+- The route selects `ui-ux-design` for settings page information hierarchy and structure.
+- The route selects `visual-design` because the primary button visual emphasis affects component visual rules.
+- The only valid design outputs are `docs/design/customer-portal/profile-settings/ui-ux-spec.md` and `docs/design/customer-portal/profile-settings/visual-system.md`.
+- The router stops at design handoff and returns implementation to `engineer-agent`; it does not invoke Engineer skills or produce implementation work.
 
 ## Without Skill Baseline
 
-Fresh without-skill baseline generated in this run on 2026-07-06: without the router skill and Designer README, a generic response could read the request as a frontend implementation planning task because it came from Engineer and mentions UI maintenance. It might return a component checklist, implementation steps, shell/test guidance, or a mixed design-plus-engineering plan, and it may not name the expected `docs/design/customer-portal/profile-settings/` artifacts or the issue #81 rule that auto-continue stops at handoff.
+Source: fresh baseline generated on 2026-07-08 using only the eval prompt and general PRD/TRD fixture facts. It did not read or apply `agents/designer/README.md`, `agents/designer/skills/designer-agent/SKILL.md`, historical `comparison.md`, or any old baseline.
+
+Baseline behavior summary:
+
+- It would likely recognize a design documentation gap because the prompt explicitly says Engineer completed alignment and asks for settings page information hierarchy plus primary button guidance.
+- It would likely preserve `customer-portal/profile-settings` because the prompt states the feature path directly.
+- It would likely avoid code because the prompt explicitly forbids code and implementation checklists.
+- It is less reliable on the repository-specific router contract: exact design artifact filenames, split routing between interaction structure and visual-system work, and the role-gated Designer stopping point are not guaranteed without the skill.
 
 ## Failures
 
-- None found. The issue #81 role-boundary check passed: Designer accepts the Engineer-sourced design gap but hands implementation back to `engineer-agent`.
+None.
 
 ## Next Steps
 
-- Keep this eval as regression coverage for Engineer-to-Designer UI maintenance handoffs and issue #81 auto-continue boundary behavior.
+- Keep the eval result as PASS for this PR #98 routing review.
+- Do not commit runtime artifacts from `tmp/eval-runs/`.
+- If the Designer router trigger wording changes again, rerun this eval with a new fresh without-skill baseline and update this comparison file in the same change set.
 
 ## Runtime Artifacts Policy
 
-- No runtime artifacts were created for this validation.
-- Runtime transcripts, verdicts, timing, output directories, diagnostics, and generated with_skill / without_skill files must not be committed.
+Runtime evidence for this validation was written only under:
+
+`tmp/eval-runs/2026-07-08-router-trigger-batch4-final/eval-003-engineer-ui-maintenance-handoff/`
+
+Files:
+
+- `with_skill.md`
+- `without_skill.md`
+- `verdict.md`
+
+These files are scratch runtime artifacts for short-term review only. They must not be committed, and they must not be copied into the fixture workspace. The durable result for the eval is this `comparison.md` file.

--- a/agents/designer/test/designer-agent/evals/workspace/eval-1-route-design-handoff/comparison.md
+++ b/agents/designer/test/designer-agent/evals/workspace/eval-1-route-design-handoff/comparison.md
@@ -7,39 +7,50 @@
 - Eval: `eval-001-route-design-handoff`
 - Test case: route-design-handoff
 - Workspace: `workspace/eval-1-route-design-handoff`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
+- Review context: PR #98 trigger description routing review
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-08
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
 - Fixture: billing notifications design route with a user request to also write React components.
-- Context read before applying the skill: `evals.json`, workspace `eval_metadata.json`, and `docs/pm/billing-notifications/PRD.md`.
+- Fixture context: `docs/pm/billing-notifications/PRD.md`, which establishes billing notification settings for channels, thresholds, and escalation preferences.
+- Context read before applying the skill: `AGENTS.md`, `agents/designer/README.md`, `agents/designer/skills/designer-agent/SKILL.md`, `agents/product_manager/skills/idea-to-spec/_internal/_shared/skill-map.md`, `evals.json`, workspace `eval_metadata.json`, and `docs/pm/billing-notifications/PRD.md`.
 
 ## Assertions
 
 - PASS `routes_ux_first`: the route starts with `ui-ux-design` for flow, page structure, IA, wireframes, and interaction states.
-- PASS `routes_visual_followup`: visual styling, component rules, colors, typography, and tone route to `visual-design`.
-- PASS `uses_real_output_filenames`: design outputs are `docs/design/{feature_path}/ui-ux-spec.md` and `docs/design/{feature_path}/visual-system.md`.
-- PASS `stops_before_code`: Designer does not write React components, tests, scripts, or deployment files.
+- PASS `routes_visual_followup`: visual styling, component rules, colors, typography, and tone route to `visual-design` as the follow-up.
+- PASS `uses_real_output_filenames`: design outputs are `docs/design/billing-notifications/ui-ux-spec.md` and `docs/design/billing-notifications/visual-system.md`.
+- PASS `stops_before_code`: Designer does not write React components, tests, scripts, deployment files, shell commands, code patches, or implementation task lists.
 - PASS `hands_off_to_engineer`: implementation is explicitly handed to `engineer-agent` after design completion.
 
 ## With Skill Behavior
 
-`designer-agent` satisfies the design-only route. It accepts confirmed PM/design context, selects the narrow design sequence `ui-ux-design` -> `visual-design` when both UX and visual scope are requested, writes only durable design deliverables, and stops before implementation. For issue #81, the inherited safety-net closeout may propose or auto-continue only to the `engineer-agent` handoff point; it does not authorize Designer to invoke Engineer specialists, write React components, or perform implementation work.
+`designer-agent` satisfies the design-only route. It treats `docs/pm/billing-notifications/PRD.md` as an equivalent confirmed PM document chain with stable feature path `billing-notifications`, then selects the narrow design sequence `ui-ux-design` -> `visual-design` because the request asks for both settings page flow and visual style.
+
+The with-skill route writes or updates only durable design deliverables under `docs/design/billing-notifications/`: `ui-ux-spec.md` for UX flow, page structure, information architecture, wireframes, and interaction states; `visual-system.md` for visual style, component rules, colors, typography, and copy tone. It refuses the requested React component implementation in the Designer stage and stops at a handoff to `engineer-agent`.
 
 ## Without Skill Baseline
 
-Fresh without-skill baseline generated in this run on 2026-07-06: without the router skill and Designer README, a generic response could honor the "不要进入实现" clause but still blend design routing with React-oriented next steps because the prompt asks to "顺手" write components. It may describe UI structure and visual style, but it is less likely to enforce the exact `ui-ux-design` -> `visual-design` sequence, the two durable design artifact filenames, or the issue #81 boundary that auto-continue stops at an Engineer handoff.
+Source: fresh without-skill baseline generated on 2026-07-08 in `tmp/eval-runs/2026-07-08-router-trigger-batch4-final/eval-001-route-design-handoff/without_skill.md`.
+
+The baseline used only the eval prompt and fixture's general billing notification settings context. It did not read or apply `agents/designer/README.md`, `agents/designer/skills/designer-agent/SKILL.md`, historical `comparison.md`, or any previous baseline output.
+
+Without the router skill, a generic response can likely honor the explicit "不要进入实现" instruction and describe settings-page flow plus visual style. It does not reliably name `ui-ux-design` first, name `visual-design` second, use the durable filenames `docs/design/billing-notifications/ui-ux-spec.md` and `docs/design/billing-notifications/visual-system.md`, or identify `engineer-agent` as the handoff owner.
 
 ## Failures
 
-- None found. The issue #81 role-boundary check passed: Designer stops before code and hands implementation to `engineer-agent`.
+- None found. All eval assertions pass in the with-skill run.
+- The without-skill baseline remains weaker on router-specific guarantees, especially specialist sequence, durable file names, and named Engineer handoff.
 
 ## Next Steps
 
-- Keep this eval as regression coverage for Designer design-only routing, implementation handoff, and issue #81 auto-continue boundary behavior.
+- Keep this eval as regression coverage for Designer trigger-description routing, design-only boundaries, durable design artifact naming, and implementation handoff behavior.
+- No follow-up action is required for this eval result.
 
 ## Runtime Artifacts Policy
 
-- No runtime artifacts were created for this validation.
-- Runtime transcripts, verdicts, timing, output directories, diagnostics, and generated with_skill / without_skill files must not be committed.
+- Runtime evidence for this run is stored only under `tmp/eval-runs/2026-07-08-router-trigger-batch4-final/eval-001-route-design-handoff/`.
+- The runtime files are `with_skill.md`, `without_skill.md`, and `verdict.md`.
+- These runtime artifacts, transcripts, verdicts, timing files, output directories, diagnostics, and generated with_skill / without_skill files must not be committed.

--- a/agents/designer/test/designer-agent/evals/workspace/eval-2-feature-path-design-handoff/comparison.md
+++ b/agents/designer/test/designer-agent/evals/workspace/eval-2-feature-path-design-handoff/comparison.md
@@ -7,13 +7,16 @@
 - Eval: `eval-002-feature-path-design-handoff`
 - Test case: feature-path-design-handoff
 - Workspace: `workspace/eval-2-feature-path-design-handoff`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
+- Review context: PR #98 trigger description routing review
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-08
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
 - Fixture: confirmed 4-level feature path `chat-interface/messages/history/search` with same-path PM PRD and Engineer TRD.
-- Context read before applying the skill: `evals.json`, workspace `eval_metadata.json`, `docs/pm/chat-interface/messages/history/search/PRD.md`, and `docs/engineer/chat-interface/messages/history/search/TRD.md`.
+- Fixture metadata: `eval_metadata.json` for `eval-002-feature-path-design-handoff`.
+- Context read before applying the skill: `AGENTS.md`, `agents/designer/README.md`, `agents/designer/skills/designer-agent/SKILL.md`, `evals.json`, workspace `eval_metadata.json`, `docs/pm/chat-interface/messages/history/search/PRD.md`, `docs/engineer/chat-interface/messages/history/search/TRD.md`, and the `skill-map.md` sections directly referenced by the skill for PM handoff fields and Safety-Net Closeout / Auto-Continue.
+- Fixture file status: both metadata-referenced fixture documents exist. PRD and TRD frontmatter both confirm `feature_path: chat-interface/messages/history/search`, `parent_feature: chat-interface/messages/history`, and feature level 4.
 
 ## Assertions
 
@@ -24,21 +27,33 @@
 
 ## With Skill Behavior
 
-`designer-agent` satisfies the feature-path mirroring contract. Its PM handoff gate requires a stable `feature_path`, and Designer README states that output directories consume the PM/Engineer path rather than inventing synonyms. The with-skill route writes only `ui-ux-spec.md` and `visual-system.md` under the full 4-level path and leaves implementation to `engineer-agent`. For issue #81, role boundaries take precedence over auto-continue, so Designer may hand off the confirmed design artifacts to `engineer-agent` but must not continue into engineering workflow, implementation steps, tests, or patches.
+`designer-agent` satisfies the feature-path mirroring contract for the PR #98 trigger description routing review. Its PM handoff gate accepts this request because the prompt provides confirmed PM context, same-path PRD/TRD sources, and a stable `feature_path`. Designer README states that output directories consume `feature_path` from PM/Engineer handoff rather than inventing synonyms. The with-skill route preserves `chat-interface/messages/history/search` and points UI/UX and visual outputs to:
+
+- `docs/design/chat-interface/messages/history/search/ui-ux-spec.md`
+- `docs/design/chat-interface/messages/history/search/visual-system.md`
+
+The route may select `ui-ux-design` for flows, page structure, and interaction work, and `visual-design` when visual-system rules are needed. It stops at design handoff and leaves implementation to `engineer-agent`; it does not produce code, tests, shell commands, patches, deployment config, or engineering implementation steps.
 
 ## Without Skill Baseline
 
-Fresh without-skill baseline generated in this run on 2026-07-06: without the router skill and Designer README, a generic design answer might preserve the topic and even copy the provided PRD/TRD paths, but it has weaker pressure to mirror the full `chat-interface/messages/history/search` path into `docs/design/`. It might shorten the path to `history-search` or `chat-interface/history-search`, and it may include implementation sequencing or test advice instead of stopping at the issue #81 Designer-to-Engineer handoff boundary.
+Fresh without-skill baseline generated in this run on 2026-07-08 from the eval prompt and fixture-level PM/Engineer document facts only. It did not use historical `comparison.md`, historical baselines, Designer README routing rules, or `designer-agent/SKILL.md` router instructions as source material for the baseline behavior.
+
+Without the router skill and Designer README, a generic answer would likely notice the explicit feature path and same-path PRD/TRD references. The weaker behavior is that it may treat "message history search" as the user-facing topic and shorten the design path to `docs/design/search/`, `docs/design/history-search/`, `docs/design/chat-history-search/`, or `docs/design/chat-interface/history-search/`. It may also include implementation sequencing, test suggestions, or frontend update advice instead of stopping strictly at the Designer-to-Engineer handoff boundary.
 
 ## Failures
 
-- None found. The issue #81 role-boundary check passed: Designer mirrors the full design path and stops before engineering work.
+- None found. All assertions pass for PR #98 trigger description routing review.
 
 ## Next Steps
 
-- Keep this eval as regression coverage for multi-level feature-path symmetry across PM, Engineer, and Designer docs, including issue #81 handoff-only auto-continue behavior.
+- Keep this eval as regression coverage for multi-level feature-path symmetry across PM, Engineer, and Designer docs.
+- Re-run fresh with-skill and without-skill validation if Designer router trigger descriptions, feature-path routing, or design handoff wording changes again.
 
 ## Runtime Artifacts Policy
 
-- No runtime artifacts were created for this validation.
-- Runtime transcripts, verdicts, timing, output directories, diagnostics, and generated with_skill / without_skill files must not be committed.
+- Runtime evidence for this validation was written only under `tmp/eval-runs/2026-07-08-router-trigger-batch4-final/eval-002-feature-path-design-handoff/`:
+  - `with_skill.md`
+  - `without_skill.md`
+  - `verdict.md`
+- These runtime files are scratch diagnostics and must not be committed.
+- Durable eval history is this `comparison.md`; runtime transcripts, verdicts, timing, output directories, diagnostics, generated with_skill files, and generated without_skill files remain outside the submitted fixture workspace.

--- a/agents/devops/skills/cicd-bootstrap/SKILL.md
+++ b/agents/devops/skills/cicd-bootstrap/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cicd-bootstrap
-description: "Internal DevOps specialist invoked by devops-agent after pm-agent handoff to add or update CI/CD automation, GitHub Actions, GitLab CI, and release workflow configuration."
+description: "Internal DevOps specialist—not a direct entry point. Invoked by devops-agent after pm-agent handoff to add or update CI/CD automation, GitHub Actions, GitLab CI, and release workflow configuration."
 visibility: internal
 ---
 

--- a/agents/devops/skills/deployment-planner/SKILL.md
+++ b/agents/devops/skills/deployment-planner/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deployment-planner
-description: "Internal DevOps specialist invoked by devops-agent after pm-agent handoff to plan deployment configuration, service targets, local runtime, Docker, Kubernetes, and deploy assets."
+description: "Internal DevOps specialist—not a direct entry point. Invoked by devops-agent after pm-agent handoff to plan deployment configuration, service targets, local runtime, Docker, Kubernetes, and deploy assets."
 visibility: internal
 ---
 

--- a/agents/devops/skills/env-config-auditor/SKILL.md
+++ b/agents/devops/skills/env-config-auditor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: env-config-auditor
-description: "Internal DevOps specialist invoked by devops-agent after pm-agent handoff to audit deployment readiness, environment variables, and configuration coverage across local, CI/CD, and runtime contexts."
+description: "Internal DevOps specialist—not a direct entry point. Invoked by devops-agent after pm-agent handoff to audit deployment readiness, environment variables, and configuration coverage across local, CI/CD, and runtime contexts."
 visibility: internal
 ---
 

--- a/agents/devops/skills/incident-playbook-writer/SKILL.md
+++ b/agents/devops/skills/incident-playbook-writer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: incident-playbook-writer
-description: "Internal DevOps specialist invoked by devops-agent after pm-agent handoff to write rollback guidance, incident response steps, troubleshooting runbooks, and on-call preparation tied to deployment setup."
+description: "Internal DevOps specialist—not a direct entry point. Invoked by devops-agent after pm-agent handoff to write rollback guidance, incident response steps, troubleshooting runbooks, and on-call preparation tied to deployment setup."
 visibility: internal
 ---
 

--- a/agents/devops/test/devops-agent/evals/workspace/eval-1-route-ci-readiness/comparison.md
+++ b/agents/devops/test/devops-agent/evals/workspace/eval-1-route-ci-readiness/comparison.md
@@ -7,13 +7,15 @@
 - Eval: `eval-001-route-ci-readiness`
 - Test case: route-ci-readiness
 - Workspace: `workspace/eval-1-route-ci-readiness`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-08 for PR #98 trigger description routing review.
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
 - Fixture: existing `deploy/docker` path with missing GitHub Actions PR gate and later config/runbook concerns.
-- Context read before applying the skill: `devops-agent/SKILL.md`, `agents/devops/README.md`, `evals.json`, workspace `eval_metadata.json`, `deploy/docker/README.md`, and the `Safety-Net Closeout and Auto-Continue` section in `skill-map.md`.
+- Validation date: 2026-07-08.
+- Review context: PR #98 trigger description routing review.
+- Context read before applying the skill: `AGENTS.md`, `agents/devops/README.md`, `agents/devops/skills/devops-agent/SKILL.md`, `evals.json`, workspace `eval_metadata.json`, `deploy/docker/README.md`, and `agents/product_manager/skills/idea-to-spec/_internal/_shared/skill-map.md`.
 
 ## Assertions
 
@@ -25,25 +27,31 @@
 
 ## With Skill Behavior
 
-`devops-agent` satisfies the CI readiness route. Its PM handoff gate allows equivalent confirmed repo-wide operational context, and this fixture supplies an existing Docker deployment path plus a CI automation gap. The router selects the narrow current owner `cicd-bootstrap`, carries forward `deploy/docker`, and lists config audit and rollback runbook work as explicit follow-ups without executing them.
+`devops-agent` satisfies the CI readiness route. The eval provides confirmed route-only DevOps context: the service already has `deploy/docker`, and the missing piece is GitHub Actions PR readiness. The router selects the narrow current owner `cicd-bootstrap`, carries forward `deploy/docker`, and does not restart deployment planning from zero.
 
-For the issue #81 safety-net behavior, the routed response remains within the DevOps role boundary: it can recommend `cicd-bootstrap` first, then propose `env-config-auditor` and `incident-playbook-writer` as later DevOps follow-ups, but it does not auto-run those follow-ups, write `.github/workflows`, or cross into another role's actual workflow. If an auto-continue instruction were present, the skill-map rule would only permit continuation through the next-owner proposal and handoff under that owner's own gates.
+The router names `env-config-auditor` for later environment-variable coverage review and `incident-playbook-writer` for later rollback documentation. Those remain explicit follow-ups, not automatic execution. The route-only instruction prevents writing `.github/workflows` files during this eval.
 
 ## Without Skill Baseline
 
-Fresh without_skill baseline generated on 2026-07-06 without reading or applying `devops-agent/SKILL.md` or `agents/devops/README.md`: a generic response would likely identify GitHub Actions as important, but it may turn the request into an implementation checklist, sketch or create a workflow despite "不要直接写 workflow", and bundle deployment, environment variables, secrets, and rollback documentation into one broad DevOps pass. It is less likely to preserve the existing Docker context while making `cicd-bootstrap` the single current route and treating config audit/runbook work as explicit later checks.
+Fresh `without_skill` baseline generated on 2026-07-08 from only the eval prompt and fixture facts, without applying `agents/devops/README.md`, `agents/devops/skills/devops-agent/SKILL.md`, historical `comparison.md`, or any old baseline output.
+
+A generic no-skill response would likely recognize GitHub Actions as important and may mention environment-variable review and rollback docs. It is weaker on the skill-specific behavior: it may blur routing with implementation, sketch workflow YAML despite "不要直接写 workflow", restart deployment planning despite existing `deploy/docker`, or bundle CI, config audit, and runbook work into one broad DevOps pass instead of selecting `cicd-bootstrap` now and naming the other two as follow-ups.
 
 ## Failures
 
 - None found.
-- No issue #81 regression found: safety-net closeout and auto-continue do not weaken the original route/gate behavior or authorize DevOps to execute another role's work.
+- No PR #98 trigger description routing regression found: CI readiness still routes to `cicd-bootstrap`; config audit and runbook work remain follow-ups; no workflow files are written.
 
 ## Next Steps
 
 - Keep this eval as regression coverage for DevOps primary-route selection and follow-up separation.
-- Keep issue #81 covered here by checking that follow-up suggestions remain proposals or gated handoffs, not automatic execution of additional DevOps skills or peer-role work.
+- Keep the PR #98 trigger description behavior covered by checking that DevOps trigger text still preserves route-only behavior, existing deployment context, and explicit follow-up separation.
 
 ## Runtime Artifacts Policy
 
-- No runtime artifacts were created for this validation.
-- Runtime transcripts, verdicts, timing, output directories, diagnostics, and generated with_skill / without_skill files must not be committed.
+- Runtime evidence for this validation was written only under `tmp/eval-runs/2026-07-08-router-trigger-batch4-final/eval-001-route-ci-readiness/`:
+  - `with_skill.md`
+  - `without_skill.md`
+  - `verdict.md`
+- These files are scratch runtime artifacts and must not be committed.
+- Runtime transcripts, verdicts, timing, output directories, diagnostics, and generated with_skill / without_skill files must not be copied into the fixture workspace.

--- a/agents/engineer/skills/codebase-analyzer/SKILL.md
+++ b/agents/engineer/skills/codebase-analyzer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: codebase-analyzer
-description: "Internal engineering specialist invoked by engineer-agent after pm-agent handoff to scan an existing codebase and summarize structure, stack, conventions, dependencies, and architecture evidence before downstream work."
+description: "Internal engineering specialist—not a direct entry point. Invoked by engineer-agent after pm-agent handoff to inspect an existing codebase and summarize structure, stack, conventions, dependencies, and architecture evidence."
 visibility: internal
 ---
 

--- a/agents/engineer/skills/debugger/SKILL.md
+++ b/agents/engineer/skills/debugger/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: debugger
-description: "Internal engineering specialist—not a direct entry point. Invoked by engineer-agent after pm-agent handoff to reproduce confirmed implementation defects, identify root cause, and produce scoped verification evidence."
+description: "Internal engineering specialist—not a direct entry point. Invoked by engineer-agent after pm-agent handoff to reproduce, diagnose, and fix confirmed implementation defects with minimal scoped changes and verification evidence."
 visibility: internal
 ---
 

--- a/agents/engineer/skills/debugger/SKILL.md
+++ b/agents/engineer/skills/debugger/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: debugger
-description: "Internal engineering specialist invoked by engineer-agent after pm-agent handoff to reproduce, diagnose, and fix confirmed implementation defects with minimal scoped changes and verification evidence."
+description: "Internal engineering specialist—not a direct entry point. Invoked by engineer-agent after pm-agent handoff to reproduce confirmed implementation defects, identify root cause, and produce scoped verification evidence."
 visibility: internal
 ---
 

--- a/agents/engineer/skills/delivery/SKILL.md
+++ b/agents/engineer/skills/delivery/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: delivery
-description: "Internal engineering specialist invoked by engineer-agent after pm-agent handoff to manage branch delivery, commits, pushes, PR creation, and PR update evidence for completed work."
+description: "Internal engineering specialist—not a direct entry point. Invoked by engineer-agent after pm-agent handoff to manage branch delivery, commits, pushes, PR creation, and PR update evidence for completed work."
 visibility: internal
 ---
 

--- a/agents/engineer/skills/feature-implementor/SKILL.md
+++ b/agents/engineer/skills/feature-implementor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: feature-implementor
-description: "Internal engineering specialist invoked by engineer-agent after pm-agent handoff to implement confirmed TRDs and PM/design inputs through a verified implementation plan."
+description: "Internal engineering specialist—not a direct entry point. Invoked by engineer-agent after pm-agent handoff to implement confirmed TRDs and PM/design inputs through a verified implementation plan."
 visibility: internal
 ---
 

--- a/agents/engineer/skills/project-bootstrap/SKILL.md
+++ b/agents/engineer/skills/project-bootstrap/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: project-bootstrap
-description: "Internal engineering specialist invoked by engineer-agent after pm-agent handoff to initialize a project only from settled PRD/TRD or approved PM scope, with PM redirection when specs are absent."
+description: "Internal engineering specialist—not a direct entry point. Invoked by engineer-agent after pm-agent handoff to initialize a project from settled PRD/TRD or approved PM scope, with PM redirection when specs are absent."
 visibility: internal
 ---
 

--- a/agents/engineer/skills/test-writer/SKILL.md
+++ b/agents/engineer/skills/test-writer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-writer
-description: "Internal engineering specialist invoked by engineer-agent after pm-agent handoff to add or update tests from confirmed PM test expectations, implementation context, and repository conventions."
+description: "Internal engineering specialist—not a direct entry point. Invoked by engineer-agent after pm-agent handoff to add or update tests from confirmed PM test expectations, implementation context, and repository conventions."
 visibility: internal
 ---
 

--- a/agents/engineer/skills/trd-gen/SKILL.md
+++ b/agents/engineer/skills/trd-gen/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: trd-gen
-description: "Internal engineering specialist invoked by engineer-agent after pm-agent handoff to create or update Engineer-owned TRDs, API docs, ADRs, and implementation blueprints from stable PM decisions."
+description: "Internal engineering specialist—not a direct entry point. Invoked by engineer-agent after pm-agent handoff to create or update Engineer-owned TRDs, API docs, ADRs, and implementation blueprints from stable PM decisions."
 visibility: internal
 ---
 

--- a/agents/engineer/test/engineer-agent/evals/workspace/eval-002-existing-feature-alignment-gate/comparison.md
+++ b/agents/engineer/test/engineer-agent/evals/workspace/eval-002-existing-feature-alignment-gate/comparison.md
@@ -7,13 +7,14 @@
 - Eval: `eval-002-existing-feature-alignment-gate`
 - Test case: existing-feature-alignment-gate
 - Workspace: `workspace/eval-002-existing-feature-alignment-gate`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-08 for PR #98 trigger description routing review.
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
 - Fixture: small existing-feature behavior change request for Notification Center archived items.
-- Context read before applying the skill: `evals.json` and workspace `eval_metadata.json`.
+- Context read before applying the skill: `AGENTS.md`, `agents/engineer/README.md`, `agents/engineer/skills/engineer-agent/SKILL.md`, `evals.json`, and workspace `eval_metadata.json`.
+- Runtime evidence: fresh subagent artifacts were generated under `tmp/eval-runs/2026-07-08-router-trigger-batch3/eval-002-existing-feature-alignment-gate/`.
 
 ## Assertions
 
@@ -26,15 +27,15 @@
 
 ## With Skill Behavior
 
-`engineer-agent` satisfies the existing-feature alignment gate. Its PM handoff entry gate accepts only an explicit packet or equivalent specialist entry basis, and its routing rules send production behavior changes through PRD/TRD alignment before `feature-implementor`. The directly referenced `feature-implementor` gate confirms that expectation changes go back to PM, TRD gaps go to `trd-gen`, and plan confirmation remains mandatory after alignment. For issue #81, `auto-continue` may carry the handoff proposal back to `pm-agent` when the archived/active behavior conflicts with approved expectations, but it does not let Engineer update PM requirements or proceed around the PRD/TRD gate.
+`engineer-agent` satisfies the existing-feature alignment gate after the PR #98 trigger description edits. The with-skill run first entered the existing-feature PRD/TRD alignment gate, required same-feature `PRD.md`, `TRD.md`, and present `DECISIONS.md` or product decision records, classified archived notifications appearing in the active list as a possible approved-expectation change, routed conflicts to `pm-agent:idea-to-spec` via `existing-project-update`, routed TRD gaps to `engineer-agent:trd-gen`, and kept `feature-implementor` blocked until alignment plus a confirmed `IMPLEMENTATION_PLAN.md`.
 
 ## Without Skill Baseline
 
-Fresh baseline generated on 2026-07-06 without applying `engineer-agent` or the Engineer README: a generic answer would likely accept the user's "small change" framing and route straight to implementation planning or code changes. It may mention checking docs, but it is less likely to classify the active-versus-archived behavior as a product expectation change, block direct implementation until PRD/TRD and decision records align, or constrain auto-continuation to a PM handoff instead of doing PM work inside Engineer.
+Fresh baseline generated on 2026-07-08 from the eval prompt, workspace metadata, and generic engineering judgment only, without applying `engineer-agent`, the Engineer README, or any previous baseline. The baseline tended to treat the request as small engineering work and only lightly suggested checking PRD/TRD; it did not reliably enforce product decision records, PM existing-project-update routing, TRD gap packet handling, or a mandatory confirmed implementation plan after alignment.
 
 ## Failures
 
-- None found. Issue #81 did not regress the existing-feature alignment gate or weaken PM-first handling of expectation changes.
+- None found. PR #98 did not regress existing-feature expectation alignment, TRD gap routing, or the block on user attempts to bypass PRD/TRD gates.
 
 ## Next Steps
 
@@ -42,5 +43,6 @@ Fresh baseline generated on 2026-07-06 without applying `engineer-agent` or the 
 
 ## Runtime Artifacts Policy
 
-- No runtime artifacts were created for this validation.
-- Runtime transcripts, verdicts, timing, output directories, diagnostics, and generated with_skill / without_skill files must not be committed.
+- Runtime artifacts were created only under `tmp/eval-runs/2026-07-08-router-trigger-batch3/eval-002-existing-feature-alignment-gate/`.
+- Generated `with_skill.md`, `without_skill.md`, and `verdict.md` are scratch evidence only and must not be committed.
+- Durable committed evidence for this run is this `comparison.md`.

--- a/agents/engineer/test/engineer-agent/evals/workspace/eval-003-nested-feature-alignment-routing/comparison.md
+++ b/agents/engineer/test/engineer-agent/evals/workspace/eval-003-nested-feature-alignment-routing/comparison.md
@@ -7,13 +7,14 @@
 - Eval: `eval-003-nested-feature-alignment-routing`
 - Test case: nested-feature-alignment-routing
 - Workspace: `workspace/eval-003-nested-feature-alignment-routing`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-08 for PR #98 trigger description routing review.
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
 - Fixture: existing `chat-interface/history-search` PRD/TRD with a small search result ordering change.
-- Context read before applying the skill: `evals.json`, workspace `README.md`, `eval_metadata.json`, `docs/pm/chat-interface/history-search/PRD.md`, and `docs/engineer/chat-interface/history-search/TRD.md`.
+- Context read before applying the skill: `AGENTS.md`, `agents/engineer/README.md`, `agents/engineer/skills/engineer-agent/SKILL.md`, `evals.json`, workspace `README.md`, `eval_metadata.json`, `docs/pm/chat-interface/history-search/PRD.md`, and `docs/engineer/chat-interface/history-search/TRD.md`.
+- Runtime evidence: fresh subagent artifacts were generated under `tmp/eval-runs/2026-07-08-router-trigger-batch3/eval-003-nested-feature-alignment-routing/`.
 
 ## Assertions
 
@@ -25,15 +26,15 @@
 
 ## With Skill Behavior
 
-`engineer-agent` satisfies the nested feature-path contract. It consumes the same-path PM and Engineer documents, preserves the canonical `feature_path`, and keeps implementation blocked until PRD/TRD expectations align. The directly referenced `trd-gen` and `feature-implementor` gates reinforce that path mismatches and stale TRDs are not fixed by implementation routing. For issue #81, safety-net closeout preserves the same resolved feature path when proposing a PM or `trd-gen` handoff, and `auto-continue` does not authorize route-only prompts to write implementation plans, code, or PM updates.
+`engineer-agent` satisfies the nested feature-path contract after the PR #98 trigger description edits. The with-skill run resolved `feature_path` as `chat-interface/history-search`, read the same-path PRD/TRD, checked approved status and `related_prd` alignment, routed approved-behavior changes to `pm-agent:idea-to-spec` with `request_type: existing-project-update`, routed missing, stale, or path-mismatched TRD/frontmatter back to `engineer-agent:trd-gen`, and stayed route-only without writing code, implementation plans, or tests.
 
 ## Without Skill Baseline
 
-Fresh baseline generated on 2026-07-06 without applying `engineer-agent` or the Engineer README: a generic response could treat "History Search" as a top-level feature or use only the parent chat interface context. It might recommend a direct sorting change because the user calls it small, missing the requirement that child feature docs and `related_prd` stay aligned before routing, and it is less likely to keep auto-continued handoff bound to the resolved nested feature path.
+Fresh baseline generated on 2026-07-08 from the eval prompt and fixture files only, without applying `engineer-agent`, the Engineer README, historical `comparison.md`, or any previous baseline. The baseline recognized the nested path and avoided direct coding, but did not reliably name `pm-agent:idea-to-spec` / `existing-project-update`, `engineer-agent:trd-gen`, or explicitly reject parent-only and sibling paths.
 
 ## Failures
 
-- None found. Issue #81 did not regress nested `feature_path` resolution, TRD mismatch routing, or route-only execution boundaries.
+- None found. PR #98 did not regress nested `feature_path` resolution, TRD mismatch routing, or route-only execution boundaries.
 
 ## Next Steps
 
@@ -41,5 +42,6 @@ Fresh baseline generated on 2026-07-06 without applying `engineer-agent` or the 
 
 ## Runtime Artifacts Policy
 
-- No runtime artifacts were created for this validation.
-- Runtime transcripts, verdicts, timing, output directories, diagnostics, and generated with_skill / without_skill files must not be committed.
+- Runtime artifacts were created only under `tmp/eval-runs/2026-07-08-router-trigger-batch3/eval-003-nested-feature-alignment-routing/`.
+- Generated `with_skill.md`, `without_skill.md`, and `verdict.md` are scratch evidence only and must not be committed.
+- Durable committed evidence for this run is this `comparison.md`.

--- a/agents/engineer/test/engineer-agent/evals/workspace/eval-004-frontend-ui-routing-contract/comparison.md
+++ b/agents/engineer/test/engineer-agent/evals/workspace/eval-004-frontend-ui-routing-contract/comparison.md
@@ -7,13 +7,14 @@
 - Eval: `eval-004-frontend-ui-routing-contract`
 - Test case: frontend-ui-routing-contract
 - Workspace: `workspace/eval-004-frontend-ui-routing-contract`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-08 for PR #98 trigger description routing review.
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
 - Fixture: frontend UI implementation request for `customer-portal/profile-settings` with same-path PRD/TRD and missing design deliverables.
-- Context read before applying the skill: `evals.json`, workspace `README.md`, `eval_metadata.json`, `docs/pm/customer-portal/profile-settings/PRD.md`, and `docs/engineer/customer-portal/profile-settings/TRD.md`.
+- Context read before applying the skill: `AGENTS.md`, `agents/engineer/README.md`, `agents/engineer/skills/engineer-agent/SKILL.md`, `evals.json`, workspace `README.md`, `eval_metadata.json`, `docs/pm/customer-portal/profile-settings/PRD.md`, and `docs/engineer/customer-portal/profile-settings/TRD.md`.
+- Runtime evidence: fresh subagent artifacts were generated under `tmp/eval-runs/2026-07-08-router-trigger-batch3/eval-004-frontend-ui-routing-contract/`.
 
 ## Assertions
 
@@ -27,15 +28,15 @@
 
 ## With Skill Behavior
 
-`engineer-agent` satisfies the frontend UI routing contract. It classifies local frontend updates as Engineering, applies the PM handoff and same-path PRD/TRD gate, checks design deliverables for page structure, interaction, visual rules, and information hierarchy, then hands design gaps to `designer-agent` without performing Designer work itself. The route returns to `feature-implementor` only after design handoff completion. For issue #81, `auto-continue` may move only as far as the Designer handoff when design deliverables are missing; it does not permit Engineer to create design deliverables, call external UI skills, or bypass the later `IMPLEMENTATION_PLAN.md` confirmation gate.
+`engineer-agent` satisfies the frontend UI routing contract after the PR #98 trigger description edits. The with-skill run treated frontend code and UI implementation as Engineering work, resolved `feature_path` as `customer-portal/profile-settings`, read same-path PRD/TRD, checked `docs/design/customer-portal/profile-settings/ui-ux-spec.md` and `visual-system.md`, identified the missing design deliverables as a Designer gap, handed the gap to `designer-agent`, and routed back to `engineer-agent` / `feature-implementor` only after design completion while preserving the `IMPLEMENTATION_PLAN.md` confirmation gate. It did not modify code, write a plan, run tests, or recommend `ui-ux-pro-max`.
 
 ## Without Skill Baseline
 
-Fresh baseline generated on 2026-07-06 without applying `engineer-agent` or the Engineer README: a generic response would likely treat the prompt as either a direct UI design task or a direct frontend implementation task. It might provide layout and button style guidance, or suggest coding steps, while missing the repository-specific design deliverable check, the prohibition on external UI reference skills for local implementation routing, and the rule that auto-continuation cannot make Engineer perform Designer work.
+Fresh baseline generated on 2026-07-08 from the eval prompt and fixture files only, without applying `engineer-agent`, the Engineer README, historical `comparison.md`, or any previous baseline. The baseline recognized a frontend update, read PRD/TRD generically, noticed missing design guidance, and suggested design confirmation before implementation, but lacked the repository-specific `engineer-agent` route contract, exact `designer-agent` handoff protocol, and required `feature-implementor` plan gate.
 
 ## Failures
 
-- None found. Issue #81 did not regress frontend UI routing, Designer handoff boundaries, or implementation-plan gating after design completion.
+- None found. PR #98 did not regress frontend UI routing, Designer handoff boundaries, external UI skill exclusion, or implementation-plan gating after design completion.
 
 ## Next Steps
 
@@ -43,5 +44,6 @@ Fresh baseline generated on 2026-07-06 without applying `engineer-agent` or the 
 
 ## Runtime Artifacts Policy
 
-- No runtime artifacts were created for this validation.
-- Runtime transcripts, verdicts, timing, output directories, diagnostics, and generated with_skill / without_skill files must not be committed.
+- Runtime artifacts were created only under `tmp/eval-runs/2026-07-08-router-trigger-batch3/eval-004-frontend-ui-routing-contract/`.
+- Generated `with_skill.md`, `without_skill.md`, and `verdict.md` are scratch evidence only and must not be committed.
+- Durable committed evidence for this run is this `comparison.md`.

--- a/agents/engineer/test/engineer-agent/evals/workspace/eval-1-route-implementation-chain/comparison.md
+++ b/agents/engineer/test/engineer-agent/evals/workspace/eval-1-route-implementation-chain/comparison.md
@@ -7,34 +7,35 @@
 - Eval: `eval-001-route-implementation-chain`
 - Test case: route-implementation-chain
 - Workspace: `workspace/eval-1-route-implementation-chain`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-08 for PR #98 trigger description routing review.
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
 - Fixture: existing service with an approved billing webhook TRD and a route-only request for implementation, tests, QA E2E handoff, and delivery.
-- Context read before applying the skill: `evals.json`, workspace `README.md`, `eval_metadata.json`, `docs/engineer/billing-webhook/TRD.md`, and `src/billing-webhook.md`.
+- Context read before applying the skill: `AGENTS.md`, `agents/engineer/README.md`, `agents/engineer/skills/engineer-agent/SKILL.md`, `evals.json`, workspace `README.md`, `eval_metadata.json`, `docs/engineer/billing-webhook/TRD.md`, and `src/billing-webhook.md`.
+- Runtime evidence: fresh subagent artifacts were generated under `tmp/eval-runs/2026-07-08-router-trigger-batch3/eval-001-route-implementation-chain/`.
 
 ## Assertions
 
 - PASS `starts_with_codebase_context`: the route starts with `codebase-analyzer` to establish repository structure, stack, constraints, and existing patterns.
 - PASS `routes_implementation_to_feature_implementor`: implementation is routed to `feature-implementor` after confirmed TRD context, with `IMPLEMENTATION_PLAN.md` as the required planning gate.
 - PASS `routes_tests_to_test_writer`: test coverage is a distinct `test-writer` route before delivery.
-- PASS `routes_qa_e2e_handoff`: post-implementation handoff must include PRD, TRD, confirmed `IMPLEMENTATION_PLAN.md`, changed files, verification commands, risks, and `docs/qa/e2e/{feature_path}/`.
+- PASS `routes_qa_e2e_handoff`: post-implementation handoff must include PRD or PM source, TRD, confirmed `IMPLEMENTATION_PLAN.md`, changed files, verification commands, risks, and `docs/qa/e2e/{feature_path}/`.
 - PASS `routes_delivery_last`: `delivery` remains the last step for commit, push, or PR work.
-- PASS `does_not_execute_directly`: the route-only prompt does not authorize code edits, test runs, or commits.
+- PASS `does_not_execute_directly`: the route-only prompt does not authorize code edits, test runs, commits, pushes, or PR creation.
 
 ## With Skill Behavior
 
-`engineer-agent` satisfies the full route chain. It preserves the PM handoff entry gate, then selects the narrow engineering sequence: `codebase-analyzer` -> `feature-implementor` -> `test-writer` -> QA E2E handoff check -> `delivery`. The skill explicitly points implementation planning to `docs/engineer/{feature_path}/IMPLEMENTATION_PLAN.md`, keeps downstream specialist gates in their owners, and does not perform implementation itself. For issue #81, the safety-net closeout can propose the next collaboration owner after the engineering route is complete, but `auto-continue` remains handoff-only across roles and does not authorize Engineer to execute QA work or bypass the implementation-plan gate.
+`engineer-agent` satisfies the full route chain after the PR #98 trigger description edits. The with-skill run treated the prompt as route-only, started with `codebase-analyzer`, routed implementation to `feature-implementor` using the confirmed TRD and requiring a confirmed `docs/engineer/billing-webhook/IMPLEMENTATION_PLAN.md`, routed tests to `test-writer`, required the QA E2E handoff package before QA work, and placed `delivery` last for commit, push, and PR wrap-up. It did not perform implementation, run tests, create a commit, push, or open a PR.
 
 ## Without Skill Baseline
 
-Fresh baseline generated on 2026-07-06 without applying `engineer-agent` or the Engineer README: a generic response would likely treat the request as a normal implementation checklist, start from the named TRD, and propose coding plus tests directly. It might include delivery at the end, but it is less likely to require codebase context first, preserve the `feature-implementor` plan gate, include the QA E2E handoff package with confirmed `IMPLEMENTATION_PLAN.md`, or distinguish auto-continued cross-role handoff from executing another role's workflow.
+Fresh baseline generated on 2026-07-08 from the eval prompt and fixture files only, without applying `engineer-agent`, the Engineer README, historical `comparison.md`, or any previous baseline. The baseline preserved a generic read-plan-implement-test-PR order, but lacked repository-specific specialist routing, the mandatory implementation-plan confirmation, and the QA E2E handoff-package requirement.
 
 ## Failures
 
-- None found. Issue #81 did not regress the original route/gate behavior or expand Engineer beyond its role boundary.
+- None found. PR #98 did not regress route-only implementation-chain routing, specialist ordering, QA E2E handoff preservation, or the no-direct-execution boundary.
 
 ## Next Steps
 
@@ -42,5 +43,6 @@ Fresh baseline generated on 2026-07-06 without applying `engineer-agent` or the 
 
 ## Runtime Artifacts Policy
 
-- No runtime artifacts were created for this validation.
-- Runtime transcripts, verdicts, timing, output directories, diagnostics, and generated with_skill / without_skill files must not be committed.
+- Runtime artifacts were created only under `tmp/eval-runs/2026-07-08-router-trigger-batch3/eval-001-route-implementation-chain/`.
+- Generated `with_skill.md`, `without_skill.md`, and `verdict.md` are scratch evidence only and must not be committed.
+- Durable committed evidence for this run is this `comparison.md`.

--- a/agents/product_manager/.claude-plugin/plugin.json
+++ b/agents/product_manager/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-agent",
   "version": "0.2.2",
-  "description": "Public entry dispatcher for product ideas, requirement changes, inherited-project feature catalogs, competitive research, battlecards, bug reports, implementation requests, tests, UI/design, deployment, security, delivery, commits, pushes, PRs, release communication, roadmaps, and GitHub project status. Classifies scope first, then hands off to downstream role agents or PM specialists when ready.",
+  "description": "Default entry plugin for new user requests. Use when the user describes product ideas, feature requests, requirement changes, bugs, build/test/deploy/review/status requests, feature catalogs, competitive research, release communication, roadmaps, or GitHub project status. Classifies scope first, then routes to PM specialists or hands off to downstream role agents.",
   "author": {
     "name": "Neplich"
   }

--- a/agents/product_manager/skills/changelog-generator/SKILL.md
+++ b/agents/product_manager/skills/changelog-generator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: changelog-generator
-description: "Internal PM specialist—not a direct entry point. Invoked by pm-agent after entry classification to generate versioned changelogs from merged PRs, tags, and repository release history."
+description: "Internal PM specialist—not a direct entry point. Invoked by pm-agent after entry classification to generate or update versioned changelogs from merged PRs, tags, and repository release history."
 visibility: internal
 ---
 

--- a/agents/product_manager/skills/changelog-generator/SKILL.md
+++ b/agents/product_manager/skills/changelog-generator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: changelog-generator
-description: "Internal PM specialist invoked by pm-agent for release communication to generate or update versioned changelogs from merged PRs, tags, and repository release history."
+description: "Internal PM specialist—not a direct entry point. Invoked by pm-agent after entry classification to generate versioned changelogs from merged PRs, tags, and repository release history."
 visibility: internal
 ---
 

--- a/agents/product_manager/skills/competitive-brief/SKILL.md
+++ b/agents/product_manager/skills/competitive-brief/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: competitive-brief
-description: "Internal PM specialist invoked by pm-agent for competitor research to produce positioning and messaging comparisons, content gaps, opportunities, and threat summaries."
+description: "Internal PM specialist—not a direct entry point. Invoked by pm-agent after entry classification to produce competitor positioning, messaging comparisons, content gaps, opportunities, and threat summaries."
 visibility: internal
 argument-hint: "<competitor or market segment>"
 ---

--- a/agents/product_manager/skills/competitive-intelligence/SKILL.md
+++ b/agents/product_manager/skills/competitive-intelligence/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: competitive-intelligence
-description: "Internal PM specialist invoked by pm-agent for competitor research to build an interactive battlecard with competitor cards and a comparison matrix."
+description: "Internal PM specialist—not a direct entry point. Invoked by pm-agent after entry classification to build sales battlecards with competitor cards and comparison matrices."
 visibility: internal
 ---
 

--- a/agents/product_manager/skills/feature-catalog/SKILL.md
+++ b/agents/product_manager/skills/feature-catalog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: feature-catalog
-description: "Internal PM specialist invoked by pm-agent for inherited projects to map routes, pages, APIs, services, data models, tests, and docs into a maintainer-confirmable feature catalog."
+description: "Internal PM specialist—not a direct entry point. Invoked by pm-agent after entry classification to map inherited-project routes, pages, APIs, services, data models, tests, and docs into a maintainer-confirmable feature catalog."
 visibility: internal
 ---
 

--- a/agents/product_manager/skills/github-reader/SKILL.md
+++ b/agents/product_manager/skills/github-reader/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-reader
-description: "Internal PM specialist invoked by pm-agent for GitHub project-state intake, including issues, PRs, milestones, backlog health, release readiness, and recent repository activity."
+description: "Internal PM specialist—not a direct entry point. Invoked by pm-agent after entry classification to summarize GitHub issues, PRs, milestones, backlog health, release readiness, and recent repository activity."
 visibility: internal
 ---
 

--- a/agents/product_manager/skills/idea-to-spec/SKILL.md
+++ b/agents/product_manager/skills/idea-to-spec/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: idea-to-spec
-description: "Internal PM specialist invoked by pm-agent to turn product ideas, empty-workspace app requests, existing-feature changes, or spec updates into structured PM/design outputs before downstream work."
+description: "Internal PM specialist—not a direct entry point. Invoked by pm-agent after entry classification to turn confirmed product discovery, empty-workspace app, existing-feature update, or spec-update scope into structured PM/design outputs."
 visibility: internal
 ---
 

--- a/agents/product_manager/skills/pm-agent/SKILL.md
+++ b/agents/product_manager/skills/pm-agent/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pm-agent
-description: Public entry router for product ideas, requirement changes, inherited-project feature catalogs, competitive research, battlecards, bug reports, implementation requests, tests, UI/design, deployment, security, delivery, commits, pushes, PRs, release communication, roadmaps, and GitHub project status. Classifies scope first, then routes to PM specialists or hands off to downstream role agents when ready.
+description: "Default entry point for any new user request. Use this when the user describes a new product idea, feature request, requirement change, bug, or asks to build, test, deploy, review, or check project status—especially when the request is vague or no confirmed scope/handoff exists yet. It also covers inherited-project feature catalogs, competitive research, battlecards, release communication, roadmaps, and GitHub project status. Classifies scope first, then routes to PM specialists or hands off to downstream role agents."
 ---
 
 # PM Agent Dispatcher

--- a/agents/product_manager/skills/release-notes-generator/SKILL.md
+++ b/agents/product_manager/skills/release-notes-generator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release-notes-generator
-description: "Internal PM specialist invoked by pm-agent for release communication to draft user-facing release notes, release announcements, and GitHub release bodies from version context."
+description: "Internal PM specialist—not a direct entry point. Invoked by pm-agent after entry classification to draft user-facing release notes, release announcements, and GitHub release bodies from version context."
 visibility: internal
 ---
 

--- a/agents/product_manager/skills/roadmap-generator/SKILL.md
+++ b/agents/product_manager/skills/roadmap-generator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: roadmap-generator
-description: "Internal PM specialist invoked by pm-agent for planning to generate or update roadmap docs from GitHub milestones, issues, PRs, and release context."
+description: "Internal PM specialist—not a direct entry point. Invoked by pm-agent after entry classification to create or update roadmap docs from GitHub milestones, issues, PRs, and release context."
 visibility: internal
 ---
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-1-route-greenfield-product-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-1-route-greenfield-product-request/comparison.md
@@ -4,9 +4,9 @@
 
 - Skill: `pm-agent`
 - Test case: route-greenfield-product-request
-- Test set: PM entry evals for issue #52 / FR-006 scenario 1
+- Test set: PM entry evals for issue #52 / FR-006 scenario 1; PR #98 trigger-description routing check
 - Entry: workspace `eval-1-route-greenfield-product-request`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-08
 
 ## Test Set / Fixture Version
 
@@ -18,32 +18,33 @@
 
 - PASS `route_to_idea_to_spec`: `pm-agent` selects `idea-to-spec` as the narrowest PM route for product discovery, scope shaping, and spec creation.
 - PASS `pm_first_guardrail`: The empty-workspace product idea is kept out of `engineer-agent` and project scaffolding unless the user explicitly bypasses PM.
-- PASS `context_to_collect`: The route names goals, core flows, scope, acceptance criteria, and open questions as the next PM context.
+- PASS `context_to_collect`: The route names user goals, core flows, scope boundaries, acceptance criteria, and open questions as the next PM context.
 - PASS `expected_pm_artifacts`: The PM outputs are PRD, BRD, and DECISIONS; TRD remains an Engineer-owned follow-up after requirements stabilize.
 - PASS `handoff_boundary`: Designer or Engineer handoff only happens after PM scope is stable.
 
 ## With Skill Behavior
 
-- The `pm-agent` protocol treats empty or near-empty product requests as PM-first and routes the AI chat assistant idea to `idea-to-spec`.
-- It blocks direct engineering bootstrap unless the user explicitly asks to skip PM.
-- It names the context to collect: user goal, core flows, scope, acceptance criteria, open questions, PRD / BRD / DECISIONS output, and later `engineer-agent:trd-gen` after scope is stable.
-- Issue #81 safety-net behavior remains within boundary: closeout can propose Designer or Engineer as the next owner after PM discovery, but `pm-agent` does not execute design or engineering work itself.
+- Fresh subagent applied the current-branch `pm-agent` SKILL.md and Product Manager Agent README.
+- The router treats the empty or near-empty AI chat assistant request as PM-first and routes it to `pm-agent:idea-to-spec`.
+- It blocks direct `engineer-agent` handoff or project scaffolding because the user is still describing product behavior and explicitly asked not to write code.
+- It names the context to collect: user goal, core chat flow, conversation-history scope, acceptance criteria, open questions, PRD / BRD / DECISIONS output, and later `engineer-agent:trd-gen` after scope is stable.
 
 ## Without Skill Baseline
 
-- Fresh without_skill baseline regenerated on 2026-07-06 without applying `pm-agent` or the Product Manager Agent README. A generic response could recommend scaffolding or implementation planning for the left-right chat UI because the user describes a concrete screen.
-- It may mention product clarification, but it is less reliable about the formal PM-first guardrail, the `idea-to-spec` route, and the delayed Designer / Engineer handoff boundary.
+- Fresh without_skill baseline was regenerated on 2026-07-08 from the eval prompt and fixture README only; it did not reuse historical baseline text and did not apply `pm-agent` SKILL.md or the Product Manager Agent README.
+- The generic baseline tends to recommend first clarifying requirements or a product spec before design and development, but it does not reliably name `idea-to-spec`, the PM-first guardrail, PRD / BRD / DECISIONS, TRD ownership, or delayed Designer / Engineer handoff.
 
 ## Failures
 
 - None. All assertions are satisfied by the current `pm-agent` routing and PM-first guardrail.
-- No issue #81 regression found; auto-continue does not bypass the empty-workspace PM-first gate or cross-role handoff boundary.
+- No routing regression found from the PR #98 trigger-description changes.
 
 ## Next Steps
 
 - Keep this eval as PM entry coverage for empty-workspace product ideas.
-- Re-run fresh validation only when `pm-agent`, `idea-to-spec`, or PM handoff rules change.
+- Re-run fresh validation only when `pm-agent`, `idea-to-spec`, PM handoff rules, or entry trigger descriptions change.
 
 ## Runtime Artifacts Policy
 
-- No runtime artifacts were created or committed. Transcripts, verdicts, timing, outputs, and diagnostics must remain outside git.
+- No runtime artifacts were committed. The validating subagent did not create runtime files.
+- If future transcripts, verdicts, timing data, outputs, or diagnostics are generated, keep them under `tmp/eval-runs/pm-agent-20260708/eval-001/` or another isolated scratch path and do not commit them.

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-10-change-tier-hotfix-fast-lane/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-10-change-tier-hotfix-fast-lane/comparison.md
@@ -6,7 +6,7 @@
 - Test case: change-tier-hotfix-fast-lane
 - Test set: change-tier contract evals for issue #55 / FR-008
 - Entry: workspace `eval-10-change-tier-hotfix-fast-lane`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-08 after PR #98 trigger-description revisions.
 
 ## Test Set / Fixture Version
 
@@ -16,32 +16,33 @@
 
 ## Assertions
 
-- PASS `classify_hotfix`: The README link fix is a `hotfix` because it does not change approved expectations and can be covered by one verification record.
-- PASS `allow_fast_lane`: `hotfix` plus delivery / status work may use the fast lane only after classification.
-- PASS `preserve_evidence`: Scope, source evidence, and verification evidence remain required.
+- PASS `classify_hotfix`: With `pm-agent` plus the AGENTS change-tier contract, the request is a `hotfix` because it is a single README link correction, it does not change approved expectations, and it is covered by the user's local link-verification evidence.
+- PASS `allow_fast_lane`: The correct `request_type` is `delivery` / `status` or an equivalent already-scoped delivery request, so the `hotfix` fast lane is allowed only after PM entry classification confirms scope, source evidence, and verification status.
+- PASS `preserve_evidence`: Fast lane does not weaken the evidence bar; the handoff still needs the bounded scope, source evidence for the README link fix, and verification evidence that the corrected link opens.
 
 ## With Skill Behavior
 
-- The `pm-agent` change-tier rule classifies unchanged-expectation lightweight fixes as `hotfix`.
-- It allows `hotfix` plus `delivery` / `status` requests to use the fast lane only after scope, source evidence, and verification status are confirmed.
-- It keeps verification evidence requirements intact rather than treating fast lane as no-evidence delivery.
-- Issue #81 safety-net behavior remains within boundary: fast lane affects delivery routing after classification, while auto-continue still cannot skip evidence or execute another role's work.
+- Applied the current repository `pm-agent` skill, Product Manager Agent README, and AGENTS change-tier contract for the with-skill pass.
+- The prompt is classified as `delivery` / `status` or an equivalent lightweight delivery request because the user asks for handling an already-scoped PR fix, not for new requirements or expectation changes.
+- `change_tier` is `hotfix`: the fix is single-file documentation/link correction work, explicitly preserves approved behavior, and has direct local verification evidence.
+- Fast lane is available only after classification; it can hand off to delivery / engineering execution without reopening full PRD/TRD alignment, but it must carry the evidence packet.
+- Required handoff evidence: scope decision that only one README link is fixed and approved expectations are unchanged, source evidence from the PR/request/README link context, and verification evidence that the corrected link was locally opened.
 
 ## Without Skill Baseline
 
-- Fresh without_skill baseline regenerated on 2026-07-06 without applying `pm-agent` or the Product Manager Agent README. A generic response could accept fast lane but omit the structured evidence requirement.
-- It may not distinguish classification-before-fast-lane from immediate delivery.
+- Fresh without_skill baseline regenerated on 2026-07-08 from the same eval prompt and fixture without applying or citing the `pm-agent` skill or Product Manager Agent README.
+- A generic assistant would likely call this a small documentation-only fix, low risk, and ready to proceed quickly because the user says the link was locally verified.
+- The generic baseline may not emit the repository's stable `request_type` / `change_tier` fields, may treat the fast lane as an immediate shortcut rather than a post-classification path, and may summarize verification informally instead of requiring a durable scope / source / verification evidence packet.
 
 ## Failures
 
-- None. The current `pm-agent` change-tier rule satisfies all hotfix fast-lane assertions.
-- No issue #81 regression found; auto-continue does not weaken fast-lane evidence requirements.
+- None. The PR #98 trigger-description revisions still lead `pm-agent` to classify this unchanged-expectation README link fix as `hotfix`, allow fast lane after classification, and preserve evidence requirements.
 
 ## Next Steps
 
 - Keep this eval as coverage for valid hotfix fast-lane handling.
-- Re-run fresh validation if change-tier definitions or fast-lane evidence requirements change.
+- Re-run fresh validation if `pm-agent` trigger descriptions, change-tier definitions, or fast-lane evidence requirements change again.
 
 ## Runtime Artifacts Policy
 
-- No runtime artifacts were created or committed. Transcripts, verdicts, timing, outputs, and diagnostics must remain outside git.
+- No runtime artifacts were created or committed for this fresh validation. Transcripts, verdicts, timing, outputs, and diagnostics must remain outside git or under an untracked scratch path such as `tmp/eval-runs/eval-010-change-tier-hotfix-fast-lane/`.

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-11-change-tier-standard-full-gate/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-11-change-tier-standard-full-gate/comparison.md
@@ -6,7 +6,7 @@
 - Test case: change-tier-standard-full-gate
 - Test set: change-tier contract evals for issue #55 / FR-008
 - Entry: workspace `eval-11-change-tier-standard-full-gate`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
+- Latest result: PASS - PR #98 trigger-description revision fresh Codex subagent validation completed on 2026-07-08
 
 ## Test Set / Fixture Version
 
@@ -22,25 +22,28 @@
 
 ## With Skill Behavior
 
-- The `pm-agent` change-tier rule rejects `hotfix` when approved product behavior changes.
-- Changing refund approval from automatic approval to admin secondary confirmation is an `existing_update` and at least `standard`.
-- The request stays on the PM path for PRD/TRD or equivalent expectation alignment before downstream implementation.
-- Issue #81 safety-net behavior remains within boundary: closeout may recommend the next PM or Engineer-alignment step, but auto-continue cannot reclassify the behavior change as hotfix or skip gates.
+- Applied `pm-agent`, the Product Manager Agent README, and the `AGENTS.md` change-tier contract.
+- The request changes an existing approved refund-approval behavior, so the correct `request_type` is `existing_update`.
+- The user's "this should be small, handle as hotfix" framing is rejected because the expected business behavior changes and PRD/TRD expectations may need to move.
+- The correct `change_tier` is `standard` or higher; `hotfix` is not allowed for this case.
+- The next gate stays on the PM path: confirm or update PRD / DECISIONS first, then align TRD or equivalent engineering expectations before any downstream implementation handoff.
+- PR #98 trigger-description revisions do not narrow entry coverage; existing behavior, rule, and scope changes remain covered by the PM entry route.
 
 ## Without Skill Baseline
 
-- Fresh without_skill baseline regenerated on 2026-07-06 without applying `pm-agent` or the Product Manager Agent README. A generic response could accept the user's "small" framing and skip expectation alignment.
-- It may hand off implementation before confirming changed business behavior and downstream document impact.
+- Fresh without_skill baseline regenerated on 2026-07-08 without applying or referencing `pm-agent` or the Product Manager Agent README.
+- A generic assistant could treat the request as a small implementation change, accept the user's `hotfix` label, and suggest adding an admin confirmation step plus a focused test.
+- It may not classify the work as `existing_update`, may omit `change_tier`, and may skip the explicit PRD/TRD expectation-alignment gate before engineering handoff.
 
 ## Failures
 
-- None. The current change-tier rule satisfies all standard full-gate assertions.
-- No issue #81 regression found; auto-continue respects the full PRD/TRD alignment gate for expectation changes.
+- None. The current `pm-agent` routing and change-tier rules satisfy all standard full-gate assertions.
+- No PR #98 regression found; trigger-description changes still route existing behavior changes through PM classification and full alignment.
 
 ## Next Steps
 
 - Keep this eval as coverage for behavior changes mislabeled as hotfix.
-- Re-run fresh validation if change-tier or existing-update gates change.
+- Re-run fresh validation if `pm-agent` trigger descriptions, change-tier routing, or existing-update gates change.
 
 ## Runtime Artifacts Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-12-change-tier-hotfix-abuse-blocked/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-12-change-tier-hotfix-abuse-blocked/comparison.md
@@ -4,44 +4,46 @@
 
 - Skill: `pm-agent`
 - Test case: change-tier-hotfix-abuse-blocked
-- Test set: change-tier contract evals for issue #55 / FR-008
+- Test set: change-tier contract evals for PR #98 trigger-description revision / issue #55 / FR-008
 - Entry: workspace `eval-12-change-tier-hotfix-abuse-blocked`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
+- Latest result: PASS - PR #98 trigger-description revision fresh Codex subagent validation completed on 2026-07-08
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
 - Fixture: membership trial duration change mislabeled as hotfix to skip PM
-- Expected output: reject hotfix abuse, identify expectation / business-rule change, and block or return to PM for scope confirmation.
+- Expected output: reject hotfix abuse, identify expectation / business-rule change, and block or return to PM for scope and expectation confirmation.
 
 ## Assertions
 
 - PASS `reject_hotfix_abuse`: The route explicitly rejects treating the request as `hotfix`.
-- PASS `expectation_change_standard`: The trial-duration change is a business-rule expectation change and must be `standard` or higher.
-- PASS `block_or_return_pm`: The request is blocked or returned to PM for scope and expectation confirmation, not handed directly to implementation.
+- PASS `expectation_change_standard`: Changing the trial duration from 7 days to 30 days is a business-rule expectation change and must be classified as `standard` or higher.
+- PASS `block_or_return_pm`: The request is blocked or returned to PM for scope and expectation confirmation, not handed directly to implementation or fast merge.
 
 ## With Skill Behavior
 
-- The `pm-agent` protocol explicitly says new requirements, expectation changes, and unclear scope stay on the PM path and must not be routed as `hotfix`.
-- Changing trial duration from 7 days to 30 days is a business-rule expectation change, so the request is `standard` or higher.
-- It blocks direct implementation and returns to PM expectation and scope confirmation.
-- Issue #81 safety-net behavior remains within boundary: auto-continue cannot turn an attempted PM bypass into implementation permission.
+- Applying `pm-agent`, the Product Manager Agent README, and the `AGENTS.md` change-tier contract, the correct answer is that this cannot be handled as a `hotfix`.
+- The request changes approved product expectations for membership trial duration, so the safe classification is `standard` or higher rather than a lightweight typo/config fix.
+- The route blocks the attempted PM bypass: it keeps the request on the PM path for scope and expectation confirmation before any downstream engineering handoff.
+- No delivery fast lane is available because the user is asking for an expectation change, not a confirmed already-scoped delivery/status action.
 
 ## Without Skill Baseline
 
-- Fresh without_skill baseline regenerated on 2026-07-06 without applying `pm-agent` or the Product Manager Agent README. A generic response could follow the user's hotfix framing and start the value change.
-- It may not catch that the request is trying to use `hotfix` as an escape hatch from PM alignment.
+- Fresh without_skill baseline regenerated on 2026-07-08 from the same prompt and fixture without applying or referencing `pm-agent` or the Product Manager Agent README.
+- A generic assistant could treat the 7-day to 30-day edit as a small constant/config change and say it can proceed as a quick hotfix if tests pass, possibly with only a lightweight note to confirm stakeholders.
+- That baseline may miss the hotfix-abuse pattern: it does not reliably classify the change as product expectation work or block direct implementation before PM alignment.
 
 ## Failures
 
-- None. The current `pm-agent` protocol satisfies all hotfix-abuse assertions.
-- No issue #81 regression found; role-boundary priority keeps expectation changes on the PM path.
+- None for the with_skill run. The current `pm-agent` protocol satisfies all hotfix-abuse assertions after the PR #98 trigger-description revision.
+- The without_skill baseline remains contrast evidence only and is not used as the pass/fail authority.
 
 ## Next Steps
 
 - Keep this eval as coverage for attempts to misuse `hotfix`.
-- Re-run fresh validation if change-tier abuse handling changes.
+- Re-run fresh validation if `pm-agent` trigger descriptions, request classification, or change-tier abuse handling changes again.
 
 ## Runtime Artifacts Policy
 
-- No runtime artifacts were created or committed. Transcripts, verdicts, timing, outputs, and diagnostics must remain outside git.
+- No runtime artifacts were created or committed in this run.
+- If future transcripts, verdicts, timing, outputs, or diagnostics are needed, keep them outside git under `tmp/eval-runs/eval-012-change-tier-hotfix-abuse-blocked/`.

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-13-change-tier-hotfix-e2e-direct-path/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-13-change-tier-hotfix-e2e-direct-path/comparison.md
@@ -6,7 +6,7 @@
 - Test case: change-tier-hotfix-e2e-direct-path
 - Test set: change-tier contract evals for issue #55 / FR-008
 - Entry: workspace `eval-13-change-tier-hotfix-e2e-direct-path`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-08 after the PR #98 trigger description revision.
 
 ## Test Set / Fixture Version
 
@@ -22,26 +22,28 @@
 
 ## With Skill Behavior
 
-- The repository change-tier contract allows hotfix QA/E2E coverage to focus on the directly affected path.
-- The `pm-agent` routing still requires verification evidence, results, and any blocked checks to be recorded.
-- It does not require the full E2E suite unless risk or scope upgrades the work to `standard` / `major`.
-- Issue #81 safety-net behavior remains within boundary: closeout may propose QA verification next, but auto-continue cannot skip evidence or make PM perform QA execution.
+- Applied `pm-agent`, the Product Manager Agent README, and the AGENTS.md change-tier / QA E2E contracts to the prompt: "这是一个 hotfix，只修登录页空状态文案；请判断 QA/E2E 是否还要做，以及覆盖范围怎么定。"
+- The correct PM classification is `hotfix` only if the copy change does not alter approved PRD/TRD expectations and can be covered by one direct verification path.
+- QA/E2E is still required as verification evidence, but the coverage can be limited to the directly affected login empty-state path.
+- The response must record the validation result, evidence source, and any blocked checks; it should not ask for a full E2E suite unless risk, expectation change, or scope ambiguity upgrades the work to `standard` / `major`.
 
 ## Without Skill Baseline
 
-- Fresh without_skill baseline regenerated on 2026-07-06 without applying `pm-agent` or the Product Manager Agent README. A generic response could either skip QA entirely because the change is "just copy" or require a full suite without considering hotfix scope.
-- It is less reliable about preserving evidence while narrowing coverage to the direct login empty-state path.
+- Fresh without_skill baseline regenerated on 2026-07-08 with the same prompt and fixture, without applying or referencing `pm-agent` or the Product Manager Agent README.
+- A generic assistant response is likely to say the copy-only hotfix needs only a quick smoke check or manual review of the login empty state. It may recommend checking the affected page and maybe a screenshot, but it is less likely to name the repository's change-tier contract, require blocked-check recording, or state the escalation condition to `standard` / `major`.
+- The baseline may also overcorrect by suggesting a broader login regression suite because login is important, without distinguishing the direct affected path from full E2E coverage.
 
 ## Failures
 
-- None. The current change-tier and QA gate language satisfies all hotfix E2E assertions.
-- No issue #81 regression found; auto-continue preserves the direct-path QA evidence gate for hotfix work.
+- None. The current `pm-agent` trigger description, change-tier contract, and QA E2E gate language satisfy all hotfix E2E assertions after the PR #98 trigger description revision.
+- New without_skill baseline generation succeeded, so this result is not reusing the previous comparison baseline.
 
 ## Next Steps
 
 - Keep this eval as coverage for hotfix QA/E2E scoping.
 - Re-run fresh validation if QA E2E gates or change-tier rules change.
+- If future trigger-description changes affect validation, delivery, or hotfix wording, refresh this comparison with a new without_skill baseline.
 
 ## Runtime Artifacts Policy
 
-- No runtime artifacts were created or committed. Transcripts, verdicts, timing, outputs, and diagnostics must remain outside git.
+- No runtime artifacts were created or committed. Transcripts, verdicts, timing, outputs, and diagnostics must remain outside git; if produced later, they must stay under `tmp/eval-runs/eval-013-change-tier-hotfix-e2e-direct-path/` and remain unstaged.

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-2-route-bugfix-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-2-route-bugfix-request/comparison.md
@@ -4,9 +4,9 @@
 
 - Skill: `pm-agent`
 - Test case: route-bugfix-request
-- Test set: PM entry evals for issue #52 / FR-006 scenario 2
+- Test set: PM entry evals for issue #52 / FR-006 scenario 2; PR #98 trigger-description routing check
 - Entry: workspace `eval-2-route-bugfix-request`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-08
 
 ## Test Set / Fixture Version
 
@@ -22,26 +22,27 @@
 
 ## With Skill Behavior
 
-- The `pm-agent` classification protocol explicitly maps bug reports to `bug_report`.
-- It requires comparing the reported token-expiry spinner against approved PRD / TRD or equivalent product expectations before diagnosing implementation.
-- It only allows Engineer/debugger handoff after expected behavior is confirmed and the issue is an implementation deviation.
-- Issue #81 safety-net behavior remains within boundary: closeout may recommend Engineer/debugger as the next owner after expectation confirmation, but does not run debugging or repair inside PM.
+- Fresh subagent applied the current-branch `pm-agent` SKILL.md and Product Manager Agent README.
+- The router classifies the token-expiry spinner report as `bug_report` instead of starting a repair.
+- It requires approved PRD / TRD or equivalent product expectations, reproduction evidence, and actual behavior before implementation diagnosis.
+- It only allows `engineer-agent` / debugger handoff after the spinner behavior is confirmed as an implementation deviation; unclear expectations should not be treated as a `hotfix`.
 
 ## Without Skill Baseline
 
-- Fresh without_skill baseline regenerated on 2026-07-06 without applying `pm-agent` or the Product Manager Agent README. A generic response could jump straight into debugging the token expiry behavior from logs.
-- It may ask for reproduction details, but is less consistent about product expectation alignment before debugger handoff.
+- Fresh without_skill baseline was regenerated on 2026-07-08 from the eval prompt and fixture README only; it did not reuse historical baseline text and did not apply `pm-agent` SKILL.md or the Product Manager Agent README.
+- The generic baseline may ask for reproduction details and expected token-expiry behavior, but it is less reliable about explicitly classifying `request_type: bug_report`, preserving `change_tier`, and enforcing the PM expectation-first gate before debugger handoff.
 
 ## Failures
 
 - None. The current `pm-agent` protocol satisfies the bug classification and expectation-first assertions.
-- No issue #81 regression found; auto-continue does not bypass expected-behavior confirmation or execute Engineer/debugger work from the PM role.
+- No routing regression found from the PR #98 trigger-description changes.
 
 ## Next Steps
 
 - Keep this eval as PM entry coverage for bug reports.
-- Re-run fresh validation if bug handling or debugger handoff gates change.
+- Re-run fresh validation if bug handling, debugger handoff gates, or entry trigger descriptions change.
 
 ## Runtime Artifacts Policy
 
-- No runtime artifacts were created or committed. Transcripts, verdicts, timing, outputs, and diagnostics must remain outside git.
+- No runtime artifacts were committed. The validating subagent did not create runtime files.
+- If future transcripts, verdicts, timing data, outputs, or diagnostics are generated, keep them under `tmp/eval-runs/pm-agent-20260708/eval-002/` or another isolated scratch path and do not commit them.

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-3-route-test-writing-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-3-route-test-writing-request/comparison.md
@@ -4,9 +4,9 @@
 
 - Skill: `pm-agent`
 - Test case: route-test-writing-request
-- Test set: PM entry evals for issue #52 / FR-006 scenario 3
+- Test set: PM entry evals for issue #52 / FR-006 scenario 3; PR #98 trigger-description routing check
 - Entry: workspace `eval-3-route-test-writing-request`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-08
 
 ## Test Set / Fixture Version
 
@@ -22,26 +22,27 @@
 
 ## With Skill Behavior
 
-- The `pm-agent` classification protocol maps test-writing and validation requests to `validation`.
-- It requires a stable test basis from PRD, TRD, confirmed implementation plan, or existing acceptance record.
-- It allows QA or Engineer/test-writer handoff only after source documents and expected behavior are named.
-- Issue #81 safety-net behavior remains within boundary: closeout can propose QA or Engineer/test-writer next, but does not write tests from the PM role.
+- Fresh subagent applied the current-branch `pm-agent` SKILL.md and Product Manager Agent README.
+- The router classifies the order-refund exception-branch test request as `validation`.
+- It does not treat the request as ready for direct test writing because the source basis is not confirmed.
+- It requires PRD, TRD, confirmed IMPLEMENTATION_PLAN, or existing acceptance evidence before handoff to `qa-agent` or `engineer-agent` test-writer path.
 
 ## Without Skill Baseline
 
-- Fresh without_skill baseline regenerated on 2026-07-06 without applying `pm-agent` or the Product Manager Agent README. A generic response could begin writing refund-flow tests from the user request alone.
-- It may ask about scenarios, but is less reliable about requiring durable PM / Engineer source evidence before test coverage.
+- Fresh without_skill baseline was regenerated on 2026-07-08 from the eval prompt and fixture README only; it did not reuse historical baseline text and did not apply `pm-agent` SKILL.md or the Product Manager Agent README.
+- The generic baseline tends to ask about refund rules, exception lists, APIs, and desired test types, and may suggest QA or a test engineer, but it does not reliably produce `request_type: validation`, `change_tier`, a PM handoff packet, or the formal test-basis gate.
 
 ## Failures
 
 - None. The current `pm-agent` protocol satisfies the validation and test-basis assertions.
-- No issue #81 regression found; auto-continue does not bypass the test-basis gate or start QA / test-writer execution inside PM.
+- No routing regression found from the PR #98 trigger-description changes.
 
 ## Next Steps
 
 - Keep this eval as PM entry coverage for test-writing requests.
-- Re-run fresh validation if QA or Engineer/test-writer handoff criteria change.
+- Re-run fresh validation if QA or Engineer/test-writer handoff criteria, test-basis rules, or entry trigger descriptions change.
 
 ## Runtime Artifacts Policy
 
-- No runtime artifacts were created or committed. Transcripts, verdicts, timing, outputs, and diagnostics must remain outside git.
+- No runtime artifacts were committed. The validating subagent did not create runtime files.
+- If future transcripts, verdicts, timing data, outputs, or diagnostics are generated, keep them under `tmp/eval-runs/pm-agent-20260708/eval-003/` or another isolated scratch path and do not commit them.

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-4-route-ui-update-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-4-route-ui-update-request/comparison.md
@@ -4,9 +4,9 @@
 
 - Skill: `pm-agent`
 - Test case: route-ui-update-request
-- Test set: PM entry evals for issue #52 / FR-006 scenario 4
+- Test set: PM entry evals for issue #52 / FR-006 scenario 4; PR #98 trigger-description routing check
 - Entry: workspace `eval-4-route-ui-update-request`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-08
 
 ## Test Set / Fixture Version
 
@@ -22,26 +22,27 @@
 
 ## With Skill Behavior
 
-- The `pm-agent` protocol distinguishes UI / UX design artifacts from frontend implementation.
-- It requires checking whether the settings page layout change alters product expectations before picking Designer or Engineer.
-- It routes design artifacts to Designer and waits for PM / TRD / design alignment before Engineer frontend implementation.
-- Issue #81 safety-net behavior remains within boundary: closeout may suggest Designer or Engineer next, but PM does not create design deliverables or implement UI changes.
+- Fresh subagent applied the current-branch `pm-agent` SKILL.md and Product Manager Agent README.
+- The router classifies the settings-page layout and interaction update as `design` or `existing_update`; it does not send the work straight to frontend implementation.
+- Because the request may alter existing product expectations, `change_tier` tends toward `standard` rather than `hotfix`.
+- The route first checks whether PM expectations or PRD / DECISIONS need alignment, then sends design artifacts to Designer when needed, and only hands off Engineer frontend implementation after PM / TRD / design alignment.
 
 ## Without Skill Baseline
 
-- Fresh without_skill baseline regenerated on 2026-07-06 without applying `pm-agent` or the Product Manager Agent README. A generic response could treat the UI request as direct frontend work.
-- It may mention design review, but is less consistent about separating PM expectation changes, design deliverables, and implementation readiness.
+- Fresh without_skill baseline was regenerated on 2026-07-08 from the eval prompt and fixture README only; it did not reuse historical baseline text and did not apply `pm-agent` SKILL.md or the Product Manager Agent README.
+- The generic baseline may still prefer design first and engineering after the layout is clear, but it does not reliably enforce `change_tier`, PM handoff gates, or the explicit PRD / TRD / design alignment requirement.
 
 ## Failures
 
 - None. The current `pm-agent` protocol satisfies the UI routing assertions.
-- No issue #81 regression found; auto-continue respects the PM -> Designer -> Engineer boundary and cannot skip alignment gates.
+- No routing regression found from the PR #98 trigger-description changes.
 
 ## Next Steps
 
 - Keep this eval as PM entry coverage for UI update routing.
-- Re-run fresh validation if Designer or Engineer handoff boundaries change.
+- Re-run fresh validation if Designer or Engineer handoff boundaries, UI update routing, or entry trigger descriptions change.
 
 ## Runtime Artifacts Policy
 
-- No runtime artifacts were created or committed. Transcripts, verdicts, timing, outputs, and diagnostics must remain outside git.
+- No runtime artifacts were committed. The validating subagent did not create runtime files.
+- If future transcripts, verdicts, timing data, outputs, or diagnostics are generated, keep them under `tmp/eval-runs/pm-agent-20260708/eval-004/` or another isolated scratch path and do not commit them.

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-5-route-deployment-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-5-route-deployment-request/comparison.md
@@ -4,9 +4,9 @@
 
 - Skill: `pm-agent`
 - Test case: route-deployment-request
-- Test set: PM entry evals for issue #52 / FR-006 scenario 5
+- Test set: PM entry evals for issue #52 / FR-006 scenario 5; PR #98 trigger-description routing check
 - Entry: workspace `eval-5-route-deployment-request`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-08
 
 ## Test Set / Fixture Version
 
@@ -22,26 +22,27 @@
 
 ## With Skill Behavior
 
-- The `pm-agent` protocol maps CI and release-readiness work to `deployment`.
-- It allows confirmed non-feature repo-wide work to use `feature_path: N/A`, related feature fields as `N/A`, and `feature_path_evidence: []`.
-- It requires operational goal, environment, release scope, rollback needs, and risks before DevOps handoff.
-- Issue #81 safety-net behavior remains within boundary: closeout may recommend DevOps as next owner, but PM does not create CI, deployment config, or release-readiness artifacts itself.
+- Fresh subagent applied the current-branch `pm-agent` SKILL.md and Product Manager Agent README.
+- The router maps repo-level CI and pre-launch checks to `request_type: deployment`.
+- Because the work is confirmed as repository-level and not feature-scoped, feature fields may use `N/A` and `feature_path_evidence: []`.
+- It prepares DevOps handoff only after recording operational goal, environment, release scope, rollback needs, and risks; PM does not directly create CI or deployment configuration.
 
 ## Without Skill Baseline
 
-- Fresh without_skill baseline regenerated on 2026-07-06 without applying `pm-agent` or the Product Manager Agent README. A generic response could jump directly into CI configuration.
-- It may not preserve the repo-wide non-feature scope rule or the complete DevOps handoff context.
+- Fresh without_skill baseline was regenerated on 2026-07-08 from the eval prompt and fixture README only; it did not reuse historical baseline text and did not apply `pm-agent` SKILL.md or the Product Manager Agent README.
+- The generic baseline can identify CI and launch readiness as DevOps/deployment work, but may jump into CI configuration advice and omit the PM handoff packet, `change_tier`, repo-wide `N/A` feature-scope rule, and full DevOps handoff context.
 
 ## Failures
 
 - None. The current `pm-agent` protocol satisfies deployment classification and repo-wide scope assertions.
-- No issue #81 regression found; auto-continue does not bypass the DevOps handoff packet or execute DevOps work from PM.
+- No routing regression found from the PR #98 trigger-description changes.
 
 ## Next Steps
 
 - Keep this eval as PM entry coverage for deployment and CI routing.
-- Re-run fresh validation if repo-wide feature-scope handling changes.
+- Re-run fresh validation if repo-wide feature-scope handling, DevOps handoff packet fields, or entry trigger descriptions change.
 
 ## Runtime Artifacts Policy
 
-- No runtime artifacts were created or committed. Transcripts, verdicts, timing, outputs, and diagnostics must remain outside git.
+- No runtime artifacts were committed. The validating subagent did not create runtime files.
+- If future transcripts, verdicts, timing data, outputs, or diagnostics are generated, keep them under `tmp/eval-runs/pm-agent-20260708/eval-005/` or another isolated scratch path and do not commit them.

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-6-route-security-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-6-route-security-request/comparison.md
@@ -4,9 +4,9 @@
 
 - Skill: `pm-agent`
 - Test case: route-security-request
-- Test set: PM entry evals for issue #52 / FR-006 scenario 6
+- Test set: PM entry evals for issue #52 / FR-006 scenario 6; PR #98 trigger-description routing check
 - Entry: workspace `eval-6-route-security-request`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-08
 
 ## Test Set / Fixture Version
 
@@ -22,26 +22,27 @@
 
 ## With Skill Behavior
 
-- The `pm-agent` protocol maps authorization, dependency risk, secrets, privacy, upload, webhook, login, and data-flow risk requests to `security`.
-- It requires recording risk surface, assets, permissions, data flow, and remediation expectations.
-- It hands off to Security with a bounded review packet instead of doing the security specialist work itself.
-- Issue #81 safety-net behavior remains within boundary: closeout may recommend Security next, but PM does not run AppSec, dependency, or privacy review work itself.
+- Fresh subagent applied the current-branch `pm-agent` SKILL.md and Product Manager Agent README.
+- The router classifies authorization control, dependency vulnerabilities, and secrets risk as `request_type: security`.
+- It records risk surface, assets, permissions, data flow, and remediation expectations before handoff.
+- It prepares a bounded Security handoff with scope decision, downstream owner, required output, and blockers / risks; PM does not run the security specialist review itself.
 
 ## Without Skill Baseline
 
-- Fresh without_skill baseline regenerated on 2026-07-06 without applying `pm-agent` or the Product Manager Agent README. A generic response could start a broad security checklist immediately.
-- It may miss the PM-side scope packet and required output definition for Security.
+- Fresh without_skill baseline was regenerated on 2026-07-08 from the eval prompt and fixture README only; it did not reuse historical baseline text and did not apply `pm-agent` SKILL.md or the Product Manager Agent README.
+- The generic baseline tends to start a security checklist for authz, dependencies, and secrets, but it does not reliably require PM-side scope capture or produce a Security handoff packet with required output.
 
 ## Failures
 
 - None. The current `pm-agent` protocol satisfies security classification and handoff assertions.
-- No issue #81 regression found; auto-continue does not bypass Security scope capture or perform downstream security specialist work.
+- No routing regression found from the PR #98 trigger-description changes.
 
 ## Next Steps
 
 - Keep this eval as PM entry coverage for security routing.
-- Re-run fresh validation if Security handoff fields change.
+- Re-run fresh validation if Security handoff fields, security routing, or entry trigger descriptions change.
 
 ## Runtime Artifacts Policy
 
-- No runtime artifacts were created or committed. Transcripts, verdicts, timing, outputs, and diagnostics must remain outside git.
+- No runtime artifacts were committed. The validating subagent did not create runtime files.
+- If future transcripts, verdicts, timing data, outputs, or diagnostics are generated, keep them under `tmp/eval-runs/pm-agent-20260708/eval-006/` or another isolated scratch path and do not commit them.

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-7-direct-downstream-without-handoff/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-7-direct-downstream-without-handoff/comparison.md
@@ -4,9 +4,9 @@
 
 - Skill: `pm-agent`
 - Test case: direct-downstream-without-handoff
-- Test set: PM entry evals for issue #52 / FR-006 scenario 7
+- Test set: PM entry evals for issue #52 / FR-006 scenario 7; PR #98 trigger-description routing check
 - Entry: workspace `eval-7-direct-downstream-without-handoff`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-08
 
 ## Test Set / Fixture Version
 
@@ -22,26 +22,27 @@
 
 ## With Skill Behavior
 
-- The `pm-agent` and downstream execution contract reject starting Engineer implementation without PM classification and source context.
-- It returns the request to `pm-agent` for request type, scope, feature path, and handoff readiness classification.
-- It requires PM handoff packet or equivalent confirmed PRD / TRD / design / test / deployment / security docs before downstream execution.
-- Issue #81 safety-net behavior remains within boundary: direct downstream invocation without prerequisite context is guided back to PM; auto-continue does not turn this into permission to execute Engineer work.
+- Fresh subagent applied the current-branch `pm-agent` SKILL.md, Product Manager Agent README, and relevant AGENTS.md downstream gate guidance.
+- The router / downstream entry gate rejects the user's attempt to directly use `engineer-agent` and start code changes for a settings-page layout adjustment.
+- Because PM handoff packet, equivalent confirmed document chain, and specialist entry basis are missing, the request returns to `pm-agent` for `request_type`, scope, `feature_path`, `change_tier`, and handoff readiness classification.
+- Only after PM classification and confirmed source documents can the work be handed to the matching role router.
 
 ## Without Skill Baseline
 
-- Fresh without_skill baseline regenerated on 2026-07-06 without applying `pm-agent` or the Product Manager Agent README. A generic response could honor the user's "directly use engineer-agent" instruction and start implementation planning.
-- It is less reliable about enforcing the PM handoff entry gate when the user explicitly asks to skip PM docs.
+- Fresh without_skill baseline was regenerated on 2026-07-08 from the eval prompt and fixture README only; it did not reuse historical baseline text and did not apply `pm-agent` SKILL.md or the Product Manager Agent README.
+- The baseline also tends to reject immediate implementation because the fixture README says missing-handoff downstream requests should return to `pm-agent`, but it does not reliably provide the full PM handoff packet fields, `change_tier`, or downstream gate rationale.
 
 ## Failures
 
 - None. The current PM entry gate satisfies all direct-downstream defense assertions.
-- No issue #81 regression found; the safety-net guidance path returns missing-basis requests to PM and does not authorize downstream work.
+- No routing regression found from the PR #98 trigger-description changes.
 
 ## Next Steps
 
 - Keep this eval as PM entry coverage for direct role-router bypass attempts.
-- Re-run fresh validation if downstream role-router entry gates change.
+- Re-run fresh validation if downstream role-router entry gates, PM handoff readiness rules, or entry trigger descriptions change.
 
 ## Runtime Artifacts Policy
 
-- No runtime artifacts were created or committed. Transcripts, verdicts, timing, outputs, and diagnostics must remain outside git.
+- No runtime artifacts were committed. The validating subagent did not create runtime files.
+- If future transcripts, verdicts, timing data, outputs, or diagnostics are generated, keep them under `tmp/eval-runs/pm-agent-20260708/eval-007/` or another isolated scratch path and do not commit them.

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-8-direct-specialist-bypass-gate/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-8-direct-specialist-bypass-gate/comparison.md
@@ -6,36 +6,37 @@
 - Test case: direct-specialist-bypass-gate
 - Test set: PM entry evals for issue #52 / FR-006 scenario 8
 - Entry: workspace `eval-8-direct-specialist-bypass-gate`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-08 for PR #98 trigger description revisions
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
 - Fixture: direct internal specialist invocation without PRD, TRD, implementation plan, or PM handoff packet
-- Expected output: specialist entry gate blocks plan/code/test implementation and returns to `pm-agent` classification.
+- Expected output: specialist entry gate blocks plan, code, and test implementation, then returns to `pm-agent` classification.
 
 ## Assertions
 
 - PASS `specialist_gate_runs`: Direct invocation of an internal specialist still triggers the PM handoff entry gate.
-- PASS `requires_handoff_or_docs`: The gate requires PM handoff packet or equivalent confirmed PRD / TRD and current implementation scope; an implementation plan is not treated as the upstream entry prerequisite.
+- PASS `requires_handoff_or_docs`: The gate requires a PM handoff packet or equivalent confirmed PRD / TRD and current implementation scope; an existing implementation plan is not treated as the upstream entry prerequisite.
 - PASS `blocks_implementation`: The route blocks plan creation, code, and tests, then returns to `pm-agent` classification.
 
 ## With Skill Behavior
 
-- The PM handoff entry gate applies even when an internal specialist is directly invoked.
-- It requires a PM handoff packet or equivalent confirmed PRD / TRD and current implementation scope before `feature-implementor` planning can proceed.
-- It blocks creating an implementation plan, writing code, or writing tests until the request returns to `pm-agent` classification.
-- Issue #81 safety-net behavior remains within boundary: auto-continue cannot bypass the specialist entry gate or let PM execute `feature-implementor` planning.
+- Applied `pm-agent` entry routing, Product Manager Agent README guidance, and `feature-implementor` specialist gate evidence.
+- The direct request to trigger `feature-implementor` cannot continue because the fixture states that PRD, TRD, implementation plan, and PM handoff packet are missing.
+- `feature-implementor` may only start planning after an explicit Engineer / delivery-adjacent PM handoff packet or an equivalent confirmed PRD / TRD plus current implementation-scope decision.
+- The correct with-skill response blocks implementation-plan creation, code changes, and test implementation, then returns the request to `pm-agent` for classification, scope, source documents, and `change_tier`.
 
 ## Without Skill Baseline
 
-- Fresh without_skill baseline regenerated on 2026-07-06 without applying `pm-agent` or the Product Manager Agent README. A generic response could treat the explicit specialist invocation as permission to start planning.
-- It may incorrectly treat the missing implementation plan as something to create immediately instead of a downstream step after confirmed PM / TRD context.
+- Fresh without_skill baseline regenerated on 2026-07-08 from the same prompt and fixture without applying or citing the `pm-agent` skill or Product Manager Agent README.
+- A generic assistant would likely notice that PRD / TRD / implementation plan are missing and ask for requirements, but it may treat the explicit specialist invocation as permission to start an implementation plan or requirements draft.
+- The baseline is weaker because it does not reliably name the internal specialist PM handoff entry gate, does not require a PM handoff packet or equivalent confirmed PRD / TRD plus current implementation scope, and may not return the request to `pm-agent`.
 
 ## Failures
 
-- None. The current gate language satisfies all direct-specialist bypass assertions.
-- No issue #81 regression found; the role-boundary priority blocks direct specialist execution without upstream basis.
+- None. The PR #98 trigger description revision and current gate language satisfy all direct-specialist bypass assertions.
+- No bypass path found: direct specialist invocation remains blocked without upstream PM handoff or equivalent confirmed documents.
 
 ## Next Steps
 
@@ -44,4 +45,5 @@
 
 ## Runtime Artifacts Policy
 
-- No runtime artifacts were created or committed. Transcripts, verdicts, timing, outputs, and diagnostics must remain outside git.
+- No tmp runtime artifacts were created in this validation.
+- Transcripts, verdicts, timing, outputs, and diagnostics must remain outside git.

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-9-missing-handoff-target-unavailable/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-9-missing-handoff-target-unavailable/comparison.md
@@ -4,15 +4,16 @@
 
 - Skill: `pm-agent`
 - Test case: missing-handoff-target-unavailable
-- Test set: PM entry evals for issue #52 / #62 missing target coverage
+- Test set: PM entry evals for issue #52 / #62 missing target coverage, refreshed after PR #98 trigger description revisions
 - Entry: workspace `eval-9-missing-handoff-target-unavailable`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-08 after PR #98 trigger description revisions
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
 - Fixture: confirmed design handoff with missing `designer-agent`
 - Expected output: mark handoff blocked, name missing capability, and do not perform Designer responsibilities inside PM.
+- Validation run: fresh Codex subagent, 2026-07-08, using the same eval prompt and fixture.
 
 ## Assertions
 
@@ -22,20 +23,22 @@
 
 ## With Skill Behavior
 
+- Fresh with_skill validation applied `pm-agent` and the Product Manager Agent README on 2026-07-08.
 - The `pm-agent` missing handoff target rule detects unavailable downstream agents or skills.
 - It names the missing `designer-agent` capability, marks that handoff stage as `blocked`, and records the blocker.
-- It does not substitute for Designer by producing visual specifications or design deliverables.
-- Issue #81 safety-net behavior remains within boundary: auto-continue stops at the unavailable target blocker instead of letting PM perform Designer responsibilities.
+- It does not substitute for Designer by producing visual specifications or design deliverables; the Designer boundary evidence keeps visual-system output owned by `designer-agent`.
+- The PR #98 trigger description revisions do not weaken the missing-target handoff behavior.
 
 ## Without Skill Baseline
 
-- Fresh without_skill baseline regenerated on 2026-07-06 without applying `pm-agent` or the Product Manager Agent README. A generic response could proceed by drafting a design spec despite the missing Designer capability.
-- It may mention installation but is less reliable about marking the handoff stage blocked and stopping at PM classification.
+- Fresh without_skill baseline regenerated on 2026-07-08 from the same eval prompt and fixture without applying or citing `pm-agent` or the Product Manager Agent README.
+- A generic assistant can infer that a missing `designer-agent` should be installed or enabled before the design handoff continues, but it has no durable PM handoff protocol to require a `blocked` stage marker.
+- It may offer interim design guidance or a lightweight visual-spec outline despite the unavailable target, so it is less reliable on the `do_not_perform_missing_role` boundary than the with_skill path.
 
 ## Failures
 
 - None. The current missing-target rule satisfies all assertions.
-- No issue #81 regression found; unavailable handoff targets remain hard blockers for auto-continue.
+- No PR #98 regression found; unavailable handoff targets remain hard blockers and PM does not perform missing Designer responsibilities.
 
 ## Next Steps
 

--- a/agents/qa/skills/bug-analyzer/SKILL.md
+++ b/agents/qa/skills/bug-analyzer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bug-analyzer
-description: "Internal QA specialist invoked by qa-agent after pm-agent handoff to analyze failing scenarios, classify defect confidence, and produce durable bug evidence for QA or engineering handoff."
+description: "Internal QA specialist—not a direct entry point. Invoked by qa-agent after pm-agent handoff to analyze confirmed failing scenarios, classify defect confidence, and produce durable bug evidence for QA or engineering handoff."
 visibility: internal
 ---
 

--- a/agents/qa/skills/exploratory-tester/SKILL.md
+++ b/agents/qa/skills/exploratory-tester/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exploratory-tester
-description: "Internal QA specialist invoked by qa-agent after pm-agent handoff to explore changed product surfaces, environmental risks, and nearby failure modes with evidence-backed charters."
+description: "Internal QA specialist—not a direct entry point. Invoked by qa-agent after pm-agent handoff to explore changed product surfaces, environmental risks, and nearby failure modes with evidence-backed charters."
 visibility: internal
 ---
 

--- a/agents/qa/skills/regression-suite/SKILL.md
+++ b/agents/qa/skills/regression-suite/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: regression-suite
-description: "Internal QA specialist invoked by qa-agent after pm-agent handoff to verify fixes with reused evidence, adjacent-risk review, and clear pass/fail or blocked reporting."
+description: "Internal QA specialist—not a direct entry point. Invoked by qa-agent after pm-agent handoff to verify fixes with reused evidence, adjacent-risk review, and clear pass/fail or blocked reporting."
 visibility: internal
 ---
 

--- a/agents/qa/skills/spec-based-tester/SKILL.md
+++ b/agents/qa/skills/spec-based-tester/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spec-based-tester
-description: "Internal QA specialist invoked by qa-agent after pm-agent handoff to validate spec-backed requirements using PM docs, implementation context, repo instructions, and the safest executable test path."
+description: "Internal QA specialist—not a direct entry point. Invoked by qa-agent after pm-agent handoff to validate spec-backed requirements using PM docs, implementation context, repo instructions, and the safest executable test path."
 visibility: internal
 ---
 

--- a/agents/qa/test/qa-agent/evals/workspace/eval-1-route-mixed-qa-request/comparison.md
+++ b/agents/qa/test/qa-agent/evals/workspace/eval-1-route-mixed-qa-request/comparison.md
@@ -7,46 +7,44 @@
 - Eval: `eval-001-route-mixed-qa-request`
 - Test case: route-mixed-qa-request
 - Workspace: `workspace/eval-1-route-mixed-qa-request`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-08 for PR #98 trigger description routing review.
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
 - Fixture: login refresh implementation with PM acceptance question and intermittent CI failure evidence.
-- Context read before applying the skill: `evals.json`, workspace `eval_metadata.json`, `docs/pm/login-refresh/PRD.md`, `docs/engineer/login-refresh/TRD.md`, `docs/qa/e2e/auth/login/login-refresh/TEST_SUITE.md`, `FLOW_INDEX.md`, `implementation/changes.md`, and `ci/login-intermittent-failure.log`.
-- #81 context read: `Safety-Net Closeout and Auto-Continue` from `agents/product_manager/skills/idea-to-spec/_internal/_shared/skill-map.md`.
+- Context read before applying the skill: `AGENTS.md`, `agents/qa/README.md`, `agents/qa/skills/qa-agent/SKILL.md`, `evals.json`, workspace `eval_metadata.json`, `docs/pm/login-refresh/PRD.md`, `docs/engineer/login-refresh/TRD.md`, `docs/qa/e2e/auth/login/login-refresh/TEST_SUITE.md`, `FLOW_INDEX.md`, `implementation/changes.md`, and `ci/login-intermittent-failure.log`.
+- Runtime evidence: fresh subagent artifacts were generated under `tmp/eval-runs/2026-07-08-router-trigger-batch3/eval-001-route-mixed-qa-request/`.
 
 ## Assertions
 
 - PASS `assertion_1`: the primary QA route is `spec-based-tester` because PM asks whether an implementation can enter documented acceptance; the intermittent CI failure remains a risk note or possible `bug-analyzer` follow-up.
-- PASS `assertion_2`: downstream context includes PM/spec, TRD, implementation changes, CI failure log, environment constraints, and test commands.
+- PASS `assertion_2`: downstream context includes PM/spec, TRD, implementation changes, CI failure log, QA E2E memory, environment constraints, and test command constraints.
 - PASS `qa`: E2E work reads the function-tree memory set under `docs/qa/e2e/{feature_path}/`, including suite, flow index, cases, scripts, prior results, and reports.
 - PASS `e2e_execution_protocol`: E2E routing requires scenario and platform version, blocks missing versions instead of writing `unknown`, selects repo harness > Chrome plugin / browser connector > Playwright fallback, and delegates TC execution to subagents.
 - PASS `credential_and_report_refs`: credential storage uses `references/e2e-credential-store.md` and `.qa/e2e/accounts.local.json`; summary reporting uses `references/e2e-test-report.md`.
 - PASS `alignment_and_plan_gate`: existing-feature and code-complete E2E updates require same-path PRD, TRD, product decisions when present, and confirmed `IMPLEMENTATION_PLAN.md`; gaps return to PM, `trd-gen`, or `feature-implementor`.
-- PASS `assertion_4`: expected artifacts include route decision, execution path, evidence references, risk notes, blockers, and handoff notes.
+- PASS `assertion_4`: expected artifacts include route decision, requirement matrix, execution path, evidence references, risk notes, blockers, and defect handoff notes.
 - PASS `assertion_5`: only one primary QA route is selected; the intermittent failure is not promoted to a confirmed bug without stronger evidence.
 
 ## With Skill Behavior
 
-`qa-agent` satisfies the mixed QA routing contract. It chooses the narrowest current evidence route, preserves the intermittent CI failure as risk or follow-up rather than a parallel execution path, and carries the required QA memory, environment, credential, report, and PRD/TRD/plan gates into the selected specialist. Because the fixture does not include a confirmed implementation plan, the route can still be selected, but E2E acceptance creation or execution would be blocked until `engineer-agent:feature-implementor` supplies the confirmed plan.
-
-#81 closeout behavior is safe for this case: after routing, `qa-agent` may propose the next collaboration-chain owner, but `auto-continue` cannot make QA perform engineering fixes, bypass E2E gates, or execute another role's workflow.
+`qa-agent` satisfies the mixed QA routing contract after the PR #98 trigger description edits. The with-skill run selected the single primary route `qa-agent:spec-based-tester` because the current evidence outcome is documented acceptance readiness. It preserved the intermittent CI failure as a risk note or possible `bug-analyzer` follow-up, not a confirmed bug, and carried the required PM/spec, TRD, implementation changes, CI evidence, QA E2E memory, platform-version gate, execution-entry priority, credential/report references, and PRD/TRD/implementation-plan gate into the selected specialist. It did not execute tests or invoke multiple QA skills.
 
 ## Without Skill Baseline
 
-Fresh baseline generated on 2026-07-06 without reading or applying `qa-agent` skill instructions or the QA Agent README: a generic response would likely either start running tests immediately or split the work into both acceptance testing and bug analysis. It might assume a localhost port or browser path, miss the durable E2E memory read set, omit credential/report references, or classify the intermittent CI log as a confirmed bug too early.
+Fresh baseline generated on 2026-07-08 from the eval prompt and fixture files only, without applying `qa-agent`, the QA Agent README, historical `comparison.md`, or any previous baseline. The baseline gave a plausible generic acceptance-validation recommendation, but omitted several repo-specific protocol details: the complete E2E memory read set, platform-version blocking rule, credential/report references, and missing implementation-plan owner.
 
 ## Failures
 
-- None found. The missing implementation plan is an expected gate condition for acceptance execution, not a router failure.
-- No #81 regression found: original single-route selection and gate behavior remain intact, and `auto-continue` does not cross the QA role boundary.
+- None found. PR #98 did not regress mixed QA single-route selection, E2E gate preservation, risk handling for intermittent CI evidence, or the no-direct-execution boundary.
 
 ## Next Steps
 
-- Keep this eval as regression coverage for mixed QA requests, single-route selection, E2E gate preservation, and #81 closeout boundary behavior.
+- Keep this eval as regression coverage for mixed QA requests, single-route selection, and E2E gate preservation.
 
 ## Runtime Artifacts Policy
 
-- No runtime artifacts were created for this validation.
-- Runtime transcripts, verdicts, timing, output directories, diagnostics, and generated with_skill / without_skill files must not be committed.
+- Runtime artifacts were created only under `tmp/eval-runs/2026-07-08-router-trigger-batch3/eval-001-route-mixed-qa-request/`.
+- Generated `with_skill.md`, `without_skill.md`, and `verdict.md` are scratch evidence only and must not be committed.
+- Durable committed evidence for this run is this `comparison.md`.

--- a/agents/qa/test/qa-agent/evals/workspace/eval-2-empty-qa-directory-expands-cases/comparison.md
+++ b/agents/qa/test/qa-agent/evals/workspace/eval-2-empty-qa-directory-expands-cases/comparison.md
@@ -7,14 +7,14 @@
 - Eval: `eval-002-empty-qa-directory-expands-cases`
 - Test case: empty-qa-directory-expands-cases
 - Workspace: `workspace/eval-2-empty-qa-directory-expands-cases`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-08 for PR #98 trigger description routing review.
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
 - Fixture: existing empty E2E function tree for profile settings plus source files and QA environment notes.
-- Context read before applying the skill: `evals.json`, workspace `eval_metadata.json`, `docs/qa/e2e/account/profile-settings/profile-form/TEST_SUITE.md`, `FLOW_INDEX.md`, `environment/qa-env.md`, `src/routes/profile-settings.md`, `src/pages/ProfileSettingsPage.tsx`, and `src/components/ProfileSettingsForm.tsx`.
-- #81 context read: `Safety-Net Closeout and Auto-Continue` from `agents/product_manager/skills/idea-to-spec/_internal/_shared/skill-map.md`.
+- Context read before applying the skill: `AGENTS.md`, `agents/qa/README.md`, `agents/qa/skills/qa-agent/SKILL.md`, `evals.json`, workspace `eval_metadata.json`, `docs/qa/e2e/account/profile-settings/profile-form/TEST_SUITE.md`, `FLOW_INDEX.md`, `environment/qa-env.md`, `src/routes/profile-settings.md`, `src/pages/ProfileSettingsPage.tsx`, and `src/components/ProfileSettingsForm.tsx`.
+- Runtime evidence: fresh subagent artifacts were generated under `tmp/eval-runs/2026-07-08-router-trigger-batch3/eval-002-empty-qa-directory-expands-cases/`.
 
 ## Assertions
 
@@ -24,28 +24,27 @@
 - PASS `e2e`: each new E2E case must be stored as `cases/TC-NNN-<short-slug>.md` with a matching `scripts/TC-NNN-<short-slug>.spec.md`, without plaintext secrets.
 - PASS `assertion_5`: validation is TC-driven, feature-update scope stays on the changed feature and direct impacts, and execution entry follows repo harness > Chrome plugin / browser connector > Playwright fallback.
 - PASS `version_and_subagent_gate`: platform version is required before execution; missing version blocks execution and reports go to `_reports/{platform-version}/test-reports-{test-time}.md` only after a real version is known.
-- PASS `assertion_6`: the router selects one narrow QA route, with `exploratory-tester` as the best fit for expanding empty E2E coverage before execution.
+- PASS `assertion_6`: the router selects one narrow QA route and does not expand QA routing into implementation repair or multiple QA specialists.
 
 ## With Skill Behavior
 
-`qa-agent` satisfies the empty-directory E2E route. It treats the existing function tree as durable memory, but not as executable coverage, and points to `exploratory-tester` as the narrow route for discovering flows and creating cases. It preserves credential hygiene, per-TC case/script persistence, subagent execution, and platform-version blocking. The fixture's `TEST_SUITE.md` states the platform version is missing, so execution is intentionally blocked until the version is provided; case expansion can still be routed as the preparatory QA work.
-
-#81 closeout behavior is safe for this case: after preparatory QA routing, `qa-agent` may propose the next owner or handoff, but `auto-continue` cannot skip the platform-version gate, execute blocked E2E work, or perform implementation fixes outside the QA role.
+`qa-agent` satisfies the empty-directory E2E route after the PR #98 trigger description edits. The with-skill run selected a single primary route, `qa-agent:spec-based-tester`, recognized that `docs/qa/e2e/account/profile-settings/profile-form/` exists but has no executable TC, required targeted exploration of route, page, form, environment, harness, and test-command context, and required updates to `TEST_SUITE.md`, `FLOW_INDEX.md`, independent `cases/TC-NNN-<short-slug>.md`, and matching `scripts/TC-NNN-<short-slug>.spec.md` before TC-driven execution. It preserved the feature-update scope, execution-entry priority, subagent execution rule, and platform-version blocker; missing platform version blocks execution and forbids `unknown` result paths.
 
 ## Without Skill Baseline
 
-Fresh baseline generated on 2026-07-06 without reading or applying `qa-agent` skill instructions or the QA Agent README: a generic response might either mark the existing QA directory as sufficient coverage or jump straight to browser execution from source files. It is less likely to create durable per-TC case/script files, preserve function-tree report paths, block missing platform version correctly, or avoid writing credentials into scripts.
+Fresh baseline generated on 2026-07-08 from the eval prompt and fixture files only, without applying `qa-agent`, the QA Agent README, historical `comparison.md`, or any previous baseline. The baseline recognized a need to inspect code and add tests, but lacked the complete function-tree persistence contract, repo harness > Chrome / browser connector > Playwright execution priority, default subagent execution, report path rules, and `unknown` prohibition.
 
 ## Failures
 
-- None found. Missing platform version is the expected execution blocker for this fixture.
-- No #81 regression found: original empty-directory expansion, E2E persistence, and version gates remain intact, and `auto-continue` does not authorize blocked execution.
+- None found. Missing platform version is the expected execution blocker for this fixture, not a router failure.
+- PR #98 did not regress empty-directory expansion, E2E persistence, version-gated execution, or QA route boundaries.
 
 ## Next Steps
 
-- Keep this eval as regression coverage for empty E2E function-tree expansion, version-gated execution, and #81 closeout boundary behavior.
+- Keep this eval as regression coverage for empty E2E function-tree expansion and version-gated execution.
 
 ## Runtime Artifacts Policy
 
-- No runtime artifacts were created for this validation.
-- Runtime transcripts, verdicts, timing, output directories, diagnostics, and generated with_skill / without_skill files must not be committed.
+- Runtime artifacts were created only under `tmp/eval-runs/2026-07-08-router-trigger-batch3/eval-002-empty-qa-directory-expands-cases/`.
+- Generated `with_skill.md`, `without_skill.md`, and `verdict.md` are scratch evidence only and must not be committed.
+- Durable committed evidence for this run is this `comparison.md`.

--- a/agents/qa/test/qa-agent/evals/workspace/eval-3-feature-path-missing-plan-blocked/comparison.md
+++ b/agents/qa/test/qa-agent/evals/workspace/eval-3-feature-path-missing-plan-blocked/comparison.md
@@ -7,14 +7,14 @@
 - Eval: `eval-003-feature-path-missing-plan-blocked`
 - Test case: feature-path-missing-plan-blocked
 - Workspace: `workspace/eval-3-feature-path-missing-plan-blocked`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-08 for PR #98 trigger description routing review.
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
 - Fixture: same-path PRD/TRD and QA E2E function tree for `account/profile/preferences`, with no confirmed implementation plan.
-- Context read before applying the skill: `evals.json`, workspace `eval_metadata.json`, `docs/pm/account/profile/preferences/PRD.md`, `docs/engineer/account/profile/preferences/TRD.md`, `docs/qa/e2e/account/profile/preferences/TEST_SUITE.md`, and `FLOW_INDEX.md`.
-- #81 context read: `Safety-Net Closeout and Auto-Continue` from `agents/product_manager/skills/idea-to-spec/_internal/_shared/skill-map.md`.
+- Context read before applying the skill: `AGENTS.md`, `agents/qa/README.md`, `agents/qa/skills/qa-agent/SKILL.md`, `evals.json`, workspace `eval_metadata.json`, `docs/pm/account/profile/preferences/PRD.md`, `docs/engineer/account/profile/preferences/TRD.md`, `docs/qa/e2e/account/profile/preferences/TEST_SUITE.md`, and `FLOW_INDEX.md`.
+- Runtime evidence: fresh subagent artifacts were generated under `tmp/eval-runs/2026-07-08-router-trigger-batch3/eval-003-feature-path-missing-plan-blocked/`.
 
 ## Assertions
 
@@ -25,24 +25,24 @@
 
 ## With Skill Behavior
 
-`qa-agent` satisfies the expected blocked behavior. Its router output requires same-path PRD/TRD and confirmed implementation plan gates for code-complete E2E acceptance updates. The directly referenced QA specialist gates confirm that a missing implementation plan blocks creating, updating, or executing acceptance TC and sends the next action to `engineer-agent:feature-implementor`.
-
-#81 closeout behavior is safe for this case: `auto-continue` may carry the handoff proposal to `engineer-agent:feature-implementor`, but QA must stop at the missing-plan blocker and must not create the plan, mutate E2E cases, or execute acceptance TC itself.
+`qa-agent` satisfies the expected blocked behavior after the PR #98 trigger description edits. The with-skill run selected the single route `qa-agent:spec-based-tester`, resolved `feature_path` as `account/profile/preferences`, read same-path PRD/TRD and the QA E2E function tree, and marked the QA work blocked because `docs/engineer/account/profile/preferences/IMPLEMENTATION_PLAN.md` is missing. It pointed the next owner to `engineer-agent:feature-implementor` and did not create, update, or execute E2E acceptance TC.
 
 ## Without Skill Baseline
 
-Fresh baseline generated on 2026-07-06 without reading or applying `qa-agent` skill instructions or the QA Agent README: a generic response could proceed from the existing PRD/TRD and QA directory into test-case creation or execution. It might treat the empty QA tree as enough context and miss that the confirmed `IMPLEMENTATION_PLAN.md` is mandatory for code-complete acceptance work.
+Fresh baseline generated on 2026-07-08 from the eval prompt and fixture files only, without applying `qa-agent`, the QA Agent README, historical `comparison.md`, or any previous baseline. The baseline also paused TC creation or execution because the fixture clearly signals a missing implementation plan, but it did not fully preserve the repo-specific single QA route, next owner, and E2E gate details.
 
 ## Failures
 
 - None found. The blocked route is the expected pass condition for this eval.
-- No #81 regression found: original missing-plan hard stop remains intact, and `auto-continue` only permits handoff to the next owner rather than QA crossing into Engineer work.
+- PR #98 did not regress same-path feature handling, missing-plan blocking, or the no-E2E-mutation boundary.
 
 ## Next Steps
 
-- Keep this eval as regression coverage for missing implementation-plan blocking before E2E acceptance mutation or execution, plus #81 closeout boundary behavior.
+- Keep this eval as regression coverage for missing implementation-plan blocking before E2E acceptance mutation or execution.
+- Product workflow represented by the fixture should continue only after `engineer-agent:feature-implementor` supplies the confirmed same-path implementation plan.
 
 ## Runtime Artifacts Policy
 
-- No runtime artifacts were created for this validation.
-- Runtime transcripts, verdicts, timing, output directories, diagnostics, and generated with_skill / without_skill files must not be committed.
+- Runtime artifacts were created only under `tmp/eval-runs/2026-07-08-router-trigger-batch3/eval-003-feature-path-missing-plan-blocked/`.
+- Generated `with_skill.md`, `without_skill.md`, and `verdict.md` are scratch evidence only and must not be committed.
+- Durable committed evidence for this run is this `comparison.md`.

--- a/agents/security/skills/appsec-checklist/SKILL.md
+++ b/agents/security/skills/appsec-checklist/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: appsec-checklist
-description: "Internal security specialist invoked by security-agent after pm-agent handoff to scan application code for common vulnerabilities and produce a release-oriented security checklist."
+description: "Internal security specialist—not a direct entry point. Invoked by security-agent after pm-agent handoff to scan application code for common vulnerabilities and produce a release-oriented security checklist."
 visibility: internal
 ---
 

--- a/agents/security/skills/authz-reviewer/SKILL.md
+++ b/agents/security/skills/authz-reviewer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: authz-reviewer
-description: "Internal security specialist invoked by security-agent after pm-agent handoff to review authentication, authorization, permission models, and access-control implementation."
+description: "Internal security specialist—not a direct entry point. Invoked by security-agent after pm-agent handoff to review authentication, authorization, permission models, and access-control implementation."
 visibility: internal
 ---
 

--- a/agents/security/skills/dependency-risk-auditor/SKILL.md
+++ b/agents/security/skills/dependency-risk-auditor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dependency-risk-auditor
-description: "Internal security specialist invoked by security-agent after pm-agent handoff to audit dependencies for vulnerabilities, abandonment, licensing, and supply-chain risk."
+description: "Internal security specialist—not a direct entry point. Invoked by security-agent after pm-agent handoff to audit dependencies for vulnerabilities, abandonment, licensing, and supply-chain risk."
 visibility: internal
 ---
 

--- a/agents/security/skills/privacy-surface-mapper/SKILL.md
+++ b/agents/security/skills/privacy-surface-mapper/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: privacy-surface-mapper
-description: "Internal security specialist invoked by security-agent after pm-agent handoff to map personal-data collection, privacy obligations, GDPR/CCPA concerns, and data-flow exposure."
+description: "Internal security specialist—not a direct entry point. Invoked by security-agent after pm-agent handoff to map personal-data collection, privacy obligations, GDPR/CCPA concerns, and data-flow exposure."
 visibility: internal
 ---
 

--- a/agents/security/test/security-agent/evals/workspace/eval-1-route-auth-release-risk/comparison.md
+++ b/agents/security/test/security-agent/evals/workspace/eval-1-route-auth-release-risk/comparison.md
@@ -7,41 +7,50 @@
 - Eval: `eval-001-route-auth-release-risk`
 - Test case: route-auth-release-risk
 - Workspace: `workspace/eval-1-route-auth-release-risk`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-06
+- Review context: PR #98 trigger description routing review
+- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-08
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
 - Fixture: auth-centered release security request with dependency-risk concern.
-- Context read before applying the skill: `security-agent/SKILL.md`, Security Agent `README.md`, `evals.json`, workspace `eval_metadata.json`, `docs/security/auth-model.md`, `package.json`, and the `Safety-Net Closeout and Auto-Continue` section in `skill-map.md`.
+- Prompt: login and permission-model refactor is preparing for release; the user primarily worries about admin authorization bypass and also wants dependency vulnerability routing.
+- Context read before applying the skill: `AGENTS.md`, Security Agent `README.md`, `security-agent/SKILL.md`, `evals.json`, workspace `eval_metadata.json`, `docs/security/auth-model.md`, `package.json`, and `agents/product_manager/skills/idea-to-spec/_internal/_shared/skill-map.md`.
+- Validation date: 2026-07-08.
 
 ## Assertions
 
-- PASS `routes_primary_to_authz`: login, roles, admin access, and authorization bypass risk route to `authz-reviewer`.
-- PASS `names_dependency_followup`: dependency vulnerability concerns are preserved as a `dependency-risk-auditor` follow-up.
-- PASS `collects_security_context`: downstream context includes auth flows, roles/permissions, sensitive routes, test evidence, and dependency manifest.
-- PASS `structured_risk_output`: expected output is a structured review, risk matrix, evidence, and remediation guidance.
+- PASS `routes_primary_to_authz`: login, roles, admin access, and authorization bypass risk route to `authz-reviewer` as the current primary route.
+- PASS `names_dependency_followup`: dependency vulnerability concerns are preserved as a `dependency-risk-auditor` follow-up instead of being ignored or folded into the auth review.
+- PASS `collects_security_context`: downstream context includes authentication flows, roles/permissions, sensitive routes and access checks, test evidence, and dependency manifests or audit data.
+- PASS `structured_risk_output`: expected output is a structured review with risk matrix, evidence, impact, and remediation guidance, not an implementation patch.
 - PASS `hands_off_remediation`: fixes are handed to `engineer-agent` or `devops-agent`, not implemented by Security.
 
 ## With Skill Behavior
 
-`security-agent` satisfies the release-risk route. Its router chooses the narrowest security outcome, so the auth/admin risk gets `authz-reviewer` as the current route while dependency audit remains a named `dependency-risk-auditor` follow-up. The selected downstream context is authentication flow, role and permission matrix, sensitive routes, test evidence, and the dependency manifest.
+`security-agent` satisfies the release-risk route. The request is release-shaped, but the dominant risk surface is login, roles, admin permissions, and authorization bypass. The router therefore selects the narrowest current route, `authz-reviewer`, while keeping dependency vulnerability review as a named `dependency-risk-auditor` follow-up.
 
-The skill preserves Security as an evidence-backed risk review role and explicitly hands remediation to `engineer-agent` or `devops-agent` when findings require code, dependency, or deployment changes. The #81 safety-net closeout is compatible with this route: the prompt asks for routing only and does not authorize auto-continue, so Security stops at the route and handoff proposal. If auto-continue were enabled later, it would automate only the next-owner handoff and would not let Security execute another role's workflow or bypass that role's gate.
+The skill preserves confirmed security context for the downstream reviewer: authentication flow, permission matrix, sensitive routes, test evidence, and dependency manifests. It also keeps Security's role boundary intact by producing evidence-backed risk review output and handing any code, dependency, or deployment remediation to `engineer-agent` or `devops-agent`.
+
+The safety-net closeout remains compatible with this route. The prompt asks for routing only and does not authorize auto-continue, so Security should stop at the route and follow-up proposal. If auto-continue is later enabled, it automates only the next-owner handoff and does not let Security execute another role's workflow or bypass that role's gate.
 
 ## Without Skill Baseline
 
-Fresh without_skill baseline generated on 2026-07-06 without reading or applying `security-agent/SKILL.md` or the Security Agent README: a generic response could blend auth review, dependency audit, and fix recommendations into one broad release checklist. It may choose a broad security review as the primary route instead of the narrower auth route, bury the dependency concern in the same checklist, and suggest direct code or package changes instead of keeping Security output as structured risk evidence with remediation handoff.
+Fresh without_skill baseline generated on 2026-07-08 from only the eval prompt and fixture facts. It did not read, reference, or apply `agents/security/README.md`, `agents/security/skills/security-agent/SKILL.md`, historical `comparison.md`, or any old baseline.
+
+The no-skill baseline could plausibly treat the request as a broad release security checklist, combine auth review and dependency audit into one generic route, and choose a broad AppSec or release-security review as the current route. It would likely mention login, roles, admin access, sensitive routes, tests, and dependencies, but it is less likely to preserve the exact specialist split: `authz-reviewer` now, `dependency-risk-auditor` later. It may also drift into direct package or code-fix recommendations instead of keeping the output as structured risk evidence with remediation handoff.
 
 ## Failures
 
-- None found. No #81 regression was observed: the original narrow routing and remediation handoff remain intact, and auto-continue does not expand the Security role boundary.
+- None found. No PR #98 trigger description routing regression was observed: the Security router still selects the auth/authz specialist as the primary route, preserves dependency audit as a follow-up, and maintains remediation handoff boundaries.
 
 ## Next Steps
 
-- Keep this eval as regression coverage for Security narrow-route selection, remediation handoff, and #81 auto-continue boundary behavior.
+- Keep this eval as regression coverage for Security narrow-route selection, dependency follow-up routing, structured risk output, and remediation handoff.
+- Do not auto-run the routed specialists from this eval result; execution of `authz-reviewer` or `dependency-risk-auditor` requires the normal downstream gates and user confirmation.
 
 ## Runtime Artifacts Policy
 
-- No runtime artifacts were created for this validation.
+- Runtime evidence for this validation was written only under `tmp/eval-runs/2026-07-08-router-trigger-batch4-final/eval-001-route-auth-release-risk/`.
+- The scratch files `with_skill.md`, `without_skill.md`, and `verdict.md` are runtime artifacts and must not be committed.
 - Runtime transcripts, verdicts, timing, output directories, diagnostics, and generated with_skill / without_skill files must not be committed.

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -4,47 +4,47 @@
     "pm-agent": {
       "source": "agents/product_manager/skills/pm-agent",
       "sourceType": "local",
-      "computedHash": "d90905d9a4342ad6a6398ee203ba6aa58c5612493a81a5d02baaf677cdf76f29"
+      "computedHash": "94927d1b381402b2f5b95d99bbd643c52acb74edaeed88336ceae9ef69cd8f19"
     },
     "idea-to-spec": {
       "source": "agents/product_manager/skills/idea-to-spec",
       "sourceType": "local",
-      "computedHash": "72f8885625c4262ea0ddb471f14791e60fe71f47c586297234f90aa65add93e8"
+      "computedHash": "9cc75ef8b5283e2cf7ba1dbdb0c2254a90130ca6be627ec5d1b467fc449838bc"
     },
     "feature-catalog": {
       "source": "agents/product_manager/skills/feature-catalog",
       "sourceType": "local",
-      "computedHash": "726ff8b9d4e6e201037ab3247a0c3fb176e6ae45e68d93ce34af543fbaa6f5b0"
+      "computedHash": "badb6fdb32affe2d8b72e23cf093f40a7fb6d0e7181bc93c4cf70479bcad2b10"
     },
     "competitive-brief": {
       "source": "agents/product_manager/skills/competitive-brief",
       "sourceType": "local",
-      "computedHash": "a4448c0edc870f025c78eea113f04acfdfdd3d16171d7e5bc494cbe258c90844"
+      "computedHash": "e90bcf026420c25a9c999313a80312782cbd4b04e0e27f3b02c7d5827c96de84"
     },
     "competitive-intelligence": {
       "source": "agents/product_manager/skills/competitive-intelligence",
       "sourceType": "local",
-      "computedHash": "9b3a5a2dd94506586b6ba4bf49080ffa9de0d36325be008e4a8a5954794af763"
+      "computedHash": "3cf55f79aa3ed884315ad27863203965f5a424beb5843d9d7978726c18f30b40"
     },
     "changelog-generator": {
       "source": "agents/product_manager/skills/changelog-generator",
       "sourceType": "local",
-      "computedHash": "1a219d4647e5f1812ced576ff0915d696f5f178115484cf4c7cb982550ae6ed0"
+      "computedHash": "50b8524e9112004717847a274f055fab10239be875f3bc391ea8e4d29151639f"
     },
     "release-notes-generator": {
       "source": "agents/product_manager/skills/release-notes-generator",
       "sourceType": "local",
-      "computedHash": "4fbcdd07a103773d9bccdc24ca85e3d1a03c0131eab45bf7298c1accedba71c1"
+      "computedHash": "bced181427fb02b0b887ce547313665604ba00e73bd7db1a00303c7b94d51413"
     },
     "roadmap-generator": {
       "source": "agents/product_manager/skills/roadmap-generator",
       "sourceType": "local",
-      "computedHash": "50a30b3bbf5389d0aebb405dd6f9b0caf456237efff3b82419753ec8b58f1de4"
+      "computedHash": "2d17e65f21990fb38513f47ae04857c7d74f7ddeb844280cc69becad21a390e3"
     },
     "github-reader": {
       "source": "agents/product_manager/skills/github-reader",
       "sourceType": "local",
-      "computedHash": "13f1ca0e25b34c9be7db37a797cd536cde1f717c4c9e1a5b66bacf593fe99b3a"
+      "computedHash": "d24ab1941342eda9e121c148ec2246a78d6fd52eb182c4b01abde4f56d3b9b2c"
     },
     "engineer-agent": {
       "source": "agents/engineer/skills/engineer-agent",
@@ -54,37 +54,37 @@
     "codebase-analyzer": {
       "source": "agents/engineer/skills/codebase-analyzer",
       "sourceType": "local",
-      "computedHash": "e86fcd9f817ca44c2140cf89a316203fc56dc1710e3a3e4ad0a459fd7140a9c2"
+      "computedHash": "f81c1850c3e57804a9d1023187c885c194d4f1ca6224d0dcd23d954b34c59753"
     },
     "trd-gen": {
       "source": "agents/engineer/skills/trd-gen",
       "sourceType": "local",
-      "computedHash": "d9b7c5016d17e5d301f449602566b622baea70d15f3336a8881700b9a799dadf"
+      "computedHash": "075ae0ead08c3817157683cfa8a732e1ce842e5a7c143c2d067c0868a1e96405"
     },
     "project-bootstrap": {
       "source": "agents/engineer/skills/project-bootstrap",
       "sourceType": "local",
-      "computedHash": "2b7754f1e85b309b67e4dd0a14c691525c683710e215bda0acc20992c7724a6c"
+      "computedHash": "eca4da296bd6f5eb7617197a0fe6bb894384d239da994bf04c9703585dbe718b"
     },
     "feature-implementor": {
       "source": "agents/engineer/skills/feature-implementor",
       "sourceType": "local",
-      "computedHash": "5f2b908295ed9fba30b21ae77485bdae9462631f9be3ff27e06081be264325f2"
+      "computedHash": "198ac1d43a43907c4a26677a0543c522638b7b70b22836d1d57dcd5e13e1cc8e"
     },
     "test-writer": {
       "source": "agents/engineer/skills/test-writer",
       "sourceType": "local",
-      "computedHash": "bb6c550128180b4f2e56f31faaf0c39137c766eb53aa186269be79ad65d45144"
+      "computedHash": "cc369e541090813cfa5e1607087dce3ac288dce15f919743811440185b450343"
     },
     "debugger": {
       "source": "agents/engineer/skills/debugger",
       "sourceType": "local",
-      "computedHash": "39a105f1d36dfa4b8a050e040f72539410ba70050b336a5a5e23e0c15d4df36e"
+      "computedHash": "329d9f0788b3713b6e65b7949c5051a33a7b26d2f5e3e98ced4481f1942c9791"
     },
     "delivery": {
       "source": "agents/engineer/skills/delivery",
       "sourceType": "local",
-      "computedHash": "ee106579a2441ce4a266ab4e551864ca759e1e506a3e6b5f909dfb54c00d5ce4"
+      "computedHash": "c6e61ef987ff47956e1b7b35e89c339b21581770dbfa84dea5e01afa57e2c5e8"
     },
     "qa-agent": {
       "source": "agents/qa/skills/qa-agent",
@@ -94,22 +94,22 @@
     "exploratory-tester": {
       "source": "agents/qa/skills/exploratory-tester",
       "sourceType": "local",
-      "computedHash": "4a692883ab6d758488e47c228dfb6a61d7ad8740935f215d766f40ec523c81a5"
+      "computedHash": "eb510d0414b95ee247ea7cec77c6ca9b918cd8c9acbc2d74bcf759925bf61889"
     },
     "spec-based-tester": {
       "source": "agents/qa/skills/spec-based-tester",
       "sourceType": "local",
-      "computedHash": "b65c172449124a41a5929fc654200322c1d290af1cf2efc30e1b54eb79bef1d3"
+      "computedHash": "dd4ebf6cc1b16853713f5a8207f8bb8a95e5510c9b21b228aa5ca458c541220e"
     },
     "bug-analyzer": {
       "source": "agents/qa/skills/bug-analyzer",
       "sourceType": "local",
-      "computedHash": "320ee69c9611fba77490ac7ca64abf3683dbcf59e852a492139753b88dd8fee3"
+      "computedHash": "219563e71efaed4489ce2e964d6db5f0fd71ac71ac85c7016c833639362220fd"
     },
     "regression-suite": {
       "source": "agents/qa/skills/regression-suite",
       "sourceType": "local",
-      "computedHash": "615a49bd16828a243c9463488ae8d114e43943649289823639d89122c603c485"
+      "computedHash": "881a555db884520894b074a89779e98d695d24b5a493bd4319ac03a296957995"
     },
     "devops-agent": {
       "source": "agents/devops/skills/devops-agent",
@@ -119,22 +119,22 @@
     "deployment-planner": {
       "source": "agents/devops/skills/deployment-planner",
       "sourceType": "local",
-      "computedHash": "7b6bfef22872946f11ddaaafc89e614bca578b96b3c36d0f39bf04d0c663c9b6"
+      "computedHash": "e3050056ac8eb1a09b46a52fe325497a76a09ed2d553fa3bffbe39303233a3d0"
     },
     "cicd-bootstrap": {
       "source": "agents/devops/skills/cicd-bootstrap",
       "sourceType": "local",
-      "computedHash": "581daa72c4f051fdb22dc90a2133c9e2bf7af3593d8bc8201bc0e235d002a5a5"
+      "computedHash": "2bc8e96120d0af8231d9a49d0c5cfc4b47230713702ce3ba04d42d09e6b64d25"
     },
     "env-config-auditor": {
       "source": "agents/devops/skills/env-config-auditor",
       "sourceType": "local",
-      "computedHash": "6ee82ed645ff9e50c888d739f88def1b1cc1bb3a2fab3d82dc1823e8f5420d3a"
+      "computedHash": "dc7a64d841211d704feb25cbf68f67c87539473baffe1b3dc936f0c206a1e7a8"
     },
     "incident-playbook-writer": {
       "source": "agents/devops/skills/incident-playbook-writer",
       "sourceType": "local",
-      "computedHash": "60d599f9bc9754e1c6b1eec0ab9e1825fd6d5d05f7939d992d52a6977852c012"
+      "computedHash": "b98c28b089a4f2cec128a611c44a89cd3908115a43ea04a16fc660c5e9f408c7"
     },
     "designer-agent": {
       "source": "agents/designer/skills/designer-agent",
@@ -144,12 +144,12 @@
     "ui-ux-design": {
       "source": "agents/designer/skills/ui-ux-design",
       "sourceType": "local",
-      "computedHash": "e74308156e9f2ed091f0c15d3bfd4be0e0337990dbc28eba192bbf480c10fcbc"
+      "computedHash": "b38ce8d37f51800323b1f0d098e6ef8298fc3e74ef855206ed092c1871e14b1c"
     },
     "visual-design": {
       "source": "agents/designer/skills/visual-design",
       "sourceType": "local",
-      "computedHash": "461f9534cda51253beda1c20ae6c520349e0d2a64163601405a9c1a206c2bb4e"
+      "computedHash": "e5851d959b70e6751f337fe296c602becaf13b49f139c72ef73ec78c14e0b5c1"
     },
     "security-agent": {
       "source": "agents/security/skills/security-agent",
@@ -159,22 +159,22 @@
     "appsec-checklist": {
       "source": "agents/security/skills/appsec-checklist",
       "sourceType": "local",
-      "computedHash": "52272c7cec76a3800ba4c383f00aff4d1d0df8def73ed2328f2284fa3f857f88"
+      "computedHash": "6d815e2c860db7121a1cb969c9fe5978ff8ea3af144682a63759b444f3a4da94"
     },
     "authz-reviewer": {
       "source": "agents/security/skills/authz-reviewer",
       "sourceType": "local",
-      "computedHash": "ffbcb4d4b257e1b7a2e87ff94997dbe8b93bd3ed42dea3f94bcd051adcdf3232"
+      "computedHash": "e98c47e6539c46d4fb541bcb842d0dd64e21dd2f11382491999480659cdc1e0b"
     },
     "dependency-risk-auditor": {
       "source": "agents/security/skills/dependency-risk-auditor",
       "sourceType": "local",
-      "computedHash": "7b0a231b34154eff74760dd27478d002d33845efedc6213f6660a588c8fd508d"
+      "computedHash": "3f63f91dae7514a98459540640bf974c68faa28f981253145014e36e8f93aaf9"
     },
     "privacy-surface-mapper": {
       "source": "agents/security/skills/privacy-surface-mapper",
       "sourceType": "local",
-      "computedHash": "e5960ac0d9c8bad72ea0d8c0c4f2343e08ac6b4f2aefb083290ae7e688bdb61b"
+      "computedHash": "1b1c974a5b34b9b57b0735958bbc1b472838df7ee610e1739ce633e77d456bb3"
     }
   }
 }

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -29,7 +29,7 @@
     "changelog-generator": {
       "source": "agents/product_manager/skills/changelog-generator",
       "sourceType": "local",
-      "computedHash": "50b8524e9112004717847a274f055fab10239be875f3bc391ea8e4d29151639f"
+      "computedHash": "a10b972b640f14a52764d5f98fc69e9059aeca0ebb37ef9dd12aaf301c089fe2"
     },
     "release-notes-generator": {
       "source": "agents/product_manager/skills/release-notes-generator",
@@ -79,7 +79,7 @@
     "debugger": {
       "source": "agents/engineer/skills/debugger",
       "sourceType": "local",
-      "computedHash": "329d9f0788b3713b6e65b7949c5051a33a7b26d2f5e3e98ced4481f1942c9791"
+      "computedHash": "10cee790b054131d3b6bb115a68bd03badb2bc1fa7e026e9fad1d724d5bd793a"
     },
     "delivery": {
       "source": "agents/engineer/skills/delivery",


### PR DESCRIPTION
## 变更

- 将 `pm-agent` 的 SKILL frontmatter description 改为默认入口场景句式，覆盖新想法、功能请求、需求变更、bug、构建、测试、部署、评审和项目状态等自然话术。
- 同步更新 `.claude-plugin/marketplace.json` 与 `agents/product_manager/.claude-plugin/plugin.json` 中 `pm-agent` plugin description。
- 收窄 29 个 specialist description，统一强化 `Internal ... specialist—not a direct entry point.` 信号；5 个 role router description 保持不动。
- 使用仓库既有 `compute_tracked_directory_hash` 计算函数刷新 `skills-lock.json`，未手写伪造 hash。

Closes #96

## 修改前后对照

### pm-agent

Before:

> Public entry router for product ideas, requirement changes, inherited-project feature catalogs, competitive research, battlecards, bug reports, implementation requests, tests, UI/design, deployment, security, delivery, commits, pushes, PRs, release communication, roadmaps, and GitHub project status. Classifies scope first, then routes to PM specialists or hands off to downstream role agents when ready.

After:

> Default entry point for any new user request. Use this when the user describes a new product idea, feature request, requirement change, bug, or asks to build, test, deploy, review, or check project status—especially when the request is vague or no confirmed scope/handoff exists yet. It also covers inherited-project feature catalogs, competitive research, battlecards, release communication, roadmaps, and GitHub project status. Classifies scope first, then routes to PM specialists or hands off to downstream role agents.

### specialist 示例：debugger

Before:

> Internal engineering specialist invoked by engineer-agent after pm-agent handoff to reproduce, diagnose, and fix confirmed implementation defects with minimal scoped changes and verification evidence.

After:

> Internal engineering specialist—not a direct entry point. Invoked by engineer-agent after pm-agent handoff to reproduce confirmed implementation defects, identify root cause, and produce scoped verification evidence.

## 验证

- `uv run scripts/check_repository_contract.py` -> PASS
- `uv run scripts/check_eval_contract.py` -> PASS
- `uv run scripts/check_eval_artifacts.py` -> PASS
- `uv run scripts/check_doc_contract.py` -> PASS
- `uv run --with pytest pytest agents/product_manager/test/idea-to-spec agents/product_manager/test/pm-agent agents/qa/test/test_qa_run_eval.py agents/designer/test/test_designer_run_eval.py agents/devops/test/test_devops_run_eval.py agents/test_doc_contract.py agents/test_eval_contract.py` -> 101 passed
- `git diff --check` -> PASS

## 后续

- 本轮按约定不执行模型 eval。
- 受影响 skill 的 eval 待维护者确认后运行，至少覆盖 `pm-agent` 路由类用例，以及 `designer-agent`、`engineer-agent`、`qa-agent`、`devops-agent`、`security-agent` 5 个 router 的 routing 用例。
- 实际执行模型 eval 或 fresh Codex subagent validation 后，再同步更新对应 durable `comparison.md`。