### PR TITLE
fix: 精确固定 docs-site 模板的 VitePress 依赖版本

### DIFF
--- a/agents/docs/skills/docs-site-bootstrap/assets/docs/site/package-lock.json
+++ b/agents/docs/skills/docs-site-bootstrap/assets/docs/site/package-lock.json
@@ -12,7 +12,7 @@
         "gray-matter": "^4.0.3",
         "mermaid": "^11.4.1",
         "picomatch": "^4.0.2",
-        "vitepress": "^1.6.3",
+        "vitepress": "1.6.4",
         "yaml": "^2.7.0"
       }
     },

--- a/agents/docs/skills/docs-site-bootstrap/assets/docs/site/package.json
+++ b/agents/docs/skills/docs-site-bootstrap/assets/docs/site/package.json
@@ -22,7 +22,7 @@
     "gray-matter": "^4.0.3",
     "mermaid": "^11.4.1",
     "picomatch": "^4.0.2",
-    "vitepress": "^1.6.3",
+    "vitepress": "1.6.4",
     "yaml": "^2.7.0"
   }
 }

--- a/agents/docs/test/docs-agent/evals/workspace/eval-005-integration-release-chain/docs/site/package-lock.json
+++ b/agents/docs/test/docs-agent/evals/workspace/eval-005-integration-release-chain/docs/site/package-lock.json
@@ -12,7 +12,7 @@
         "gray-matter": "^4.0.3",
         "mermaid": "^11.4.1",
         "picomatch": "^4.0.2",
-        "vitepress": "^1.6.3",
+        "vitepress": "1.6.4",
         "yaml": "^2.7.0"
       }
     },

--- a/agents/docs/test/docs-agent/evals/workspace/eval-005-integration-release-chain/docs/site/package.json
+++ b/agents/docs/test/docs-agent/evals/workspace/eval-005-integration-release-chain/docs/site/package.json
@@ -22,7 +22,7 @@
     "gray-matter": "^4.0.3",
     "mermaid": "^11.4.1",
     "picomatch": "^4.0.2",
-    "vitepress": "^1.6.3",
+    "vitepress": "1.6.4",
     "yaml": "^2.7.0"
   }
 }

--- a/agents/docs/test/docs-site-bootstrap/evals/workspace/eval-001-bootstrap-empty-workspace/comparison.md
+++ b/agents/docs/test/docs-site-bootstrap/evals/workspace/eval-001-bootstrap-empty-workspace/comparison.md
@@ -4,51 +4,54 @@
 
 - Skill: `docs-site-bootstrap`
 - Eval: `eval-001-bootstrap-empty-workspace`
-- Review context: issue #150 fresh paired eval group A
+- Review context: issue #155 fresh paired eval
 
 ## Test Set / Fixture Version
 
 - Fixture: pristine empty host from `workspace/eval-001-bootstrap-empty-workspace`
 - Asset snapshot: current 40-file `assets/docs/site/` inventory
-- Actual validation date: `2026-07-21`
+- Dependency fact under review: the VitePress declaration is pinned exactly to `1.6.4` in both `package.json` and the root and resolved entries of `package-lock.json`
+- Actual validation date: `2026-07-22`
 - Execution cleanup: isolated lane started without `docs/site/`
 
 ## Latest Result
 
-**PASS (6/6 assertions)** — the fresh with-skill lane created the complete bounded scaffold, generated and read back a 40-entry manifest, passed host checks, and demonstrated a zero-content-diff repeat classification.
+**PASS (6/6 assertions)** — the fresh with-skill lane created the complete bounded scaffold, generated and read back a sorted 40-entry manifest, passed the applicable host checks and both site builds with VitePress 1.6.4, and demonstrated a zero-content-diff repeat classification.
 
 ## Assertions
 
 - `creates_complete_inventory`: PASS. All 40 packaged assets were copied byte-for-byte; manifest parsing returned 40 sorted `created` entries.
 - `delivers_deterministic_scaffold_assets`: PASS. `package.json` has exactly one `new:doc`; the scaffold script and test exist; each of five templates has exactly one `docs-scaffold` block and all five are indexed.
