### PR TITLE
chore: 发布 v0.3.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "PM-first agent skill marketplace with one public pm-agent entry and downstream PM-orchestrated engineering, QA, DevOps, design, security, and documentation capabilities",
-    "version": "0.3.2"
+    "version": "0.3.3"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 仓库级发布变更记录按版本归档到 `docs/changelog/`。
 
+- [v0.3.3](./docs/changelog/changelog-v0.3.3.md)
 - [v0.3.2](./docs/changelog/changelog-v0.3.2.md)
 - [v0.3.1](./docs/changelog/changelog-v0.3.1.md)
 - [v0.3.0](./docs/changelog/changelog-v0.3.0.md)

--- a/agents/designer/.claude-plugin/plugin.json
+++ b/agents/designer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "designer-agent",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Downstream design capability invoked after pm-agent handoff for confirmed UX flows, information architecture, wireframes, reference-pattern analysis, and reference-backed visual system work.",
   "author": {
     "name": "Neplich"

--- a/agents/devops/.claude-plugin/plugin.json
+++ b/agents/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops-agent",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Downstream DevOps capability invoked after pm-agent handoff for confirmed deployment planning, CI/CD automation, environment audits, release readiness, rollback, and runbook preparation.",
   "author": {
     "name": "Neplich"

--- a/agents/docs/.claude-plugin/plugin.json
+++ b/agents/docs/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "docs-agent",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Downstream documentation capability invoked after pm-agent handoff for confirmed formal documentation bootstrap, synchronization, backfill, and release audit.",
   "author": {
     "name": "Neplich"

--- a/agents/engineer/.claude-plugin/plugin.json
+++ b/agents/engineer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "engineer-agent",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Downstream engineering capability invoked after pm-agent handoff for confirmed codebase analysis, TRDs, bootstrapping, implementation, tests, debugging, and delivery. Skills remain available for PM-orchestrated execution, not as standalone starting points.",
   "author": {
     "name": "Neplich"

--- a/agents/product_manager/.claude-plugin/plugin.json
+++ b/agents/product_manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pm-agent",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Default entry plugin for new user requests. Use when the user describes product ideas, feature requests, requirement changes, bugs, build/test/deploy/review/status requests, feature catalogs, competitive research, release communication, roadmaps, or GitHub project status. Classifies scope first, then routes to PM specialists or hands off to downstream role agents.",
   "author": {
     "name": "Neplich"

--- a/agents/qa/.claude-plugin/plugin.json
+++ b/agents/qa/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qa-agent",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Downstream QA capability invoked after pm-agent handoff for confirmed acceptance, exploratory testing, bug analysis, and regression verification. Requirement or implementation gaps return through the PM-orchestrated handoff path.",
   "author": {
     "name": "Neplich"

--- a/agents/security/.claude-plugin/plugin.json
+++ b/agents/security/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "security-agent",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Downstream security capability invoked after pm-agent handoff for confirmed AppSec, auth/authz, dependency risk, privacy, and data-flow reviews, with remediation routed through the PM handoff path.",
   "author": {
     "name": "Neplich"

--- a/docs/changelog/changelog-v0.3.3.md
+++ b/docs/changelog/changelog-v0.3.3.md
@@ -23,9 +23,9 @@ last_updated: 2026-07-22
 
 ## Skill Eval 汇总（v0.3.3 发版前）
 
-本节逐一核对当前仓库已提交的 durable `comparison.md`，按 skill 去重汇总最新结论。共核对 **152** 份 durable comparison：**126 PASS、26 PARTIAL**。
+本节以当前 eval 定义契约的 canonical `agents/{agent}/test/{skill}/evals/workspace/{eval}/comparison.md` 为统计范围，按 skill 去重汇总最新结论。共核对 **152** 份 canonical durable comparison：**126 PASS、26 PARTIAL**；未按现行 `evals/workspace` 合同归档的 legacy workspace comparison 不纳入本表。
 
-| Agent | Skill（eval 范围） | Durable comparison 数 | 最新结论 |
+| Agent | Skill（eval 范围） | Canonical durable comparison 数 | 最新结论 |
 | --- | --- | ---: | --- |
 | Designer | `designer-agent` | 3 | 3 PASS |
 | Designer | `ui-ux-design` | 3 | 1 PASS、2 PARTIAL |

--- a/docs/changelog/changelog-v0.3.3.md
+++ b/docs/changelog/changelog-v0.3.3.md
@@ -23,49 +23,13 @@ last_updated: 2026-07-22
 
 ## Skill Eval 汇总（v0.3.3 发版前）
 
-本节逐一核对当前仓库已提交的 durable `comparison.md`，按 skill 去重汇总最新结论。共核对 **152** 份 durable comparison：**126 PASS、26 PARTIAL**。
+本版本复用各 PR 合并时已经完成并写入 durable `comparison.md` 的 fresh `with_skill` / `without_skill` 成对复验结果，不在发版环节重复运行 eval。
 
-| Agent | Skill（eval 范围） | Durable comparison 数 | 最新结论 |
-| --- | --- | ---: | --- |
-| Designer | `designer-agent` | 3 | 3 PASS |
-| Designer | `ui-ux-design` | 3 | 1 PASS、2 PARTIAL |
-| Designer | `visual-design` | 1 | 1 PARTIAL |
-| DevOps | `cicd-bootstrap` | 2 | 1 PASS、1 PARTIAL |
-| DevOps | `deployment-planner` | 3 | 1 PASS、2 PARTIAL |
-| DevOps | `devops-agent` | 1 | 1 PASS |
-| DevOps | `env-config-auditor` | 1 | 1 PASS |
-| DevOps | `incident-playbook-writer` | 2 | 1 PASS、1 PARTIAL |
-| Docs | `docs-agent`（router eval-001–004；integration eval-005） | 5 | router：4/4 PASS（14/14 assertions）；integration：1/1 PASS（8/8 with-skill assertions） |
-| Docs | `docs-audit`（eval-001–013） | 13 | 13/13 PASS（81/81 assertions） |
-| Docs | `docs-site-bootstrap`（eval-001–003） | 3 | 3/3 PASS（12/12 assertions） |
-| Docs | `formal-docs-sync`（eval-001–010） | 10 | 10/10 PASS（42/42 assertions） |
-| Docs | `release-notes-generator`（eval-001–003） | 3 | 3/3 PASS（11/11 assertions） |
-| Engineer | `codebase-analyzer` | 3 | 1 PASS、2 PARTIAL |
-| Engineer | `debugger` | 5 | 3 PASS、2 PARTIAL |
-| Engineer | `delivery` | 1 | 1 PARTIAL |
-| Engineer | `engineer-agent` | 4 | 4 PASS |
-| Engineer | `feature-implementor` | 14 | 14 PASS |
-| Engineer | `project-bootstrap` | 2 | 2 PARTIAL |
-| Engineer | `test-writer` | 2 | 1 PASS、1 PARTIAL |
-| Engineer | `trd-gen` | 5 | 2 PASS、3 PARTIAL |
-| Product Manager | `changelog-generator` | 3 | 3 PARTIAL |
-| Product Manager | `competitive-brief` | 1 | 1 PARTIAL |
-| Product Manager | `competitive-intelligence` | 1 | 1 PARTIAL |
-| Product Manager | `feature-catalog` | 4 | 4 PASS |
-| Product Manager | `github-reader` | 4 | 1 PASS、3 PARTIAL |
-| Product Manager | `github-release-generator`（eval-001–005） | 5 | 5/5 PASS（21/21 assertions） |
-| Product Manager | `idea-to-spec` | 1 | 1 PASS |
-| Product Manager | `pm-agent` router（eval-001–014） | 14 | 14/14 PASS（45/45 assertions） |
-| QA | `bug-analyzer` | 3 | 3 PASS |
-| QA | `exploratory-tester` | 3 | 3 PASS |
-| QA | `qa-agent` | 3 | 3 PASS |
-| QA | `regression-suite` | 3 | 3 PASS |
-| QA | `spec-based-tester` | 3 | 3 PASS |
-| Security | `security-agent` router（eval-001） | 1 | 1/1 PASS（6/6 assertions） |
-| Security | `appsec-checklist`（eval-001–005） | 5 | 5/5 PASS（21/21 assertions） |
-| Security | `authz-reviewer`（eval-001–004） | 4 | 4/4 PASS（16/16 assertions） |
-| Security | `dependency-risk-auditor`（eval-001–004） | 4 | 4/4 PASS（16/16 assertions） |
-| Security | `privacy-surface-mapper`（eval-001–004） | 4 | 4/4 PASS（16/16 assertions） |
-| **合计** | **39 个 skill 分组** | **152** | **126 PASS、26 PARTIAL** |
+| Agent | Skill（eval 范围） | 复验结论 |
+| --- | --- | --- |
+| Product Manager | `github-release-generator`（既有 eval-001–004） | 4/4 eval PASS，18/18 assertions PASS |
+| Product Manager | `github-release-generator`（新增 eval-005） | 1/1 eval PASS，3/3 assertions PASS |
+| Security | `appsec-checklist`、`authz-reviewer`、`dependency-risk-auditor`、`privacy-surface-mapper`（各 eval-001–003） | 12/12 eval PASS，48/48 assertions PASS |
+| Docs | `docs-site-bootstrap`（3 个）、`formal-docs-sync`（5 个）、`release-notes-generator`（3 个）、`docs-agent`（1 个 integration） | 12/12 eval PASS |
 
-本版本直接涉及的复验结果为：`github-release-generator` 的 4 个既有 eval 复验 **18/18 assertions PASS**，新增 eval-005 复验 **3/3 assertions PASS**；四个 Security specialist 的 12 个薄 fixture eval 复验 **48/48 assertions PASS**；`docs-site-bootstrap`、`formal-docs-sync`、`release-notes-generator` 与 `docs-agent` 的 12 个相关 eval 复验全部 PASS。以上均已在对应 PR 合并时完成 fresh `with_skill` / `without_skill` 成对复验并更新各自 `comparison.md`；本版本仅汇总并复用这些已提交结论，不重跑 skill eval。表中其余 **26 个 PARTIAL** 沿用各 skill 既有 durable 结论，主要记录历史 comparison 未生成 fresh `without_skill` baseline 等证据缺口，不是本版回归。
+以上结果均已在对应 PR 合并时完成 fresh 成对复验并更新各自 `comparison.md`；本版本仅汇总并复用这些已提交结论，不重跑 skill eval。

--- a/docs/changelog/changelog-v0.3.3.md
+++ b/docs/changelog/changelog-v0.3.3.md
@@ -23,9 +23,9 @@ last_updated: 2026-07-22
 
 ## Skill Eval 汇总（v0.3.3 发版前）
 
-本节以当前 eval 定义契约的 canonical `agents/{agent}/test/{skill}/evals/workspace/{eval}/comparison.md` 为统计范围，按 skill 去重汇总最新结论。共核对 **152** 份 canonical durable comparison：**126 PASS、26 PARTIAL**；未按现行 `evals/workspace` 合同归档的 legacy workspace comparison 不纳入本表。
+本节按 marketplace 当前注册的 **40 个 skill** 逐一汇总最新结论：39 个 skill 使用现行 eval 定义契约下 canonical `agents/{agent}/test/{skill}/evals/workspace/{eval}/comparison.md` 的 152 份 durable comparison；尚未迁移到 canonical 路径的 `roadmap-generator` 使用其 3 份当前 legacy workspace comparison。共核对 **155** 份当前结论：**129 PASS、26 PARTIAL**；已有 canonical 结论的 skill 不重复计入旧迭代 legacy comparison。
 
-| Agent | Skill（eval 范围） | Canonical durable comparison 数 | 最新结论 |
+| Agent | Skill（eval 范围） | 纳入汇总的 durable comparison 数 | 最新结论 |
 | --- | --- | ---: | --- |
 | Designer | `designer-agent` | 3 | 3 PASS |
 | Designer | `ui-ux-design` | 3 | 1 PASS、2 PARTIAL |
@@ -56,6 +56,7 @@ last_updated: 2026-07-22
 | Product Manager | `github-release-generator`（eval-001–005） | 5 | 5/5 PASS（21/21 assertions） |
 | Product Manager | `idea-to-spec` | 1 | 1 PASS |
 | Product Manager | `pm-agent` router（eval-001–014） | 14 | 14/14 PASS（45/45 assertions） |
+| Product Manager | `roadmap-generator`（legacy workspace） | 3 | 3 PASS |
 | QA | `bug-analyzer` | 3 | 3 PASS |
 | QA | `exploratory-tester` | 3 | 3 PASS |
 | QA | `qa-agent` | 3 | 3 PASS |
@@ -66,6 +67,6 @@ last_updated: 2026-07-22
 | Security | `authz-reviewer`（eval-001–004） | 4 | 4/4 PASS（16/16 assertions） |
 | Security | `dependency-risk-auditor`（eval-001–004） | 4 | 4/4 PASS（16/16 assertions） |
 | Security | `privacy-surface-mapper`（eval-001–004） | 4 | 4/4 PASS（16/16 assertions） |
-| **合计** | **39 个 skill 分组** | **152** | **126 PASS、26 PARTIAL** |
+| **合计** | **40 个 marketplace skill 分组** | **155** | **129 PASS、26 PARTIAL** |
 
 本版本直接涉及的复验结果为：`github-release-generator` 的 4 个既有 eval 复验 **18/18 assertions PASS**，新增 eval-005 复验 **3/3 assertions PASS**；四个 Security specialist 的 12 个薄 fixture eval 复验 **48/48 assertions PASS**；`docs-site-bootstrap`、`formal-docs-sync`、`release-notes-generator` 与 `docs-agent` 的 12 个相关 eval 复验全部 PASS。以上均已在对应 PR 合并时完成 fresh `with_skill` / `without_skill` 成对复验并更新各自 `comparison.md`；本版本仅汇总并复用这些已提交结论，不重跑 skill eval。表中其余 **26 个 PARTIAL** 沿用各 skill 既有 durable 结论，主要记录历史 comparison 未生成 fresh `without_skill` baseline 等证据缺口，不是本版回归。

--- a/docs/changelog/changelog-v0.3.3.md
+++ b/docs/changelog/changelog-v0.3.3.md
@@ -23,13 +23,49 @@ last_updated: 2026-07-22
 
 ## Skill Eval 汇总（v0.3.3 发版前）
 
-本版本复用各 PR 合并时已经完成并写入 durable `comparison.md` 的 fresh `with_skill` / `without_skill` 成对复验结果，不在发版环节重复运行 eval。
+本节逐一核对当前仓库已提交的 durable `comparison.md`，按 skill 去重汇总最新结论。共核对 **152** 份 durable comparison：**126 PASS、26 PARTIAL**。
 
-| Agent | Skill（eval 范围） | 复验结论 |
-| --- | --- | --- |
-| Product Manager | `github-release-generator`（既有 eval-001–004） | 4/4 eval PASS，18/18 assertions PASS |
-| Product Manager | `github-release-generator`（新增 eval-005） | 1/1 eval PASS，3/3 assertions PASS |
-| Security | `appsec-checklist`、`authz-reviewer`、`dependency-risk-auditor`、`privacy-surface-mapper`（各 eval-001–003） | 12/12 eval PASS，48/48 assertions PASS |
-| Docs | `docs-site-bootstrap`（3 个）、`formal-docs-sync`（5 个）、`release-notes-generator`（3 个）、`docs-agent`（1 个 integration） | 12/12 eval PASS |
+| Agent | Skill（eval 范围） | Durable comparison 数 | 最新结论 |
+| --- | --- | ---: | --- |
+| Designer | `designer-agent` | 3 | 3 PASS |
+| Designer | `ui-ux-design` | 3 | 1 PASS、2 PARTIAL |
+| Designer | `visual-design` | 1 | 1 PARTIAL |
+| DevOps | `cicd-bootstrap` | 2 | 1 PASS、1 PARTIAL |
+| DevOps | `deployment-planner` | 3 | 1 PASS、2 PARTIAL |
+| DevOps | `devops-agent` | 1 | 1 PASS |
+| DevOps | `env-config-auditor` | 1 | 1 PASS |
+| DevOps | `incident-playbook-writer` | 2 | 1 PASS、1 PARTIAL |
+| Docs | `docs-agent`（router eval-001–004；integration eval-005） | 5 | router：4/4 PASS（14/14 assertions）；integration：1/1 PASS（8/8 with-skill assertions） |
+| Docs | `docs-audit`（eval-001–013） | 13 | 13/13 PASS（81/81 assertions） |
+| Docs | `docs-site-bootstrap`（eval-001–003） | 3 | 3/3 PASS（12/12 assertions） |
+| Docs | `formal-docs-sync`（eval-001–010） | 10 | 10/10 PASS（42/42 assertions） |
+| Docs | `release-notes-generator`（eval-001–003） | 3 | 3/3 PASS（11/11 assertions） |
+| Engineer | `codebase-analyzer` | 3 | 1 PASS、2 PARTIAL |
+| Engineer | `debugger` | 5 | 3 PASS、2 PARTIAL |
+| Engineer | `delivery` | 1 | 1 PARTIAL |
+| Engineer | `engineer-agent` | 4 | 4 PASS |
+| Engineer | `feature-implementor` | 14 | 14 PASS |
+| Engineer | `project-bootstrap` | 2 | 2 PARTIAL |
+| Engineer | `test-writer` | 2 | 1 PASS、1 PARTIAL |
+| Engineer | `trd-gen` | 5 | 2 PASS、3 PARTIAL |
+| Product Manager | `changelog-generator` | 3 | 3 PARTIAL |
+| Product Manager | `competitive-brief` | 1 | 1 PARTIAL |
+| Product Manager | `competitive-intelligence` | 1 | 1 PARTIAL |
+| Product Manager | `feature-catalog` | 4 | 4 PASS |
+| Product Manager | `github-reader` | 4 | 1 PASS、3 PARTIAL |
+| Product Manager | `github-release-generator`（eval-001–005） | 5 | 5/5 PASS（21/21 assertions） |
+| Product Manager | `idea-to-spec` | 1 | 1 PASS |
+| Product Manager | `pm-agent` router（eval-001–014） | 14 | 14/14 PASS（45/45 assertions） |
+| QA | `bug-analyzer` | 3 | 3 PASS |
+| QA | `exploratory-tester` | 3 | 3 PASS |
+| QA | `qa-agent` | 3 | 3 PASS |
+| QA | `regression-suite` | 3 | 3 PASS |
+| QA | `spec-based-tester` | 3 | 3 PASS |
+| Security | `security-agent` router（eval-001） | 1 | 1/1 PASS（6/6 assertions） |
+| Security | `appsec-checklist`（eval-001–005） | 5 | 5/5 PASS（21/21 assertions） |
+| Security | `authz-reviewer`（eval-001–004） | 4 | 4/4 PASS（16/16 assertions） |
+| Security | `dependency-risk-auditor`（eval-001–004） | 4 | 4/4 PASS（16/16 assertions） |
+| Security | `privacy-surface-mapper`（eval-001–004） | 4 | 4/4 PASS（16/16 assertions） |
+| **合计** | **39 个 skill 分组** | **152** | **126 PASS、26 PARTIAL** |
 
-以上结果均已在对应 PR 合并时完成 fresh 成对复验并更新各自 `comparison.md`；本版本仅汇总并复用这些已提交结论，不重跑 skill eval。
+本版本直接涉及的复验结果为：`github-release-generator` 的 4 个既有 eval 复验 **18/18 assertions PASS**，新增 eval-005 复验 **3/3 assertions PASS**；四个 Security specialist 的 12 个薄 fixture eval 复验 **48/48 assertions PASS**；`docs-site-bootstrap`、`formal-docs-sync`、`release-notes-generator` 与 `docs-agent` 的 12 个相关 eval 复验全部 PASS。以上均已在对应 PR 合并时完成 fresh `with_skill` / `without_skill` 成对复验并更新各自 `comparison.md`；本版本仅汇总并复用这些已提交结论，不重跑 skill eval。表中其余 **26 个 PARTIAL** 沿用各 skill 既有 durable 结论，主要记录历史 comparison 未生成 fresh `without_skill` baseline 等证据缺口，不是本版回归。

--- a/docs/changelog/changelog-v0.3.3.md
+++ b/docs/changelog/changelog-v0.3.3.md
@@ -9,11 +9,12 @@ last_updated: 2026-07-22
 
 ## [v0.3.3] - 2026-07-22
 
-本版本收紧 GitHub Release 正文边界，将固定 outline 确立为唯一结构来源，禁止继承相邻 Release 的格式或写入内部质量证据；补齐四个 Security specialist 的薄 fixture 确认上下文与可审查样本，使 12 个既有 eval 恢复为完整 PASS；同时修复 VitePress 1.6.4 下 Mermaid fence 与旧 DOM 扫描选择器不匹配的问题，改用 Markdown-it fence renderer 和独立 Vue 组件稳定渲染 Mermaid。本版本覆盖 v0.3.2 之后合并到 `main` 的全部变更（#147、#149、#151）。
+本版本收紧 GitHub Release 正文边界，将固定 outline 确立为唯一结构来源，禁止继承相邻 Release 的格式或写入内部质量证据；补齐四个 Security specialist 的薄 fixture 确认上下文与可审查样本，使 12 个既有 eval 恢复为完整 PASS；同时修复 VitePress 1.6.4 下 Mermaid fence 与旧 DOM 扫描选择器不匹配的问题，改用 Markdown-it fence renderer 和独立 Vue 组件稳定渲染 Mermaid。本版本覆盖 v0.3.2 之后合并到 `main` 的全部变更（#147、#149、#151、#152）。
 
 ### Changed
 
 - **Security specialist eval fixture**：为 `appsec-checklist`、`authz-reviewer`、`dependency-risk-auditor`、`privacy-surface-mapper` 的 12 个薄 fixture eval 补齐 PM handoff、已确认 `feature_path`、正式 PRD 与最小可审查代码或配置样本，在不修改 specialist skill 行为与既有 assertions 的前提下恢复完整确认上下文，关闭 [issue #143](https://github.com/Neplich/dev-agent-skills/issues/143)。([#149](https://github.com/Neplich/dev-agent-skills/pull/149))
+- **README Codex 快速安装入口**：英文 README 恢复单句 Codex 快速安装提示，中文 README 同步移除手动 clone 与 Python 脚本步骤，保留 Codex Guide 作为实现原理与排障入口；不涉及安装脚本或安装行为变更。([#152](https://github.com/Neplich/dev-agent-skills/pull/152))
 
 ### Fixed
 
@@ -22,13 +23,49 @@ last_updated: 2026-07-22
 
 ## Skill Eval 汇总（v0.3.3 发版前）
 
-本版本复用各 PR 合并时已经完成并写入 durable `comparison.md` 的 fresh `with_skill` / `without_skill` 成对复验结果，不在发版环节重复运行 eval。
+本节逐一核对当前仓库已提交的 durable `comparison.md`，按 skill 去重汇总最新结论。共核对 **152** 份 durable comparison：**126 PASS、26 PARTIAL**。
 
-| Agent | Skill（eval 范围） | 复验结论 |
-| --- | --- | --- |
-| Product Manager | `github-release-generator`（既有 eval-001–004） | 4/4 eval PASS，18/18 assertions PASS |
-| Product Manager | `github-release-generator`（新增 eval-005） | 1/1 eval PASS，3/3 assertions PASS |
-| Security | `appsec-checklist`、`authz-reviewer`、`dependency-risk-auditor`、`privacy-surface-mapper`（各 eval-001–003） | 12/12 eval PASS，48/48 assertions PASS |
-| Docs | `docs-site-bootstrap`（3 个）、`formal-docs-sync`（5 个）、`release-notes-generator`（3 个）、`docs-agent`（1 个 integration） | 12/12 eval PASS |
+| Agent | Skill（eval 范围） | Durable comparison 数 | 最新结论 |
+| --- | --- | ---: | --- |
+| Designer | `designer-agent` | 3 | 3 PASS |
+| Designer | `ui-ux-design` | 3 | 1 PASS、2 PARTIAL |
+| Designer | `visual-design` | 1 | 1 PARTIAL |
+| DevOps | `cicd-bootstrap` | 2 | 1 PASS、1 PARTIAL |
+| DevOps | `deployment-planner` | 3 | 1 PASS、2 PARTIAL |
+| DevOps | `devops-agent` | 1 | 1 PASS |
+| DevOps | `env-config-auditor` | 1 | 1 PASS |
+| DevOps | `incident-playbook-writer` | 2 | 1 PASS、1 PARTIAL |
+| Docs | `docs-agent`（router eval-001–004；integration eval-005） | 5 | router：4/4 PASS（14/14 assertions）；integration：1/1 PASS（8/8 with-skill assertions） |
+| Docs | `docs-audit`（eval-001–013） | 13 | 13/13 PASS（81/81 assertions） |
+| Docs | `docs-site-bootstrap`（eval-001–003） | 3 | 3/3 PASS（12/12 assertions） |
+| Docs | `formal-docs-sync`（eval-001–010） | 10 | 10/10 PASS（42/42 assertions） |
+| Docs | `release-notes-generator`（eval-001–003） | 3 | 3/3 PASS（11/11 assertions） |
+| Engineer | `codebase-analyzer` | 3 | 1 PASS、2 PARTIAL |
+| Engineer | `debugger` | 5 | 3 PASS、2 PARTIAL |
+| Engineer | `delivery` | 1 | 1 PARTIAL |
+| Engineer | `engineer-agent` | 4 | 4 PASS |
+| Engineer | `feature-implementor` | 14 | 14 PASS |
+| Engineer | `project-bootstrap` | 2 | 2 PARTIAL |
+| Engineer | `test-writer` | 2 | 1 PASS、1 PARTIAL |
+| Engineer | `trd-gen` | 5 | 2 PASS、3 PARTIAL |
+| Product Manager | `changelog-generator` | 3 | 3 PARTIAL |
+| Product Manager | `competitive-brief` | 1 | 1 PARTIAL |
+| Product Manager | `competitive-intelligence` | 1 | 1 PARTIAL |
+| Product Manager | `feature-catalog` | 4 | 4 PASS |
+| Product Manager | `github-reader` | 4 | 1 PASS、3 PARTIAL |
+| Product Manager | `github-release-generator`（eval-001–005） | 5 | 5/5 PASS（21/21 assertions） |
+| Product Manager | `idea-to-spec` | 1 | 1 PASS |
+| Product Manager | `pm-agent` router（eval-001–014） | 14 | 14/14 PASS（45/45 assertions） |
+| QA | `bug-analyzer` | 3 | 3 PASS |
+| QA | `exploratory-tester` | 3 | 3 PASS |
+| QA | `qa-agent` | 3 | 3 PASS |
+| QA | `regression-suite` | 3 | 3 PASS |
+| QA | `spec-based-tester` | 3 | 3 PASS |
+| Security | `security-agent` router（eval-001） | 1 | 1/1 PASS（6/6 assertions） |
+| Security | `appsec-checklist`（eval-001–005） | 5 | 5/5 PASS（21/21 assertions） |
+| Security | `authz-reviewer`（eval-001–004） | 4 | 4/4 PASS（16/16 assertions） |
+| Security | `dependency-risk-auditor`（eval-001–004） | 4 | 4/4 PASS（16/16 assertions） |
+| Security | `privacy-surface-mapper`（eval-001–004） | 4 | 4/4 PASS（16/16 assertions） |
+| **合计** | **39 个 skill 分组** | **152** | **126 PASS、26 PARTIAL** |
 
-以上结果均已在对应 PR 合并时完成 fresh 成对复验并更新各自 `comparison.md`；本版本仅汇总并复用这些已提交结论，不重跑 skill eval。
+本版本直接涉及的复验结果为：`github-release-generator` 的 4 个既有 eval 复验 **18/18 assertions PASS**，新增 eval-005 复验 **3/3 assertions PASS**；四个 Security specialist 的 12 个薄 fixture eval 复验 **48/48 assertions PASS**；`docs-site-bootstrap`、`formal-docs-sync`、`release-notes-generator` 与 `docs-agent` 的 12 个相关 eval 复验全部 PASS。以上均已在对应 PR 合并时完成 fresh `with_skill` / `without_skill` 成对复验并更新各自 `comparison.md`；本版本仅汇总并复用这些已提交结论，不重跑 skill eval。表中其余 **26 个 PARTIAL** 沿用各 skill 既有 durable 结论，主要记录历史 comparison 未生成 fresh `without_skill` baseline 等证据缺口，不是本版回归。

--- a/docs/changelog/changelog-v0.3.3.md
+++ b/docs/changelog/changelog-v0.3.3.md
@@ -1,0 +1,34 @@
+---
+feature: release-changelog
+version: 0.3.3
+date: 2026-07-22
+last_updated: 2026-07-22
+---
+
+# Changelog - v0.3.3
+
+## [v0.3.3] - 2026-07-22
+
+本版本收紧 GitHub Release 正文边界，将固定 outline 确立为唯一结构来源，禁止继承相邻 Release 的格式或写入内部质量证据；补齐四个 Security specialist 的薄 fixture 确认上下文与可审查样本，使 12 个既有 eval 恢复为完整 PASS；同时修复 VitePress 1.6.4 下 Mermaid fence 与旧 DOM 扫描选择器不匹配的问题，改用 Markdown-it fence renderer 和独立 Vue 组件稳定渲染 Mermaid。本版本覆盖 v0.3.2 之后合并到 `main` 的全部变更（#147、#149、#151）。
+
+### Changed
+
+- **Security specialist eval fixture**：为 `appsec-checklist`、`authz-reviewer`、`dependency-risk-auditor`、`privacy-surface-mapper` 的 12 个薄 fixture eval 补齐 PM handoff、已确认 `feature_path`、正式 PRD 与最小可审查代码或配置样本，在不修改 specialist skill 行为与既有 assertions 的前提下恢复完整确认上下文，关闭 [issue #143](https://github.com/Neplich/dev-agent-skills/issues/143)。([#149](https://github.com/Neplich/dev-agent-skills/pull/149))
+
+### Fixed
+
+- **GitHub Release 正文契约**：`github-release-generator` 以 `release-outline.md` 为唯一结构来源，不再读取或继承相邻 GitHub Release 的格式习惯；固定保留“重点更新 / 其他改进 / 升级说明 / 变更明细”四节，并明确 skill eval、assertion 计数、review 轮次与 QA 汇总等内部质量证据只进入仓库 changelog 的 Skill Eval 汇总，不进入用户向 GitHub Release 正文，关闭 [issue #146](https://github.com/Neplich/dev-agent-skills/issues/146)。([#147](https://github.com/Neplich/dev-agent-skills/pull/147))
+- **VitePress Mermaid 脚手架 DOM 适配**：修复 VitePress 1.6.4 将 Mermaid fence 渲染为 `<div class="language-mermaid"><pre><code>...` 后旧选择器无法命中、页面只显示源码的问题；新实现由 Markdown-it fence renderer 输出全局注册的独立 `Mermaid.vue` 组件，支持严格安全级别、深浅色重渲染、多实例唯一 ID，以及失败时显示错误和原始源码，关闭 [issue #150](https://github.com/Neplich/dev-agent-skills/issues/150)。([#151](https://github.com/Neplich/dev-agent-skills/pull/151))
+
+## Skill Eval 汇总（v0.3.3 发版前）
+
+本版本复用各 PR 合并时已经完成并写入 durable `comparison.md` 的 fresh `with_skill` / `without_skill` 成对复验结果，不在发版环节重复运行 eval。
+
+| Agent | Skill（eval 范围） | 复验结论 |
+| --- | --- | --- |
+| Product Manager | `github-release-generator`（既有 eval-001–004） | 4/4 eval PASS，18/18 assertions PASS |
+| Product Manager | `github-release-generator`（新增 eval-005） | 1/1 eval PASS，3/3 assertions PASS |
+| Security | `appsec-checklist`、`authz-reviewer`、`dependency-risk-auditor`、`privacy-surface-mapper`（各 eval-001–003） | 12/12 eval PASS，48/48 assertions PASS |
+| Docs | `docs-site-bootstrap`（3 个）、`formal-docs-sync`（5 个）、`release-notes-generator`（3 个）、`docs-agent`（1 个 integration） | 12/12 eval PASS |
+
+以上结果均已在对应 PR 合并时完成 fresh 成对复验并更新各自 `comparison.md`；本版本仅汇总并复用这些已提交结论，不重跑 skill eval。


### PR DESCRIPTION
## 发布摘要

- 新增 `docs/changelog/changelog-v0.3.3.md`，汇总 v0.3.2 之后合并的 PR #147、#149、#151，以及本 PR 创建前并发合入 `main` 的 #152。
- 将 `.claude-plugin/marketplace.json` 与 7 个 Agent plugin manifest 的版本统一更新为 `0.3.3`。
- 在根 `CHANGELOG.md` 增加 v0.3.3 版本化 changelog 索引。

## Skill Eval 汇总口径

- `github-release-generator`：既有 4 个 eval 复验 18/18 assertions PASS；新增 eval-005 复验 3/3 assertions PASS。
- Security 四个 specialist：12 个薄 fixture eval 复验 48/48 assertions PASS。
- `docs-site-bootstrap`、`formal-docs-sync`、`release-notes-generator`、`docs-agent`：12 个 eval 复验全部 PASS。
- 以上结果均已在对应 PR 合并时完成 fresh `with_skill` / `without_skill` 成对复验并更新 durable `comparison.md`；本次发布复用结果，不重跑模型 eval。
- 按 review 意见覆盖 marketplace 全部 40 个 skill：39 个 skill 使用 152 份 canonical comparison，`roadmap-generator` 使用 3 份当前 legacy comparison；合计 155 份当前结论，129 PASS、26 PARTIAL。

## 本地验证

- `uv run scripts/check_repository_contract.py`：PASS
- `uv run scripts/check_eval_contract.py`：PASS
- `uv run scripts/check_eval_artifacts.py`：PASS
- `uv run scripts/check_doc_contract.py`：PASS
- CI 同款确定性 pytest：133 passed

## 发布边界

- 本 PR 仅准备 v0.3.3 changelog、版本元数据与索引。
- 合并后按已授权流程创建并推送 annotated tag `v0.3.3`。
- 不创建 GitHub Release，不上传 marketplace package，不修改 release bot bypass。
