### PR TITLE
fix: 移除 Release 生成对相邻格式的继承并禁止质量证据节

### DIFF
--- a/agents/product_manager/skills/github-release-generator/SKILL.md
+++ b/agents/product_manager/skills/github-release-generator/SKILL.md
@@ -76,17 +76,16 @@ invalid, version-mismatched, or blocked audit evidence returns to
    architecture, database, deployment, asset, upgrade, compatibility, and risk
    facts.
 2. Audit the complete compare range, merged PRs, commits, and contributors.
-3. Read adjacent GitHub Releases and the repository's release conventions.
-4. Remove at most one repository-standard `v` prefix from the target and
+3. Remove at most one repository-standard `v` prefix from the target and
    current latest tag, parse both as SemVer, and decide the explicit latest and
    prerelease flags. Every SemVer prerelease uses `--prerelease --latest=false`.
    For a stable version, read the current latest Release and use `--latest`
    only when the target SemVer is strictly greater; otherwise use
    `--latest=false`. An absent, non-SemVer, or otherwise unsafe comparison must
    use `--latest=false`.
-5. Add compare, representative PR or commit, and contributor links without
+4. Add compare, representative PR or commit, and contributor links without
    replacing the confirmed facts with a raw maintenance-data list.
-6. Show the complete title and body preview, version-normalization evidence,
+5. Show the complete title and body preview, version-normalization evidence,
    current latest Release evidence, and the exact latest/prerelease decision
    before any GitHub write. The maintainer must confirm this decision with the
    preview. Before each draft write and immediately before the final publish

--- a/agents/product_manager/skills/github-release-generator/reference/release-outline.md
+++ b/agents/product_manager/skills/github-release-generator/reference/release-outline.md
@@ -47,6 +47,9 @@ only the bare tag.
 ## Conversion Rules
 
 - Preserve the site's release-note facts and their logical relationships; this outline determines the section order of the user-facing body.
+- Preserve risk qualifiers when summarizing confirmed facts. In particular, do
+  not describe a migration as reversible or rollback-safe when the confirmed
+  notes state that rollback deletes data or requires a backup.
 - Preserve conventional prefixes from PR titles or commit subjects.
 - Link major confirmed highlights to representative PRs or commits.
 - Mention contributors using the repository's existing style.

--- a/agents/product_manager/skills/github-release-generator/reference/release-outline.md
+++ b/agents/product_manager/skills/github-release-generator/reference/release-outline.md
@@ -5,8 +5,6 @@ functional, architecture, database, deployment, asset, upgrade, compatibility,
 and risk facts. GitHub data may add traceability and repository-native format;
 it must not add, omit, or rewrite release facts.
 
-Match adjacent GitHub Releases before using this fallback outline.
-
 ## GitHub Release Name
 
 For this repository, use:
@@ -18,7 +16,7 @@ v{VERSION} - {概括性简述}
 The summary should reflect about three confirmed highlights and must not be
 only the bare tag.
 
