### PR TITLE
docs: 恢复 Codex 快速安装入口

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,15 +54,10 @@ It includes:
 
 ### Codex
 
-```bash
-git clone https://github.com/Neplich/dev-agent-skills.git ~/.agents/dev-agent-skills
-cd ~/.agents/dev-agent-skills
+Tell Codex:
 
-# Install all role router and specialist skills by default.
-python3 scripts/install_codex_skills.py
-
-# Optional minimal mode: expose only the seven role router skills.
-python3 scripts/install_codex_skills.py --routers-only
+```text
+Fetch and follow instructions from https://raw.githubusercontent.com/Neplich/dev-agent-skills/refs/heads/main/.codex/INSTALL.md
 ```
 
 Implementation details and troubleshooting are in the [Codex Guide](./docs/README.codex.md).

--- a/README_zh.md
+++ b/README_zh.md
@@ -54,15 +54,10 @@
 
 ### Codex
 
-```bash
-git clone https://github.com/Neplich/dev-agent-skills.git ~/.agents/dev-agent-skills
-cd ~/.agents/dev-agent-skills
+告诉 Codex：
 
-# 默认安装全部 role router 和 specialist skills
-python3 scripts/install_codex_skills.py
-
-# 可选最小模式：只暴露 7 个 role router skills
-python3 scripts/install_codex_skills.py --routers-only
+```text
+Fetch and follow instructions from https://raw.githubusercontent.com/Neplich/dev-agent-skills/refs/heads/main/.codex/INSTALL.md
 ```
 
 实现原理与排障见 [Codex Guide](./docs/README.codex.md)。


### PR DESCRIPTION
## 变更摘要

- 将英文 README 的 Codex 快速安装入口恢复为单句提示
- 同步更新中文 README，移除不便的手动 clone 与 Python 脚本步骤
- 保留 Codex Guide 作为实现原理与排障入口

## 验证

- `git diff --check`
- `UV_CACHE_DIR=/tmp/uv-cache uv run scripts/check_repository_contract.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run scripts/check_doc_contract.py`

## 变更范围

仅修改 `README.md` 与 `README_zh.md`，不修改安装脚本或安装行为。