-- `validates_seven_frontmatter_fields`: PASS. `npm run test:docs` passed the shared frontmatter checker, including the allowed `doc_type` set and non-empty array requirements.
-- `writes_only_docs_site`: PASS. The generated scaffold and runtime manifest were confined to the isolated `docs/site/` root.
-- `requires_explicit_opt_in`: PASS. Execution relied on the prompt's explicit repository, fixed root, full scaffold, and manifest authorization; the skill gate would stop before writes without that basis.
-- `reports_manifest_readback`: PASS. The manifest was parsed successfully and a checksum dry-run found no file-content delta on repeat classification; only directory timestamps were observable.
+- `validates_seven_frontmatter_fields`: PASS. `npm run test:docs` passed the shared frontmatter checker and all 74 Node tests.
+- `writes_only_docs_site`: PASS. The generated scaffold and runtime manifest were confined to the isolated `docs/site/` root; evaluation evidence remained outside the generated host root under the issue scratch directory.
+- `requires_explicit_opt_in`: PASS. Execution relied on the prompt's explicit host fixture, fixed `docs/site/` root, full scaffold, and manifest authorization; without that entry basis the skill gate stops before writes.
+- `reports_manifest_readback`: PASS. The manifest parsed with 40 valid paths and dispositions, and a second full static-content checksum comparison was zero-diff with the original `createdAt` unchanged.
 
 ## With-Skill Behavior
 
-- Read the Docs Agent boundary, bootstrap skill, internal 40-file inventory, manifest protocol, and shared frontmatter contract only after the explicit opt-in gate passed.
-- Copied 40/40 static assets exactly and created `.meta/bootstrap-manifest.json` with stable sorted paths and `createdAt`.
-- Ran `npm ci --ignore-scripts`, then `npm run test:docs` in the isolated `docs/site/`; exit status was `0`, with 74/74 Node tests passing.
-- The isolated fixture initially inherited the outer worktree's exact tag `v0.3.2`. The final run used a runtime-only Git wrapper that makes only `git describe --exact-match` unavailable while delegating every other Git command, preventing an unrelated ancestor tag from contaminating fixture version checks.
+- Source: fresh issue #155 with-skill lane under `tmp/eval-runs/issue-155/with_skill/eval-001`, using the current Docs README, target skill, internal inventory protocol, shared frontmatter contract, eval prompt, and pristine fixture.
+- Copied 40/40 static assets exactly, created `.meta/bootstrap-manifest.json` with stable sorted paths, and read every generated static target back against its packaged source.
+- Confirmed `vitepress: "1.6.4"` in `package.json`, the lockfile root dependency, and the resolved `node_modules/vitepress` record.
+- Ran `npm ci`, `npm run test:docs`, `npm run build:public`, and `npm run build:internal`; all exited `0`, and both build logs identified VitePress 1.6.4.
+- Reclassified the complete static inventory and compared checksums after host checks; scaffold content and manifest remained zero-diff. Generated `.generated/**` trees and `node_modules/**` were treated only as runtime evidence.
 
 ## Fresh Without-Skill Baseline
 
-- Source: fresh `without_skill` lane from the same pristine empty fixture and the same eval prompt/assertions; it did not read the target `SKILL.md`, Docs README, internal instructions, old comparison, or with-skill output.
-- The baseline independently found the packaged assets, produced the 40-file scaffold and manifest, and passed the same isolated host checks; it satisfied 6/6 assertions.
-- Its artifact result was correct, but it lacked the skill's authoritative explanation of persistent manifest dispositions, conflict-state transitions, and safety-net handoff behavior.
+- Source: a newly spawned independent issue #155 baseline worker using the same prompt and empty scratch fixture. It was explicitly prohibited from reading the target skill, Docs README, internal instructions, old comparisons, with-skill output, and packaged assets.
+- Result: `BLOCKED`. The empty scratch exposed no scaffold source, complete inventory, manifest rules, or runner, so the worker correctly refused to guess and created no `docs/site/` output.
+- No historical baseline was reused. The inability to generate the requested scaffold demonstrates the behavioral value of the skill and does not block the valid with-skill result.
 
 ## Failures
 