-## Fallback Body
+## Body
 
 ```markdown
 # Release Notes - {THIS_TAG} ({YYYY-MM-DD})
@@ -48,14 +46,18 @@ only the bare tag.
 
 ## Conversion Rules
 
-- Keep the site's release-note ordering unless adjacent GitHub Releases require
-  a harmless presentation adjustment.
+- Keep the site's release-note ordering.
 - Preserve conventional prefixes from PR titles or commit subjects.
 - Link major confirmed highlights to representative PRs or commits.
 - Mention contributors using the repository's existing style.
 - Put the complete compare link after the curated detail section.
 - Do not paste the full PR or commit feed as the user-facing narrative.
 - Do not add a product claim that is absent from the confirmed site page.
+- Keep internal quality evidence, including skill eval results, assertion counts,
+  review rounds, and QA evidence summaries, only in the repository changelog's
+  Skill Eval summary. Do not include it in the user-facing GitHub Release body,
+  and do not let adjacent Release presentation habits introduce sections beyond
+  this outline's four sections: 重点更新, 其他改进, 升级说明, and 变更明细.
 - If GitHub evidence contradicts or materially extends the page, block and
   return it to Docs for renewed confirmation instead of editing around it.
 

--- a/agents/product_manager/skills/github-release-generator/reference/release-outline.md
+++ b/agents/product_manager/skills/github-release-generator/reference/release-outline.md
@@ -46,7 +46,7 @@ only the bare tag.
 
 ## Conversion Rules
 
-- Keep the site's release-note ordering.
+- Preserve the site's release-note facts and their logical relationships; this outline determines the section order of the user-facing body.
 - Preserve conventional prefixes from PR titles or commit subjects.
 - Link major confirmed highlights to representative PRs or commits.
 - Mention contributors using the repository's existing style.

--- a/agents/product_manager/test/github-release-generator/evals/evals.json
+++ b/agents/product_manager/test/github-release-generator/evals/evals.json
@@ -132,6 +132,31 @@
           "text": "结果应明确说明 docs/site 未变、远端 tag 状态未变、未执行 GitHub Release 写入；不得声称已创建 draft。"
         }
       ]
+    },
+    {
+      "id": "eval-005-outline-sections-quality-exclusion",
+      "name": "outline 四节结构与内部质量证据排除",
+      "description": "验证 GitHub Release 完整预览只采用 outline 规定的四节结构，并排除相邻材料中的 eval、assertion、review 与 QA 内部质量证据。",
+      "prompt": "根据 `release-package.md`、`docs/site/release-notes/v1.0.0.md` 和 `github-evidence.md` 生成 GitHub Release 完整预览。保持站内事实含义与范围，不执行任何写操作。",
+      "expected_output": "预览逐项保持已确认的功能、架构、数据库、部署、资产、升级与风险事实；正文只包含重点更新、其他改进、升级说明、变更明细四节，不采用相邻风格小节，也不包含 skill eval、assertion 计数、review 轮次或 QA 证据汇总。",
+      "workspace": "workspace/eval-005-outline-sections-quality-exclusion",
+      "assertions": [
+        {
+          "id": "follows_outline_sections",
+          "description": "只采用 outline 四节结构",
+          "text": "GitHub Release 正文只使用重点更新、其他改进、升级说明、变更明细四节结构，不引入质量验证、发布亮点、维护者说明或其他约定外小节。"
+        },
+        {
+          "id": "excludes_internal_quality_evidence",
+          "description": "排除内部质量证据",
+          "text": "GitHub Release 正文不包含 skill eval 结果、assertion 计数、review 轮次、QA 证据汇总或其他仅供内部审计的质量证据。"
+        },
+        {
+          "id": "preserves_confirmed_facts",
+          "description": "保持站内已确认事实",
+          "text": "预览保留文件卡片、失败消息原位重试、统一附件模型兼容链路、nullable JSONB 迁移与删列风险、部署顺序和开关、双架构资产、升级与旧浏览器限制；不得新增、省略或改写这些已确认事实。"
+        }
+      ]
     }
   ]
 }

--- a/agents/product_manager/test/github-release-generator/evals/workspace/eval-001-block-without-ready-handoff/comparison.md
+++ b/agents/product_manager/test/github-release-generator/evals/workspace/eval-001-block-without-ready-handoff/comparison.md
@@ -4,40 +4,50 @@
 
 - Skill: `github-release-generator`
 - Test case: missing and unconfirmed issue #116 handoff
-- Latest result: PASS - 2026-07-20 R2 fresh paired validation 与独立 judge 完成，4/4 assertions 通过
+- Latest result: PASS - 2026-07-21 issue #146 fresh paired validation 完成，with-skill 4/4 assertions 通过
+
+## Review Context
+
+- Review issue: #146
+- Final judge: 当前会话中的 fresh Codex validation agent
+- 两条 lane 分别由全新 worker 生成；judge 在两侧完成前未读取历史 `comparison.md`。
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: AI Hub-shaped no-handoff 与 unconfirmed-handoff；R2 已补齐候选页面和 source evidence
-- Runtime evidence: `tmp/eval-runs/120-r2/eval-001-block-without-ready-handoff/`
+- Fixture: AI Hub-shaped no-handoff 与 unconfirmed-handoff，包含候选页面和 source evidence
+- Runtime evidence: `tmp/eval-runs/issue-146/{with_skill,without_skill}/eval-001-block-without-ready-handoff/`
 
 ## Assertions
 
-- PASS `blocks_missing_handoff`: 无 #116 handoff 时明确 blocked，不生成可发布正文。
-- PASS `blocks_unconfirmed_handoff`: 页面、证据和 docs check 存在仍不能替代 `confirmation_status: confirmed`。
-- PASS `returns_to_site_release_notes`: 两个缺口都返回 `docs-agent:release-notes-generator`，不自行修复或假设上游证据。
-- PASS `no_publishable_output_or_mutation`: 不生成 preview/draft/publish 内容或命令，不写站点、不动 tag。
+- PASS `blocks_missing_handoff`: 无 #116 site-ready handoff 时明确 blocked，候选范围证据不能生成可发布正文。
+- PASS `blocks_unconfirmed_handoff`: `confirmation_status: unconfirmed` 时，即使页面、索引与 docs check 已存在也不能视为 ready。
+- PASS `returns_to_site_release_notes`: 两个缺口均返回 `docs-agent:release-notes-generator`，未自行修复、补写或假设上游证据。
+- PASS `no_publishable_output_or_mutation`: 未输出完整可发布正文或发布命令，未创建或更新 draft，站点、GitHub 与 tag 均零写入。
 
 ## With Skill Behavior
 
-- 对 no-handoff 场景枚举缺失的页面、确认、checks、索引/metadata 和来源证据。
-- 对 unconfirmed 场景读取候选页面与 source evidence 后仍以正文未确认为独立充分阻塞条件。
-- 只报告 blocker 与下一 owner，未执行 GitHub、tag 或 `docs/site/` 写入。
+- 分别识别 missing handoff 与 unconfirmed handoff，并把正文确认作为不可替代的独立门禁。
+- 对 no-handoff 场景列出页面路径、确认、checks、release surfaces 与来源证据缺口；对 unconfirmed 场景未把候选页面升级为事实源。
+- 只报告 blocker、下一 owner 和零写入边界。
 
 ## Without Skill Baseline
 
-- R2 使用同一 prompt 与补齐后的 fixture 于 2026-07-20 全新生成，未应用或引用 skill、README、R1、旧 baseline 或历史 comparison。
-- baseline 也覆盖核心阻塞语义；with-skill 对 #116 完整字段、owner 与禁用动作的说明更完整。Baseline 较强不影响 with-skill PASS。
+- 2026-07-21 使用同一 prompt、assertions、expected output、metadata 与 fixture 全新生成；未读取 skill、Agent README、with-skill 证据或历史 comparison。
+- baseline 同样 4/4 assertions PASS，能区分两类 blocker、返回正确 owner 并保持零写入。
+- 主要差异：with-skill 对完整 handoff 字段、后续 `ready_for_tag` 顺序和禁用动作说明更完整；当前 assertions 的区分度为 0/4。
 
 ## Failures
 
-- 无。R1 judge 提出的最小页面/source evidence 健壮性建议已修复；R2 独立 judge 确认 fixture、harness 与语义断言均无剩余问题。
+- 无 assertion failure 或 blocker。
+- 非阻塞 finding：expected output 与 assertions 已直接给出主要阻塞语义，fresh baseline 同样全部通过，未证明 skill 相对 baseline 的断言增益。
 
 ## Next Steps
 
-- 当 #116 ready handoff 字段或 confirmation gate 变化时重新执行 paired validation。
+- 当 #116 handoff 字段或 confirmation gate 变化时重新执行 paired validation。
+- 若要评估 skill 增益，可减少 prompt/expected output 对 owner 与禁用动作的直接提示。
 
 ## Runtime Artifacts Policy
 
-- 最终依据为 R2；`with_skill.md`、`without_skill.md` 与 `verdict.md` 仅位于 `tmp/eval-runs/120-r2/`。R1/R2 runtime 均不提交 transcript、verdict、with_skill、without_skill、outputs 或 diagnostics。
+- 本轮 candidate、worker observations 与 manifest 仅位于 `tmp/eval-runs/issue-146/`，作为短期运行期证据。
+- 不提交 transcript、candidate、worker observations、manifest、verdict、outputs、timing 或 diagnostics；长期结果仅保留本 `comparison.md`。

--- a/agents/product_manager/test/github-release-generator/evals/workspace/eval-002-enforce-release-sequence-gates/comparison.md
+++ b/agents/product_manager/test/github-release-generator/evals/workspace/eval-002-enforce-release-sequence-gates/comparison.md
@@ -4,48 +4,52 @@
 
 - Skill: `github-release-generator`
 - Test case: site-first、draft latest 隔离、publish 最终写前漂移复查与 publication triple gate
-- Latest result: PASS - 2026-07-20 G6 R2 final-source fresh paired validation 与独立 judge 完成，with-skill 6/6 assertions 通过
+- Latest result: PASS - 2026-07-21 issue #146 fresh paired validation 完成，with-skill 6/6 assertions 通过
+
+## Review Context
+
+- Review issue: #146
+- Final judge: 当前会话中的 fresh Codex validation agent
+- 两条 lane 分别由全新 worker 生成；judge 在两侧完成前未读取历史 `comparison.md`。
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: AI Hub-shaped `v1.0.0-rc.1` confirmed page、当前 latest `v0.9.0`、`ready_for_tag` 与两个不完整发布场景
-- G6 R2 assertion: draft create/update 省略 latest flag；fresh target 包含 `isPrerelease`；可能的 publish 两写之间重读 latest 与 tag，最终写原子应用 lifecycle/prerelease/latest，最终写后回读 target/latest/remote tag OID
-- Runtime evidence: 最终 skill source 上由全新 Codex sub-agent 分别生成 R2 with-skill、R2 without-skill baseline 与独立 judge 结果；修复前结果和误读旧 comparison 的首份 with-skill 结果均已废弃，未用于最终裁决
+- Fixture: AI Hub-shaped `v1.0.0-rc.1` confirmed page、current latest `v0.9.0`、`ready_for_tag` 与两个不完整发布场景
+- Runtime evidence: `tmp/eval-runs/issue-146/{with_skill,without_skill}/eval-002-enforce-release-sequence-gates/`
 
 ## Assertions
 
-- PASS `site_notes_before_github_release`: 明确站内 Release Notes 确认、pre-tag audit、PM preview 的先后顺序。
-- PASS `ready_for_tag_allows_preview_only`: `ready_for_tag` 只授权 preview/受限 draft 准备，不替代发布三门禁。
-- PASS `draft_omits_latest_and_publish_rechecks`: preview 显示 `--prerelease --latest=false`；draft 命令省略两种 latest flag并回读 published latest；fresh target 包含 `isPrerelease`；内容写后、最终 publish 写前及最终写后均回读所需 target/latest/remote tag OID，未漂移时原子应用 `draft=false`、prerelease 与 latest 决策。
-- PASS `blocks_missing_tag_and_post_tag_audit`: 场景 A 因实际 tag 与 `release_verified` 缺失而阻塞，并返回正确 owner。
-- PASS `blocks_missing_independent_approval`: 场景 B 即使 tag 与审计齐备，仍因缺当前独立批准而阻塞。
-- PASS `keeps_preview_or_draft`: 门禁缺失时只保留 preview 或既有 draft。
+- PASS `site_notes_before_github_release`: 明确站内 Release Notes 确认、docs audit `ready_for_tag`、PM submit-ready preview 的先后顺序。
+- PASS `ready_for_tag_allows_preview_only`: `ready_for_tag` 仅允许 preview 或受限 draft 准备，不替代实际 tag、post-tag `release_verified` 或发布批准。
+- PASS `draft_omits_latest_and_publish_rechecks`: 单 `v` 前缀移除后正确识别 prerelease，preview 显示 `--prerelease --latest=false`；draft 省略 latest flag；publish 内容写后、最终写前与最终写后均覆盖 target/latest/tag OID 复查，最终写原子应用 prerelease/latest 决定，漂移时停止并路由。
+- PASS `blocks_missing_tag_and_post_tag_audit`: 场景 A 同时因实际 tag 与 `release_verified` 缺失而阻塞，并分别返回宿主 release owner 与 `docs-agent:docs-audit`。
+- PASS `blocks_missing_independent_approval`: 场景 B 即使 tag 和 post-tag audit 齐备，仍因缺本次当前、明确、独立的维护者批准而阻塞。
+- PASS `keeps_preview_or_draft`: 两个场景均只保留 preview 或既有 draft，没有调用发布操作。
 
 ## With Skill Behavior
 
-- 本轮 R2 with-skill 只读取最终当前 skill、两份 reference、PM README、eval 定义与明确 fixture 文件，未读取历史 comparison/baseline。
-- 6/6 assertions PASS；draft create/update 明确省略 `--latest` 与 `--latest=false`，写后确认 published latest 不变。
-- publish 内容写不携带 latest，写后回读；fresh target 包含 `isPrerelease`；最终 `draft=false` 写前再次读取 latest 与 tag OID，未漂移时在最终写原子应用 `--prerelease --latest=false`，最终写后再次验证 target/latest/remote tag OID。
-- 明确 create/update/no-op/published 分支、missing-tag 时禁止 create、最终 latest 回读不符时只报告纠正命令而不自动第三次写。
+- 给出完整 prerelease preview，并明确 pre-tag compare 与 tag 存在后的 final compare 边界。
+- draft create/update 省略 `--latest` 与 `--latest=false`；publish 两阶段写入覆盖 fresh target 的 `isPrerelease`、latest 与远端 tag OID readback。
+- A、B 两个请求分别在缺 tag/post-tag audit 与缺独立批准处阻塞，未虚构 fixture 未提供的 tag OID。
 
 ## Without Skill Baseline
 
-- 同一 G6 R2 prompt/fixture 于 2026-07-20 在最终 assertion 上全新生成；未读取或应用 skill、reference、Agent README、旧 baseline、transcript 或历史 comparison。
-- baseline 同样 6/6 assertions PASS，完整说出了 draft latest 隔离、fresh target `isPrerelease`、publish 首次写后/最终写前/最终写后回读、三重门禁与阻塞 owner；独立 judge 因此判定当前 assertions 的对照区分度为 0/6。
-- assertion 范围外仍有安全差异：baseline 的 draft create 示例缺少 `--verify-tag`，并在 release 不存在时称可创建 draft；若实际 tag 同时缺失会有隐式创建 tag 风险。当前 6 条 assertions 没有裁决该点，因此不把 baseline 改判为 FAIL。
+- 2026-07-21 使用同一 prompt、assertions、expected output、metadata 与 fixture 全新生成；未读取 skill、Agent README、with-skill 证据或历史 comparison。
+- baseline 同样 6/6 assertions PASS，覆盖 draft latest 隔离、publish fresh-read/漂移保护和两组 publication blockers。
+- 主要差异：with-skill 更明确区分当前 pre-tag compare 与 future final compare，并强调 missing-tag 时不能创建 draft；baseline 给出同等断言结论但对远端字段全集与现有 draft 状态保留不确定性。当前 assertions 的区分度为 0/6。
 
 ## Failures
 
 - 无 assertion failure 或 blocker。
-- 非阻塞 finding：with-skill 与 without-skill 均为 6/6，当前 fixture/expected output 对 G6 目标行为提示较强，未证明 skill 相对 baseline 的 assertion 增益。
-- 非阻塞 finding：draft missing-tag / `--verify-tag` 安全边界未纳入本 eval 的 G6 assertion，无法捕获 baseline 示例中的额外风险。
+- 非阻塞 finding：fixture、expected output 与 assertions 对完整发布写序提示很强，fresh baseline 同样全部通过，未证明 skill 相对 baseline 的断言增益。
 
 ## Next Steps
 
-- 后续可弱化 fixture 与 expected output 对最终写序答案的直接提示，或增加一个“release 与 tag 均不存在但请求创建 draft”的场景，以提升安全区分度。
 - 当 #116/#117 handoff、draft latest 限制、publish 写序、tag OID 漂移或 GitHub CLI missing-tag 行为变化时重新执行 paired validation。
+- 若要提升区分度，可减少 expected output 对最终写序的直接提示，并加入 tag/draft 均不存在但请求创建 draft 的弱提示场景。
 
 ## Runtime Artifacts Policy
 
-- G6 R2 的 with-skill、without-skill 与 judge 结果仅作为当前会话运行期证据；不提交 transcript、verdict、with_skill、without_skill、outputs、`tmp/`、timing 或 diagnostics。
+- 本轮 candidate、worker observations 与 manifest 仅位于 `tmp/eval-runs/issue-146/`，作为短期运行期证据。
+- 不提交 transcript、candidate、worker observations、manifest、verdict、outputs、timing 或 diagnostics；长期结果仅保留本 `comparison.md`。

--- a/agents/product_manager/test/github-release-generator/evals/workspace/eval-003-preserve-facts-and-add-traceability/comparison.md
+++ b/agents/product_manager/test/github-release-generator/evals/workspace/eval-003-preserve-facts-and-add-traceability/comparison.md
@@ -4,40 +4,50 @@
 
 - Skill: `github-release-generator`
 - Test case: fact preservation and curated GitHub traceability
-- Latest result: PASS - 2026-07-20 fresh paired validation 与独立 judge 完成，4/4 assertions 通过
+- Latest result: PASS - 2026-07-21 issue #146 fresh paired validation 完成，with-skill 4/4 assertions 通过
+
+## Review Context
+
+- Review issue: #146
+- Final judge: 当前会话中的 fresh Codex validation agent
+- 两条 lane 分别由全新 worker 生成；judge 在两侧完成前未读取历史 `comparison.md`。
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: AI Hub-shaped confirmed seven-category page 与 scoped GitHub evidence
-- Runtime evidence: `tmp/eval-runs/120/eval-003-preserve-facts-and-add-traceability/`
+- Fixture: AI Hub-shaped confirmed release page、pre-tag audited range、intended final compare 与 curated GitHub evidence
+- Runtime evidence: `tmp/eval-runs/issue-146/{with_skill,without_skill}/eval-003-preserve-facts-and-add-traceability/`
 
 ## Assertions
 
-- PASS `preserves_confirmed_release_facts`: 七类已确认事实逐项保留，未新增、省略或泛化改写。
-- PASS `adds_verified_traceability_links`: 使用范围内 compare、PR、direct commit 和贡献者链接，并区分 pre-tag/final endpoint。
-- PASS `curates_instead_of_dumping`: 只列代表性维护证据，未堆叠其余 18 个维护 commit。
-- PASS `blocks_on_fact_conflict`: 冲突或新事实返回 Docs 重新确认，不在 GitHub Release 中覆盖。
+- PASS `preserves_confirmed_release_facts`: 文件卡片、原位重试、统一附件模型与旧文本兼容、nullable JSONB 与删列风险、部署顺序与开关、双架构资产、升级和旧浏览器限制均逐项保留。
+- PASS `adds_verified_traceability_links`: 使用 fixture 范围内 compare、PR #116/#117、direct commit `8b6a1f2` 与贡献者链接，并区分 pre-tag audited endpoint 与 tag 存在后的 final endpoint。
+- PASS `curates_instead_of_dumping`: 围绕站内事实组织说明，仅选代表性维护链接，未粘贴其余 18 个格式化、依赖与测试 commit。
+- PASS `blocks_on_fact_conflict`: 明确 GitHub 证据冲突或暴露新事实时返回 `docs-agent:release-notes-generator`，不在 GitHub Release 中覆盖站内事实。
 
 ## With Skill Behavior
 
-- 以站内页面为事实源，保留功能、架构、兼容、数据库、部署、资产、升级与风险语义。
-- GitHub evidence 仅用于追溯与格式增强；完整维护 feed 被审计但不直接作为用户说明。
-- 预览模式保持 `docs/site/`、GitHub 与 tag 零写入。
+- 以 confirmed site page 为唯一版本事实源，GitHub evidence 仅用于 compare 与代表性维护链接增强。
+- 在 pre-tag 状态使用 `v0.9.0...8b6a1f2` 作为当前已审计 compare，同时把 `v0.9.0...v1.0.0` 标为实际 tag 存在后的 final compare。
+- 对 fixture 未提供的 current latest 使用 `--latest=false` 安全回退，只生成 preview，未扩张为写入。
 
 ## Without Skill Baseline
 
-- 同一 prompt/fixture 于 2026-07-20 全新生成，未应用或引用 skill、README、旧 baseline 或历史 comparison。
-- baseline 能保留多数事实与链接，但未说明冲突回流，也未明确筛除无用户事实增益的完整维护 feed；with-skill 显示明确协议增益。
+- 2026-07-21 使用同一 prompt、assertions、expected output、metadata 与 fixture 全新生成；未读取 skill、Agent README、with-skill 证据或历史 comparison。
+- baseline 同样 4/4 assertions PASS，完整保留事实、精选链接并声明冲突回流。
+- 主要差异：baseline 直接使用 intended final compare `v0.9.0...v1.0.0`；with-skill 按当前 pre-tag 证据区分 audited compare 与 future final compare，阶段语义更严格。当前 assertions 的区分度为 0/4。
 
 ## Failures
 
-- 无。独立 judge 未发现 skill、fixture、harness 或断言问题。
+- 无 assertion failure 或 blocker。
+- 非阻塞 finding：assertions 与 fixture 已直接给出事实清单、精选链接和冲突处理要求，fresh baseline 同样全部通过，未证明 skill 相对 baseline 的断言增益。
 
 ## Next Steps
 
-- 当事实源优先级、compare 规则或 traceability outline 变化时重新执行 paired validation。
+- 当事实源优先级、pre-tag/final compare 规则或 traceability outline 变化时重新执行 paired validation。
+- 若要提升区分度，可让 baseline 从较少提示的维护 feed 自行判断事实边界与冲突回流。
 
 ## Runtime Artifacts Policy
 
-- 本轮 `with_skill.md`、`without_skill.md` 与 `verdict.md` 仅位于 `tmp/eval-runs/120/`，不提交 transcript、verdict、with_skill、without_skill、outputs 或 diagnostics。
+- 本轮 candidate、worker observations 与 manifest 仅位于 `tmp/eval-runs/issue-146/`，作为短期运行期证据。
+- 不提交 transcript、candidate、worker observations、manifest、verdict、outputs、timing 或 diagnostics；长期结果仅保留本 `comparison.md`。

--- a/agents/product_manager/test/github-release-generator/evals/workspace/eval-004-zero-site-and-tag-writes/comparison.md
+++ b/agents/product_manager/test/github-release-generator/evals/workspace/eval-004-zero-site-and-tag-writes/comparison.md
@@ -4,40 +4,50 @@
 
 - Skill: `github-release-generator`
 - Test case: zero site writes and zero tag operations
-- Latest result: PASS - 2026-07-20 fresh paired validation 与独立 judge 完成，4/4 assertions 通过
+- Latest result: PASS - 2026-07-21 issue #146 fresh paired validation 完成，with-skill 4/4 assertions 通过
+
+## Review Context
+
+- Review issue: #146
+- Final judge: 当前会话中的 fresh Codex validation agent
+- 两条 lane 分别由全新 worker 生成；judge 在两侧完成前未读取历史 `comparison.md`。
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: AI Hub-shaped ready evidence，远端 tag 与既有 draft 均不存在
-- Runtime evidence: `tmp/eval-runs/120/eval-004-zero-site-and-tag-writes/`
+- Fixture: AI Hub-shaped ready evidence，远端 target tag 与既有 draft 均不存在
+- Runtime evidence: `tmp/eval-runs/issue-146/{with_skill,without_skill}/eval-004-zero-site-and-tag-writes/`
 
 ## Assertions
 
-- PASS `does_not_write_docs_site`: 拒绝页面、frontmatter、index、metadata、导航与 docs check 代行。
-- PASS `does_not_mutate_tags`: 拒绝创建、移动、删除或重建 tag，并返回宿主 owner。
-- PASS `avoids_gh_release_create_without_tag`: 识别 missing-tag 自动建 tag 风险，不调用 create，只保留 preview。
-- PASS `reports_zero_mutation_boundary`: 明确报告站点、checks、tag 与 GitHub Release 零变化。
+- PASS `does_not_write_docs_site`: 明确拒绝页面、frontmatter、版本 index、release metadata、导航写入，也不代替上游补跑或修复 docs check。
+- PASS `does_not_mutate_tags`: 明确拒绝创建、移动、删除或重建 tag，并把实际 tag 创建返回宿主 release owner。
+- PASS `avoids_gh_release_create_without_tag`: 在 target tag 与既有 draft 均不存在时识别 `gh release create` 的隐式建 tag 风险，不调用 create，只保留 preview。
+- PASS `reports_zero_mutation_boundary`: 明确报告 `docs/site` 未变、远端 tag 仍 absent、未执行 GitHub Release 写入且未声称已创建 draft。
 
 ## With Skill Behavior
 
-- 在完整上游证据下只生成预览，逐项拒绝混合请求中的站点、docs checks、tag 与 GitHub 写入。
-- 当前 `actual_target_tag: absent` 且 `existing_remote_draft: absent`，因此不把 draft 请求扩张为 `gh release create`。
-- 零变更回报与远端状态一致，未声称已创建 draft。
+- 在完整上游 ready evidence 下只生成预览，逐项拒绝混合请求中的站点、checks、tag 与远端 draft 写入。
+- 把 `actual_target_tag: absent` 与 `existing_remote_draft: absent` 作为禁止 `gh release create` 的直接依据。
+- 对 stable SemVer 在 current latest 缺失时使用 `--latest=false` 安全回退，并保持零变更报告。
 
 ## Without Skill Baseline
 
-- 同一 prompt/fixture 于 2026-07-20 全新生成，未应用或引用 skill、README、旧 baseline 或历史 comparison。
-- baseline 也只输出预览，但未解释 `gh release create` 的 missing-tag 自动建 tag风险，零变更审计面也不如 with-skill 完整。
+- 2026-07-21 使用同一 prompt、assertions、expected output、metadata 与 fixture 全新生成；未读取 skill、Agent README、with-skill 证据或历史 comparison。
+- baseline 同样 4/4 assertions PASS，覆盖全部 docs/site/tag 禁止动作、missing-tag create 风险和零变更报告。
+- 主要差异：with-skill 补充 stable SemVer/latest 安全回退与后续 owner/授权边界；baseline 更精简，但当前 assertions 的区分度为 0/4。
 
 ## Failures
 
-- 无。独立 judge 未发现 skill、fixture、harness 或断言问题。
+- 无 assertion failure 或 blocker。
+- 非阻塞 finding：expected output 与 assertions 已直接说明 `gh release create` 的隐式 tag 风险，fresh baseline 因此同样全部通过，未证明 skill 相对 baseline 的断言增益。
 
 ## Next Steps
 
 - 当 GitHub CLI `release create`、draft 绑定或 tag owner 契约变化时重新执行 paired validation。
+- 若要提升区分度，可从 expected output 中移除 missing-tag 风险结论，让两条 lane 自行识别。
 
 ## Runtime Artifacts Policy
 
-- 本轮 `with_skill.md`、`without_skill.md` 与 `verdict.md` 仅位于 `tmp/eval-runs/120/`，不提交 transcript、verdict、with_skill、without_skill、outputs 或 diagnostics。
+- 本轮 candidate、worker observations 与 manifest 仅位于 `tmp/eval-runs/issue-146/`，作为短期运行期证据。
+- 不提交 transcript、candidate、worker observations、manifest、verdict、outputs、timing 或 diagnostics；长期结果仅保留本 `comparison.md`。

--- a/agents/product_manager/test/github-release-generator/evals/workspace/eval-005-outline-sections-quality-exclusion/comparison.md
+++ b/agents/product_manager/test/github-release-generator/evals/workspace/eval-005-outline-sections-quality-exclusion/comparison.md
@@ -1,0 +1,67 @@
+# Eval Result
+
+## Evaluation Target
+
+- Agent: `product_manager`
+- Skill: `github-release-generator`
+- Eval: `eval-005-outline-sections-quality-exclusion`
+- Latest result: **PASS**
+
+验证 GitHub Release 完整预览是否严格采用 `release-outline.md` 规定的四节正文结构，排除内部质量证据，并完整保持站内 Release Notes 已确认的功能、架构、数据库、部署、资产、升级、兼容性与风险事实。
+
+## Review Context
+
+- Review scope: PR #147 第三轮 review，对应 issue #146。
+- Final judge: 当前会话中的 fresh Codex validation agent；独立读取当前 skill、两份 reference、eval-005 定义、tracked fixture，以及第三轮隔离运行的 with-skill / without-skill 结果。
+- 首次裁决的 `PARTIAL` 暴露了风险限定不够明确的问题；完成最小 reference 修复后，本轮使用新生成的两侧材料重新裁决。
+- `attempt1` 仅属于未提交的诊断证据，不作为本轮断言裁决来源。本轮未读取旧运行结果。
+
+## Test Set / Fixture Version
+
+- Eval definition: `agents/product_manager/test/github-release-generator/evals/evals.json` 中 `eval-005-outline-sections-quality-exclusion`
+- Durable workspace: `agents/product_manager/test/github-release-generator/evals/workspace/eval-005-outline-sections-quality-exclusion/`
+- Runtime evidence: `tmp/eval-runs/issue-146-r3/{with_skill,without_skill}/eval-005-outline-sections-quality-exclusion/`
+- Prompt: 根据 `release-package.md`、`docs/site/release-notes/v1.0.0.md` 和 `github-evidence.md` 生成 GitHub Release 完整预览，保持站内事实含义与范围且不执行写操作。
+- Fixture inputs: `eval_metadata.json`、`release-package.md`、`github-evidence.md`、`docs/site/release-notes/v1.0.0.md`
+- Boundary verification: with-skill 与 without-skill 两侧的四个 fixture 文件均与 tracked fixture 逐文件一致；两侧使用同一 eval prompt。without-skill worker 明确未读取或应用 skill、reference、Agent README、with-skill 结果或旧运行产物。
+
+## Assertions
+
+| Assertion | Result | Evidence |
+| --- | --- | --- |
+| `follows_outline_sections` | **PASS** | with-skill 的 GitHub Release 正文仅包含 `重点更新`、`其他改进`、`升级说明`、`变更明细` 四个二级小节；没有采用相邻材料建议的 `发布亮点`、`质量验证`、`维护者说明` 或其他约定外小节。 |
+| `excludes_internal_quality_evidence` | **PASS** | 正文未包含 skill eval 结果、assertion 计数、review 轮次、QA 证据汇总，也未原样堆入额外 18 个维护 commit。引用的 PR #116、PR #117 和 commit `8b6a1f2` 仅用于支撑已确认事实。 |
+| `preserves_confirmed_facts` | **PASS** | 预览分别保留文件卡片与失败消息原位重试；保留 `workflow_finished` 到统一附件模型、Web/Gateway 共享字段契约和旧文本消息兼容；保留 nullable JSONB `message_files`、先加列后回填、不改为 `NOT NULL`、删列会丢失附件元数据及备份要求；保留数据库迁移到 Gateway 再到 Web 的部署顺序、生产默认关闭开关、Web/Gateway 双架构镜像、静态 manifest file-card chunk、升级验证步骤及旧浏览器限制。 |
+
+## With Skill Behavior
+
+with-skill 结果完整生成标题、正文、事实来源、交接与审计状态、版本窗口、compare 链接、SemVer 与 latest/prerelease 保守判定，以及 preview-only 边界。正文严格遵循四节 outline，并把内部质量材料和不支撑新用户事实的 maintenance feed 排除在用户可见 Release 叙述之外。
+
+风险限定得到明确保持：删除 `message_files` 列会丢失附件元数据，执行前必须备份，且不得将该回滚描述为无损或天然安全。未发现新增、遗漏或改写已确认事实；未执行 draft、publish、tag 或 docs 写操作。
+
+## Without Skill Baseline
+
+### 来源
+
+baseline 由第三轮 fresh without-skill worker 基于同一 eval prompt、eval-005 定义和相同 fixture 独立生成。worker 未读取或应用 `github-release-generator/SKILL.md`、两份 reference、Agent README、with-skill 输出、现有 comparison、attempt1 或旧运行产物。
+
+### 行为摘要
+
+without-skill baseline 同样只使用四个约定正文小节，排除了内部质量证据，并保留了断言要求的全部已确认事实，因此三项断言也均可判定为 PASS。其正文内容正确，但相比 with-skill 缺少完整的 #116 / #117 gate 展示、current latest 缺失时的保守 flag 判定、预标签 compare 与最终 compare 的状态区分，以及后续 draft / publish 写入边界说明。
+
+本 eval 的结论是 skill 结果满足全部可用性断言；baseline 同样通过说明 fixture 与断言本身已提供较强约束，不构成 with-skill 失败。
+
+## Failures
+
+无。本轮未发现断言失败、材料边界污染、事实遗漏、风险限定弱化或越权写操作。
+
+## Next Steps
+
+- 接受本轮 `PASS` 作为 PR #147 第三轮 eval-005 的 fresh validation 结论。
+- 保留当前最小 reference 修复与该 fixture，后续修改 release outline、内部质量证据排除规则或风险事实转换规则时重新运行此 eval。
+
+## Runtime Artifacts Policy
+
+- 本轮运行期证据位于 `tmp/eval-runs/issue-146-r3/{with_skill,without_skill}/eval-005-outline-sections-quality-exclusion/`，包括 `candidate-output.md` 与 `worker-observations.md`。
+- `with_skill/`、`without_skill/`、transcript、worker observations、diagnostics 和 attempt1 均为未提交运行期或诊断产物，不进入 durable fixture。
+- 长期提交结果仅为本 `comparison.md`；运行期目录不得作为仓库长期结果提交。

--- a/agents/product_manager/test/github-release-generator/evals/workspace/eval-005-outline-sections-quality-exclusion/docs/site/release-notes/v1.0.0.md
+++ b/agents/product_manager/test/github-release-generator/evals/workspace/eval-005-outline-sections-quality-exclusion/docs/site/release-notes/v1.0.0.md
@@ -1,0 +1,36 @@
+---
+title: "AI Hub v1.0.0"
+visibility: public
+doc_type: release
+stage: current
+owners:
+  - docs-platform
+  - release-engineering
+related_code:
+  - apps/web/src/features/chat
+  - services/gateway/src/workflow-events.ts
+last_verified_version: v1.0.0
+---
+
+# AI Hub v1.0.0
+
+## 用户功能
+
+- 新增文件卡片，显示文件名、类型和下载动作。
+- 新增失败消息原位重试；两项不得合并成泛化的“聊天体验改进”。
+
+## 架构与兼容
+
+Gateway 将 `workflow_finished` 转换为统一附件模型，Web 与 Gateway 共享消息文件字段契约；旧文本消息渲染继续保留。
+
+## 数据库
+
+新增 nullable JSONB `message_files`，先加列再后台回填，不改成 NOT NULL。回滚删除列会丢失附件元数据，必须先备份。
+
+## 部署与资产
+
+先执行数据库迁移，再部署 Gateway，最后部署 Web；`features.fileCards.enabled` 生产默认 false。Web 与 Gateway 镜像均支持 amd64/arm64，静态 manifest 新增 file-card chunk。
+
+## 升级与风险
+
+升级前备份，分步部署并验证旧文本与附件事件，冒烟通过后再开启文件卡片。旧浏览器不支持流式下载进度，但普通下载可用。

--- a/agents/product_manager/test/github-release-generator/evals/workspace/eval-005-outline-sections-quality-exclusion/eval_metadata.json
+++ b/agents/product_manager/test/github-release-generator/evals/workspace/eval-005-outline-sections-quality-exclusion/eval_metadata.json
@@ -1,0 +1,16 @@
+{
+  "eval_id": "eval-005-outline-sections-quality-exclusion",
+  "eval_name": "outline-sections-quality-exclusion",
+  "workspace_root": "agents/product_manager/test/github-release-generator/evals/workspace/eval-005-outline-sections-quality-exclusion",
+  "skill_availability_goal": "Verify that the release outline remains the only body section source and internal quality evidence stays out of the user-facing GitHub Release.",
+  "prompt": "根据 `release-package.md`、`docs/site/release-notes/v1.0.0.md` 和 `github-evidence.md` 生成 GitHub Release 完整预览。保持站内事实含义与范围，不执行任何写操作。",
+  "fixture_context": [
+    "release-package.md",
+    "github-evidence.md",
+    "docs/site/release-notes/v1.0.0.md"
+  ],
+  "execution_cleanup": [
+    "release-preview.md",
+    "release-action.md"
+  ]
+}

--- a/agents/product_manager/test/github-release-generator/evals/workspace/eval-005-outline-sections-quality-exclusion/github-evidence.md
+++ b/agents/product_manager/test/github-release-generator/evals/workspace/eval-005-outline-sections-quality-exclusion/github-evidence.md
@@ -1,0 +1,31 @@
+# GitHub 维护证据
+
+## Release window
+
+- repository: `example/ai-hub`
+- range: `v0.9.0...8b6a1f2`
+- compare: https://github.com/example/ai-hub/compare/v0.9.0...8b6a1f2
+- intended final compare: https://github.com/example/ai-hub/compare/v0.9.0...v1.0.0
+
+## Curated support links
+
+- [PR #116](https://github.com/example/ai-hub/pull/116) `feat: 增加文件卡片与统一附件模型` by [@alice](https://github.com/alice)
+- [PR #117](https://github.com/example/ai-hub/pull/117) `fix: 支持失败消息原位重试` by [@bob](https://github.com/bob)
+- [commit 8b6a1f2](https://github.com/example/ai-hub/commit/8b6a1f2) `chore: 增加双架构交付清单` by [@carol](https://github.com/carol)
+
+## Adjacent release presentation material
+
+上一版 Release 使用了 `## 发布亮点`、`## 质量验证` 和 `## 维护者说明` 等相邻风格小节。维护者素材建议沿用这些小节，以突出发布过程。
+
+## Internal quality evidence
+
+- github-release-generator skill eval：PASS
+- assertions：17/17 通过
+- PR review：已完成第三轮
+- QA 证据汇总：12 条 E2E 用例全部通过，覆盖附件兼容、迁移、回滚和双架构资产
+
+以上内容只用于仓库内部审计，不是站内已确认的用户版本事实。
+
+## Complete maintenance feed
+
+该范围另有 18 个格式化、依赖更新和测试 commit。它们属于审计范围，但不支持新的用户版本事实，不应原样堆入正文。

