### PR TITLE
docs: 新增中文 CONTRIBUTING_zh 并将 CONTRIBUTING 英文化

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,14 @@
-# 贡献指南
+# Contributing Guide
 
-本文件只作为贡献者命令清单。仓库规则、文档契约、eval 策略、发布约束、commit / PR 文案和维护边界均以 [AGENTS.md](./AGENTS.md) 为权威。
+> Other languages: [中文](./CONTRIBUTING_zh.md)
 
-## 本地验证
+This file is only a contributor command list. Repository rules, document contracts, eval strategy, release constraints, commit / PR wording, and maintenance boundaries are all governed by [AGENTS.md](./AGENTS.md) as the single source of authority.
 
-仓库内 Python 验证脚本和 eval runner 默认使用 `uv run ...`。
+## Local Validation
 
-PR 检查按 CI 顺序执行：
+Python validation scripts and the eval runner in this repository use `uv run ...` by default.
+
+PR checks run in CI order:
 
 ```bash
 # 1. repository-contract
@@ -31,16 +33,16 @@ uv run --with pytest pytest \
   scripts/test_install_codex_skills.py
 ```
 
-可选 JSON 静态格式检查：
+Optional JSON static format check:
 
 ```bash
 uv run python -m json.tool .claude-plugin/marketplace.json >/tmp/marketplace.json.out
 uv run python -m json.tool skills-lock.json >/tmp/skills-lock.json.out
 ```
 
-## 手动 Eval
+## Manual Eval
 
-本地模型 eval 是质量检查，不属于第一版 PR 必跑 status check：
+Local model evals are quality checks and are not part of the first-round required PR status checks:
 
 ```bash
 # Designer eval diagnostics
@@ -50,19 +52,19 @@ uv run agents/designer/test/run_all_evals.py
 uv run agents/qa/test/run_all_evals.py
 ```
 
