### PR TITLE
docs: 同步贡献指南中的 Docs 测试与手动 Eval 入口

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,7 @@ uv run --with pytest pytest \
   agents/qa/test/test_qa_run_eval.py \
   agents/designer/test/test_designer_run_eval.py \
   agents/devops/test/test_devops_run_eval.py \
+  agents/docs/test/test_docs_run_eval.py \
   agents/test_doc_contract.py \
   agents/test_eval_contract.py \
   scripts/test_install_codex_skills.py
@@ -48,11 +49,14 @@ Local model evals are quality checks and are not part of the first-round require
 # Designer eval diagnostics
 uv run agents/designer/test/run_all_evals.py
 
+# Docs eval diagnostics
+uv run agents/docs/test/run_all_evals.py
+
 # QA model eval
 uv run agents/qa/test/run_all_evals.py
 ```
 
-Changes involving skill behavior, routing, eval fixtures, or release readiness follow the eval strategy in [AGENTS.md](./AGENTS.md#skill-测试). The GitHub Actions `Manual Evals` workflow accepts `all`, `designer`, or `qa`; the QA eval requires the repository `OPENAI_API_KEY` secret.
+Changes involving skill behavior, routing, eval fixtures, or release readiness follow the eval strategy in [AGENTS.md](./AGENTS.md#skill-测试). The GitHub Actions `Manual Evals` workflow accepts `all`, `designer`, `docs`, or `qa`; the QA eval requires the repository `OPENAI_API_KEY` secret.
 
 ## Eval Maintenance Checklist
 

--- a/CONTRIBUTING_zh.md
+++ b/CONTRIBUTING_zh.md
@@ -28,6 +28,7 @@ uv run --with pytest pytest \
   agents/qa/test/test_qa_run_eval.py \
   agents/designer/test/test_designer_run_eval.py \
   agents/devops/test/test_devops_run_eval.py \
+  agents/docs/test/test_docs_run_eval.py \
   agents/test_doc_contract.py \
   agents/test_eval_contract.py \
   scripts/test_install_codex_skills.py
@@ -48,11 +49,14 @@ uv run python -m json.tool skills-lock.json >/tmp/skills-lock.json.out
 # Designer eval diagnostics
 uv run agents/designer/test/run_all_evals.py
 
+# Docs eval diagnostics
+uv run agents/docs/test/run_all_evals.py
+
 # QA model eval
 uv run agents/qa/test/run_all_evals.py
 ```
 
-涉及 skill 行为、routing、eval fixture 或 release readiness 的变更，按 [AGENTS.md](./AGENTS.md#skill-测试) 的 eval 策略执行。GitHub Actions 的 `Manual Evals` workflow 可选择 `all`、`designer` 或 `qa`；QA eval 需要仓库 `OPENAI_API_KEY` secret。
+涉及 skill 行为、routing、eval fixture 或 release readiness 的变更，按 [AGENTS.md](./AGENTS.md#skill-测试) 的 eval 策略执行。GitHub Actions 的 `Manual Evals` workflow 可选择 `all`、`designer`、`docs` 或 `qa`；QA eval 需要仓库 `OPENAI_API_KEY` secret。
 
 ## Eval 维护清单
 


### PR DESCRIPTION
## 修改摘要

- 在中英文贡献指南的必跑 pytest 列表中加入 Docs Agent 确定性测试入口。
- 在中英文贡献指南的 Manual Eval 命令中加入 Docs eval diagnostics。
- 将中英文贡献指南中的 Manual Evals target 选项同步为 `all`、`designer`、`docs`、`qa`，与 `.github/workflows/ci.yml` 和 `.github/workflows/evals.yml` 对齐。

## 验证结果

以下命令全部通过：

```text
uv run scripts/check_repository_contract.py
uv run scripts/check_eval_contract.py
uv run scripts/check_eval_artifacts.py
uv run scripts/check_doc_contract.py
uv run --with pytest pytest agents/product_manager/test/idea-to-spec agents/product_manager/test/pm-agent agents/qa/test/test_qa_run_eval.py agents/designer/test/test_designer_run_eval.py agents/devops/test/test_devops_run_eval.py agents/docs/test/test_docs_run_eval.py agents/test_doc_contract.py agents/test_eval_contract.py scripts/test_install_codex_skills.py
```

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)