-- No assertion failures.
-- `npm ci` reported 3 audit advisories (2 moderate, 1 high); installation and required docs checks still exited `0`, so this is not a failure of the evaluated bootstrap behavior.
+- No with-skill assertion failures or blocked checks.
+- The fresh without-skill lane was blocked by absent implementation sources and satisfied none of the artifact assertions.
+- `npm ci` reported 3 audit advisories (2 moderate, 1 high); installation, 74/74 tests, and both required builds still passed, so this is recorded as non-blocking runtime evidence rather than an eval failure.
 
 ## Next Steps
 
-- Keep this PASS as the issue #150 fresh result. Re-run paired validation whenever the 40-file inventory, frontmatter contract, manifest state machine, or scaffold tests change.
+- Retain this PASS as the issue #155 result. Re-run paired validation whenever the packaged inventory, dependency declarations, manifest state machine, frontmatter contract, or scaffold tests change.
 
 ## Runtime Artifact Policy
 
-- Runtime lanes, `node_modules`, manifests, test output, and the isolation wrapper remain under `tmp/eval-runs/issue-150/group-a/` and are not durable repository artifacts.
-- Only this `comparison.md` is retained; no transcript, candidate, verdict, timing, diagnostics, build output, or runtime dependency directory is submitted.
+- Runtime lanes, manifests, checksums, `node_modules`, generated site trees, and baseline reports remain under `tmp/eval-runs/issue-155/` and are not durable repository artifacts.
+- Only this `comparison.md` is retained; no transcript, candidate, verdict, timing, diagnostics, dependency directory, or generated site output is submitted.

--- a/agents/docs/test/docs-site-bootstrap/evals/workspace/eval-002-repeat-bootstrap-idempotent/comparison.md
+++ b/agents/docs/test/docs-site-bootstrap/evals/workspace/eval-002-repeat-bootstrap-idempotent/comparison.md
@@ -4,46 +4,50 @@
 
 - Skill: `docs-site-bootstrap`
 - Eval: `eval-002-repeat-bootstrap-idempotent`
-- Review context: issue #150 fresh paired eval group A
+- Review context: issue #155 fresh paired eval
 
 ## Test Set / Fixture Version
 
 - Fixture: `issue-122-assets-v2-c5r`
 - Scope: 9 materialized targets; all omitted targets are explicitly assumed present and byte-identical to the current 40-file inventory
-- Actual validation date: `2026-07-21`
+- Dependency fact under review: the representative `package.json` VitePress declaration is pinned exactly to `1.6.4`
+- Actual validation date: `2026-07-22`
 
 ## Latest Result
 
-**PASS (3/3 assertions)** — the with-skill repeat classification preserved the existing manifest and host state with zero file-content changes.
+**PASS (3/3 assertions)** — the fresh with-skill repeat classification preserved every representative target, the existing manifest dispositions, and the original `createdAt` with zero content changes.
 
 ## Assertions
 
-- `produces_zero_diff`: PASS. All materialized targets compared byte-identical to packaged assets; no file was rewritten and `createdAt` remained `2026-07-16T08:00:00+08:00`.
+- `produces_zero_diff`: PASS. All nine materialized targets compared byte-identical to packaged assets; before/after SHA-256 sets matched and `createdAt` remained `2026-07-16T08:00:00+08:00`.
 - `reports_skipped_identical`: PASS. The nine representative paths remain persisted as `skipped-identical` in the existing manifest.
-- `preserves_existing_state`: PASS. `standards/change-map.yaml`, `.meta/releases.json`, standards pages, templates, and all other fixture content remained unchanged.
+- `preserves_existing_state`: PASS. `standards/change-map.yaml`, `.meta/releases.json`, standards pages, templates, package metadata, manifest, and all other fixture content remained unchanged.
 
 ## With-Skill Behavior
 
