### PR TITLE
fix: 防止安装器删除自身 checkout

### DIFF
--- a/scripts/install_codex_skills.py
+++ b/scripts/install_codex_skills.py
@@ -174,12 +174,18 @@ def is_relative_to(path: Path, parent: Path) -> bool:
     return True
 
 
+def removal_guard_path(path: Path) -> Path:
+    if path.is_symlink():
+        return path.parent.resolve(strict=False) / path.name
+    return path.resolve(strict=False)
+
+
 def validate_removals_do_not_touch_source(root: Path, paths: list[Path]) -> None:
     source = root.resolve(strict=False)
     conflicts: list[Path] = []
 
     for path in paths:
-        target = path.resolve(strict=False)
+        target = removal_guard_path(path)
         if target == source or is_relative_to(target, source) or is_relative_to(source, target):
             conflicts.append(path)
 

--- a/scripts/install_codex_skills.py
+++ b/scripts/install_codex_skills.py
@@ -174,6 +174,22 @@ def is_relative_to(path: Path, parent: Path) -> bool:
     return True
 
 
+def validate_removals_do_not_touch_source(root: Path, paths: list[Path]) -> None:
+    source = root.resolve(strict=False)
+    conflicts: list[Path] = []
+
+    for path in paths:
+        target = path.resolve(strict=False)
+        if target == source or is_relative_to(target, source) or is_relative_to(source, target):
+            conflicts.append(path)
+
+    if conflicts:
+        raise ValueError(
+            "安装源 checkout 位于目标删除路径内，请先把 checkout 移出 target 或换用其他 --target: "
+            f"{summarize_paths(conflicts)}"
+        )
+
+
 def marketplace_name(path: Path) -> str | None:
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
@@ -264,6 +280,7 @@ def summarize_paths(paths: list[Path]) -> str:
 
 
 def build_preflight_plan(
+    root: Path,
     all_specs: list[SkillSpec],
     selected_specs: list[SkillSpec],
     target_root: Path,
@@ -331,6 +348,14 @@ def build_preflight_plan(
             legacy_remove.append(legacy)
         else:
             legacy_skipped.append(legacy)
+
+    planned_removals: list[Path] = []
+    if mirror.exists() or mirror.is_symlink():
+        planned_removals.append(mirror)
+    planned_removals.extend(existing.target for existing in selected_existing)
+    planned_removals.extend(existing.target for existing in unselected_remove)
+    planned_removals.extend(legacy_remove)
+    validate_removals_do_not_touch_source(root, planned_removals)
 
     return PreflightPlan(
         selected_existing=selected_existing,
@@ -616,6 +641,7 @@ def main(argv: list[str]) -> int:
         all_specs = parse_skill_specs(root)
         specs = select_skill_specs(all_specs, routers_only=args.routers_only)
         plan = build_preflight_plan(
+            root,
             all_specs,
             specs,
             target_root,

--- a/scripts/test_install_codex_skills.py
+++ b/scripts/test_install_codex_skills.py
@@ -262,7 +262,7 @@ def test_checkout_symlink_is_migrated_to_hidden_mirror_symlink(tmp_path: Path) -
     assert is_under(target / "debugger", target / MIRROR_DIR)
 
 
-def test_selected_source_checkout_symlink_errors_without_deleting(tmp_path: Path) -> None:
+def test_selected_source_checkout_symlink_migrates_without_deleting_checkout(tmp_path: Path) -> None:
     target = tmp_path / "skills"
     target.mkdir(parents=True)
     checkout_target = ROOT / skill_source_rel("debugger")
@@ -270,11 +270,13 @@ def test_selected_source_checkout_symlink_errors_without_deleting(tmp_path: Path
 
     result = run_installer(target)
 
-    assert result.returncode == 1
-    assert "安装源 checkout 位于目标删除路径内" in result.stderr
-    assert (target / "debugger").is_symlink()
-    assert (target / "debugger").resolve(strict=True) == checkout_target
-    assert not (target / MIRROR_DIR).exists()
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "migrated: debugger" in result.stdout
+    assert_relative_mirror_link(target, "debugger")
+    assert is_under(target / "debugger", target / MIRROR_DIR)
+    assert checkout_target.is_dir()
+    assert (checkout_target / "SKILL.md").is_file()
+    assert INSTALLER.is_file()
 
 
 def test_owned_legacy_aggregate_symlink_is_removed_before_install(tmp_path: Path) -> None:

--- a/scripts/test_install_codex_skills.py
+++ b/scripts/test_install_codex_skills.py
@@ -1,5 +1,6 @@
 import json
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -19,6 +20,40 @@ def run_installer(target: Path, *args: str) -> subprocess.CompletedProcess[str]:
         text=True,
         capture_output=True,
         check=False,
+    )
+
+
+def write_dev_agent_marketplace_marker(root: Path) -> None:
+    (root / ".claude-plugin").mkdir(parents=True, exist_ok=True)
+    (root / ".claude-plugin/marketplace.json").write_text(
+        json.dumps({"name": "dev-agent-skills"}),
+        encoding="utf-8",
+    )
+
+
+def make_minimal_checkout(root: Path) -> None:
+    (root / "scripts").mkdir(parents=True)
+    shutil.copy2(INSTALLER, root / "scripts" / "install_codex_skills.py")
+    (root / ".claude-plugin").mkdir()
+    (root / "agents/product_manager/skills/pm-agent").mkdir(parents=True)
+    (root / "agents/product_manager/skills/pm-agent/SKILL.md").write_text(
+        "---\nname: pm-agent\n---\n",
+        encoding="utf-8",
+    )
+    (root / ".claude-plugin/marketplace.json").write_text(
+        json.dumps(
+            {
+                "name": "dev-agent-skills",
+                "plugins": [
+                    {
+                        "name": "pm-agent",
+                        "source": "./agents/product_manager",
+                        "skills": ["./skills/pm-agent"],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
     )
 
 
@@ -213,7 +248,10 @@ def test_force_errors_on_unowned_unselected_directory_without_partial_changes(tm
 def test_checkout_symlink_is_migrated_to_hidden_mirror_symlink(tmp_path: Path) -> None:
     target = tmp_path / "skills"
     target.mkdir(parents=True)
-    checkout_target = ROOT / skill_source_rel("debugger")
+    old_checkout = tmp_path / "old-checkout"
+    write_dev_agent_marketplace_marker(old_checkout)
+    checkout_target = old_checkout / skill_source_rel("debugger")
+    checkout_target.mkdir(parents=True)
     (target / "debugger").symlink_to(checkout_target, target_is_directory=True)
 
     result = run_installer(target)
@@ -224,10 +262,27 @@ def test_checkout_symlink_is_migrated_to_hidden_mirror_symlink(tmp_path: Path) -
     assert is_under(target / "debugger", target / MIRROR_DIR)
 
 
+def test_selected_source_checkout_symlink_errors_without_deleting(tmp_path: Path) -> None:
+    target = tmp_path / "skills"
+    target.mkdir(parents=True)
+    checkout_target = ROOT / skill_source_rel("debugger")
+    (target / "debugger").symlink_to(checkout_target, target_is_directory=True)
+
+    result = run_installer(target)
+
+    assert result.returncode == 1
+    assert "安装源 checkout 位于目标删除路径内" in result.stderr
+    assert (target / "debugger").is_symlink()
+    assert (target / "debugger").resolve(strict=True) == checkout_target
+    assert not (target / MIRROR_DIR).exists()
+
+
 def test_owned_legacy_aggregate_symlink_is_removed_before_install(tmp_path: Path) -> None:
     target = tmp_path / "skills"
     target.mkdir(parents=True)
-    (target / "dev-agent-skills").symlink_to(ROOT, target_is_directory=True)
+    old_checkout = tmp_path / "old-checkout"
+    write_dev_agent_marketplace_marker(old_checkout)
+    (target / "dev-agent-skills").symlink_to(old_checkout, target_is_directory=True)
 
     result = run_installer(target)
 
@@ -235,6 +290,37 @@ def test_owned_legacy_aggregate_symlink_is_removed_before_install(tmp_path: Path
     assert "Removed legacy aggregate entries:" in result.stdout
     assert not (target / "dev-agent-skills").exists()
     assert_relative_mirror_link(target, "pm-agent")
+
+
+def test_source_checkout_inside_legacy_aggregate_delete_path_errors_without_deleting(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "skills"
+    checkout = target / "dev-agent-skills"
+    make_minimal_checkout(checkout)
+    sentinel = checkout / "local-change.txt"
+    sentinel.write_text("keep local checkout", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(checkout / "scripts" / "install_codex_skills.py"),
+            "--target",
+            str(target),
+        ],
+        cwd=checkout,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "安装源 checkout 位于目标删除路径内" in result.stderr
+    assert sentinel.read_text(encoding="utf-8") == "keep local checkout"
+    assert (checkout / ".claude-plugin/marketplace.json").is_file()
+    assert (checkout / "agents/product_manager/skills/pm-agent/SKILL.md").is_file()
+    assert not (target / MIRROR_DIR).exists()
+    assert not (target / "pm-agent").exists()
 
 
 def test_mirror_does_not_contain_plugin_manifests(tmp_path: Path) -> None:


### PR DESCRIPTION
## 背景

PR #97 最后一轮 Codex review 的 P1 意见在合并前遗漏：当安装源 checkout 位于 target 删除路径内时，legacy aggregate 清理可能在 mirror 重建前删除 source checkout。

Closes #99

## 变更

- 在安装器 preflight 阶段统一校验所有计划删除路径，覆盖 legacy aggregate、unselected 清理、mirror 重建路径和 selected 替换目标。
- 删除路径与 source root `resolve()` 后相等、互为祖先关系时直接报错终止，并提示把 checkout 移出 target 或换用其他 `--target`。
- 补充回归测试，覆盖 `<target>/dev-agent-skills` 作为安装源时的报错保留，以及 selected symlink 指向当前 source 时的保护；保留外部旧 checkout symlink 迁移路径。

## 验证

- `uv run scripts/check_repository_contract.py`
- `uv run scripts/check_eval_contract.py`
- `uv run scripts/check_eval_artifacts.py`
- `uv run scripts/check_doc_contract.py`
- `uv run --with pytest pytest scripts/test_install_codex_skills.py -q`
- `uv run --with pytest pytest -q`
- 临时目录 smoke：正常安装成功，生成 hidden mirror 和 skill symlink
- 临时目录 smoke：自删场景报错，checkout、marketplace、SKILL.md 和本地文件保留

## 说明

本 PR 只修安装器删除前防护和对应回归测试，不合并。
