### PR TITLE
docs: 澄清 formal-docs-sync v0.3.0 的 API-only MVP 边界

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Downstream role routers and specialist skills remain installed as PM-orchestrate
 | `qa-agent` | Spec validation, exploratory testing, bug analysis, regression verification | 5 (`1 + 4`) | PM handoff only | [qa](./agents/qa/README.md) |
 | `devops-agent` | Deployment planning, CI/CD, environment configuration audits, incident playbooks | 5 (`1 + 4`) | PM handoff only | [devops](./agents/devops/README.md) |
 | `security-agent` | AppSec, authorization review, dependency risk, privacy data-flow mapping | 5 (`1 + 4`) | PM handoff only | [security](./agents/security/README.md) |
-| `docs-agent` | Formal documentation routing, site bootstrap, evidence-backed synchronization, and release audit | 4 (`1 + 3`) | PM handoff only | [docs](./agents/docs/README.md) |
+| `docs-agent` | Formal documentation routing, site bootstrap, evidence-backed synchronization (v0.3.0 accepted automation surface: API docs only), and release audit | 4 (`1 + 3`) | PM handoff only | [docs](./agents/docs/README.md) |
 
 > [!TIP]
 > Use `/pm-agent` as the direct user entry. PM classifies the request and hands off to downstream role routers or specialist skills when the scope is ready.

--- a/README_zh.md
+++ b/README_zh.md
@@ -89,7 +89,7 @@ python3 scripts/install_codex_skills.py --routers-only
 | `qa-agent` | 规范验收、探索测试、缺陷分析、回归验证 | 5 (`1 + 4`) | 仅 PM handoff | [qa](./agents/qa/README_zh.md) |
 | `devops-agent` | 部署规划、CI/CD、环境配置审计、故障手册 | 5 (`1 + 4`) | 仅 PM handoff | [devops](./agents/devops/README_zh.md) |
 | `security-agent` | 应用安全、授权审查、依赖风险、隐私数据流 | 5 (`1 + 4`) | 仅 PM handoff | [security](./agents/security/README_zh.md) |
-| `docs-agent` | 正式文档分流、站点初始化、证据驱动同步与发版审计 | 4 (`1 + 3`) | 仅 PM handoff | [docs](./agents/docs/README.md) |
+| `docs-agent` | 正式文档分流、站点初始化、证据驱动同步（v0.3.0 已验收自动化范围仅 API 文档）与发版审计 | 4 (`1 + 3`) | 仅 PM handoff | [docs](./agents/docs/README.md) |
 
 > [!TIP]
 > 直接用户入口使用 `/pm-agent`。PM 会先分类请求，范围明确后再 handoff 到下游 role router 或 specialist skill。

--- a/agents/docs/README.md
+++ b/agents/docs/README.md
@@ -26,7 +26,7 @@ requests to the matching documentation specialist.
 | --- | --- | --- |
 | `docs-agent` | Formal documentation request routing | Specialist selection or a bounded blocked handoff |
 | `docs-site-bootstrap` | The maintainer explicitly asks to initialize a formal documentation site | A technology-neutral `docs/site/` foundation and standards |
-| `formal-docs-sync` | A confirmed feature, deployment, release, or existing system needs formal documentation synchronization or backfill | Current-state formal docs and `change-map.yaml` updates; the MVP acceptance surface is API documentation |
+| `formal-docs-sync` | A confirmed feature, deployment, release, or existing system needs formal documentation synchronization or backfill | Current-state formal docs and `change-map.yaml` updates; the v0.3.0 accepted automation surface is API documentation only |
 | `docs-audit` | Release readiness requires formal-document coverage and fact verification | Version-scoped audit report, release recommendation, and unified version stamp when all pages are verified |
 
 ## Routing Rules
@@ -35,6 +35,25 @@ requests to the matching documentation specialist.
 - Feature, deployment, or release synchronization, or existing-system backfill:
   use `formal-docs-sync`.
 - Release documentation audit: use `docs-audit`.