-- Applied the 40-file inventory and manifest persistence rules while honoring the fixture's explicit omitted-target equivalence assumption.
-- Byte comparisons for the nine materialized targets all returned equal; manifest read-back showed the original timestamp and dispositions.
-- The fixture intentionally omits scripts and most of the complete site, so `npm run test:docs` is not executable for this minimal idempotency case. Validation used exact asset comparisons, manifest parsing, and before/after content checks as required by the fixture scope.
+- Source: fresh issue #155 with-skill lane under `tmp/eval-runs/issue-155/with_skill/eval-002`, using the current target skill and internal inventory rules with the same eval prompt and copied minimal fixture.
+- Applied the 40-file inventory and persistent manifest rules while honoring the fixture's explicit omitted-target byte-equivalence assumption.
+- Exact comparisons for all nine materialized targets returned equal; manifest read-back preserved all nine `skipped-identical` dispositions and the original timestamp.
+- The representative package declares VitePress exactly as `1.6.4` and remained byte-identical to the current packaged asset.
+- The fixture intentionally omits scripts, the lockfile, and most of the complete site, so host tests and builds are not applicable. Validation used exact asset comparisons, manifest parsing, and before/after content hashes; no complete-host checks are claimed.
 
 ## Fresh Without-Skill Baseline
 
-- Source: fresh `without_skill` lane from the same pristine fixture and prompt/assertions; it did not read the target skill, Docs README, internal instructions, old comparison, or with-skill output.
-- The baseline also compared the representative assets and preserved the manifest and host state, satisfying 3/3 assertions.
-- It did not independently supply the skill's complete persistent-disposition and future-conflict semantics, but that gap did not change this fixture's idempotency result.
+- Source: a newly spawned independent issue #155 baseline worker using the same prompt and copied fixture, with the target skill, Docs README, internal instructions, old comparisons, and with-skill output prohibited.
+- Result: `PARTIAL / NO-OP`. It used the fixture's omitted-target assumption and existing manifest to preserve all content and report zero target changes, but it had no bootstrap runner or complete inventory source and therefore did not claim a real repeat execution.
+- No historical baseline was reused. Its no-op evidence is directionally consistent with the three assertions, while the skill supplied the authoritative inventory and persistent-disposition semantics needed for a complete PASS.
 
 ## Failures
 
-- No assertion failures or blocked checks.
-- Host docs tests are not applicable to this deliberately minimized fixture because its scripts and full package are not materialized.
+- No with-skill assertion failures or blocked checks.
+- Host docs tests and builds are not applicable to this deliberately minimized fixture because the scripts, lockfile, and full site are not materialized.
+- The baseline's missing runner and inventory source limit it to `PARTIAL`; this does not affect the complete with-skill byte and manifest evidence.
 
 ## Next Steps
 
-- Keep this PASS. Re-run if the inventory, representative targets, omitted-target assumption, or manifest disposition rules change.
+- Retain this PASS. Re-run if the inventory, representative targets, omitted-target assumption, dependency declaration, or manifest disposition rules change.
 
 ## Runtime Artifact Policy
 
-- Runtime copies and byte-comparison output stay under `tmp/eval-runs/issue-150/group-a/` and are not submitted.
-- Only this durable comparison is retained; no runtime output, dependencies, transcript, candidate, verdict, timing, or diagnostics are committed.
+- Runtime copies, checksums, and baseline reports remain under `tmp/eval-runs/issue-155/` and are not submitted.
+- Only this durable comparison is retained; no runtime output, dependency directory, generated site, transcript, candidate, verdict, timing, or diagnostics are committed.

--- a/agents/docs/test/docs-site-bootstrap/evals/workspace/eval-002-repeat-bootstrap-idempotent/docs/site/package.json
+++ b/agents/docs/test/docs-site-bootstrap/evals/workspace/eval-002-repeat-bootstrap-idempotent/docs/site/package.json
@@ -22,7 +22,7 @@
     "gray-matter": "^4.0.3",
     "mermaid": "^11.4.1",
     "picomatch": "^4.0.2",
-    "vitepress": "^1.6.3",
+    "vitepress": "1.6.4",
     "yaml": "^2.7.0"
   }
 }

--- a/agents/docs/test/docs-site-bootstrap/evals/workspace/eval-003-block-bootstrap-conflict/comparison.md
+++ b/agents/docs/test/docs-site-bootstrap/evals/workspace/eval-003-block-bootstrap-conflict/comparison.md
@@ -4,46 +4,51 @@
 
 - Skill: `docs-site-bootstrap`
 - Eval: `eval-003-block-bootstrap-conflict`