-涉及 skill 行为、routing、eval fixture 或 release readiness 的变更，按 [AGENTS.md](./AGENTS.md#skill-测试) 的 eval 策略执行。GitHub Actions 的 `Manual Evals` workflow 可选择 `all`、`designer` 或 `qa`；QA eval 需要仓库 `OPENAI_API_KEY` secret。
+Changes involving skill behavior, routing, eval fixtures, or release readiness follow the eval strategy in [AGENTS.md](./AGENTS.md#skill-测试). The GitHub Actions `Manual Evals` workflow accepts `all`, `designer`, or `qa`; the QA eval requires the repository `OPENAI_API_KEY` secret.
 
-## Eval 维护清单
+## Eval Maintenance Checklist
 
-仓库只保留 eval 定义和最新持久化结论，运行日志和 transcript 不进 git。详细规则见 [AGENTS.md](./AGENTS.md#skill-测试)。
+The repository keeps only eval definitions and the latest persisted conclusions; run logs and transcripts do not enter git. See [AGENTS.md](./AGENTS.md#skill-测试) for the detailed rules.
 
-1. 新建或更新 skill 与 eval fixture。
-2. 运行相关确定性检查和已批准的手动 eval。
-3. 将最新持久化结果写入 `comparison.md`。
-4. 开 PR 前删除运行期产物。
-5. 只提交 eval 定义、metadata、fixture、README 文件和 `comparison.md`。
+1. Create or update the skill and eval fixtures.
+2. Run the relevant deterministic checks and the approved manual evals.
+3. Write the latest persisted result into `comparison.md`.
+4. Remove runtime artifacts before opening a PR.
+5. Commit only eval definitions, metadata, fixtures, README files, and `comparison.md`.
 
-`comparison.md` 使用以下结构：
+`comparison.md` uses the following structure:
 
 ```markdown
 # Eval Result: <eval-name>
@@ -77,10 +79,10 @@ uv run agents/qa/test/run_all_evals.py
 ## Runtime Artifacts Policy
 ```
 
-## 维护索引
+## Maintenance Index
 
-- 仓库工作流、分支和 PR 规则：[AGENTS.md](./AGENTS.md#开发工作流)
-- 文档结构与 frontmatter 契约：[AGENTS.md](./AGENTS.md#文档组织)
-- release 与 changelog 规则：[AGENTS.md](./AGENTS.md#仓库治理)
-- skill eval schema 与 artifact 策略：[AGENTS.md](./AGENTS.md#skill-测试)
-- QA E2E 持久化与凭据处理：[AGENTS.md](./AGENTS.md#qa-e2e-测试用例持久化)
+- Repository workflow, branch, and PR rules: [AGENTS.md](./AGENTS.md#开发工作流)
+- Document structure and frontmatter contract: [AGENTS.md](./AGENTS.md#文档组织)
+- Release and changelog rules: [AGENTS.md](./AGENTS.md#仓库治理)
+- Skill eval schema and artifact policy: [AGENTS.md](./AGENTS.md#skill-测试)
+- QA E2E persistence and credential handling: [AGENTS.md](./AGENTS.md#qa-e2e-测试用例持久化)

--- a/CONTRIBUTING_zh.md
+++ b/CONTRIBUTING_zh.md
@@ -1,0 +1,88 @@
+# 贡献指南
+
+> 其他语言：[English](./CONTRIBUTING.md)
+
+本文件只作为贡献者命令清单。仓库规则、文档契约、eval 策略、发布约束、commit / PR 文案和维护边界均以 [AGENTS.md](./AGENTS.md) 为权威。
+
+## 本地验证
+
+仓库内 Python 验证脚本和 eval runner 默认使用 `uv run ...`。
+
+PR 检查按 CI 顺序执行：
+
+```bash
+# 1. repository-contract
+uv run scripts/check_repository_contract.py
+
+# 2. eval-contract
+uv run scripts/check_eval_contract.py
+uv run scripts/check_eval_artifacts.py
+
+# 3. doc-contract
+uv run scripts/check_doc_contract.py
+
+# 4. python-tests
+uv run --with pytest pytest \
+  agents/product_manager/test/idea-to-spec \
+  agents/product_manager/test/pm-agent \
+  agents/qa/test/test_qa_run_eval.py \
+  agents/designer/test/test_designer_run_eval.py \
+  agents/devops/test/test_devops_run_eval.py \
+  agents/test_doc_contract.py \
+  agents/test_eval_contract.py \
+  scripts/test_install_codex_skills.py
+```
+
+可选 JSON 静态格式检查：
+
+```bash
+uv run python -m json.tool .claude-plugin/marketplace.json >/tmp/marketplace.json.out
+uv run python -m json.tool skills-lock.json >/tmp/skills-lock.json.out
+```
+
+## 手动 Eval
+
+本地模型 eval 是质量检查，不属于第一版 PR 必跑 status check：
+
+```bash
+# Designer eval diagnostics
+uv run agents/designer/test/run_all_evals.py
+
+# QA model eval
+uv run agents/qa/test/run_all_evals.py
+```
+
+涉及 skill 行为、routing、eval fixture 或 release readiness 的变更，按 [AGENTS.md](./AGENTS.md#skill-测试) 的 eval 策略执行。GitHub Actions 的 `Manual Evals` workflow 可选择 `all`、`designer` 或 `qa`；QA eval 需要仓库 `OPENAI_API_KEY` secret。
+
+## Eval 维护清单
+
+仓库只保留 eval 定义和最新持久化结论，运行日志和 transcript 不进 git。详细规则见 [AGENTS.md](./AGENTS.md#skill-测试)。
+
+1. 新建或更新 skill 与 eval fixture。
+2. 运行相关确定性检查和已批准的手动 eval。
+3. 将最新持久化结果写入 `comparison.md`。
+4. 开 PR 前删除运行期产物。
+5. 只提交 eval 定义、metadata、fixture、README 文件和 `comparison.md`。
+
+`comparison.md` 使用以下结构：
+
+```markdown
+# Eval Result: <eval-name>
+
+## Evaluation Target
+## Test Set / Fixture Version
+## Latest Result
+## With Skill
+## Without Skill / Baseline
+## Failures
+## Next Steps
+## Runtime Artifacts Policy
+```
+
+## 维护索引
+
+- 仓库工作流、分支和 PR 规则：[AGENTS.md](./AGENTS.md#开发工作流)
+- 文档结构与 frontmatter 契约：[AGENTS.md](./AGENTS.md#文档组织)
+- release 与 changelog 规则：[AGENTS.md](./AGENTS.md#仓库治理)
+- skill eval schema 与 artifact 策略：[AGENTS.md](./AGENTS.md#skill-测试)
+- QA E2E 持久化与凭据处理：[AGENTS.md](./AGENTS.md#qa-e2e-测试用例持久化)

--- a/README_zh.md
+++ b/README_zh.md
@@ -123,13 +123,13 @@ PRD/TRD 对齐、实现计划确认和 QA E2E handoff 等工程门禁见 [Engine
 
 - [Codex Guide](./docs/README.codex.md)：Codex 安装模型、镜像机制、排障和按路径禁用。
 - [Agents Guide](./AGENTS.md)：agent 仓库指导、文档契约、维护流程、eval 规则和 PR 检查的唯一事实源。
-- [Contributing](./CONTRIBUTING.md)：本地验证命令和维护流程链接。
+- [Contributing](./CONTRIBUTING_zh.md)：本地验证命令和维护流程链接。
 - [Changelog Index](./CHANGELOG.md)：版本化 release changelog 入口。
 - Agent 文档：[PM](./agents/product_manager/README_zh.md)、[Designer](./agents/designer/README_zh.md)、[Engineer](./agents/engineer/README_zh.md)、[QA](./agents/qa/README_zh.md)、[DevOps](./agents/devops/README_zh.md)、[Security](./agents/security/README_zh.md)。
 
 ## 贡献
 
-本地检查和贡献流程见 [CONTRIBUTING.md](./CONTRIBUTING.md)。`AGENTS.md` 仍是仓库指导的唯一事实源。
+本地检查和贡献流程见 [CONTRIBUTING_zh.md](./CONTRIBUTING_zh.md)。`AGENTS.md` 仍是仓库指导的唯一事实源。
 
 ## License
 


### PR DESCRIPTION
## 背景

修复 issue #104。此前 `README_zh.md` 已将贡献指南链接改为 `CONTRIBUTING_zh.md`，但仓库中并无该文件，会产生坏链。按维护决策不回退中文 README 链接，改为新增真实的中文贡献入口。

## 改动

- 新增根目录 `CONTRIBUTING_zh.md`，作为中文贡献者命令清单与维护索引
- 将 `CONTRIBUTING.md` 改写为等价英文版，对齐仓库「基名英文、`_zh` 中文」约定
- 两文件顶部互加 `> 其他语言` 语言切换链接
- `README_zh.md` 两处贡献链接指向 `CONTRIBUTING_zh.md`
- `CONTRIBUTING_zh.md` 不复制 `AGENTS.md` 完整治理规则，仅保留命令清单与指针

## 验证

- `uv run scripts/check_repository_contract.py` PASS
- `uv run scripts/check_doc_contract.py` PASS
- 轻量链接检查：README / README_zh / CONTRIBUTING 双语互链，60 条相对链接全部解析

## 验收对照（issue #104）

- [x] `CONTRIBUTING_zh.md` 存在并被 git 跟踪
- [x] `README_zh.md` 中所有 `CONTRIBUTING_zh.md` 链接有效
- [x] `CONTRIBUTING_zh.md` 不复制 `AGENTS.md` 完整治理规则
- [x] `uv run scripts/check_doc_contract.py` 通过
- [x] 轻量链接检查通过

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)
