### PR TITLE
chore: 发布 v0.2.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "PM-first agent skill marketplace with one public pm-agent entry and downstream PM-orchestrated engineering, QA, DevOps, design, and security capabilities",
-    "version": "0.2.2"
+    "version": "0.2.3"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 仓库级发布变更记录按版本归档到 `docs/changelog/`。
 
+- [v0.2.3](./docs/changelog/changelog-v0.2.3.md)
 - [v0.2.2](./docs/changelog/changelog-v0.2.2.md)
 - [v0.2.1](./docs/changelog/changelog-v0.2.1.md)
 - [v0.2.0](./docs/changelog/changelog-v0.2.0.md)

--- a/agents/designer/.claude-plugin/plugin.json
+++ b/agents/designer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "designer-agent",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Downstream design capability invoked after pm-agent handoff for confirmed UX flows, information architecture, wireframes, reference-pattern analysis, and reference-backed visual system work.",
   "author": {
     "name": "Neplich"

--- a/agents/devops/.claude-plugin/plugin.json
+++ b/agents/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops-agent",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Downstream DevOps capability invoked after pm-agent handoff for confirmed deployment planning, CI/CD automation, environment audits, release readiness, rollback, and runbook preparation.",
   "author": {
     "name": "Neplich"

--- a/agents/engineer/.claude-plugin/plugin.json
+++ b/agents/engineer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "engineer-agent",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Downstream engineering capability invoked after pm-agent handoff for confirmed codebase analysis, TRDs, bootstrapping, implementation, tests, debugging, and delivery. Skills remain available for PM-orchestrated execution, not as standalone starting points.",
   "author": {
     "name": "Neplich"

--- a/agents/product_manager/.claude-plugin/plugin.json
+++ b/agents/product_manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pm-agent",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Default entry plugin for new user requests. Use when the user describes product ideas, feature requests, requirement changes, bugs, build/test/deploy/review/status requests, feature catalogs, competitive research, release communication, roadmaps, or GitHub project status. Classifies scope first, then routes to PM specialists or hands off to downstream role agents.",
   "author": {
     "name": "Neplich"

--- a/agents/qa/.claude-plugin/plugin.json
+++ b/agents/qa/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qa-agent",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Downstream QA capability invoked after pm-agent handoff for confirmed acceptance, exploratory testing, bug analysis, and regression verification. Requirement or implementation gaps return through the PM-orchestrated handoff path.",
   "author": {
     "name": "Neplich"

--- a/agents/security/.claude-plugin/plugin.json
+++ b/agents/security/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "security-agent",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Downstream security capability invoked after pm-agent handoff for confirmed AppSec, auth/authz, dependency risk, privacy, and data-flow reviews, with remediation routed through the PM handoff path.",
   "author": {
     "name": "Neplich"

--- a/docs/changelog/changelog-v0.2.3.md
+++ b/docs/changelog/changelog-v0.2.3.md
@@ -1,0 +1,51 @@
+---
+feature: release-changelog
+version: 0.2.3
+date: 2026-07-14
+last_updated: 2026-07-14
+---
+
+# Changelog - v0.2.3
+
+## [v0.2.3] - 2026-07-14
+
+聚焦 Codex 安装体验与入口路由的清晰化：新增 Codex 复制式安装脚本消除 plugin.json namespace 前缀（#97），修复安装器可能删除自身 checkout 的风险（#100），把 `pm-agent` 明确为唯一直接入口并收窄各 specialist 的触发面描述（#98），并重构 README / CONTRIBUTING 文档门面（#101 / #103 / #106）。无破坏性变更，已有安装可继续使用。
+
+### Added
+
+- **Codex 复制式安装脚本**：新增 `scripts/install_codex_skills.py`，以复制方式安装 skill，消除祖先 plugin manifest 造成的 namespace 前缀问题，并补充对应安装测试。([#97](https://github.com/Neplich/dev-agent-skills/pull/97))
+
+### Changed
+
+- **README 入口瘦身**：精简 README / README_zh 入口内容，将 Agents 明细、协作方式与维护流程分流到各自文档，突出 `pm-agent` 唯一直接入口与文档索引。([#103](https://github.com/Neplich/dev-agent-skills/pull/103))
+- **中文贡献入口**：新增中文 `CONTRIBUTING_zh.md` 承接 README_zh 的贡献链接，并将 `CONTRIBUTING.md` 英文化，两文件互加语言切换链接；`AGENTS.md` 仍为仓库治理唯一事实源。([#106](https://github.com/Neplich/dev-agent-skills/pull/106))
+- **README_zh Eval 维护说明补齐**：补齐 README_zh 中 Eval 维护流程缺失的说明段落，与英文 README 对齐。([#101](https://github.com/Neplich/dev-agent-skills/pull/101))
+
+### Fixed
+
+- **入口路由触发面收窄**：将 `pm-agent` 入口描述改为场景句式作为唯一直接入口，并把各 specialist 的 frontmatter `description` 收窄为「非直接入口、经 pm-agent 分类后调用」，消除下游 skill 抢占用户直达触发面的问题。([#98](https://github.com/Neplich/dev-agent-skills/pull/98))
+- **安装器自我删除防护**：修复安装器在特定路径下可能删除自身 checkout 的风险，避免复制式安装误删来源目录。([#100](https://github.com/Neplich/dev-agent-skills/pull/100))
+
+## Skill Eval 汇总（v0.2.3 发版前）
+
+本版唯一涉及 skill 行为的变更是 #98，且仅修改各 skill 的 frontmatter `description`（触发面收窄），**未改动任何 skill 的正文执行协议**，因此影响面是入口路由，由 6 个 dispatcher 的 routing eval 覆盖。
+
+#98 在合并（2026-07-08）时已对全部受影响的 dispatcher routing eval 完成 fresh Codex subagent validation 并同步更新 `comparison.md`，覆盖完整、无遗漏。按发版规则「skill 有更新且更新后遗漏测试才需重跑」，本版 skill 变更未漏测，发版直接复用最新 `comparison.md` 结论，不再重跑。
+
+### Routing Eval 结论（#98，dispatcher 维度）
+
+| Dispatcher | Routing eval | 结论 | 验证来源 |
+| --- | :---: | :---: | --- |
+| `pm-agent` | 13 | 全部 PASS | 2026-07-08 fresh Codex subagent validation |
+| `engineer-agent` | 4 | 全部 PASS | 2026-07-08 fresh Codex subagent validation |
+| `qa-agent` | 3 | 全部 PASS | 2026-07-08 fresh Codex subagent validation |
+| `designer-agent` | 3 | 全部 PASS | 2026-07-08 fresh Codex subagent validation |
+| `devops-agent` | 1 | 全部 PASS | 2026-07-08 fresh Codex subagent validation |
+| `security-agent` | 1 | 全部 PASS | 2026-07-08 fresh Codex subagent validation |
+| **合计** | **25** | **25 PASS / 0 FAIL** | — |
+
+各 routing eval 的 `comparison.md` 均记录 `No routing regression found from the PR #98 trigger-description changes`。
+
+### Specialist 执行 eval
+
+各 specialist 的执行协议（SKILL.md 正文）本版未变更，其执行类 eval 不受 #98 影响，沿用上一版本（v0.2.1 / v0.2.2）最新 `comparison.md` 结论，未重新运行。发版未新增 skill 执行协议变更，因此不触发 specialist 执行 eval 重跑。


### PR DESCRIPTION
## 背景

发布仓库正式版本 v0.2.3。基于当前 `main`，收尾 v0.2.2 之后合并的 6 个 PR，并按发布 checklist 更新版本注册与 changelog。

## 改动

- `.claude-plugin/marketplace.json` `metadata.version` 0.2.2 → 0.2.3
- 6 个 `agents/*/.claude-plugin/plugin.json` version 同步 0.2.2 → 0.2.3
- 新增 `docs/changelog/changelog-v0.2.3.md`
- 根 `CHANGELOG.md` 索引新增 v0.2.3 条目

## Changelog 摘要（v0.2.2..main 6 个 PR）

- **Added**：Codex 复制式安装脚本消除 plugin.json 前缀（#97）
- **Fixed**：入口路由触发面收窄，`pm-agent` 为唯一直接入口（#98）；安装器自我删除防护（#100）
- **Changed**：README 入口瘦身（#103）、中文 CONTRIBUTING_zh 承接（#106）、README_zh Eval 维护说明补齐（#101）

## Skill Eval 汇总

本版唯一 skill 行为变更是 #98，且仅改 frontmatter `description`（触发面收窄），未动正文执行协议。#98 合并（2026-07-08）时已对全部受影响的 6 个 dispatcher routing eval 完成 fresh Codex subagent validation 并更新 `comparison.md`，**25/25 全部 PASS、无遗漏**。按发版规则「skill 有更新且更新后遗漏测试才需重跑」，本版未漏测，直接复用现有结论，不重跑；specialist 执行协议未变，其执行类 eval 沿用上版。

## 验证

- `check_repository_contract.py` PASS
- `check_eval_contract.py` / `check_eval_artifacts.py` PASS
- `check_doc_contract.py` PASS
- python-tests：117 passed

## 发布 checklist

- [x] `marketplace.json` metadata.version = 0.2.3（不带 v 前缀）
- [x] 6 个 plugin.json version = 0.2.3
- [x] `docs/changelog/changelog-v0.2.3.md` 存在并被根 `CHANGELOG.md` 索引
- [x] PR CI 全绿
- [ ] 合并后在 main 打 tag `v0.2.3` 并 push（不自动创建 GitHub Release、不上传 marketplace package）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