-- Review context: issue #150 fresh paired eval group A
+- Review context: issue #155 fresh paired eval
 
 ## Test Set / Fixture Version
 
 - Fixture: `issue-122-assets-conflict-v1`
 - Scope: one known host conflict plus representative identical targets; omitted targets follow the fixture's missing-or-identical assumption
-- Actual validation date: `2026-07-21`
+- Dependency fact under review: the representative `package.json` VitePress declaration is pinned exactly to `1.6.4`
+- Actual validation date: `2026-07-22`
 
 ## Latest Result
 
-**PASS (3/3 assertions)** — the with-skill lane found the complete known conflict, preserved the host file and manifest byte-for-byte, and blocked pending an explicit resolution.
+**PASS (3/3 assertions)** — the fresh with-skill lane identified the complete materialized conflict, preserved the customized host file and partial manifest byte-for-byte, and blocked the overwrite stage pending one of three explicit decisions.
 
 ## Assertions
 
-- `blocks_on_complete_conflict_list`: PASS. `docs/site/standards/index.md` was the complete materialized conflict list and the unresolved overwrite phase remained blocked; the manifest gained no success state for that path.
-- `does_not_overwrite_conflict`: PASS. The target still matches the pristine host customization and differs from the packaged asset; no merge, formatting, normalization, or partial overwrite occurred.
-- `offers_explicit_resolution_choices`: PASS. The result offers overwrite, an explicitly reviewed merge, or keep; `kept-as-is` may be recorded only after the user selects keep.
+- `blocks_on_complete_conflict_list`: PASS. `docs/site/standards/index.md` is the complete conflict list under the fixture scope; the unresolved overwrite stage remains blocked and the manifest has no success state for that path.
+- `does_not_overwrite_conflict`: PASS. The target still matches the pristine host customization and differs from the packaged asset; before/after SHA-256 sets match, with no merge, formatting, normalization, or partial overwrite.
+- `offers_explicit_resolution_choices`: PASS. The with-skill result requires the user to choose overwrite, an explicitly reviewed merge, or keep; `kept-as-is` is recorded only after an explicit keep decision.
 
 ## With-Skill Behavior
 
-- Classified `package.json` and `.meta/releases.json` as identical and `standards/index.md` as the known unresolved conflict, while respecting the fixture's omitted-target scope.
-- Read-back confirmed the host-customized index stayed byte-identical to pristine input and the manifest still contains only the two pre-existing `skipped-identical` entries.
-- The fixture is deliberately partial and lacks executable site scripts, so host docs tests are not applicable; conflict preservation and manifest checks are the executable evidence for this case.
+- Source: fresh issue #155 with-skill lane under `tmp/eval-runs/issue-155/with_skill/eval-003`, using the current target skill and conflict protocol with the same eval prompt and copied minimal fixture.
+- Classified `package.json` and `.meta/releases.json` as byte-identical and `standards/index.md` as the single known unresolved conflict; the representative package declares VitePress exactly as `1.6.4`.
+- Read-back confirmed the customized index and manifest stayed byte-identical to input; the manifest still contains only the two pre-existing `skipped-identical` entries and no state for the conflict.
+- The valid outcome is blocked pending overwrite, explicit merge, or keep. A future keep decision would add `kept-as-is`; no such decision was inferred in this run.
+- The fixture deliberately omits executable site scripts and most inventory files, so host tests and builds are not applicable. Conflict comparison, manifest parsing, and before/after hashes are the executable evidence; no complete-host checks are claimed.
 
 ## Fresh Without-Skill Baseline
 