--- a/agents/product_manager/test/github-release-generator/evals/workspace/eval-005-outline-sections-quality-exclusion/release-package.md
+++ b/agents/product_manager/test/github-release-generator/evals/workspace/eval-005-outline-sections-quality-exclusion/release-package.md
@@ -1,0 +1,15 @@
+# Release Package
+
+- issue_116_handoff_status: ready
+- release_version: `v1.0.0`
+- site_release_note_path: `docs/site/release-notes/v1.0.0.md`
+- confirmation_status: `confirmed`
+- docs_checks: `npm run test:docs` from `docs/site`, exit 0
+- updated_release_surfaces: index, releases metadata and generated navigation updated
+- source_evidence: confirmed six-category evidence
+- issue_117_phase: `pre-tag`
+- issue_117_phase_result: `ready_for_tag`
+- base_ref: `v0.9.0`
+- target_ref: `8b6a1f2`
+- intended_tag: `v1.0.0`
+- requested_mode: preview only

--- a/docs/engineer/agents/pm-agent/skills/github-release-generator/TRD.md
+++ b/docs/engineer/agents/pm-agent/skills/github-release-generator/TRD.md
@@ -123,7 +123,7 @@ skill 必须先验证以下字段和证据：
 
 在 `ready_for_tag` 后：
 
