### PR TITLE
docs: 瘦身 README 入口并分流维护内容

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,86 @@
+# 贡献指南
+
+本文件只作为贡献者命令清单。仓库规则、文档契约、eval 策略、发布约束、commit / PR 文案和维护边界均以 [AGENTS.md](./AGENTS.md) 为权威。
+
+## 本地验证
+
+仓库内 Python 验证脚本和 eval runner 默认使用 `uv run ...`。
+
+PR 检查按 CI 顺序执行：
+
+```bash
+# 1. repository-contract
+uv run scripts/check_repository_contract.py
+
+# 2. eval-contract
+uv run scripts/check_eval_contract.py
+uv run scripts/check_eval_artifacts.py
+
+# 3. doc-contract
+uv run scripts/check_doc_contract.py
+
+# 4. python-tests
+uv run --with pytest pytest \
+  agents/product_manager/test/idea-to-spec \
+  agents/product_manager/test/pm-agent \
+  agents/qa/test/test_qa_run_eval.py \
+  agents/designer/test/test_designer_run_eval.py \
+  agents/devops/test/test_devops_run_eval.py \
+  agents/test_doc_contract.py \
+  agents/test_eval_contract.py \
+  scripts/test_install_codex_skills.py
+```
+
+可选 JSON 静态格式检查：
+
+```bash
+uv run python -m json.tool .claude-plugin/marketplace.json >/tmp/marketplace.json.out
+uv run python -m json.tool skills-lock.json >/tmp/skills-lock.json.out
+```
+
+## 手动 Eval
+
+本地模型 eval 是质量检查，不属于第一版 PR 必跑 status check：
+
+```bash
+# Designer eval diagnostics
+uv run agents/designer/test/run_all_evals.py
+
+# QA model eval
+uv run agents/qa/test/run_all_evals.py
+```
+
+涉及 skill 行为、routing、eval fixture 或 release readiness 的变更，按 [AGENTS.md](./AGENTS.md#skill-测试) 的 eval 策略执行。GitHub Actions 的 `Manual Evals` workflow 可选择 `all`、`designer` 或 `qa`；QA eval 需要仓库 `OPENAI_API_KEY` secret。
+
+## Eval 维护清单
+
+仓库只保留 eval 定义和最新持久化结论，运行日志和 transcript 不进 git。详细规则见 [AGENTS.md](./AGENTS.md#skill-测试)。
+
+1. 新建或更新 skill 与 eval fixture。
+2. 运行相关确定性检查和已批准的手动 eval。
+3. 将最新持久化结果写入 `comparison.md`。
+4. 开 PR 前删除运行期产物。
+5. 只提交 eval 定义、metadata、fixture、README 文件和 `comparison.md`。
+
+`comparison.md` 使用以下结构：
+
+```markdown
+# Eval Result: <eval-name>
+
+## Evaluation Target
+## Test Set / Fixture Version
+## Latest Result
+## With Skill
+## Without Skill / Baseline
+## Failures
+## Next Steps
+## Runtime Artifacts Policy
+```
+
+## 维护索引
+
+- 仓库工作流、分支和 PR 规则：[AGENTS.md](./AGENTS.md#开发工作流)
+- 文档结构与 frontmatter 契约：[AGENTS.md](./AGENTS.md#文档组织)
+- release 与 changelog 规则：[AGENTS.md](./AGENTS.md#仓库治理)
+- skill eval schema 与 artifact 策略：[AGENTS.md](./AGENTS.md#skill-测试)
+- QA E2E 持久化与凭据处理：[AGENTS.md](./AGENTS.md#qa-e2e-测试用例持久化)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Multi-agent skills for the full software delivery lifecycle.
 
 `pm-agent` • `designer-agent` • `engineer-agent` • `qa-agent` • `devops-agent` • `security-agent`
 
-[Quick Start](#quick-start) • [Agents](#agents) • [Collaboration Model](#collaboration-model) • [Repository Structure](#repository-structure) • [Local Validation](#local-validation)
+[Quick Start](#quick-start) • [Usage Examples](#usage-examples) • [Agents](#agents) • [Collaboration Model](#collaboration-model) • [Documentation](#documentation)
 
 </div>
 
@@ -28,10 +28,55 @@ It includes:
 - Claude Code marketplace configuration
 - Codex native skill discovery installation instructions
 - Agent-level eval fixtures and local validation scripts
-- Reference-backed visual design system data and lookup scripts for Designer Agent
 
 > [!NOTE]
 > These agents collaborate through Markdown documents and project assets. They do not require a shared runtime or fixed state machine. Use `pm-agent` as the direct user entry; install downstream role plugins only when PM handoff should have those capabilities available.
+
+## Quick Start
+
+### Claude Code
+
+```bash
+# Add the marketplace
+/plugin marketplace add Neplich/dev-agent-skills
+
+# Install the public entry
+/plugin install pm-agent@dev-agent-skills
+
+# Optional downstream capabilities for PM handoff
+/plugin install designer-agent@dev-agent-skills
+/plugin install engineer-agent@dev-agent-skills
+/plugin install qa-agent@dev-agent-skills
+/plugin install devops-agent@dev-agent-skills
+/plugin install security-agent@dev-agent-skills
+```
+
+### Codex
+
+```bash
+git clone https://github.com/Neplich/dev-agent-skills.git ~/.agents/dev-agent-skills
+cd ~/.agents/dev-agent-skills
+
+# Install all role router and specialist skills by default.
+python3 scripts/install_codex_skills.py
+
+# Optional minimal mode: expose only the six role router skills.
+python3 scripts/install_codex_skills.py --routers-only
+```
+
+Implementation details and troubleshooting are in the [Codex Guide](./docs/README.codex.md).
+
+## Usage Examples
+
+```text
+/pm-agent "I want to build a task management app. Help me shape the requirements first."
+/pm-agent "There is a bug in the login flow. Classify the expected behavior and route the fix."
+/pm-agent "Validate the checkout flow against the spec."
+/pm-agent "Prepare CI/CD and release readiness checks."
+/pm-agent "Review authorization and dependency risk before release."
+```
+
+Downstream role routers and specialist skills remain installed as PM-orchestrated capabilities. Prefer `pm-agent` for direct user requests; downstream skills are intended for work whose scope has already been confirmed by PM handoff or an equivalent document chain.
 
 ## Agents
 
@@ -62,17 +107,7 @@ flowchart LR
     Security --> Engineer
 ```
 
-Engineering guardrails:
-
-```mermaid
-flowchart LR
-    Align["PRD/TRD alignment"] --> TRD["TRD confirmed"]
-    TRD --> Plan["IMPLEMENTATION_PLAN confirmed"]
-    Plan --> Work["implementation / debug"]
-    Work --> QAHandOff["QA E2E handoff"]
-```
-
-Existing feature changes, bug fixes, and user-visible implementation should pass PRD/TRD alignment before engineering execution. Engineer confirms the TRD and `IMPLEMENTATION_PLAN.md` before implementation, then hands user-flow impact to QA through a QA E2E package.
+Engineering guardrails for PRD/TRD alignment, implementation planning, and QA E2E handoff are documented in the [Engineer Agent guide](./agents/engineer/README.md).
 
 Common chains:
 
@@ -84,228 +119,18 @@ Common chains:
 
 Not every project needs the full chain. Each agent can complete its own role-specific loop, and cross-agent handoff happens only when another role is needed.
 
-## Quick Start
+## Documentation
 
-### Claude Code
+- [Codex Guide](./docs/README.codex.md): Codex installation model, mirror behavior, troubleshooting, and path-based disabling.
+- [Agents Guide](./AGENTS.md): repository guidance source for agents, document contracts, maintenance workflow, eval rules, and PR checks.
+- [Contributing](./CONTRIBUTING.md): local validation commands and maintainer workflow links.
+- [Changelog Index](./CHANGELOG.md): versioned release changelog entrypoint.
+- Agent guides: [PM](./agents/product_manager/README.md), [Designer](./agents/designer/README.md), [Engineer](./agents/engineer/README.md), [QA](./agents/qa/README.md), [DevOps](./agents/devops/README.md), [Security](./agents/security/README.md).
 
-```bash
-# Add the marketplace
-/plugin marketplace add Neplich/dev-agent-skills
+## Contributing
 
-# Install the public entry
-/plugin install pm-agent@dev-agent-skills
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for local checks and contributor workflow. `AGENTS.md` remains the single source of repository guidance.
 
-# Optional downstream capabilities for PM handoff
-/plugin install designer-agent@dev-agent-skills
-/plugin install engineer-agent@dev-agent-skills
-/plugin install qa-agent@dev-agent-skills
-/plugin install devops-agent@dev-agent-skills
-/plugin install security-agent@dev-agent-skills
-```
+## License
 
-Claude Code scans installed plugins by plugin root. This repository scopes each plugin to its own agent directory, but installing only the agents you need is still recommended.
-
-### Codex
-
-Clone or update this repository, then run the mirror-based installer:
-
-```bash
-git clone https://github.com/Neplich/dev-agent-skills.git ~/.agents/dev-agent-skills
-cd ~/.agents/dev-agent-skills
-
-# Install all role router and specialist skills by default.
-python3 scripts/install_codex_skills.py
-
-# Optional minimal mode: expose only the six role router skills.
-python3 scripts/install_codex_skills.py --routers-only
-```
-
-Codex resolves skill symlinks to their real path before looking upward for plugin manifests. If skills are symlinked directly into this repository clone, Codex can find `agents/{role}/.claude-plugin/plugin.json` and add namespace prefixes such as `Pm Agent:` to every skill. The installer mirrors the repository `agents/` tree into `~/.agents/skills/.dev-agent-skills/` without plugin manifests or agent test directories, then creates relative symlinks such as `~/.agents/skills/pm-agent -> .dev-agent-skills/agents/product_manager/skills/pm-agent`. The resolved skill path stays inside the hidden mirror, and repo-relative shared instructions remain loadable without path rewriting. See [issue #95](https://github.com/Neplich/dev-agent-skills/issues/95).
-
-The default install links all role router and specialist skills so `pm-agent` and role-router orchestration can call downstream specialists. Use `--routers-only` only for a minimal entry-classification install; in that mode only the six router symlinks are exposed at the target root, while the full hidden mirror remains available for shared instruction references. Switching modes removes no-longer-selected symlinks only when they are proven to belong to this installer. Existing symlinks into a dev-agent-skills checkout are migrated automatically. Real directories and symlinks to other locations are treated as unowned: they are skipped by default, and `--force` reports them as conflicts instead of deleting them. The hidden mirror itself is protected the same way: an existing `.dev-agent-skills` directory without the installer marker is reported as a conflict and is never deleted. Use `--target <path>` for a project-local or custom skill directory, and `--force` to rebuild the mirror and replace owned symlinks.
-
-To disable one installed skill by path, add a path-specific entry to `~/.codex/config.toml`:
-
-```toml
-[[skills.config]]
-path = "/Users/you/.agents/skills/debugger"
-enabled = false
-```
-
-See [docs/README.codex.md](./docs/README.codex.md) for the full Codex guide.
-
-## Usage Examples
-
-```text
-/pm-agent "I want to build a task management app. Help me shape the requirements first."
-/pm-agent "There is a bug in the login flow. Classify the expected behavior and route the fix."
-/pm-agent "Validate the checkout flow against the spec."
-/pm-agent "Prepare CI/CD and release readiness checks."
-/pm-agent "Review authorization and dependency risk before release."
-```
-
-Downstream role routers and specialist skills remain installed as PM-orchestrated capabilities. Prefer `pm-agent` for direct user requests; downstream skills are intended for work whose scope has already been confirmed by PM handoff or an equivalent document chain.
-
-## Repository Structure
-
-```text
-dev-agent-skills/
-├── .claude-plugin/          # Claude Code marketplace configuration
-├── .codex/                  # Codex installation entrypoint
-├── agents/                  # 6 agents with skills and evals
-├── docs/                    # Public docs and historical design notes
-├── skills-lock.json         # Skill metadata lock file
-├── AGENTS.md                # Single source of repository guidance
-└── CLAUDE.md                # Symlink to AGENTS.md for Claude Code compatibility
-```
-
-Each agent follows the same basic shape:
-
-```text
-agents/{agent}/
-├── README.md
-├── skills/
-│   └── {skill}/
-│       └── SKILL.md
-└── test/
-    └── {skill}/
-        └── evals/
-            └── evals.json
-```
-
-Some skills also include `_internal/`, `references/`, or script directories for protocol details, design data, or validation helpers.
-
-## Design System Data
-
-Designer Agent's `visual-design` skill includes reference-backed design system capability:
-
-- Local path: `agents/designer/skills/visual-design/references/design-system-data/`
-- Data coverage: product types, style patterns, colors, typography, UX guidelines, charts, landing patterns, icons, and stack guidelines
-- Usage boundary: design reasoning and design-system documentation only; it must not generate application code, install commands, or engineering task lists
-
-The data design follows ui ux pro max's organization model and is maintained under this repository's own paths and documentation.
-
-## Local Validation
-
-> [!NOTE]
-> Use `uv run ...` for Python-based validation scripts and eval runners in this repository.
-
-PR CI uses four required checks in this order:
-
-```bash
-# repository-contract
-uv run scripts/check_repository_contract.py
-
-# eval-contract
-uv run scripts/check_eval_contract.py
-uv run scripts/check_eval_artifacts.py
-
-# doc-contract
-uv run scripts/check_doc_contract.py
-
-# python-tests
-uv run --with pytest pytest \
-  agents/product_manager/test/idea-to-spec \
-  agents/product_manager/test/pm-agent \
-  agents/qa/test/test_qa_run_eval.py \
-  agents/designer/test/test_designer_run_eval.py \
-  agents/devops/test/test_devops_run_eval.py \
-  agents/test_doc_contract.py \
-  agents/test_eval_contract.py \
-  scripts/test_install_codex_skills.py
-```
-
-Additional local model evals are manual quality checks, not first-version PR required checks:
-
-```bash
-# Designer eval diagnostics
-uv run agents/designer/test/run_all_evals.py
-
-# QA model eval
-uv run agents/qa/test/run_all_evals.py
-```
-
-For changes that affect skill behavior, routing, eval fixtures, or release readiness, an administrator should run the manual model eval workflow before merging and use the result as merge evidence. Model evals are not required status checks because model output, runtime, and environment can vary.
-
-The same manual checks are available from GitHub Actions: open `Manual Evals`, choose `Run workflow`, select `all`, `designer`, or `qa`, and review the uploaded short-lived runtime artifacts. The QA eval job requires the `OPENAI_API_KEY` repository secret because it calls `codex exec`; `designer` can be run independently without that secret and reports runtime-output gaps as warnings for artifact review.
-
-Extra static format checks:
-
-```bash
-# JSON format checks
-uv run python -m json.tool .claude-plugin/marketplace.json >/tmp/marketplace.json.out
-uv run python -m json.tool skills-lock.json >/tmp/skills-lock.json.out
-```
-
-## Maintenance Notes
-
-- Follow the existing `agents/*` structure when adding a new agent or skill.
-- Keep `AGENTS.md` as the only edited guidance source; `CLAUDE.md` must remain a symlink to it.
-- Update versioned changelog files under [`docs/changelog/`](./docs/changelog/) for release-facing, user-facing, or developer-facing changes; keep root [`CHANGELOG.md`](./CHANGELOG.md) as an index and keep README focused on the current project state.
-- Keep `.claude-plugin/marketplace.json` `metadata.version` aligned with the repository release version without the `v` prefix. Before creating a release tag, update `metadata.version`, add the matching `docs/changelog/changelog-v{version}.md`, and update the root changelog index.
-- Restrictive repository permissions default to the sole administrator; add maintainers or bots explicitly when needed.
-- Skill evals should verify role boundaries, context reading, execution-path selection, and structured artifacts instead of generic answer quality alone.
-- All skill eval definitions use the shared `evals.json` schema v1.0; do not add agent-specific schema exceptions.
-
-### Eval maintenance flow
-
-When adding or updating a skill eval, keep the repository as the source of eval definitions and latest conclusions, not a log archive:
-
-1. Create or update the skill and its eval fixture.
-2. Run the existing or updated test set. Use a temporary or scratch workspace when the runner supports it.
-3. Write the latest comparison in `comparison.md`.
-4. Delete runtime files before opening a PR.
-5. Commit only eval definitions, metadata, fixtures, README files, and `comparison.md`.
-
-Do not commit `with_skill/`, `without_skill/`, `baseline/`, `iteration2/`, `outputs/`, `comparison.auto.md`, transcripts, candidate outputs, subagent verdicts, timing files, run status files, or diagnostics directories. Eval runners write runtime files under scratch workspaces such as `tmp/eval-runs/...`; these files are temporary and must not be copied into eval fixtures. Metadata fields such as `with_skill_outputs`, `without_skill_outputs`, and baseline outputs describe runner expectations; they do not mean those runtime files belong in git. `with_skill_outputs` may act as runner gates; `without_skill_outputs` and baseline output metadata are comparison evidence and should be reported without independently failing deterministic runners. Manual or scheduled model eval workflows may upload transcripts, verdicts, timing, and diagnostics as short-lived CI artifacts for debugging, but the durable repository result remains `comparison.md`.
-
-The baseline is the without-skill comparison input for `comparison.md`; it is not an independently machine-graded artifact. The durable `Latest result` is the conclusion from the sub-agent, fresh judge, or human reviewer after comparing with-skill behavior, without-skill baseline behavior, assertions, and fixture context. Deterministic contract checks validate eval definitions, required workspaces, durable comparison presence, and runtime artifact hygiene; they do not infer PASS, PARTIAL, or BLOCKED from free-form baseline text.
-
-Fresh Sub-Agent gate: every fresh Codex subagent skill eval must generate a new `without_skill` baseline from the same eval prompt and fixture. Do not reuse historical baseline text as the current run. If the new baseline cannot be generated or reviewed, record the impact in `comparison.md`; deterministic runners should not grade the baseline prose itself.
-
-Every `evals.json` must live at `agents/{agent}/test/{skill-name}/evals/evals.json` and declare `schema_version: "1.0"`, `agent`, `skill_name`, and non-empty `evals`. Each eval item must include `id`, `name`, `description`, `prompt`, explicit `workspace` pointing to `workspace/...`, `expected_output`, and object assertions with lower snake_case `id`, `description`, and semantic `text`. Prompt-only evals still need a minimal workspace with `eval_metadata.json` and durable `comparison.md`. Run `uv run scripts/check_eval_contract.py` with eval definition changes.
-
-Eval runners write runtime files to a system temp directory or `tmp/eval-runs/...`, then copy only the confirmed `comparison.md` back to the eval workspace. New metadata schemas should make the split explicit with runtime-output fields and a durable-result field. Keep Python test module names unique across test roots, such as `test_pm_run_eval.py` and `test_qa_run_eval.py`, so pytest can collect all deterministic tests in one process.
-
-### QA E2E Local Account File
-
-QA E2E credentials use a local ignored account file instead of committed
-plaintext or encrypted credential files:
-
-```text
-.qa/e2e/accounts.local.json
-```
-
-The file is excluded by `.gitignore`. QA documents, test cases, scripts,
-results, and eval fixtures may only reference credential IDs such as
-`platform.default.admin` or `ssh.default.deploy`; they must not include real
-usernames, passwords, tokens, cookies, sessions, SSH passwords, SSH key
-contents, or passphrases.
-
-When a QA agent receives platform or SSH credential details from a user, it
-should upsert them into `.qa/e2e/accounts.local.json` according to
-[`e2e-credential-store.md`](./agents/qa/skills/qa-agent/references/e2e-credential-store.md)
-and keep file permissions local-only when possible. E2E summary reports must
-follow
-[`e2e-test-report.md`](./agents/qa/skills/qa-agent/references/e2e-test-report.md).
-
-Use this `comparison.md` shape for durable results:
-
-```markdown
-# Eval Result: <eval-name>
-
-## Evaluation Target
-## Test Set / Fixture Version
-## Latest Result
-## With Skill
-## Without Skill / Baseline
-## Failures
-## Next Steps
-## Runtime Artifacts Policy
-```
-
-<div align="center">
-
-[中文](./README_zh.md) • [Claude Guide](./CLAUDE.md) • [Agents Guide](./AGENTS.md) • [Codex Guide](./docs/README.codex.md)
-
-</div>
+This project is licensed under the [Apache License 2.0](./LICENSE).

--- a/README_zh.md
+++ b/README_zh.md
@@ -10,7 +10,7 @@
 
 `pm-agent` • `designer-agent` • `engineer-agent` • `qa-agent` • `devops-agent` • `security-agent`
 
-[快速开始](#快速开始) • [Agents](#agents) • [协作方式](#协作方式) • [仓库结构](#仓库结构) • [本地验证](#本地验证)
+[快速开始](#快速开始) • [使用示例](#使用示例) • [Agents](#agents) • [协作方式](#协作方式) • [文档索引](#文档索引)
 
 </div>
 
@@ -28,10 +28,55 @@
 - Claude Code marketplace 配置
 - Codex 原生 skill discovery 安装入口
 - Agent 级 eval fixtures 与本地验证脚本
-- Designer Agent 的 reference-backed visual design system 数据和查询能力
 
 > [!NOTE]
 > 这些 Agent 通过 Markdown 文档和项目资产协作，不依赖共享运行时或固定状态机。直接用户入口只推荐 `pm-agent`；下游 role plugin 只在 PM handoff 需要对应能力时安装。
+
+## 快速开始
+
+### Claude Code
+
+```bash
+# 添加 marketplace
+/plugin marketplace add Neplich/dev-agent-skills
+
+# 安装公开入口
+/plugin install pm-agent@dev-agent-skills
+
+# 按需安装 PM handoff 的下游能力
+/plugin install designer-agent@dev-agent-skills
+/plugin install engineer-agent@dev-agent-skills
+/plugin install qa-agent@dev-agent-skills
+/plugin install devops-agent@dev-agent-skills
+/plugin install security-agent@dev-agent-skills
+```
+
+### Codex
+
+```bash
+git clone https://github.com/Neplich/dev-agent-skills.git ~/.agents/dev-agent-skills
+cd ~/.agents/dev-agent-skills
+
+# 默认安装全部 role router 和 specialist skills
+python3 scripts/install_codex_skills.py
+
+# 可选最小模式：只暴露 6 个 role router skills
+python3 scripts/install_codex_skills.py --routers-only
+```
+
+实现原理与排障见 [Codex Guide](./docs/README.codex.md)。
+
+## 使用示例
+
+```text
+/pm-agent "我想做一个任务管理应用，先帮我梳理需求"
+/pm-agent "登录流程有 bug，先帮我确认预期再安排修复"
+/pm-agent "按 spec 验证登录功能"
+/pm-agent "补一套 CI/CD 和发布前检查"
+/pm-agent "上线前看一下权限和依赖风险"
+```
+
+下游 role router 和 specialist skills 仍会作为 PM 编排能力安装。直接用户请求优先从 `pm-agent` 进入；下游 skills 用于 PM handoff 或等效已确认文档链已经明确范围后的工作。
 
 ## Agents
 
@@ -62,17 +107,7 @@ flowchart LR
     Security --> Engineer
 ```
 
-工程门禁：
-
-```mermaid
-flowchart LR
-    Align["PRD/TRD 对齐"] --> TRD["TRD 已确认"]
-    TRD --> Plan["IMPLEMENTATION_PLAN 已确认"]
-    Plan --> Work["实现 / 修复"]
-    Work --> QAHandOff["QA E2E handoff"]
-```
-
-现有功能变更、bug fix 和用户可见实现应先完成 PRD/TRD 对齐，再进入工程执行。Engineer 在实现前确认 TRD 和 `IMPLEMENTATION_PLAN.md`；影响用户流程的实现完成后，通过 QA E2E 交接包移交给 QA。
+PRD/TRD 对齐、实现计划确认和 QA E2E handoff 等工程门禁见 [Engineer Agent 文档](./agents/engineer/README_zh.md)。
 
 常见链路：
 
@@ -84,218 +119,18 @@ flowchart LR
 
 不是所有项目都要走完整链路。每个 Agent 都能独立完成自己的角色闭环，只有在需要跨角色协作时才 handoff。
 
-## 快速开始
+## 文档索引
 
-### Claude Code
+- [Codex Guide](./docs/README.codex.md)：Codex 安装模型、镜像机制、排障和按路径禁用。
+- [Agents Guide](./AGENTS.md)：agent 仓库指导、文档契约、维护流程、eval 规则和 PR 检查的唯一事实源。
+- [Contributing](./CONTRIBUTING.md)：本地验证命令和维护流程链接。
+- [Changelog Index](./CHANGELOG.md)：版本化 release changelog 入口。
+- Agent 文档：[PM](./agents/product_manager/README_zh.md)、[Designer](./agents/designer/README_zh.md)、[Engineer](./agents/engineer/README_zh.md)、[QA](./agents/qa/README_zh.md)、[DevOps](./agents/devops/README_zh.md)、[Security](./agents/security/README_zh.md)。
 
-```bash
-# 添加 marketplace
-/plugin marketplace add Neplich/dev-agent-skills
+## 贡献
 
-# 安装公开入口
-/plugin install pm-agent@dev-agent-skills
+本地检查和贡献流程见 [CONTRIBUTING.md](./CONTRIBUTING.md)。`AGENTS.md` 仍是仓库指导的唯一事实源。
 
-# 按需安装 PM handoff 的下游能力
-/plugin install designer-agent@dev-agent-skills
-/plugin install engineer-agent@dev-agent-skills
-/plugin install qa-agent@dev-agent-skills
-/plugin install devops-agent@dev-agent-skills
-/plugin install security-agent@dev-agent-skills
-```
+## License
 
-Claude Code 会按 plugin root 扫描已安装插件。本仓库已经把每个 plugin 收敛到各自的 agent 子目录，但仍建议按需安装，不要默认一次装满 6 个 Agent。
-
-### Codex
-
-clone 或更新本仓库后，运行镜像式安装脚本：
-
-```bash
-git clone https://github.com/Neplich/dev-agent-skills.git ~/.agents/dev-agent-skills
-cd ~/.agents/dev-agent-skills
-
-# 默认安装全部 role router 和 specialist skills
-python3 scripts/install_codex_skills.py
-
-# 可选最小模式：只暴露 6 个 role router skills
-python3 scripts/install_codex_skills.py --routers-only
-```
-
-Codex 会先把 skill 软链接解析到真实路径，再向上查找 plugin manifest。若把 skill 直接软链接进本仓库 clone，Codex 会命中 `agents/{role}/.claude-plugin/plugin.json`，并给所有 skill 加上 `Pm Agent:` 这类 namespace 前缀。该脚本把仓库 `agents/` 树镜像到 `~/.agents/skills/.dev-agent-skills/`，剔除 plugin manifest 和 agent test 目录，再在目标根目录创建 `~/.agents/skills/pm-agent -> .dev-agent-skills/agents/product_manager/skills/pm-agent` 这类相对软链。解析后的 skill 路径停留在隐藏镜像内，共享 repo-relative 指令无需改写即可读取。详见 [issue #95](https://github.com/Neplich/dev-agent-skills/issues/95)。
-
-默认安装全部 role router 和 specialist skills，确保 `pm-agent` 和 role router 编排流程可以调用下游 specialist。`--routers-only` 只适合入口分类所需的最小安装；该模式只在目标根目录暴露 6 个 router 软链，但隐藏镜像仍保留完整 `agents/` 树供共享指令引用。切换模式时，脚本只会清理能证明归属本安装器的不再 selected 软链。已有指向 dev-agent-skills checkout 的旧软链会自动迁移到隐藏镜像软链。真实目录或指向其他位置的软链都视为非归属目标：默认跳过，`--force` 会报错列出冲突项而不是删除。隐藏镜像自身也遵循同一保护：已有 `.dev-agent-skills` 目录缺少安装器 marker 时会报冲突，绝不删除。使用 `--target <path>` 可指定项目级或自定义 skill 目录，使用 `--force` 可重建镜像并替换归属软链。
-
-如需按路径禁用单个已安装 skill，可在 `~/.codex/config.toml` 中添加：
-
-```toml
-[[skills.config]]
-path = "/Users/you/.agents/skills/debugger"
-enabled = false
-```
-
-完整说明见 [docs/README.codex.md](./docs/README.codex.md)。
-
-## 使用示例
-
-```text
-/pm-agent "我想做一个任务管理应用，先帮我梳理需求"
-/pm-agent "登录流程有 bug，先帮我确认预期再安排修复"
-/pm-agent "按 spec 验证登录功能"
-/pm-agent "补一套 CI/CD 和发布前检查"
-/pm-agent "上线前看一下权限和依赖风险"
-```
-
-下游 role router 和 specialist skills 仍会作为 PM 编排能力安装。直接用户请求优先从 `pm-agent` 进入；下游 skills 用于 PM handoff 或等效已确认文档链已经明确范围后的工作。
-
-## 仓库结构
-
-```text
-dev-agent-skills/
-├── .claude-plugin/          # Claude Code marketplace 配置
-├── .codex/                  # Codex 安装入口
-├── agents/                  # 6 个 Agent 及其 skills / evals
-├── docs/                    # 对外文档和历史设计说明
-├── skills-lock.json         # skill 元数据锁文件
-├── AGENTS.md                # 仓库指导的唯一事实源
-└── CLAUDE.md                # 指向 AGENTS.md 的软链接，用于兼容 Claude Code
-```
-
-单个 Agent 的结构：
-
-```text
-agents/{agent}/
-├── README.md
-├── skills/
-│   └── {skill}/
-│       └── SKILL.md
-└── test/
-    └── {skill}/
-        └── evals/
-            └── evals.json
-```
-
-部分 skill 会带有 `_internal/`、`references/` 或脚本目录，用于保存协议细节、设计数据库或本地验证辅助工具。
-
-## 设计系统数据
-
-Designer Agent 的 `visual-design` 包含 reference-backed design system 能力：
-
-- 本地路径：`agents/designer/skills/visual-design/references/design-system-data/`
-- 数据范围：产品类型、风格模式、颜色、字体、UX guidelines、charts、landing patterns、icons、stack guidelines
-- 使用边界：只用于设计推理和设计系统文档，不生成应用代码、安装命令或工程任务清单
-
-该数据设计参考了 ui ux pro max 的组织方式，并按本仓库自己的路径和文档结构维护。
-
-## 本地验证
-
-> [!NOTE]
-> 仓库内 Python 验证脚本和 eval runner 默认使用 `uv run ...`。
-
-PR CI 使用 4 个必跑检查，顺序如下：
-
-```bash
-# repository-contract
-uv run scripts/check_repository_contract.py
-
-# eval-contract
-uv run scripts/check_eval_contract.py
-uv run scripts/check_eval_artifacts.py
-
-# doc-contract
-uv run scripts/check_doc_contract.py
-
-# python-tests
-uv run --with pytest pytest \
-  agents/product_manager/test/idea-to-spec \
-  agents/product_manager/test/pm-agent \
-  agents/qa/test/test_qa_run_eval.py \
-  agents/designer/test/test_designer_run_eval.py \
-  agents/devops/test/test_devops_run_eval.py \
-  agents/test_doc_contract.py \
-  agents/test_eval_contract.py \
-  scripts/test_install_codex_skills.py
-```
-
-额外本地模型 eval 是质量检查，不属于第一版 PR 必跑门禁：
-
-```bash
-# Designer eval diagnostics
-uv run agents/designer/test/run_all_evals.py
-
-# QA model eval
-uv run agents/qa/test/run_all_evals.py
-```
-
-涉及 skill 行为、routing、eval fixture 或 release 前变更时，管理员应在合并前运行手动模型 eval workflow，并把结果作为 merge 判断依据。模型 eval 不作为 required status check，因为模型输出、运行耗时和环境都可能波动。
-
-同一组手动检查也可在 GitHub Actions 中触发：打开 `Manual Evals`，点击 `Run workflow`，选择 `all`、`designer` 或 `qa`，再查看上传的短期运行 artifact。QA eval job 会调用 `codex exec`，因此需要仓库 secret `OPENAI_API_KEY`；`designer` 可独立运行，不依赖该 secret，并把运行期输出缺口作为 warning 提醒人工查看 artifact。
-
-额外静态格式检查：
-
-```bash
-# JSON 格式检查示例
-uv run python -m json.tool .claude-plugin/marketplace.json >/tmp/marketplace.json.out
-uv run python -m json.tool skills-lock.json >/tmp/skills-lock.json.out
-```
-
-## 维护约定
-
-- 新增 Agent 或 skill 时，优先遵循现有 `agents/*` 结构。
-- `AGENTS.md` 是唯一编辑源；`CLAUDE.md` 必须保持为指向它的软链接。
-- 涉及发布、面向用户或面向开发者的变更时，同步维护 [`docs/changelog/`](./docs/changelog/) 下的版本化 changelog；根目录 [`CHANGELOG.md`](./CHANGELOG.md) 只作为索引，README 只保留当前项目状态。
-- `.claude-plugin/marketplace.json` 的 `metadata.version` 必须与仓库 release 版本保持一致，但不带 `v` 前缀。创建 release tag 前，先更新 `metadata.version`、新增对应的 `docs/changelog/changelog-v{version}.md`，并同步根目录 changelog 索引。
-- 仓库限制性权限默认只授予唯一管理员；后续需要维护者或机器人时再显式添加。
-- Skill eval 应验证角色边界、上下文读取、执行路径和结构化产物，而不是只检查泛化回答质量。
-- 所有 skill eval 定义统一使用 `evals.json` schema v1.0，不新增 agent 专属 schema 例外。
-
-### Eval 维护流程
-
-新增或更新 skill eval 时，仓库只作为评测定义和最新结论的事实源，不作为运行日志归档：
-
-1. 新建或更新 skill 与 eval fixture。
-2. 使用已有或更新后的测试集进行评测；runner 支持时优先使用临时目录或 scratch workspace。
-3. 将最新评测比对结果写入 `comparison.md`。
-4. 提交 PR 前删除运行过程文件。
-5. 只提交 eval 定义、metadata、fixture、README 和 `comparison.md`。
-
-不要提交 `with_skill/`、`without_skill/`、`baseline/`、`iteration2/`、`outputs/`、`comparison.auto.md`、transcript、candidate output、subagent verdict、timing、run status 或 diagnostics 目录。Eval runner 会把运行期文件写入 `tmp/eval-runs/...` 这类 scratch workspace；这些文件只是临时文件，不应复制回 eval fixture。`with_skill_outputs`、`without_skill_outputs`、baseline outputs 等 metadata 字段只描述 runner 的运行期预期，不代表这些过程文件需要进入 git。手动或定时模型 eval workflow 可以把 transcript、verdict、timing 和 diagnostics 作为短期 CI artifact 上传用于排查，但仓库里长期保留的结果仍然是 `comparison.md`。
-
-Baseline 是 `comparison.md` 使用的 without-skill 对照输入，不是独立的机器判定产物。durable 的 `Latest result` 是 sub-agent、fresh judge 或人工 reviewer 在比较 with-skill 行为、without-skill baseline 行为、assertions 和 fixture 上下文后得出的结论。确定性 contract 检查只校验 eval 定义、必需 workspace、durable comparison 是否存在，以及运行期 artifact 是否合规；不会根据自由文本的 baseline 推断 PASS、PARTIAL 或 BLOCKED。
-
-Fresh Sub-Agent 门禁：每次全新 Codex subagent 执行 skill eval 时，都必须基于同一份 eval prompt 和 fixture 重新生成新的 `without_skill` baseline。不要复用历史 baseline 文本充当本次运行结果。如果新的 baseline 无法生成或无法被评审，应在 `comparison.md` 中记录其影响；确定性 runner 不对 baseline 文本本身打分。
-
-每个 `evals.json` 必须位于 `agents/{agent}/test/{skill-name}/evals/evals.json`，并声明 `schema_version: "1.0"`、`agent`、`skill_name` 和非空 `evals`。每个 eval item 必须包含 `id`、`name`、`description`、`prompt`、指向 `workspace/...` 的显式 `workspace`、`expected_output`，以及对象形式的 assertions；assertion 必须包含 lower snake_case `id`、`description` 和语义化 `text`。prompt-only eval 也需要最小 workspace，并包含 `eval_metadata.json` 和 durable `comparison.md`。修改 eval 定义时运行 `uv run scripts/check_eval_contract.py`。
-
-Eval runner 应将运行期文件写入系统临时目录或 `tmp/eval-runs/...`，再只把确认后的 `comparison.md` 同步回 eval workspace。新的 metadata schema 应显式区分 runtime output 字段和 durable result 字段。Python 测试文件名需要跨测试目录保持唯一，例如 `test_pm_run_eval.py` 和 `test_qa_run_eval.py`，确保 pytest 能在同一个进程里收集所有确定性测试。
-
-### QA E2E 本地账号文件
-
-QA E2E 凭据使用本地 ignore 账号文件，不提交明文或加密凭据文件：
-
-```text
-.qa/e2e/accounts.local.json
-```
-
-该文件已由 `.gitignore` 屏蔽。QA 文档、测试用例、脚本、结果和 eval fixture 只能引用账号 ID，例如 `platform.default.admin` 或 `ssh.default.deploy`；不得写入真实用户名、密码、token、cookie、session、SSH 密码、SSH key 内容或 passphrase。
-
-QA Agent 收到用户提供的平台账号、平台密码、SSH 账号、SSH 密码或 SSH key 路径时，应按 [`e2e-credential-store.md`](./agents/qa/skills/qa-agent/references/e2e-credential-store.md) 自动 upsert 到 `.qa/e2e/accounts.local.json`，并在本地环境允许时设置仅当前用户可读写。E2E 汇总报告必须遵循 [`e2e-test-report.md`](./agents/qa/skills/qa-agent/references/e2e-test-report.md) 的固定格式。
-
-`comparison.md` 使用以下结构：
-
-```markdown
-# Eval Result: <eval-name>
-
-## Evaluation Target
-## Test Set / Fixture Version
-## Latest Result
-## With Skill
-## Without Skill / Baseline
-## Failures
-## Next Steps
-## Runtime Artifacts Policy
-```
-
-<div align="center">
-
-[English](./README.md) • [Claude Guide](./CLAUDE.md) • [Agents Guide](./AGENTS.md) • [Codex Guide](./docs/README.codex.md)
-
-</div>
+本项目使用 [Apache License 2.0](./LICENSE)。

--- a/agents/designer/README.md
+++ b/agents/designer/README.md
@@ -74,7 +74,13 @@ agents/designer/skills/visual-design/references/
 └── anti-patterns.md             # General and scenario-specific anti-patterns
 ```
 
-The `design-system-data/` data design references ui ux pro max across product types, style patterns, colors, typography, UX rules, charts, landing patterns, icons, and stack guidelines.
+Design system data:
+
+- Local path: `agents/designer/skills/visual-design/references/design-system-data/`
+- Data coverage: product types, style patterns, colors, typography, UX guidelines, charts, landing patterns, icons, and stack guidelines
+- Usage boundary: design reasoning and design-system documentation only
+
+The data design follows ui ux pro max's organization model and is maintained under this repository's own paths and documentation.
 
 These references are only used for design reasoning. Even if raw data contains stack/code fields, final design documents must not include Tailwind config, CSS variable implementation, React/Vue/SwiftUI components, install commands, or engineering task lists.
 

--- a/agents/designer/README_zh.md
+++ b/agents/designer/README_zh.md
@@ -72,7 +72,13 @@ agents/designer/skills/visual-design/references/
 └── anti-patterns.md             # 通用与场景反模式
 ```
 
-`design-system-data/` 的数据设计参考了 ui ux pro max，包括产品类型、风格模式、颜色、字体、UX 规则、图表、landing pattern、icons 和 stack guideline 等维度。
+设计系统数据：
+
+- 本地路径：`agents/designer/skills/visual-design/references/design-system-data/`
+- 数据范围：产品类型、风格模式、颜色、字体、UX guidelines、charts、landing patterns、icons、stack guidelines
+- 使用边界：只用于设计推理和设计系统文档
+
+该数据设计参考了 ui ux pro max 的组织方式，并按本仓库自己的路径和文档结构维护。
 
 这些 references 只用于设计推理。即使原始数据中存在 stack/code 字段，最终设计文档也不能包含 Tailwind config、CSS 变量落地、React/Vue/SwiftUI 组件、安装命令或工程任务清单。
 

--- a/agents/engineer/README.md
+++ b/agents/engineer/README.md
@@ -65,6 +65,18 @@ flowchart LR
     Test --> Delivery["delivery"]
 ```
 
+## Engineering Guardrails
+
+Existing feature changes, bug fixes, and user-visible implementation should pass PRD/TRD alignment before engineering execution. Engineer confirms the TRD and `IMPLEMENTATION_PLAN.md` before implementation, then hands user-flow impact to QA through a QA E2E package.
+
+```mermaid
+flowchart LR
+    Align["PRD/TRD alignment"] --> TRD["TRD confirmed"]
+    TRD --> Plan["IMPLEMENTATION_PLAN confirmed"]
+    Plan --> Work["implementation / debug"]
+    Work --> QAHandOff["QA E2E handoff"]
+```
+
 ## Inputs And Outputs
 
 Engineer mainly consumes:

--- a/agents/engineer/README_zh.md
+++ b/agents/engineer/README_zh.md
@@ -65,6 +65,18 @@ flowchart LR
     Test --> Delivery["delivery"]
 ```
 
+## 工程门禁
+
+现有功能变更、bug fix 和用户可见实现应先完成 PRD/TRD 对齐，再进入工程执行。Engineer 在实现前确认 TRD 和 `IMPLEMENTATION_PLAN.md`；影响用户流程的实现完成后，通过 QA E2E 交接包移交给 QA。
+
+```mermaid
+flowchart LR
+    Align["PRD/TRD 对齐"] --> TRD["TRD 已确认"]
+    TRD --> Plan["IMPLEMENTATION_PLAN 已确认"]
+    Plan --> Work["实现 / 修复"]
+    Work --> QAHandOff["QA E2E handoff"]
+```
+
 ## 输入与产物
 
 Engineer 主要消费：

--- a/agents/qa/README.md
+++ b/agents/qa/README.md
@@ -73,6 +73,8 @@ Workflow:
 7. Store credentials only in `.qa/e2e/accounts.local.json` using account IDs from `agents/qa/skills/qa-agent/references/e2e-credential-store.md`; committed QA docs must not contain plaintext credentials.
 8. Write the main-agent report using `agents/qa/skills/qa-agent/references/e2e-test-report.md`.
 
+Credential storage details are defined in [`e2e-credential-store.md`](./skills/qa-agent/references/e2e-credential-store.md). E2E summary reports follow [`e2e-test-report.md`](./skills/qa-agent/references/e2e-test-report.md). Keep this README as a role guide instead of duplicating credential schema or report templates here.
+
 ## Typical Flow
 
 ```mermaid

--- a/agents/qa/README_zh.md
+++ b/agents/qa/README_zh.md
@@ -73,6 +73,8 @@ docs/qa/e2e/
 7. 凭据只写入 `.qa/e2e/accounts.local.json`，并按 `agents/qa/skills/qa-agent/references/e2e-credential-store.md` 使用账号 ID；提交文档不得包含明文凭据。
 8. 主 agent 汇总报告使用 `agents/qa/skills/qa-agent/references/e2e-test-report.md` 的固定格式。
 
+凭据存储细节以 [`e2e-credential-store.md`](./skills/qa-agent/references/e2e-credential-store.md) 为准，E2E 汇总报告以 [`e2e-test-report.md`](./skills/qa-agent/references/e2e-test-report.md) 为准。本 README 只保留角色说明，不复制凭据 schema 或报告模板。
+
 ## 典型工作流
 
 ```mermaid

--- a/docs/README.codex.md
+++ b/docs/README.codex.md
@@ -30,7 +30,7 @@ Codex 会先确认两个问题：
 
 Codex 会先把 skill 软链接解析到真实路径，再从该真实路径向上查找 `.codex-plugin/plugin.json` 或 `.claude-plugin/plugin.json`。本仓库为了兼容 Claude marketplace，必须保留 `agents/{role}/.claude-plugin/plugin.json`。
 
-如果 `~/.agents/skills/<skill-name>` 软链接到仓库 clone 内的 `agents/{role}/skills/<skill-name>`，Codex 会在祖先目录命中该 role 的 `plugin.json`，并给 skill 名加上 `Pm Agent:` 这类 namespace 前缀。镜像式安装会把仓库 `agents/` 树复制到 `~/.agents/skills/.dev-agent-skills/`，剔除 plugin manifest 和 agent test 目录，再在目标根目录创建 `~/.agents/skills/<skill-name> -> .dev-agent-skills/agents/{role}/skills/{skill-name}` 这类相对软链。解析后的真实路径仍在隐藏镜像内，祖先链不含 plugin manifest；共享 repo-relative skill references 保持原样可读，不需要 marker、support tree 或路径改写。详见 [issue #95](https://github.com/Neplich/dev-agent-skills/issues/95)。
+如果 `~/.agents/skills/<skill-name>` 软链接到仓库 clone 内的 `agents/{role}/skills/<skill-name>`，Codex 会在祖先目录命中该 role 的 `plugin.json`，并给 skill 名加上 `Pm Agent:` 这类 namespace 前缀。镜像式安装会把仓库 `agents/` 树复制到 `~/.agents/skills/.dev-agent-skills/`，剔除 plugin manifest 和 agent test 目录，再在目标根目录创建 `~/.agents/skills/<skill-name> -> .dev-agent-skills/agents/{role}/skills/{skill-name}` 这类相对软链。解析后的真实路径仍在隐藏镜像内，祖先链不含 plugin manifest；共享 repo-relative skill references 保持原样可读，不需要 support tree 或路径改写。详见 [issue #95](https://github.com/Neplich/dev-agent-skills/issues/95)。
 
 ```mermaid
 flowchart TD
@@ -110,9 +110,13 @@ python3 "$CLONE_ROOT/scripts/install_codex_skills.py" --target "$SKILL_ROOT" --r
 
 `--routers-only` 会输出警告，因为该模式只在目标根目录创建 6 个 role router 软链，`pm-agent` / role router 编排无法调用下游 specialist 工作流，只适合入口分类最小安装。隐藏镜像仍保留完整 `agents/` 树，供共享指令引用。
 
-脚本只管理两类目标：解析路径落在 `<skill-root>/.dev-agent-skills/` 内的软链，以及解析路径落在 dev-agent-skills checkout 内的旧软链。旧 checkout 软链会自动迁移到隐藏镜像软链。`<skill-root>/dev-agent-skills` legacy aggregate 若能证明归属，也会在安装前移除；非归属 aggregate 会告警并保留。
+`--target <path>` 指定可见 skill 软链所在目录；默认值是 `~/.agents/skills`。无论目标是个人级还是项目级，隐藏镜像都创建在 `<target>/.dev-agent-skills/`。
 
-真实目录或指向其他位置的软链都视为非归属目标：默认跳过，`--force` 会报错列出冲突项并在重建镜像或替换软链前退出。需要重建隐藏镜像并替换所有归属软链时使用 `--force`：
+隐藏镜像内的 `.dev-agent-skills-mirror.json` 是安装器 ownership marker。已有隐藏镜像若是软链，或包含这个 marker，才会被视为本安装器可管理；已有真实目录缺少 marker 时会报冲突，不会删除。
+
+脚本只管理两类目标：解析路径落在 `<target>/.dev-agent-skills/` 内的软链，以及解析路径落在 dev-agent-skills checkout 内的旧软链。旧 checkout 软链会自动迁移到隐藏镜像软链。`<target>/dev-agent-skills` legacy aggregate 若能证明归属，也会在安装前移除；非归属 aggregate 会告警并保留。
+
+真实目录、无 owner marker 的隐藏镜像、以及指向其他位置的软链都视为非归属目标：默认跳过或报冲突，`--force` 也不会删除它们。`--force` 的语义是重建隐藏镜像并替换所有归属软链；如果目标里存在非归属 skill 名冲突，脚本会列出冲突项并在修改前退出：
 
 ```bash
 python3 "$CLONE_ROOT/scripts/install_codex_skills.py" --target "$SKILL_ROOT" --force


### PR DESCRIPTION
## 概要

Closes #102

- 将根 `README.md` / `README_zh.md` 收敛为开源用户入口和文档索引，当前均为 136 行。
- 新增薄 `CONTRIBUTING.md`，只保留命令清单、CI 顺序、eval 维护清单和 `AGENTS.md` 权威规则链接。
- 将维护者/角色细节分流到 Codex Guide 与各 agent README，不修改脚本、marketplace、版本号或 CI 配置。

## 外移与删除内容去向

- 主 README 的 engineering guardrails Mermaid 图和说明：移入 `agents/engineer/README.md` / `agents/engineer/README_zh.md` 的工程门禁小节；根 README 仅保留一行指向 Engineer README。
- 主 README 的 Codex symlink 原理两段：根 README 仅保留安装命令和 Codex Guide 链接；镜像目录、installer marker、旧 checkout symlink 迁移、无主 symlink / 真实目录冲突处理、`--target` / `--force` 语义和 issue #95 说明合并到 `docs/README.codex.md`。
- 主 README 的按路径禁用单个 Codex skill 示例：保留在 `docs/README.codex.md` 的“按路径禁用单个 skill”小节，根 README 不再重复。
- 主 README 的 `Design System Data` 整节：移入 `agents/designer/README.md` / `agents/designer/README_zh.md` 的 `Visual Design References` 小节，包含本地路径、数据覆盖、使用边界和 ui ux pro max 组织模型说明。
- 主 README 的 `Local Validation` 整节：移入 `CONTRIBUTING.md` 的“本地验证”，保留 repository-contract、eval-contract、doc-contract、python-tests 顺序和完整命令。
- 主 README 的手动 eval 与 JSON 格式检查：移入 `CONTRIBUTING.md` 的“手动 Eval”和“本地验证”可选检查；详细规则继续指向 `AGENTS.md`。
- 主 README 的 `Maintenance Notes`：改为 `CONTRIBUTING.md` 的“维护索引”，只链接 `AGENTS.md` 对应章节，不复制权威规则。
- 主 README 的 `Eval maintenance flow` 和 `comparison.md` 模板：移入 `CONTRIBUTING.md` 的“Eval 维护清单”，详细 eval 规则仍指向 `AGENTS.md#skill-测试`。
- 主 README 的 `QA E2E Local Account File` 整节：根 README 删除；角色说明归入 `agents/qa/README.md` / `agents/qa/README_zh.md`，凭据 schema 与报告模板分别指向 `e2e-credential-store.md` 和 `e2e-test-report.md`，不在 README 复制凭据细节。
- 主 README 的 `Repository Structure` 整节：根入口删除；结构性规则继续由 `AGENTS.md` 与各 agent README 承接，根 README 的 `Documentation` 索引提供入口。
- 根 README 底部链接区：改为正文中的 `Documentation`、`Contributing` 和 `License` 段落，链接不丢失。

## 验证

- `uv run scripts/check_repository_contract.py`
- `uv run scripts/check_eval_contract.py`
- `uv run scripts/check_eval_artifacts.py`
- `uv run scripts/check_doc_contract.py`
- `uv run --with pytest pytest agents/product_manager/test/idea-to-spec agents/product_manager/test/pm-agent agents/qa/test/test_qa_run_eval.py agents/designer/test/test_designer_run_eval.py agents/devops/test/test_devops_run_eval.py agents/test_doc_contract.py agents/test_eval_contract.py scripts/test_install_codex_skills.py`
- 轻量相对链接检查通过