-- Source: fresh `without_skill` lane from the same pristine fixture and prompt/assertions; it did not read the target skill, Docs README, internal instructions, old comparison, or with-skill output.
-- The explicit `known_conflict` fixture field was sufficient for the baseline to preserve the file, block, and offer all three choices; it satisfied 3/3 assertions.
-- The skill added authoritative guarantees for complete inventory classification and persistent `kept-as-is` semantics that the baseline did not independently define.
+- Source: a newly spawned independent issue #155 baseline worker using the same prompt and copied fixture, with the target skill, Docs README, internal instructions, old comparisons, and with-skill output prohibited.
+- Result: `BLOCKED`. It preserved the customized conflict and partial manifest, but lacked the full inventory source and could not complete omitted-target classification or bootstrap.
+- The baseline identified keep and overwrite as decisions but omitted the required explicit-merge option, so its behavior satisfies conflict preservation but not the full three-choice assertion. No historical baseline was reused.
 
 ## Failures
 
-- No assertion failures.
-- The blocked overwrite is the expected successful behavior, not an eval failure.
+- No with-skill assertion failures.
+- The blocked overwrite stage is the expected successful behavior, not an eval failure.
+- Host docs tests and builds are not applicable to this deliberately partial conflict fixture.
+- The baseline did not provide the full three-option conflict protocol and remained blocked by missing inventory; this comparison does not promote it to PASS.
 
 ## Next Steps
 
-- Keep this PASS. A real bootstrap remains paused until the maintainer selects overwrite, an approved merge, or keep for each conflict.
+- Retain this PASS. A real bootstrap remains paused until the maintainer selects overwrite, an approved explicit merge, or keep for every conflict.
 
 ## Runtime Artifact Policy
 
-- Runtime copies, comparisons, and conflict evidence stay under `tmp/eval-runs/issue-150/group-a/` and are not submitted.
-- Only this comparison is durable; no runtime transcript, candidate, verdict, timing, diagnostics, dependencies, or build output is committed.
+- Runtime copies, hashes, conflict evidence, and baseline reports remain under `tmp/eval-runs/issue-155/` and are not submitted.
+- Only this durable comparison is retained; no runtime transcript, candidate, verdict, timing, diagnostics, dependencies, or generated site output is committed.

--- a/agents/docs/test/docs-site-bootstrap/evals/workspace/eval-003-block-bootstrap-conflict/docs/site/package.json
+++ b/agents/docs/test/docs-site-bootstrap/evals/workspace/eval-003-block-bootstrap-conflict/docs/site/package.json
@@ -22,7 +22,7 @@
     "gray-matter": "^4.0.3",
     "mermaid": "^11.4.1",
     "picomatch": "^4.0.2",
-    "vitepress": "^1.6.3",
+    "vitepress": "1.6.4",
     "yaml": "^2.7.0"
   }
 }

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-001-sync-feature-api/docs/site/package-lock.json
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-001-sync-feature-api/docs/site/package-lock.json
@@ -12,7 +12,7 @@
         "gray-matter": "^4.0.3",
         "mermaid": "^11.4.1",
         "picomatch": "^4.0.2",
-        "vitepress": "^1.6.3",
+        "vitepress": "1.6.4",
         "yaml": "^2.7.0"
       }
     },

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-001-sync-feature-api/docs/site/package.json
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-001-sync-feature-api/docs/site/package.json
@@ -22,7 +22,7 @@
     "gray-matter": "^4.0.3",
     "mermaid": "^11.4.1",
     "picomatch": "^4.0.2",
-    "vitepress": "^1.6.3",
+    "vitepress": "1.6.4",
     "yaml": "^2.7.0"
   }
 }

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-007-feature-database-design/docs/site/package-lock.json
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-007-feature-database-design/docs/site/package-lock.json
@@ -12,7 +12,7 @@
         "gray-matter": "^4.0.3",
         "mermaid": "^11.4.1",
         "picomatch": "^4.0.2",
-        "vitepress": "^1.6.3",
+        "vitepress": "1.6.4",
         "yaml": "^2.7.0"
       }
     },

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-007-feature-database-design/docs/site/package.json
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-007-feature-database-design/docs/site/package.json
@@ -22,7 +22,7 @@
     "gray-matter": "^4.0.3",
     "mermaid": "^11.4.1",
     "picomatch": "^4.0.2",