-1. 读取站内 Release Notes、GitHub compare 和相邻 Release 风格。
+1. 读取站内 Release Notes、GitHub compare 和 `reference/release-outline.md` 结构定义。
 2. 生成标题与正文预览，标明事实来源与补充链接；同时标明目标版本分类、当前 latest
    Release 证据、SemVer 比较结果以及将用于写入的显式 prerelease/latest flag。
 3. 仅在用户明确要求时创建或更新 draft；无现有 draft 且实际 tag 不存在时只保留完整

--- a/docs/engineer/agents/pm-agent/skills/github-release-generator/TRD.md
+++ b/docs/engineer/agents/pm-agent/skills/github-release-generator/TRD.md
@@ -9,7 +9,7 @@ version: "1.1.0"
 status: Approved
 author: "Neplich Codex"
 date: "2026-07-20"
-last_updated: "2026-07-20"
+last_updated: "2026-07-21"
 generated_by: "trd-gen"
 related_prd: "docs/pm/agents/pm-agent/skills/github-release-generator/PRD.md"
 related_issues:
@@ -80,7 +80,6 @@ skill 必须先验证以下字段和证据：
 - 上一发布 tag `previous_tag`；
 - tag 尚不存在时使用 `previous_tag...target_ref` 审计范围；tag 存在后复核其指向已审计内容，并生成 `previous_tag...target_tag` 最终 compare URL；
 - compare 中的 merged PR、commit 和 contributor 集合；