+
+## `formal-docs-sync` Capability Boundary (v0.3.0)
+
+The v0.3.0 accepted automation surface is API documentation only. This is the
+current acceptance boundary, not the final product boundary of
+`formal-docs-sync`.
+
+- Feature delivery and existing-system backfill are accepted for API pages and
+  API `code_glob` entries only.
+- Deployment verification and release modes currently focus on evidence
+  checking, scope judgment, and handoff; they do not yet provide a fully
+  accepted synchronization surface.
+- Database, design, ops, and product formal docs still require manual
+  maintenance or a separate handoff; multi-type synchronization migration is
+  tracked in [#121](https://github.com/Neplich/dev-agent-skills/issues/121) and
+  is not shipped in v0.3.0.
+- Release notes are not part of `formal-docs-sync`; a dedicated documentation
+  release-notes skill is tracked in
+  [#116](https://github.com/Neplich/dev-agent-skills/issues/116).
 
 ## Collaboration Position
 

--- a/docs/changelog/changelog-v0.3.0.md
+++ b/docs/changelog/changelog-v0.3.0.md
@@ -13,7 +13,7 @@ last_updated: 2026-07-16
 
 ### Added
 
-- **第 7 个角色 `docs-agent`**：新增 router 与 3 个 specialist，形成 4-skill 终态。`docs-site-bootstrap` 以显式 opt-in、幂等和冲突门禁生成公开站点与内部站点骨架；`formal-docs-sync` 支持按变更影响域同步正式文档，并可按 feature catalog 或 API surface 分批回填存量项目；`docs-audit` 在发版前核对文档与代码事实，输出 verified / stale / mismatch 三态审计结论，存在 stale 或 mismatch 时阻止发布。([#108](https://github.com/Neplich/dev-agent-skills/pull/108)、[#110](https://github.com/Neplich/dev-agent-skills/pull/110)、[#111](https://github.com/Neplich/dev-agent-skills/pull/111))
+- **第 7 个角色 `docs-agent`**：新增 router 与 3 个 specialist，形成 4-skill 终态。`docs-site-bootstrap` 以显式 opt-in、幂等和冲突门禁生成公开站点与内部站点骨架；`formal-docs-sync` 支持按变更影响域同步正式文档，并可按 feature catalog 或 API surface 分批回填存量项目，v0.3.0 已验收的自动化范围仅为 API 文档，deployment / release 模式当前主要负责证据检查、范围判断与 handoff，database、design、ops、product 页面仍需人工维护或另行 handoff；`docs-audit` 在发版前核对文档与代码事实，输出 verified / stale / mismatch 三态审计结论，存在 stale 或 mismatch 时阻止发布。([#108](https://github.com/Neplich/dev-agent-skills/pull/108)、[#110](https://github.com/Neplich/dev-agent-skills/pull/110)、[#111](https://github.com/Neplich/dev-agent-skills/pull/111))
 - **正式文档消费契约**：新增共享 `consumption-contract.md`，覆盖 Product Manager、Engineer、QA、DevOps、Designer、Security 6 个既有 Agent 的 22 个 specialist；其中 21 个接入通用指针，`debugger` 增加 expected-behavior 安全规则，`release-notes-generator` 增加站点发布说明输出规则。契约要求以 change-map 定位文档、以代码和测试作为事实源，并结构化报告分歧。([#109](https://github.com/Neplich/dev-agent-skills/pull/109))
 - **PM 入口 Docs 路由**：`pm-agent` 与共享 skill map 增加正式文档 bootstrap、sync/backfill、audit 的分类与 handoff，Docs Agent 纳入 PM-first 协作链。([#110](https://github.com/Neplich/dev-agent-skills/pull/110)、[#111](https://github.com/Neplich/dev-agent-skills/pull/111))
 

--- a/docs/changelog/changelog-v0.3.0.md
+++ b/docs/changelog/changelog-v0.3.0.md
@@ -2,7 +2,7 @@
 feature: release-changelog
 version: 0.3.0
 date: 2026-07-16
-last_updated: 2026-07-16
+last_updated: 2026-07-17
 ---
 
 # Changelog - v0.3.0


### PR DESCRIPTION
## 目标

修正 v0.3.0 对外能力说明，使其与 `formal-docs-sync` 实际验收范围一致（issue #119，`change_tier: hotfix`）。

## 修改点

- `README.md` / `README_zh.md`：docs-agent 能力行标注 v0.3.0 已验收自动化范围仅 API 文档
- `agents/docs/README.md`：skills 表同步更新，并新增「`formal-docs-sync` Capability Boundary (v0.3.0)」章节，明确 API-only 验收面、deployment/release 模式的证据检查与 handoff 定位、database/design/ops/product 仍需人工维护或另行 handoff（#121 跟踪）、Release Notes 由 #116 的独立 Skill 负责
- `docs/changelog/changelog-v0.3.0.md`：Added 条目补充已验收范围限定

## 不在范围内

- 不扩展 `formal-docs-sync` 行为，不修改 SKILL.md 与 `_internal/` 指令
- v0.3.0 GitHub Release 正文修订需维护者批准后单独执行

## 验证

- `uv run scripts/check_repository_contract.py` 通过
- `uv run scripts/check_eval_contract.py` 通过
- `uv run scripts/check_eval_artifacts.py` 通过
- `uv run scripts/check_doc_contract.py` 通过
- `uv run --with pytest pytest <CI 同款路径集>` 126 passed

本次未修改任何 SKILL.md、`_internal/` 指令或 eval fixture，不触发 skill eval。

Closes #119
关联跟踪：#115

🤖 Generated with [Claude Code](https://claude.com/claude-code)