-    "vitepress": "^1.6.3",
+    "vitepress": "1.6.4",
     "yaml": "^2.7.0"
   }
 }

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-008-deployment-ops-upgrade/docs/site/package-lock.json
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-008-deployment-ops-upgrade/docs/site/package-lock.json
@@ -12,7 +12,7 @@
         "gray-matter": "^4.0.3",
         "mermaid": "^11.4.1",
         "picomatch": "^4.0.2",
-        "vitepress": "^1.6.3",
+        "vitepress": "1.6.4",
         "yaml": "^2.7.0"
       }
     },

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-008-deployment-ops-upgrade/docs/site/package.json
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-008-deployment-ops-upgrade/docs/site/package.json
@@ -22,7 +22,7 @@
     "gray-matter": "^4.0.3",
     "mermaid": "^11.4.1",
     "picomatch": "^4.0.2",
-    "vitepress": "^1.6.3",
+    "vitepress": "1.6.4",
     "yaml": "^2.7.0"
   }
 }

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-009-release-product-ops/docs/site/package-lock.json
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-009-release-product-ops/docs/site/package-lock.json
@@ -12,7 +12,7 @@
         "gray-matter": "^4.0.3",
         "mermaid": "^11.4.1",
         "picomatch": "^4.0.2",
-        "vitepress": "^1.6.3",
+        "vitepress": "1.6.4",
         "yaml": "^2.7.0"
       }
     },

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-009-release-product-ops/docs/site/package.json
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-009-release-product-ops/docs/site/package.json
@@ -22,7 +22,7 @@
     "gray-matter": "^4.0.3",
     "mermaid": "^11.4.1",
     "picomatch": "^4.0.2",
-    "vitepress": "^1.6.3",
+    "vitepress": "1.6.4",
     "yaml": "^2.7.0"
   }
 }

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-010-release-notes-boundary/docs/site/package-lock.json
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-010-release-notes-boundary/docs/site/package-lock.json
@@ -12,7 +12,7 @@
         "gray-matter": "^4.0.3",
         "mermaid": "^11.4.1",
         "picomatch": "^4.0.2",
-        "vitepress": "^1.6.3",
+        "vitepress": "1.6.4",
         "yaml": "^2.7.0"
       }
     },

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-010-release-notes-boundary/docs/site/package.json
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-010-release-notes-boundary/docs/site/package.json
@@ -22,7 +22,7 @@
     "gray-matter": "^4.0.3",
     "mermaid": "^11.4.1",
     "picomatch": "^4.0.2",
-    "vitepress": "^1.6.3",
+    "vitepress": "1.6.4",
     "yaml": "^2.7.0"
   }
 }

--- a/agents/docs/test/release-notes-generator/evals/workspace/eval-001-generate-site-release-notes/docs/site/package-lock.json
+++ b/agents/docs/test/release-notes-generator/evals/workspace/eval-001-generate-site-release-notes/docs/site/package-lock.json
@@ -12,7 +12,7 @@
         "gray-matter": "^4.0.3",
         "mermaid": "^11.4.1",
         "picomatch": "^4.0.2",
-        "vitepress": "^1.6.3",
+        "vitepress": "1.6.4",
         "yaml": "^2.7.0"
       }
     },

--- a/agents/docs/test/release-notes-generator/evals/workspace/eval-001-generate-site-release-notes/docs/site/package.json
+++ b/agents/docs/test/release-notes-generator/evals/workspace/eval-001-generate-site-release-notes/docs/site/package.json
@@ -22,7 +22,7 @@
     "gray-matter": "^4.0.3",
     "mermaid": "^11.4.1",
     "picomatch": "^4.0.2",
-    "vitepress": "^1.6.3",
+    "vitepress": "1.6.4",
     "yaml": "^2.7.0"
   }
 }

--- a/agents/docs/test/release-notes-generator/evals/workspace/eval-002-confirmation-gate/docs/site/package-lock.json
+++ b/agents/docs/test/release-notes-generator/evals/workspace/eval-002-confirmation-gate/docs/site/package-lock.json
@@ -12,7 +12,7 @@
         "gray-matter": "^4.0.3",
         "mermaid": "^11.4.1",
         "picomatch": "^4.0.2",
-        "vitepress": "^1.6.3",
+        "vitepress": "1.6.4",
         "yaml": "^2.7.0"
       }
     },