-- 相邻已发布 GitHub Release 的标题/正文风格。
 
 对带 `v` 与不带 `v` 的来源先执行 SemVer 规范化比较，但 Git 命令和 GitHub Release
 仍使用仓库真实 tag 字面值。版本不存在、范围为空且无法解释、范围交叉或事实不一致时
@@ -174,7 +173,7 @@ post-tag audit，不自动修 tag。
 | merged PR | 选择与正文事实对应的代表性 PR | 重点条目的 PR 链接 |
 | commit | 用于范围审计和必要的精确追溯 | 不输出未经整理的原始 commit dump |
 | contributor | 从已纳入条目和 compare 中归并 | 项目既有风格的贡献者署名 |
-| 相邻 Release | 提取标题、章节和链接格式 | 与项目既有 GitHub Release 风格一致 |
+| `reference/release-outline.md` | 作为标题与正文结构的唯一来源，不读取或继承相邻 Release 格式 | 内部质量证据只进入 changelog 的 Skill Eval 汇总，不进入用户向 GitHub Release 正文 |
 
 正文不得新增站内页面未确认的产品事实。若 GitHub 证据揭示页面遗漏或冲突，停止生成
 并将差异交回 `docs-agent:release-notes-generator` 重新确认和校验；不能在 GitHub Release

