### PR TITLE
test: 验证 delivery 无 skill 基线交付

### DIFF
--- a/runtime-proof/delivery-eval-without-skill.md
+++ b/runtime-proof/delivery-eval-without-skill.md
@@ -1,0 +1,10 @@
+# Delivery Eval Runtime Proof
+
+- Mode: `without_skill`
+- Eval: `delivery/eval-001-create-pr-with-commits`
+- Fixture: `agents/engineer/test/delivery/evals/workspace/eval-001-create-pr-with-commits`
+- Base: `test/issue-158-round1-thin-fixtures`
+- Canonical PM document: `agents/engineer/test/delivery/evals/workspace/eval-001-create-pr-with-commits/docs/pm/notifications/PRD.md`
+- Local verification: `npm test`
+
+This temporary proof exists only for hosted delivery validation and must not be merged.


### PR DESCRIPTION
## 摘要

- 为 `delivery/eval-001-create-pr-with-commits` 提供最小 hosted runtime proof
- 验证 without-skill baseline 的 branch、commit、push、PR 与 hosted CI 链路
- 此 PR 仅用于临时验证，不得合并

## PM 文档

- PRD: `agents/engineer/test/delivery/evals/workspace/eval-001-create-pr-with-commits/docs/pm/notifications/PRD.md`
- Delivery handoff: `agents/engineer/test/delivery/evals/workspace/eval-001-create-pr-with-commits/DELIVERY_HANDOFF.md`
- Relates to #123

## 变更

- 新增 1 个最小 runtime proof 文件，不修改 canonical fixture 或产品代码

## 测试状态

- [x] `npm test --prefix agents/engineer/test/delivery/evals/workspace/eval-001-create-pr-with-commits`（1/1 PASS）
- [x] `git diff --staged --check`
- [x] Hosted CI：repository-contract、eval-contract、doc-contract、python-tests 全部 PASS

## Checklist

- [x] Conventional Commit
- [x] Self-review completed
- [x] Temporary validation only; do not merge