--- a/agents/docs/test/release-notes-generator/evals/workspace/eval-002-confirmation-gate/docs/site/package.json
+++ b/agents/docs/test/release-notes-generator/evals/workspace/eval-002-confirmation-gate/docs/site/package.json
@@ -22,7 +22,7 @@
     "gray-matter": "^4.0.3",
     "mermaid": "^11.4.1",
     "picomatch": "^4.0.2",
-    "vitepress": "^1.6.3",
+    "vitepress": "1.6.4",
     "yaml": "^2.7.0"
   }
 }

--- a/agents/docs/test/release-notes-generator/evals/workspace/eval-003-github-release-boundary/docs/site/package-lock.json
+++ b/agents/docs/test/release-notes-generator/evals/workspace/eval-003-github-release-boundary/docs/site/package-lock.json
@@ -12,7 +12,7 @@
         "gray-matter": "^4.0.3",
         "mermaid": "^11.4.1",
         "picomatch": "^4.0.2",
-        "vitepress": "^1.6.3",
+        "vitepress": "1.6.4",
         "yaml": "^2.7.0"
       }
     },

--- a/agents/docs/test/release-notes-generator/evals/workspace/eval-003-github-release-boundary/docs/site/package.json
+++ b/agents/docs/test/release-notes-generator/evals/workspace/eval-003-github-release-boundary/docs/site/package.json
@@ -22,7 +22,7 @@
     "gray-matter": "^4.0.3",
     "mermaid": "^11.4.1",
     "picomatch": "^4.0.2",
-    "vitepress": "^1.6.3",
+    "vitepress": "1.6.4",
     "yaml": "^2.7.0"
   }
 }

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -189,7 +189,7 @@
     "docs-site-bootstrap": {
       "source": "agents/docs/skills/docs-site-bootstrap",
       "sourceType": "local",
-      "computedHash": "b6cc4a20f8b8c5041c8658616aa05d42f0f15afa59f7154400afa04b99802311"
+      "computedHash": "ed5b48be45230d35295b31a6ff09af6b742daab2da71edf7997d87f98ffc22b5"
     },
     "formal-docs-sync": {
       "source": "agents/docs/skills/formal-docs-sync",


### PR DESCRIPTION
## 概要

- 将 `docs-site-bootstrap` 模板的 VitePress 依赖从 caret 范围精确固定为已验证版本 `1.6.4`
- 同步 docs-site-bootstrap、formal-docs-sync、release-notes-generator 与 docs-agent 相关 eval fixture
- 使用仓库同款算法刷新 `docs-site-bootstrap` 的 `computedHash`
- fresh 成对复验 docs-site-bootstrap 的 3 个 eval，并更新 durable `comparison.md`

## 无漂移验证

- 10 个 `package-lock.json` 均只修改顶层 `packages[""].dependencies.vitepress` 声明行
- `node_modules/vitepress.version` 仍为 `1.6.4`
- resolved URL、integrity、Mermaid、Vite、Vue、Shiki 及其他依赖版本均未变化
- 未执行依赖升级或 lockfile 重新解析

## Fresh eval

- `eval-001-bootstrap-empty-workspace`：PASS，6/6 assertions；74/74 docs tests、public/internal build 通过
- `eval-002-repeat-bootstrap-idempotent`：PASS，3/3 assertions；代表性 fixture zero-diff
- `eval-003-block-bootstrap-conflict`：PASS，3/3 assertions；冲突文件与 manifest 保持 zero-diff
- 三项均使用同一 prompt/fixture 全新生成 without-skill baseline，未复用历史 baseline
- 其他 skill 的 eval 本轮未重跑：相关 fixture 仅修改 VitePress 声明行，未改变 skill 行为、assertions 或 fixture 结构
- 运行期产物保留在 gitignored scratch 中，未提交

## 验证

- `uv run scripts/check_repository_contract.py`
- `uv run scripts/check_eval_contract.py`
- `uv run scripts/check_eval_artifacts.py`
- `uv run scripts/check_doc_contract.py`
- CI 同款确定性 pytest：133 passed

Closes #155