--- a/docs/pm/agents/pm-agent/skills/github-release-generator/PRD.md
+++ b/docs/pm/agents/pm-agent/skills/github-release-generator/PRD.md
@@ -9,7 +9,7 @@ version: "1.0.0"
 status: Approved
 author: "Neplich Codex"
 date: "2026-07-20"
-last_updated: "2026-07-20"
+last_updated: "2026-07-21"
 generated_by: "idea-to-spec"
 related_issues:
   - "https://github.com/Neplich/dev-agent-skills/issues/120"
@@ -81,7 +81,7 @@ docs-agent；issue #117 已将发版审计拆成 pre-tag `ready_for_tag` 与 pos
 | FR-003 | #117 pre-tag 门禁 | P0 | 仅在可信 pre-tag handoff 返回 `ready_for_tag` 后生成可提交预览或创建/更新 draft |
 | FR-004 | 事实一致性 | P0 | 读取已确认站内 Release Notes，保留功能、架构、数据库、部署、资产、升级和风险事实，不覆盖改写 |
 | FR-005 | GitHub 可追溯性 | P0 | 补充完整 compare、代表性 PR/commit 和贡献者链接，且不以原始清单替代用户版本说明 |
-| FR-006 | 风格匹配与预览 | P0 | 读取相邻 GitHub Release 和项目规范；任何 draft 写入前先展示标题与正文预览 |
+| FR-006 | 结构来源与预览 | P0 | 以 `reference/release-outline.md` 作为标题与正文结构的唯一来源，不读取或继承相邻 GitHub Release 格式；任何 draft 写入前先展示标题与正文预览；eval 结果、assertion 计数、review 轮次、QA 证据汇总等内部质量证据只进入 changelog 的 Skill Eval 汇总，不进入用户向 GitHub Release 正文 |
 | FR-007 | draft 生命周期 | P0 | `ready_for_tag` 后可生成完整 draft 预览；仅在用户明确要求且不产生 tag 副作用时创建或更新远端 draft，缺少现有 draft 与实际 tag 时保持预览并阻塞远端创建；写后回读并核对 tag、标题、正文、draft 状态和远端 tag 零变化 |
 | FR-008 | 发布三重门禁 | P0 | 实际 tag 存在、#117 post-tag 为 `release_verified`、维护者另行明确批准，三者齐备才可发布 |
 | FR-009 | 发布后验证 | P0 | 发布后回读 GitHub Release，核对 tag、标题、正文、draft/published 状态和 URL |

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -34,7 +34,7 @@
     "github-release-generator": {
       "source": "agents/product_manager/skills/github-release-generator",
       "sourceType": "local",
-      "computedHash": "950953002384843415140e82d7f78a52e759c49e6790e0e714677bf0bb90808a"
+      "computedHash": "1ac1da282776a2da5adda940ec5d1ad0e59ce06d4212077d79821f121d00cc9e"
     },
     "release-notes-generator": {
       "source": "agents/docs/skills/release-notes-generator",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -34,7 +34,7 @@
     "github-release-generator": {
       "source": "agents/product_manager/skills/github-release-generator",
       "sourceType": "local",
-      "computedHash": "2a90c841ced20e13c7feea3d332df17e152a7f2daea1630815fa1d62d394d96b"
+      "computedHash": "950953002384843415140e82d7f78a52e759c49e6790e0e714677bf0bb90808a"
     },
     "release-notes-generator": {
       "source": "agents/docs/skills/release-notes-generator",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -34,7 +34,7 @@
     "github-release-generator": {
       "source": "agents/product_manager/skills/github-release-generator",
       "sourceType": "local",
-      "computedHash": "1ac1da282776a2da5adda940ec5d1ad0e59ce06d4212077d79821f121d00cc9e"
+      "computedHash": "50c05bd9beea0063be34e6baaa7dcecd87d7e46db16cb142870ed2a2933a930b"
     },
     "release-notes-generator": {
       "source": "agents/docs/skills/release-notes-generator",


### PR DESCRIPTION
## 改动摘要

- 将 `release-outline.md` 从 fallback 明确为 GitHub Release 正文的唯一结构来源，移除对相邻 GitHub Release 格式习惯的读取与继承。
- 保持“重点更新 / 其他改进 / 升级说明 / 变更明细”四节结构不变，并禁止相邻 Release 引入额外小节。
- 明确 skill eval 结果、assertion 计数、review 轮次、QA 证据汇总等内部质量证据只进入仓库 changelog 的 Skill Eval 汇总，不进入用户向 GitHub Release 正文。
- 同步更新 `github-release-generator` 的生成步骤编号和 `skills-lock.json` 计算哈希。

## Eval 复验结论

- 对 `github-release-generator` 的 4 个 eval 完成 issue #146 fresh paired validation。
- with-skill：18/18 assertions PASS。
- fresh without-skill baseline：18/18 assertions PASS。
- 当前 assertions 区分度为 0/18；comparison 如实记录了 skill 在阶段边界、compare 语义、missing-tag 安全保护和 owner/授权说明上的行为差异，以及该非阻塞 finding。
- 4 份 `comparison.md` 已更新；运行期 candidate、observations、manifest、transcript、verdict、timing 等均未提交。

## 契约检查结果

- `uv run scripts/check_repository_contract.py`：PASS
- `uv run scripts/check_eval_contract.py`：PASS
- `uv run scripts/check_eval_artifacts.py`：PASS
- `uv run scripts/check_doc_contract.py`：PASS
- CI 同款确定性 pytest：133 passed

Closes #146
