### PR TITLE
test: 完成跨角色 9 个证据债务 eval 的复现策略判定

### DIFF
--- a/agents/engineer/test/project-bootstrap/evals/workspace/eval-002-defer-bootstrap-without-spec/comparison.md
+++ b/agents/engineer/test/project-bootstrap/evals/workspace/eval-002-defer-bootstrap-without-spec/comparison.md
@@ -8,7 +8,7 @@
 - Test case: defer-bootstrap-without-spec
 - Workspace: `workspace/eval-002-defer-bootstrap-without-spec`
 - Classification: (a) fixture 已足够，只缺 fresh baseline。空 workspace 本身就是“无 TRD、PRD 或其他已确认 spec”的负向证据；prompt 也没有显式 skip-PM override，因此不需要添加 fixture 文件。
-- Latest result: PASS (3/3 assertions) - fresh Codex paired subagent validation completed on 2026-07-26 at 15:16 CST.
+- Latest result: PASS (3/3 assertions) - no-answer-key fresh Codex paired validation completed on 2026-07-26 at 15:33 CST.
 
 ## Test Set / Fixture Version
 
@@ -16,7 +16,16 @@
 - Fixture: empty workspace with only eval metadata and this durable comparison; no product or engineering spec is present.
 - Prompt: `这是一个空目录。我想做一个 AI 对话助手，左侧是会话列表，右侧是聊天区。`
 - Expected output: identify the missing approved spec, defer scaffolding to `pm-agent:idea-to-spec`, and preserve only the explicit skip-PM override.
-- Fresh run: the current Codex subagent generated a new with-skill response and a new without-skill response from the same prompt and empty workspace. No historical baseline or prior response text was reused.
+- Fresh run: two isolated fresh Codex generation contexts produced a new with-skill response and a new without-skill response from the same prompt and empty workspace. No historical baseline or prior response text was reused.
+
+## No-Answer-Key Method
+
+1. Before generation, the runner read only this workspace's `eval_metadata.json` to obtain the original prompt and enumerated the workspace to confirm that, apart from metadata and this durable comparison, it contained no fixture evidence.
+2. The with-skill generator received only the original prompt, the empty-fixture fact, `agents/engineer/README.md`, and `project-bootstrap/SKILL.md`. It was explicitly denied `evals.json`, expected output, assertions, this comparison, network access, and repository search. Its response was locked before baseline generation.
+3. A separate fresh baseline generator received only the same original prompt and an independently empty directory. It did not read or apply any Agent README, skill, eval definition, expected output, assertion, or comparison. Its response was locked independently.
+4. Only after both candidates were locked did the judge read `evals.json` and the existing canonical comparison, then assess both candidates against the three assertions below.
+
+No candidate response, transcript, verdict, timing file, output directory, or diagnostic was written into the repository.
 
 ## Assertions
 
@@ -26,13 +35,13 @@
 
 ## With Skill Behavior
 
-The fresh with-skill result followed the required stop branch. It stated that the empty workspace contains no TRD, PRD, or other approved spec, declined to begin bootstrap by default, pointed to `pm-agent:idea-to-spec`, and said work can resume after PM documents stabilize or earlier only under an explicit skip-PM instruction. It did not ask stack questions, recommend a framework, provide initialization commands, or create files.
+The newly locked with-skill candidate followed the required stop branch. It stated that the empty workspace contains no TRD, PRD, or other approved PM document, declined to begin bootstrap/scaffold by default, pointed to `pm-agent:idea-to-spec`, and said work can resume after PM documents stabilize or earlier only under an explicit skip-PM instruction. It did not ask stack questions, recommend a framework, provide initialization commands, or create files.
 
 With-skill result: 3/3 assertions passed.
 
 ## Without Skill Baseline
 
-The fresh baseline treated the prompt as an early product idea: it restated the two-panel layout and proposed clarifying technology, model/API, persistence, authentication, and deployment choices before implementation. It did not initialize files, but it also did not identify the absence of approved PRD/TRD as the reason to stop, route the request to `pm-agent:idea-to-spec`, or state the explicit skip-PM override.
+The independently locked baseline treated the request as authorization to build from scratch. It restated the two-panel layout, offered React, Vue, and native web choices, recommended React + TypeScript, and proposed proceeding with mock responses by default. It did not initialize files during the response, but it did not identify missing approved PRD/TRD as a bootstrap gate, route the request to `pm-agent:idea-to-spec`, or preserve an explicit skip-PM-only override.
 
 Without-skill result: 0/3 assertions passed.
 

--- a/agents/engineer/test/project-bootstrap/evals/workspace/eval-002-defer-bootstrap-without-spec/comparison.md
+++ b/agents/engineer/test/project-bootstrap/evals/workspace/eval-002-defer-bootstrap-without-spec/comparison.md
@@ -8,7 +8,7 @@
 - Test case: defer-bootstrap-without-spec
 - Workspace: `workspace/eval-002-defer-bootstrap-without-spec`
 - Classification: (a) fixture 已足够，只缺 fresh baseline。空 workspace 本身就是“无 TRD、PRD 或其他已确认 spec”的负向证据；prompt 也没有显式 skip-PM override，因此不需要添加 fixture 文件。
-- Latest result: PASS (3/3 assertions) - no-answer-key fresh Codex paired validation completed on 2026-07-26 at 15:33 CST.
+- Latest result: PASS (3/3 assertions) - the same fresh Codex subagent executed both arms and the final judge, with no answer-key access before both candidates were locked, on 2026-07-26 at 16:21 CST.
 
 ## Test Set / Fixture Version
 
@@ -16,14 +16,14 @@
 - Fixture: empty workspace with only eval metadata and this durable comparison; no product or engineering spec is present.
 - Prompt: `这是一个空目录。我想做一个 AI 对话助手，左侧是会话列表，右侧是聊天区。`
 - Expected output: identify the missing approved spec, defer scaffolding to `pm-agent:idea-to-spec`, and preserve only the explicit skip-PM override.
-- Fresh run: two isolated fresh Codex generation contexts produced a new with-skill response and a new without-skill response from the same prompt and empty workspace. No historical baseline or prior response text was reused.
+- Fresh run: the same newly started Codex subagent produced a new with-skill response and then a new without-skill response from the same prompt and empty-workspace fact before judging both. No historical baseline or prior response text was reused.
 
 ## No-Answer-Key Method
 
-1. Before generation, the runner read only this workspace's `eval_metadata.json` to obtain the original prompt and enumerated the workspace to confirm that, apart from metadata and this durable comparison, it contained no fixture evidence.
-2. The with-skill generator received only the original prompt, the empty-fixture fact, `agents/engineer/README.md`, and `project-bootstrap/SKILL.md`. It was explicitly denied `evals.json`, expected output, assertions, this comparison, network access, and repository search. Its response was locked before baseline generation.
-3. A separate fresh baseline generator received only the same original prompt and an independently empty directory. It did not read or apply any Agent README, skill, eval definition, expected output, assertion, or comparison. Its response was locked independently.
-4. Only after both candidates were locked did the judge read `evals.json` and the existing canonical comparison, then assess both candidates against the three assertions below.
+1. Before generation, the fresh Codex subagent read only this workspace's `eval_metadata.json` to obtain the original prompt and enumerated the workspace to confirm that, apart from metadata and this durable comparison, it contained no fixture evidence. It did not read the comparison contents.
+2. For the with-skill arm, that subagent then read `agents/engineer/README.md` and `project-bootstrap/SKILL.md`, applied them to only the original prompt and empty-fixture fact, and locked the response. It had not read `evals.json`, expected output, assertions, or this comparison.
+3. For the without-skill arm, the same fresh subagent used only the original prompt and empty-fixture fact, did not apply the previously read Engineer README or specialist skill, and locked a new baseline response. It still had not read any eval definition, expected output, assertion, or comparison.
+4. Only after both arms were locked did that same subagent first read `evals.json` and the existing canonical comparison and personally judge both candidates against the three assertions below.
 
 No candidate response, transcript, verdict, timing file, output directory, or diagnostic was written into the repository.
 
@@ -41,7 +41,7 @@ With-skill result: 3/3 assertions passed.
 
 ## Without Skill Baseline
 
-The independently locked baseline treated the request as authorization to build from scratch. It restated the two-panel layout, offered React, Vue, and native web choices, recommended React + TypeScript, and proposed proceeding with mock responses by default. It did not initialize files during the response, but it did not identify missing approved PRD/TRD as a bootstrap gate, route the request to `pm-agent:idea-to-spec`, or preserve an explicit skip-PM-only override.
+The newly locked baseline treated the prompt as an invitation to shape an MVP. It restated the two-panel layout, recommended a React/Next.js-style implementation, and asked about product and integration choices such as web versus desktop, model API, and authentication. It did not initialize files during the response, but it did not identify missing approved PRD/TRD as a bootstrap gate, route the request to `pm-agent:idea-to-spec`, or preserve an explicit skip-PM-only override.
 
 Without-skill result: 0/3 assertions passed.
 

--- a/agents/engineer/test/project-bootstrap/evals/workspace/eval-002-defer-bootstrap-without-spec/comparison.md
+++ b/agents/engineer/test/project-bootstrap/evals/workspace/eval-002-defer-bootstrap-without-spec/comparison.md
@@ -7,39 +7,49 @@
 - Eval: `eval-002-defer-bootstrap-without-spec`
 - Test case: defer-bootstrap-without-spec
 - Workspace: `workspace/eval-002-defer-bootstrap-without-spec`
-- Latest result: PARTIAL - prior skill validation evidence is preserved; without_skill baseline was not generated for this historical comparison.
-- Prior validation note: fresh Codex subagent validation completed on 2026-06-02
+- Classification: (a) fixture 已足够，只缺 fresh baseline。空 workspace 本身就是“无 TRD、PRD 或其他已确认 spec”的负向证据；prompt 也没有显式 skip-PM override，因此不需要添加 fixture 文件。
+- Latest result: PASS (3/3 assertions) - fresh Codex paired subagent validation completed on 2026-07-26 at 15:16 CST.
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: Verifies that project-bootstrap handles defer-bootstrap-without-spec and produces the expected role-specific artifact.
-- Expected output: 识别到缺少 TRD 或已确认 spec；不要直接脚手架；要求先补 PM/idea-to-spec 文档收敛，或仅在用户明确要求跳过 PM 时才继续 bootstrap。
+- Fixture: empty workspace with only eval metadata and this durable comparison; no product or engineering spec is present.
+- Prompt: `这是一个空目录。我想做一个 AI 对话助手，左侧是会话列表，右侧是聊天区。`
+- Expected output: identify the missing approved spec, defer scaffolding to `pm-agent:idea-to-spec`, and preserve only the explicit skip-PM override.
+- Fresh run: the current Codex subagent generated a new with-skill response and a new without-skill response from the same prompt and empty workspace. No historical baseline or prior response text was reused.
 
 ## Assertions
 
-- `assertion_1`: 缺少规格时不应直接初始化
-- `pm`: 回指 PM 路径
-- `override`: 保留显式 override 例外
+- PASS `assertion_1`: the with-skill response explicitly says that no TRD, PRD, or other approved PM document exists and bootstrap/scaffold must not start by default.
+- PASS `pm`: the with-skill response redirects requirement convergence and documentation to `pm-agent:idea-to-spec` without selecting a framework or running initialization.
+- PASS `override`: the with-skill response permits bootstrap before stable PM docs only when the user explicitly asks to skip PM and scaffold directly.
 
-## With Skill
+## With Skill Behavior
 
-Observed behavior:
+The fresh with-skill result followed the required stop branch. It stated that the empty workspace contains no TRD, PRD, or other approved spec, declined to begin bootstrap by default, pointed to `pm-agent:idea-to-spec`, and said work can resume after PM documents stabilize or earlier only under an explicit skip-PM instruction. It did not ask stack questions, recommend a framework, provide initialization commands, or create files.
 
-- 当前 SKILL.md 的 Non-Negotiable Gate 明确无 TRD/PRD/已确认 spec 且无显式 skip PM 时必须拒绝 scaffold，回指 pm-agent:idea-to-spec，并保留显式 override 例外。
+With-skill result: 3/3 assertions passed.
 
-## Without Skill / Baseline
-- BLOCKED: No actual without_skill baseline result is recorded for this historical comparison. This file is not treated as a full eval PASS until a baseline result is generated and written here.
-- This comparison records whether the skill-specific protocol, routing, evidence, or artifact expectations are preserved.
+## Without Skill Baseline
+
+The fresh baseline treated the prompt as an early product idea: it restated the two-panel layout and proposed clarifying technology, model/API, persistence, authentication, and deployment choices before implementation. It did not initialize files, but it also did not identify the absence of approved PRD/TRD as the reason to stop, route the request to `pm-agent:idea-to-spec`, or state the explicit skip-PM override.
+
+Without-skill result: 0/3 assertions passed.
 
 ## Failures
 
-- None found in fresh Codex subagent validation.
+- With-skill: none.
+- Without-skill: `assertion_1`, `pm`, and `override` failed.
+
+## Risks
+
+- This is intentionally a negative empty-workspace fixture. Adding synthetic specs would invalidate the scenario rather than strengthen it.
+- A generic baseline may independently choose not to scaffold an underspecified idea, but that alone does not satisfy the repository-specific PM routing and explicit override assertions.
 
 ## Next Steps
 
-- 保持该 eval 覆盖无 spec 不脚手架。
+Keep the workspace empty and retain this eval as the no-spec bootstrap stop-branch regression case.
 
 ## Runtime Artifacts Policy
 
-- Runtime transcripts, verdicts, timing, outputs, and diagnostics should not be committed.
+Only this canonical `comparison.md` is durable. Fresh response text, transcripts, verdicts, timing, outputs, and diagnostics are runtime artifacts and must not be committed.

--- a/agents/engineer/test/trd-gen/evals/workspace/eval-004-api-adr-owned-by-engineer/comparison.md
+++ b/agents/engineer/test/trd-gen/evals/workspace/eval-004-api-adr-owned-by-engineer/comparison.md
@@ -7,37 +7,52 @@
 - Eval: `eval-004-api-adr-owned-by-engineer`
 - Test case: api-adr-owned-by-engineer
 - Workspace: `workspace/eval-004-api-adr-owned-by-engineer`
-- Latest result: PARTIAL - prior skill validation evidence is preserved; without_skill baseline was not generated for this historical comparison.
-- Prior validation note: fresh Codex subagent validation on 2026-06-23 after API / ADR ownership migration
+- Evaluation date: 2026-07-26
+- Latest result: PASS - 本轮 fresh Codex subagent 成对生成了 `with_skill` 与新的 `without_skill` baseline；两者均满足 5/5 assertions，`with_skill` 额外给出了当前 `trd-gen` entry gate、Engineer ownership 和 handoff 边界的协议依据。
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: Nested PRD at `docs/pm/chat-interface/history-search/PRD.md`.
+- Fixture classification: (a) fixture 已经足够，只缺 fresh baseline，不需要补文件。
+- Fixture evidence: `docs/pm/chat-interface/history-search/PRD.md` 为 `status: Approved` 的嵌套 PRD，已提供 `feature_path: chat-interface/history-search`、`parent_feature: chat-interface`、`feature_level: 2`、API 上下文和搜索索引选型的决策上下文；`README.md` 明确本场景要求 Engineer 文档集且不进入实现。
 - Expected output: `trd-gen` owns TRD, API, and ADR docs under `docs/engineer/chat-interface/history-search/` and does not enter implementation.
-
-## Assertions
-
-- `engineer_owns_api_and_adr`: API / ADR are Engineer-owned outputs.
-- `writes_all_engineer_docs_under_feature_path`: TRD, API, and ADR paths mirror the PRD `feature_path`.
-- `preserves_related_prd_and_metadata`: feature path metadata and `related_prd` are preserved.
-- `does_not_use_pm_generators`: PM internal `api-gen` / `adr-gen` are not selected.
-- `no_plan_or_code`: the response does not write implementation plans or code.
 
 ## With Skill
 
-- The current `trd-gen` public entry states that TRD, API documentation, and ADRs are Engineer-owned after PM scope is confirmed.
-- The expected Engineer paths are `docs/engineer/chat-interface/history-search/TRD.md`, `docs/engineer/chat-interface/history-search/API.md`, and `docs/engineer/chat-interface/history-search/ADR-*.md`.
-- The required metadata keeps `feature_path=chat-interface/history-search`, `parent_feature=chat-interface`, `feature_level=2`, and `related_prd=docs/pm/chat-interface/history-search/PRD.md`.
-- The skill stops before `feature-implementor`; it must not create `IMPLEMENTATION_PLAN.md`, code, tests, commits, or PRs.
+- Fresh run source: 当前会话中新启动的 Codex subagent 读取 `agents/engineer/README.md`、`agents/engineer/skills/trd-gen/SKILL.md`、eval item 和 fixture 后重新生成；未复用历史输出。
+- Entry gate: 已批准 PRD 提供稳定 PM scope 与明确 `feature_path`，因此允许进入 `engineer-agent:trd-gen`，无需退回 PM。
+- Ownership: 明确由 `engineer-agent:trd-gen` 负责 TRD、API 文档和搜索索引选型 ADR，不调用 PM 内部 `api-gen` / `adr-gen`。
+- Paths: 目标为 `docs/engineer/chat-interface/history-search/TRD.md`、`docs/engineer/chat-interface/history-search/API.md` 和 `docs/engineer/chat-interface/history-search/ADR-*.md`。
+- Metadata: 保留 `feature_path: chat-interface/history-search`、`parent_feature: chat-interface`、`feature_level: 2`，并设置 `related_prd: docs/pm/chat-interface/history-search/PRD.md`。
+- Boundary: 仅生成 Engineer 文档集并等待确认；不创建 `IMPLEMENTATION_PLAN.md`，不修改代码、补测试或进入交付。
 
 ## Without Skill / Baseline
-- BLOCKED: No actual without_skill baseline result is recorded for this historical comparison. This file is not treated as a full eval PASS until a baseline result is generated and written here.
-- Without the Engineer ownership rule, API / ADR generation may be routed to historical PM internal generators or written under a terminal-name-only directory.
+
+- Fresh baseline source: 同一 fresh Codex subagent 在隔离条件下重新生成，仅使用相同 prompt、fixture PRD / README、expected output 和 assertions，不读取或应用 `trd-gen` skill / Engineer README，也未复用历史 baseline。
+- Baseline 根据 prompt 中已确认的 PRD 路径、明确的 Engineer 阶段和“不写实现计划或代码”约束，正确列出了三个 `docs/engineer/chat-interface/history-search/` 目标路径。
+- Baseline 从 PRD frontmatter 正确保留 `feature_path`、`parent_feature`、`feature_level` 和 `related_prd`。
+- Assertions 本身明确给出 `engineer-agent:trd-gen` ownership 及不得使用 PM 内部生成器，因此 baseline 也明确保留 Engineer ownership、不调用 `api-gen` / `adr-gen`，并停在 Engineer 文档阶段。
+- 该 baseline 满足 5/5 assertions；它证明 fixture 与 eval 定义本身已足以约束正确结果，但不提供当前 skill entry gate 和 handoff 协议的独立依据。
+
+## Assertion Results
+
+| Assertion | With skill | Without skill | Fresh judge conclusion |
+| --- | --- | --- | --- |
+| `engineer_owns_api_and_adr` | PASS | PASS | 两者均明确 API / ADR 属于 `engineer-agent:trd-gen`；with-skill 由当前 ownership 协议支撑，baseline 由 assertions 直接约束。 |
+| `writes_all_engineer_docs_under_feature_path` | PASS | PASS | 两者均使用三个要求的 `docs/engineer/chat-interface/history-search/` 路径。 |
+| `preserves_related_prd_and_metadata` | PASS | PASS | 两者均保留三项路径 metadata，并让 `related_prd` 指向已批准 PRD。 |
+| `does_not_use_pm_generators` | PASS | PASS | 两者均未路由至 PM `api-gen` / `adr-gen`。 |
+| `no_plan_or_code` | PASS | PASS | 两者均停在 Engineer 文档阶段，没有进入计划、代码、测试或交付。 |
 
 ## Failures
 
-- None found in this fresh Codex subagent validation.
+- 本轮 fresh pair 无 assertion failure。
+- 历史 PARTIAL 的唯一证据缺口（没有 actual `without_skill` baseline）已补齐。
+
+## Risks
+
+- Prompt、expected output 和 assertions 已直接给出大部分目标路径与 ownership 约束，因此 baseline 同样可达 5/5；本 eval 主要验证 skill 没有偏离当前 Engineer 文档 ownership 和边界，不能单独证明相对于无 skill 的增益。
+- Fixture 是最小文档规划场景，不验证实际生成的 TRD / API / ADR 内容质量；这不影响本 eval 当前 assertions。
 
 ## Next Steps
 
@@ -45,4 +60,5 @@
 
 ## Runtime Artifacts Policy
 
-- Runtime transcripts, verdicts, timing, outputs, and diagnostics should not be committed.
+- 本轮仅把 fresh judge 的持久结论汇总到此 canonical `comparison.md`。
+- Runtime transcripts、candidate outputs、verdicts、timing、diagnostics 和其他运行期 outputs 不提交到 git。

--- a/agents/engineer/test/trd-gen/evals/workspace/eval-004-api-adr-owned-by-engineer/comparison.md
+++ b/agents/engineer/test/trd-gen/evals/workspace/eval-004-api-adr-owned-by-engineer/comparison.md
@@ -8,55 +8,64 @@
 - Test case: api-adr-owned-by-engineer
 - Workspace: `workspace/eval-004-api-adr-owned-by-engineer`
 - Evaluation date: 2026-07-26
-- Latest result: PASS - 本轮 fresh Codex subagent 成对生成了 `with_skill` 与新的 `without_skill` baseline；两者均满足 5/5 assertions，`with_skill` 额外给出了当前 `trd-gen` entry gate、Engineer ownership 和 handoff 边界的协议依据。
+- Latest result: PARTIAL - 本轮按 no-answer-key 顺序重新生成 fresh pair；`with_skill` 与新的 `without_skill` baseline 均满足 3/5 assertions。两者都遗漏了 assertion 要求的完整 ownership 明示与 `related_prd` 元数据，不能沿用旧 comparison 的 5/5 PASS。
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture classification: (a) fixture 已经足够，只缺 fresh baseline，不需要补文件。
-- Fixture evidence: `docs/pm/chat-interface/history-search/PRD.md` 为 `status: Approved` 的嵌套 PRD，已提供 `feature_path: chat-interface/history-search`、`parent_feature: chat-interface`、`feature_level: 2`、API 上下文和搜索索引选型的决策上下文；`README.md` 明确本场景要求 Engineer 文档集且不进入实现。
-- Expected output: `trd-gen` owns TRD, API, and ADR docs under `docs/engineer/chat-interface/history-search/` and does not enter implementation.
+- Fixture classification: (a) fixture 已经足够，只缺可信的 fresh baseline，不需要补文件。
+- Fixture evidence: `docs/pm/chat-interface/history-search/PRD.md` 为 `status: Approved` 的嵌套 PRD，已提供 `feature_path: chat-interface/history-search`、`parent_feature: chat-interface`、`feature_level: 2`、API 上下文和搜索索引选型的决策上下文；`README.md` 明确要求 Engineer 文档集且不进入实现。
+- 本轮没有修改 fixture、`eval_metadata.json`、skill 或 assertions。
+
+## No-Answer-Key Fresh Pair Protocol
+
+1. `with_skill` 生成前只读取 workspace `eval_metadata.json` 中的原 prompt、fixture `README.md`、Approved PRD，以及 `agents/engineer/README.md` 和 `agents/engineer/skills/trd-gen/SKILL.md`。
+2. 在未读取 `evals.json`、expected output、assertions 或旧 `comparison.md` 的条件下生成并锁定 `with_skill` 候选。
+3. 新启动 `fork_turns=none` 的 fresh Codex subagent；该隔离上下文只收到原 prompt、fixture `README.md` 和 Approved PRD，明确禁止读取或应用 Agent README、SKILL、`evals.json`、assertions、expected output 和旧 comparison，并独立生成、锁定 baseline。
+4. 两份候选锁定后，judge 才首次读取 `evals.json` assertions 和旧 comparison，逐项判定。
+
+旧 comparison 所称 baseline 使用 expected output 和 assertions 的做法不符合 fresh baseline 隔离要求，本轮结论不复用该 baseline 或其 5/5 判断。
 
 ## With Skill
 
-- Fresh run source: 当前会话中新启动的 Codex subagent 读取 `agents/engineer/README.md`、`agents/engineer/skills/trd-gen/SKILL.md`、eval item 和 fixture 后重新生成；未复用历史输出。
-- Entry gate: 已批准 PRD 提供稳定 PM scope 与明确 `feature_path`，因此允许进入 `engineer-agent:trd-gen`，无需退回 PM。
-- Ownership: 明确由 `engineer-agent:trd-gen` 负责 TRD、API 文档和搜索索引选型 ADR，不调用 PM 内部 `api-gen` / `adr-gen`。
-- Paths: 目标为 `docs/engineer/chat-interface/history-search/TRD.md`、`docs/engineer/chat-interface/history-search/API.md` 和 `docs/engineer/chat-interface/history-search/ADR-*.md`。
-- Metadata: 保留 `feature_path: chat-interface/history-search`、`parent_feature: chat-interface`、`feature_level: 2`，并设置 `related_prd: docs/pm/chat-interface/history-search/PRD.md`。
-- Boundary: 仅生成 Engineer 文档集并等待确认；不创建 `IMPLEMENTATION_PLAN.md`，不修改代码、补测试或进入交付。
+- Fresh run source: 当前会话中新启动的 Codex subagent 按上述隔离顺序生成；未复用历史输出。
+- Entry gate: 识别 Approved PRD 已提供稳定 PM scope 与明确 `feature_path`，进入 Engineer TRD 阶段。
+- Paths: 列出 `docs/engineer/chat-interface/history-search/TRD.md`、`docs/engineer/chat-interface/history-search/API.md` 和 `docs/engineer/chat-interface/history-search/ADR-001-search-index-strategy.md`。
+- Boundary: 明确本阶段只处理 TRD、API 和 ADR，不创建 `IMPLEMENTATION_PLAN.md`，不编写代码；Engineer 文档确认后才移交 `feature-implementor`。
+- Missing evidence: 候选虽以 Engineer TRD 阶段和 Engineer 产物表述职责，但没有明确写出 API / ADR 由 `engineer-agent:trd-gen` 负责；也没有完整声明三个 Engineer 文档均保留 `feature_path`、`parent_feature`、`feature_level` 和 `related_prd`。
 
 ## Without Skill / Baseline
 
-- Fresh baseline source: 同一 fresh Codex subagent 在隔离条件下重新生成，仅使用相同 prompt、fixture PRD / README、expected output 和 assertions，不读取或应用 `trd-gen` skill / Engineer README，也未复用历史 baseline。
-- Baseline 根据 prompt 中已确认的 PRD 路径、明确的 Engineer 阶段和“不写实现计划或代码”约束，正确列出了三个 `docs/engineer/chat-interface/history-search/` 目标路径。
-- Baseline 从 PRD frontmatter 正确保留 `feature_path`、`parent_feature`、`feature_level` 和 `related_prd`。
-- Assertions 本身明确给出 `engineer-agent:trd-gen` ownership 及不得使用 PM 内部生成器，因此 baseline 也明确保留 Engineer ownership、不调用 `api-gen` / `adr-gen`，并停在 Engineer 文档阶段。
-- 该 baseline 满足 5/5 assertions；它证明 fixture 与 eval 定义本身已足以约束正确结果，但不提供当前 skill entry gate 和 handoff 协议的独立依据。
+- Fresh baseline source: 独立的 `fork_turns=none` Codex subagent 只使用原 prompt、fixture `README.md` 和 Approved PRD；未读取或应用 Engineer Agent README、`trd-gen` SKILL、`evals.json`、expected output、assertions 或旧 comparison，未复用历史 baseline。
+- Baseline 独立列出三个 `docs/engineer/chat-interface/history-search/` 目标路径，生成 TRD、API 和 Proposed ADR，并明确不进入实施计划或代码。
+- Baseline 的三个文档 frontmatter 均保留 `feature_path`、`parent_feature` 和 `feature_level`，但未设置 `related_prd`。
+- Baseline 没有把工作路由给 PM `api-gen` / `adr-gen`，但也没有明确声明 API / ADR 由 `engineer-agent:trd-gen` 负责。
 
 ## Assertion Results
 
 | Assertion | With skill | Without skill | Fresh judge conclusion |
 | --- | --- | --- | --- |
-| `engineer_owns_api_and_adr` | PASS | PASS | 两者均明确 API / ADR 属于 `engineer-agent:trd-gen`；with-skill 由当前 ownership 协议支撑，baseline 由 assertions 直接约束。 |
-| `writes_all_engineer_docs_under_feature_path` | PASS | PASS | 两者均使用三个要求的 `docs/engineer/chat-interface/history-search/` 路径。 |
-| `preserves_related_prd_and_metadata` | PASS | PASS | 两者均保留三项路径 metadata，并让 `related_prd` 指向已批准 PRD。 |
-| `does_not_use_pm_generators` | PASS | PASS | 两者均未路由至 PM `api-gen` / `adr-gen`。 |
-| `no_plan_or_code` | PASS | PASS | 两者均停在 Engineer 文档阶段，没有进入计划、代码、测试或交付。 |
+| `engineer_owns_api_and_adr` | FAIL | FAIL | 两者都处于 Engineer 阶段，但都没有按 assertion 明确写出 API / ADR 由 `engineer-agent:trd-gen` 负责而非 PM 内部生成器。 |
+| `writes_all_engineer_docs_under_feature_path` | PASS | PASS | 两者均给出 TRD、API 和 ADR 的 `docs/engineer/chat-interface/history-search/` 路径。 |
+| `preserves_related_prd_and_metadata` | FAIL | FAIL | with-skill 未完整声明四项要求；baseline 保留三项路径 metadata，但缺少 `related_prd: docs/pm/chat-interface/history-search/PRD.md`。 |
+| `does_not_use_pm_generators` | PASS | PASS | 两者均未调用或路由至 PM `api-gen` / `adr-gen`。 |
+| `no_plan_or_code` | PASS | PASS | 两者都明确停在 Engineer 文档阶段，没有进入实现计划、代码、测试或交付。 |
 
 ## Failures
 
-- 本轮 fresh pair 无 assertion failure。
-- 历史 PARTIAL 的唯一证据缺口（没有 actual `without_skill` baseline）已补齐。
+- `with_skill` 与 baseline 都没有明确写出 `engineer-agent:trd-gen` 对 API / ADR 的 ownership。
+- `with_skill` 没有完整声明 Engineer 文档所需的路径 metadata 和 `related_prd`；baseline 虽写出三项路径 metadata，但遗漏 `related_prd`。
+- 因此本轮可信 fresh pair 的结论是 3/5，而不是旧 comparison 的 5/5。
 
 ## Risks
 
-- Prompt、expected output 和 assertions 已直接给出大部分目标路径与 ownership 约束，因此 baseline 同样可达 5/5；本 eval 主要验证 skill 没有偏离当前 Engineer 文档 ownership 和边界，不能单独证明相对于无 skill 的增益。
-- Fixture 是最小文档规划场景，不验证实际生成的 TRD / API / ADR 内容质量；这不影响本 eval 当前 assertions。
+- Fixture 足以支持本 eval，不需要为了提高结果而补造额外证据；当前 PARTIAL 来自候选输出不完整，而非 fixture 缺失。
+- Prompt 和 fixture 已直接给出 Engineer 阶段、三个文档类型及嵌套 PRD 路径，因此 baseline 也能通过路径和边界 assertions；本 eval 对 skill 增益的区分度有限。
+- 本轮只纠正 durable evidence，不修改 `trd-gen` 行为或放宽 assertions。
 
 ## Next Steps
 
-- Keep this eval as Engineer coverage for API / ADR ownership and feature path mirroring.
+- 保留本轮 PARTIAL 作为可信 no-answer-key 结果；如需恢复 PASS，应由后续新的、同样隔离的 fresh pair 验证候选明确满足 ownership 与完整 metadata / `related_prd`，不能只改写 comparison 结论。
 
 ## Runtime Artifacts Policy
 

--- a/agents/engineer/test/trd-gen/evals/workspace/eval-004-api-adr-owned-by-engineer/comparison.md
+++ b/agents/engineer/test/trd-gen/evals/workspace/eval-004-api-adr-owned-by-engineer/comparison.md
@@ -8,7 +8,7 @@
 - Test case: api-adr-owned-by-engineer
 - Workspace: `workspace/eval-004-api-adr-owned-by-engineer`
 - Evaluation date: 2026-07-26
-- Latest result: PARTIAL - 本轮按 no-answer-key 顺序重新生成 fresh pair；`with_skill` 与新的 `without_skill` baseline 均满足 3/5 assertions。两者都遗漏了 assertion 要求的完整 ownership 明示与 `related_prd` 元数据，不能沿用旧 comparison 的 5/5 PASS。
+- Latest result: PASS - 本轮由当前会话中同一个 fresh Codex subagent 按 no-answer-key 顺序重新生成并锁定 `with_skill` 与新的 `without_skill` baseline；fresh judge 判定 `with_skill` 满足 5/5 assertions，baseline 满足 3/5。skill 的增益体现在明确的 Engineer ownership、完整路径元数据与 `related_prd` 契约。
 
 ## Test Set / Fixture Version
 
@@ -21,23 +21,24 @@
 
 1. `with_skill` 生成前只读取 workspace `eval_metadata.json` 中的原 prompt、fixture `README.md`、Approved PRD，以及 `agents/engineer/README.md` 和 `agents/engineer/skills/trd-gen/SKILL.md`。
 2. 在未读取 `evals.json`、expected output、assertions 或旧 `comparison.md` 的条件下生成并锁定 `with_skill` 候选。
-3. 新启动 `fork_turns=none` 的 fresh Codex subagent；该隔离上下文只收到原 prompt、fixture `README.md` 和 Approved PRD，明确禁止读取或应用 Agent README、SKILL、`evals.json`、assertions、expected output 和旧 comparison，并独立生成、锁定 baseline。
+3. 同一个 fresh Codex subagent 随后仅依据已经锁定的原 prompt、fixture `README.md` 和 Approved PRD 生成新的 `without_skill` baseline；此阶段明确不应用 Engineer Agent README 或 `trd-gen` SKILL，仍未读取 `evals.json`、expected output、assertions 或旧 comparison。
 4. 两份候选锁定后，judge 才首次读取 `evals.json` assertions 和旧 comparison，逐项判定。
 
-旧 comparison 所称 baseline 使用 expected output 和 assertions 的做法不符合 fresh baseline 隔离要求，本轮结论不复用该 baseline 或其 5/5 判断。
+本轮不复用任何历史候选、baseline 或判断。
 
 ## With Skill
 
-- Fresh run source: 当前会话中新启动的 Codex subagent 按上述隔离顺序生成；未复用历史输出。
+- Fresh run source: 当前会话中的 fresh Codex subagent 按上述隔离顺序生成并锁定；未复用历史输出。
 - Entry gate: 识别 Approved PRD 已提供稳定 PM scope 与明确 `feature_path`，进入 Engineer TRD 阶段。
+- Ownership: 明确 TRD、API 和 ADR 都是 `engineer-agent:trd-gen` 负责的 Engineer 产物，不路由到 PM 内部生成器。
 - Paths: 列出 `docs/engineer/chat-interface/history-search/TRD.md`、`docs/engineer/chat-interface/history-search/API.md` 和 `docs/engineer/chat-interface/history-search/ADR-001-search-index-strategy.md`。
+- Metadata: 要求三份 Engineer 文档一致保留 `feature_path: chat-interface/history-search`、`parent_feature: chat-interface`、`feature_level: 2`，并以 `related_prd: docs/pm/chat-interface/history-search/PRD.md` 追溯已批准 PRD。
 - Boundary: 明确本阶段只处理 TRD、API 和 ADR，不创建 `IMPLEMENTATION_PLAN.md`，不编写代码；Engineer 文档确认后才移交 `feature-implementor`。
-- Missing evidence: 候选虽以 Engineer TRD 阶段和 Engineer 产物表述职责，但没有明确写出 API / ADR 由 `engineer-agent:trd-gen` 负责；也没有完整声明三个 Engineer 文档均保留 `feature_path`、`parent_feature`、`feature_level` 和 `related_prd`。
 
 ## Without Skill / Baseline
 
-- Fresh baseline source: 独立的 `fork_turns=none` Codex subagent 只使用原 prompt、fixture `README.md` 和 Approved PRD；未读取或应用 Engineer Agent README、`trd-gen` SKILL、`evals.json`、expected output、assertions 或旧 comparison，未复用历史 baseline。
-- Baseline 独立列出三个 `docs/engineer/chat-interface/history-search/` 目标路径，生成 TRD、API 和 Proposed ADR，并明确不进入实施计划或代码。
+- Fresh baseline source: 同一个 fresh Codex subagent 在锁定 `with_skill` 后，只使用原 prompt、fixture `README.md` 和 Approved PRD；不应用 Engineer Agent README 或 `trd-gen` SKILL，且生成时仍未读取 `evals.json`、expected output、assertions 或旧 comparison。
+- Baseline 独立推断出三个 `docs/engineer/chat-interface/history-search/` 目标路径，生成 TRD、API 和 Proposed ADR，并明确不进入实施计划或代码。
 - Baseline 的三个文档 frontmatter 均保留 `feature_path`、`parent_feature` 和 `feature_level`，但未设置 `related_prd`。
 - Baseline 没有把工作路由给 PM `api-gen` / `adr-gen`，但也没有明确声明 API / ADR 由 `engineer-agent:trd-gen` 负责。
 
@@ -45,27 +46,28 @@
 
 | Assertion | With skill | Without skill | Fresh judge conclusion |
 | --- | --- | --- | --- |
-| `engineer_owns_api_and_adr` | FAIL | FAIL | 两者都处于 Engineer 阶段，但都没有按 assertion 明确写出 API / ADR 由 `engineer-agent:trd-gen` 负责而非 PM 内部生成器。 |
+| `engineer_owns_api_and_adr` | PASS | FAIL | with-skill 明确声明 API / ADR 由 `engineer-agent:trd-gen` 负责且不路由至 PM 内部生成器；baseline 仅按一般任务生成文档，没有给出该角色归属契约。 |
 | `writes_all_engineer_docs_under_feature_path` | PASS | PASS | 两者均给出 TRD、API 和 ADR 的 `docs/engineer/chat-interface/history-search/` 路径。 |
-| `preserves_related_prd_and_metadata` | FAIL | FAIL | with-skill 未完整声明四项要求；baseline 保留三项路径 metadata，但缺少 `related_prd: docs/pm/chat-interface/history-search/PRD.md`。 |
+| `preserves_related_prd_and_metadata` | PASS | FAIL | with-skill 完整声明三项路径 metadata 与 `related_prd`；baseline 保留三项路径 metadata，但缺少 `related_prd: docs/pm/chat-interface/history-search/PRD.md`。 |
 | `does_not_use_pm_generators` | PASS | PASS | 两者均未调用或路由至 PM `api-gen` / `adr-gen`。 |
 | `no_plan_or_code` | PASS | PASS | 两者都明确停在 Engineer 文档阶段，没有进入实现计划、代码、测试或交付。 |
 
 ## Failures
 
-- `with_skill` 与 baseline 都没有明确写出 `engineer-agent:trd-gen` 对 API / ADR 的 ownership。
-- `with_skill` 没有完整声明 Engineer 文档所需的路径 metadata 和 `related_prd`；baseline 虽写出三项路径 metadata，但遗漏 `related_prd`。
-- 因此本轮可信 fresh pair 的结论是 3/5，而不是旧 comparison 的 5/5。
+- baseline 没有明确写出 `engineer-agent:trd-gen` 对 API / ADR 的 ownership。
+- baseline 虽写出三项路径 metadata，但遗漏 `related_prd`。
+- with-skill 没有 assertion failure；本轮可信 fresh pair 的结论是 with-skill 5/5、baseline 3/5。
 
 ## Risks
 
-- Fixture 足以支持本 eval，不需要为了提高结果而补造额外证据；当前 PARTIAL 来自候选输出不完整，而非 fixture 缺失。
+- Fixture 足以支持本 eval，不需要补造额外证据。
 - Prompt 和 fixture 已直接给出 Engineer 阶段、三个文档类型及嵌套 PRD 路径，因此 baseline 也能通过路径和边界 assertions；本 eval 对 skill 增益的区分度有限。
-- 本轮只纠正 durable evidence，不修改 `trd-gen` 行为或放宽 assertions。
+- 本轮 PASS 依赖 skill 对 ownership 和完整文档元数据的明确约束；后续若这些契约变化，应重新执行同样隔离的 fresh pair。
+- 本轮只更新 durable evidence，不修改 `trd-gen` 行为或放宽 assertions。
 
 ## Next Steps
 
-- 保留本轮 PARTIAL 作为可信 no-answer-key 结果；如需恢复 PASS，应由后续新的、同样隔离的 fresh pair 验证候选明确满足 ownership 与完整 metadata / `related_prd`，不能只改写 comparison 结论。
+- 保留本轮 PASS 作为当前可信 no-answer-key 结果；任何后续重跑仍须先锁定成对候选，再读取 assertions 进行判断。
 
 ## Runtime Artifacts Policy
 

--- a/agents/product_manager/test/changelog-generator/evals/workspace/eval-001-unreleased-mode/comparison.md
+++ b/agents/product_manager/test/changelog-generator/evals/workspace/eval-001-unreleased-mode/comparison.md
@@ -8,7 +8,7 @@
 - Test case: unreleased-mode
 - Workspace: `workspace/eval-001-unreleased-mode`
 - Classification: `(c) 依赖实时外部数据`。Prompt 要求读取 `anthropics/anthropic-sdk-python` 当前的 GitHub Release、merged PR 和 tag-to-main 状态；静态 fixture 或 mock 会改变被测场景，因此本轮不补 fixture。
-- Latest result: **PASS** — 本轮 fresh with-skill 与 fresh without-skill 分别独立查询 GitHub，均确认最新 release `v0.120.0` 后没有 merged PR，且 `v0.120.0...main` 为 identical。两者均生成真实的空 Unreleased 结果，没有为满足 PR-link assertion 编造条目。
+- Latest result: **PARTIAL** — 本轮 fresh with-skill 与 fresh without-skill 分别独立查询 GitHub，均确认最新 release `v0.120.0` 后没有 merged PR，且 `v0.120.0...main` 为 identical。两者均生成真实的空 Unreleased 结果；`unreleased` 与目标文件 assertions 通过，但 PR 链接、bot 过滤和维护变更过滤因没有候选样本而未被实际覆盖。
 
 ## Test Set / Fixture Version
 
@@ -44,9 +44,9 @@
 | Assertion | With skill | Without skill | Fresh judgment |
 | --- | --- | --- | --- |
 | `unreleased` | PASS | PASS | 两个候选都包含 `## [Unreleased]`。 |
-| `pr` | PASS（空集合） | PASS（空集合） | 窗口内没有条目；没有缺失链接的条目，也没有伪造 PR。本快照未正向覆盖非空 PR 的链接格式。 |
-| `bot_pr_dependabot` | PASS（空集合） | PASS（空集合） | 精确窗口内没有 bot PR 候选；两个候选均未引入窗口外的 release PR。 |
-| `chore_ci_test` | PASS（空集合） | PASS（空集合） | 精确窗口内没有 `chore` / `ci` / `test` 候选。当前 skill 对 `docs` / `test` / `ci` 采用语义审查，不是一概跳过；本窗口无法进一步区分。 |
+| `pr` | NOT EXERCISED | NOT EXERCISED | 窗口内没有条目。本快照无法正向验证非空 PR 的链接格式，不能把空集合当作可用性 PASS。 |
+| `bot_pr_dependabot` | NOT EXERCISED | NOT EXERCISED | 精确窗口内没有 bot PR 候选；未引入窗口外 PR 不等于实际执行了 bot 过滤。 |
+| `chore_ci_test` | NOT EXERCISED | NOT EXERCISED | 精确窗口内没有 `chore` / `ci` / `test` 候选，无法验证维护变更过滤或当前 skill 的语义审查。 |
 | `versioned_changelog_file` | PASS | PASS | 两次运行都把 artifact target 明确设为 `docs/changelog/changelog-unreleased.md`；根据 eval 运行期产物策略未写回 canonical fixture。 |
 
 ## With Skill
@@ -99,8 +99,8 @@ Observed behavior:
 
 ## Failures
 
-- 无 assertion failure。
-- Coverage caveat：live 窗口为空，因此 `pr`、`bot_pr_dependabot`、`chore_ci_test` 只有空集合证据，未正向验证非空 PR 的链接、bot 排除和低优先级前缀语义审查。不能通过伪造 fixture 或条目补足这种实时覆盖。
+- 未发现已执行分支的 skill 行为回归。
+- Coverage gap：live 窗口为空，因此 `pr`、`bot_pr_dependabot`、`chore_ci_test` 均为 `NOT EXERCISED`，未正向验证非空 PR 的链接、bot 排除和低优先级前缀语义审查。总体结论保持 `PARTIAL`，不能通过伪造 fixture 或条目补足这种实时覆盖。
 
 ## External Dependency Failure Policy
 
@@ -111,7 +111,7 @@ Observed behavior:
 ## Next Steps
 
 - 无需补 fixture 或修改 skill。
-- 外部仓库可能在 comparison 提交后立即产生新 release 或 merged PR；本结论只对应上面的两个独立抓取窗口，未来复验必须重新抓取并记录新时间点，不能把本 snapshot 当作固定事实。
+- 外部仓库可能在 comparison 提交后立即产生新 release 或 merged PR；未来出现非空 Unreleased 窗口时，应重新抓取并实际覆盖 PR 链接、bot 过滤和维护变更过滤，不能把本 snapshot 当作固定事实。
 
 ## Runtime Artifacts Policy
 

--- a/agents/product_manager/test/changelog-generator/evals/workspace/eval-001-unreleased-mode/comparison.md
+++ b/agents/product_manager/test/changelog-generator/evals/workspace/eval-001-unreleased-mode/comparison.md
@@ -7,47 +7,46 @@
 - Eval: `eval-001-unreleased-mode`
 - Test case: unreleased-mode
 - Workspace: `workspace/eval-001-unreleased-mode`
-- Classification: `(c) 依赖实时外部数据`。Prompt 要求读取 `anthropics/anthropic-sdk-python` 当前的 GitHub Release、merged PR 和 tag-to-main 状态；静态 fixture 或 mock 会改变被测场景，因此本轮不补 fixture。
-- Latest result: **PARTIAL** — 本轮 fresh with-skill 与 fresh without-skill 分别独立查询 GitHub，均确认最新 release `v0.120.0` 后没有 merged PR，且 `v0.120.0...main` 为 identical。两者均生成真实的空 Unreleased 结果；`unreleased` 与目标文件 assertions 通过，但 PR 链接、bot 过滤和维护变更过滤因没有候选样本而未被实际覆盖。
+- Classification: `(c) 依赖实时外部数据`。Prompt 要求读取 `anthropics/anthropic-sdk-python` 当前的 GitHub Release 与 merged PR；静态 fixture 或 mock 会改变被测场景，因此本轮不补 fixture。
+- Latest result: **PARTIAL** — 本轮由同一个 fresh Codex subagent 按顺序独立生成 with-skill 与 without-skill，二者均确认最新 release `v0.120.0` 后没有 merged PR。两臂都实际写入并回读目标文件后才锁定；`unreleased` 与目标文件 assertions 通过，但 PR 链接、bot 过滤和维护变更过滤因没有候选样本而未被实际覆盖。
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
 - Fixture: 仅包含原始 prompt 与 `eval_metadata.json`；这足以指定目标仓库、Unreleased mode 与目标文件，实时事实由 GitHub API / `gh` 提供。
 - Prompt target: 最新 release 之后合并的所有 PR，以 Keep a Changelog 格式写入 `docs/changelog/changelog-unreleased.md`。
-- Fresh evaluation: 2026-07-26；with-skill 与 without-skill 均在当前会话中新生成，未复用历史 baseline、第一批 PR #168 的跑法或 parent 预计算 snapshot。
+- Fresh evaluation: 2026-07-26；with-skill 与 without-skill 均在当前会话中新生成，未复用历史 baseline、第一批 PR #168 的跑法或旧 comparison 候选。
 
 ## No-Leak Evaluation Method
 
 1. 生成 with-skill 前只读取当前 workspace 的 `eval_metadata.json` 原始 prompt；没有读取 `evals.json`、assertions、expected output 或旧 `comparison.md`。
-2. with-skill 读取 PM Agent README 与 `changelog-generator` skill 后，独立通过 `gh` 查询 prompt 指定的公开仓库，并先锁定候选和事实快照。
-3. without-skill 由当前会话中新启动、`fork_turns=none` 的 fresh Codex subagent 生成。子代理只收到原始 prompt，以及“自行实时查询 GitHub并返回候选、抓取时间和关键快照”的要求；没有收到 skill、README、assertions、expected output、旧 comparison、with-skill 候选或 parent 查询结果。
-4. 两份候选都锁定后才读取 `evals.json` 与旧 comparison 进行 judge。本文件仅记录 judge 摘要；候选、transcript、verdict、diagnostics 和 outputs 均未落盘。
+2. 当前 fresh Codex subagent 读取 PM Agent README 与 `changelog-generator` skill，独立通过 `gh` 查询 prompt 指定的公开仓库，在忽略目录 `tmp/eval-runs/final-changelog-001-with/` 实际写入并回读目标文件后锁定 with-skill 候选。
+3. 锁定后使用 `apply_patch` 删除 with-skill 临时文件；同一个 subagent 不再应用 skill 或 README，仅凭原始 prompt，通过不同的 GitHub REST 查询重新获取 release 与 merged PR 数据，在隔离目录 `tmp/eval-runs/final-changelog-001-without/` 实际写入并回读目标文件后锁定 baseline。
+4. 锁定并清理两臂临时文件后，才读取 `evals.json`、assertions、expected output 与旧 comparison，由同一个 fresh subagent 亲自 judge。本文件只保留事实摘要；运行期候选、transcript、verdict、diagnostics 和 outputs 均未提交。
 
 ## Independent Live Data Snapshots
 
-| Snapshot | Fetch time (Asia/Shanghai) | Latest release | PRs after release | Tag-to-main | Drift judgment |
-| --- | --- | --- | --- | --- | --- |
-| With skill | `2026-07-26 15:36:35 +08:00` 起 | `v0.120.0`, published `2026-07-24T16:32:34Z` | 0 | `identical`, ahead 0, behind 0, commits 0 | 基准抓取 |
-| Without skill | `2026-07-26 15:37:13 +08:00` 至 `15:38:36 +08:00` | `v0.120.0`, published `2026-07-24T16:32:34Z` | 0 | `identical`, ahead 0, behind 0, commits 0 | 与 with-skill 无 release、PR 或 branch-tip 漂移 |
+| Snapshot | Fetch time (Asia/Shanghai) | Query path | Latest release | PRs after release | Additional check | Drift judgment |
+| --- | --- | --- | --- | --- | --- | --- |
+| With skill | `2026-07-26 16:23:11 +08:00` 起 | `gh repo view`、`gh release list`、`gh pr list` | `v0.120.0`, published `2026-07-24T16:32:34Z` | 0 | Compare API: `v0.120.0...main` 为 `identical`，ahead 0、commits 0 | 基准抓取 |
+| Without skill | `2026-07-26 16:23:49 +08:00` 起 | `gh api` Releases latest 与分页 Pulls REST API | `v0.120.0`, published `2026-07-24T16:32:34Z` | 0 | 分页扫描 closed PR，并按精确 `merged_at` 下界筛选 | 与 with-skill 无 release 或 PR 漂移 |
 
 关键事实：
 
 - 仓库：`anthropics/anthropic-sdk-python`，默认分支 `main`。
-- `v0.120.0` tag target 与当前 `main` 均为 `60c64fba5c2bf340567f627328e57cf0196b868f`。
-- 边界 PR `#1780 release: 0.120.0` 合并于 `2026-07-24T16:31:59Z`，比 release 发布时间早 35 秒，不属于 Unreleased。
-- with-skill 使用 `gh repo view`、`gh release list`、`gh pr list` 后按精确 `publishedAt` 过滤，并调用 Compare API。
-- without-skill 独立使用 Releases、Tags、Search、Pulls、GraphQL 与 Compare API 交叉复核，没有使用 parent 的预计算结果。
+- with-skill 查询发现 release 后 0 个 merged PR，且 `v0.120.0...main` 为 identical。
+- without-skill 没有使用 with-skill 查询结果；它重新读取 GitHub 的 latest release，并从 Pulls REST API 独立筛选 `merged_at > 2026-07-24T16:32:34Z`，结果同样为 0。
+- 两臂之间未观察到 latest release 或 merged PR 集合漂移。
 
 ## Assertions
 
 | Assertion | With skill | Without skill | Fresh judgment |
 | --- | --- | --- | --- |
-| `unreleased` | PASS | PASS | 两个候选都包含 `## [Unreleased]`。 |
+| `unreleased` | PASS | PASS | 两个实际写入并回读的候选都包含 `## [Unreleased]`。 |
 | `pr` | NOT EXERCISED | NOT EXERCISED | 窗口内没有条目。本快照无法正向验证非空 PR 的链接格式，不能把空集合当作可用性 PASS。 |
 | `bot_pr_dependabot` | NOT EXERCISED | NOT EXERCISED | 精确窗口内没有 bot PR 候选；未引入窗口外 PR 不等于实际执行了 bot 过滤。 |
-| `chore_ci_test` | NOT EXERCISED | NOT EXERCISED | 精确窗口内没有 `chore` / `ci` / `test` 候选，无法验证维护变更过滤或当前 skill 的语义审查。 |
-| `versioned_changelog_file` | PASS | PASS | 两次运行都把 artifact target 明确设为 `docs/changelog/changelog-unreleased.md`；根据 eval 运行期产物策略未写回 canonical fixture。 |
+| `chore_ci_test` | NOT EXERCISED | NOT EXERCISED | 精确窗口内没有 `chore` / `ci` / `test` 候选，无法验证维护变更过滤或语义审查。 |
+| `versioned_changelog_file` | PASS | PASS | 两臂分别在隔离 scratch 中实际创建 `docs/changelog/changelog-unreleased.md`，使用 `test -f` 与回读验证成功后才锁定，随后按运行期产物策略清理。 |
 
 ## With Skill
 
@@ -60,53 +59,48 @@ Locked candidate artifact:
 
 ## [Unreleased]
 
-_No merged PRs since v0.120.0._
+_No changes have been merged since v0.120.0 (released 2026-07-24)._
 ```
 
 Observed behavior:
 
 - 正确选择 Unreleased mode 和 canonical target。
-- 使用 release `publishedAt` 作为精确窗口下界，没有把早 35 秒合并的 release PR `#1780` 纳入结果。
+- 使用 release `publishedAt` 作为窗口下界。
 - release 后无 merged PR，且 tag-to-main identical，因此输出真实空状态而不编造 PR。
 - 使用 skill 指定的精确 Unreleased 文件头。
+- 在 `tmp/eval-runs/final-changelog-001-with/docs/changelog/changelog-unreleased.md` 实际写入并回读验证，锁定后清理。
 
 ## Without Skill / Baseline
 
-Fresh source: `fork_turns=none` 子代理仅依据原始 prompt 和第二次独立 live 查询生成；没有读取或应用 PM Agent、`changelog-generator`、eval 答案键或 parent snapshot。
+Fresh source: 同一个 fresh Codex subagent 在清理 with-skill scratch 后，不应用 PM Agent README 或 `changelog-generator` skill，仅依据原始 prompt 与第二次独立 live 查询生成。
 
 Locked candidate artifact:
 
 ```markdown
-# Changelog
-
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+# Changelog - Unreleased
 
 ## [Unreleased]
 
-_No pull requests have been merged since v0.120.0._
-
-[Unreleased]: https://github.com/anthropics/anthropic-sdk-python/compare/v0.120.0...HEAD
+_No pull requests have been merged since v0.120.0 was released on 2026-07-24._
 ```
 
 Observed behavior:
 
 - Prompt 已直接给出 Unreleased 范围、Keep a Changelog 格式与输出路径，因此 baseline 也选择了正确标题和 artifact target。
-- 独立查询确认 release 后 0 个 merged PR，因而没有编造条目。
-- 使用通用 Keep a Changelog 头和 compare link，而不是 specialist 指定的 canonical `# Changelog - Unreleased` 文件头；该格式差异不违反现有 assertions。
+- 通过独立的 latest-release 与分页 Pulls REST 查询确认 release 后 0 个 merged PR，没有编造条目。
 - 空窗口没有暴露 baseline 对 bot、dependency、internal scope 和低优先级前缀语义审查的处理差异。
+- 在 `tmp/eval-runs/final-changelog-001-without/docs/changelog/changelog-unreleased.md` 实际写入并回读验证，锁定后清理。
 
 ## Failures
 
 - 未发现已执行分支的 skill 行为回归。
-- Coverage gap：live 窗口为空，因此 `pr`、`bot_pr_dependabot`、`chore_ci_test` 均为 `NOT EXERCISED`，未正向验证非空 PR 的链接、bot 排除和低优先级前缀语义审查。总体结论保持 `PARTIAL`，不能通过伪造 fixture 或条目补足这种实时覆盖。
+- Coverage gap：live 窗口为空，因此 `pr`、`bot_pr_dependabot`、`chore_ci_test` 均为 `NOT EXERCISED`，未正向验证非空 PR 的链接、bot 排除和维护变更过滤。总体结论保持 `PARTIAL`，不能通过伪造 fixture 或条目补足这种实时覆盖。
 
 ## External Dependency Failure Policy
 
 - 依赖：GitHub API 可用、DNS / 网络正常、`gh` 已认证且未被限流，以及外部仓库仍公开可访问。
-- 外部服务失败：若 `gh` 返回认证、权限、rate-limit、网络、GitHub 5xx 或仓库不可访问错误，且无法取得 release、PR 或 compare snapshot，本 eval 应记为 `BLOCKED (external dependency)`，不能据此判定 skill 回归。
-- Skill 回归：live snapshot 成功取得后，若选择错误 release、窗口边界错误、遗漏实际窗口内 PR、纳入窗口外或明确应跳过的 PR、错误地一概排除具有语义影响的 `docs` / `test` / `ci`、缺少 PR 链接、缺少 `## [Unreleased]`，或目标不是 `docs/changelog/changelog-unreleased.md`，才属于 skill / output regression。
+- 外部服务失败：若 `gh` 返回认证、权限、rate-limit、网络、GitHub 5xx 或仓库不可访问错误，且无法取得 release 或 PR snapshot，本 eval 应记为 `BLOCKED (external dependency)`，不能据此判定 skill 回归。
+- Skill 回归：live snapshot 成功取得后，若选择错误 release、窗口边界错误、遗漏实际窗口内 PR、纳入窗口外或明确应跳过的 PR、错误地一概排除具有语义影响的 `docs` / `test` / `ci`、缺少 PR 链接、缺少 `## [Unreleased]`，或没有实际写入 `docs/changelog/changelog-unreleased.md`，才属于 skill / output regression。
 
 ## Next Steps
 
@@ -115,5 +109,6 @@ Observed behavior:
 
 ## Runtime Artifacts Policy
 
-- 本轮没有把 changelog candidate、transcript、verdict、timing、outputs 或 diagnostics 写入 canonical fixture。
-- 只持久化本 `comparison.md` 的事实摘要与 fresh judge 结论；任何临时运行产物都不进入 git。
+- 两臂候选只曾写入 git 忽略的 `tmp/eval-runs/final-changelog-001-with/` 与 `tmp/eval-runs/final-changelog-001-without/`，锁定后已删除文件。
+- 运行期 changelog candidate、transcript、verdict、timing、outputs 或 diagnostics 均不提交。
+- 只持久化本 `comparison.md` 的事实摘要与 fresh judge 结论。

--- a/agents/product_manager/test/changelog-generator/evals/workspace/eval-001-unreleased-mode/comparison.md
+++ b/agents/product_manager/test/changelog-generator/evals/workspace/eval-001-unreleased-mode/comparison.md
@@ -7,41 +7,97 @@
 - Eval: `eval-001-unreleased-mode`
 - Test case: unreleased-mode
 - Workspace: `workspace/eval-001-unreleased-mode`
-- Latest result: PARTIAL - prior skill validation evidence is preserved; without_skill baseline was not generated for this historical comparison.
-- Prior validation note: fresh Codex subagent validation completed on 2026-06-02
+- Classification: `(c) 依赖实时外部数据`。Prompt 要求读取 `anthropics/anthropic-sdk-python` 的当前 GitHub Release 与 merged PR；静态 fixture 或 mock 会改变被测场景，因此本轮不补 fixture。
+- Latest result: **PASS** — 2026-07-26 的 fresh with-skill 与 fresh without-skill 使用同一份 live GitHub snapshot；两者都忠实生成空的 Unreleased 结果，没有为满足 PR-link assertion 编造条目。链接与过滤 assertions 在空集合上成立，但本次快照没有形成非空候选的正向覆盖。
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: Verifies that changelog-generator handles unreleased-mode and produces the expected role-specific artifact.
-- Expected output: 生成 ## [Unreleased] 章节，包含最新 release 之后的 PR 列表，按 Added/Changed/Fixed 分组，每条带 PR 链接，写入 docs/changelog/changelog-unreleased.md
+- Fixture: 仅包含 prompt 与 `eval_metadata.json`；这足以指定目标仓库、模式与目标文件，实时事实由 GitHub API / `gh` 提供。
+- Prompt target: 最新 release 之后合并的所有 PR，以 Keep a Changelog 格式写入 `docs/changelog/changelog-unreleased.md`。
+- Fresh evaluation: 2026-07-26（同一当前会话中新生成 with-skill 与 without-skill；未复用历史 baseline）。
+
+## Live Data Snapshot
+
+- 抓取时间：`2026-07-26T15:18:44+08:00` 至 `2026-07-26T15:19:34+08:00`（Asia/Shanghai；对应截止时间 `2026-07-26T07:19:34Z`）。
+- 仓库：`anthropics/anthropic-sdk-python`，默认分支 `main`。
+- 最新非 draft GitHub Release：`v0.120.0`，published at `2026-07-24T16:32:34Z`，tag target `60c64fba5c2bf340567f627328e57cf0196b868f`。
+- 实际 PR 窗口：`mergedAt > 2026-07-24T16:32:34Z` 且 `mergedAt <= 2026-07-26T07:19:34Z`。
+- 查询结果：0 个 merged PR。日期预筛选唯一返回的 PR 是 `#1780 release: 0.120.0`，其 `mergedAt` 为 `2026-07-24T16:31:59Z`，早于 release 发布时间 35 秒，按精确窗口正确排除。
+- 关键 live 命令：
+  - `gh repo view anthropics/anthropic-sdk-python --json nameWithOwner,url,defaultBranchRef`
+  - `gh release list -R anthropics/anthropic-sdk-python --json tagName,publishedAt,name,isDraft,isPrerelease --order desc --limit 10`
+  - `gh api repos/anthropics/anthropic-sdk-python/releases/latest`
+  - `gh pr list -R anthropics/anthropic-sdk-python --state merged --search 'merged:>=2026-07-24' --limit 200 --json number,title,body,mergedAt,author,url`，再以精确 UTC release 时间过滤。
 
 ## Assertions
 
-- `unreleased`: 输出包含 ## [Unreleased] 标题
-- `pr`: 每个条目包含 PR 链接，格式为 (#数字)
-- `bot_pr_dependabot`: 跳过了 bot PR（dependabot 等）
-- `chore_ci_test`: 不包含 chore/ci/test 等内部变更
-- `versioned_changelog_file`: 输出写入了 docs/changelog/changelog-unreleased.md 文件
+| Assertion | With skill | Without skill | Fresh judgment |
+| --- | --- | --- | --- |
+| `unreleased` | PASS | PASS | 两个候选都包含 `## [Unreleased]`。 |
+| `pr` | PASS（空集合） | PASS（空集合） | 窗口内无条目；没有缺失链接的条目，也没有伪造 PR。该快照未正向覆盖非空 PR 的链接格式。 |
+| `bot_pr_dependabot` | PASS（空集合） | PASS（空集合） | 精确窗口内没有 bot PR 可纳入；候选均未错误引入窗口外的 release bot PR。 |
+| `chore_ci_test` | PASS（空集合） | PASS（空集合） | 精确窗口内没有 `chore` / `ci` / `test` 候选。当前 skill 规则是语义审查 `docs` / `test` / `ci`，不是一概跳过；本窗口没有候选可进一步区分。 |
+| `versioned_changelog_file` | PASS | PASS | 两个候选都将 artifact target 明确设为 `docs/changelog/changelog-unreleased.md`；运行期候选未写回 canonical fixture。 |
 
 ## With Skill
 
+Fresh source: 当前会话先读取 PM Agent README 与 `changelog-generator` skill，再执行其 repo detection、release discovery、精确 PR-window 与分类协议。
+
+Candidate artifact:
+
+```markdown
+# Changelog - Unreleased
+
+## [Unreleased]
+
+_No merged PRs since v0.120.0._
+```
+
 Observed behavior:
 
-- 当前 skill 明确支持 Unreleased mode：定位最新 release 后的 merged PR，跳过 bot 和 chore/ci/test 等内部变更，按 Keep a Changelog 输出 ## [Unreleased] 并写入 docs/changelog/changelog-unreleased.md。
+- 选择 Unreleased mode 和正确的 canonical target。
+- 以 release `publishedAt` 而不是仅按日期作为窗口下界，并对 `gh pr list` 的日期预筛选结果再次按精确时间过滤。
+- 结果为空时明确输出空状态；未把 release PR `#1780`、bot、维护项或不存在的 PR 填入 changelog。
+- 保留当前 skill 的语义规则：`docs` / `test` / `ci` 只有在正文或文件上下文表明影响 skill 行为、eval 契约、release workflow、installation 或协作边界时才进入 changelog。本次窗口没有这类候选。
 
 ## Without Skill / Baseline
-- BLOCKED: No actual without_skill baseline result is recorded for this historical comparison. This file is not treated as a full eval PASS until a baseline result is generated and written here.
-- This comparison records whether the skill-specific protocol, routing, evidence, or artifact expectations are preserved.
+
+Fresh source: 在同一当前会话中，使用相同 prompt 和上面的同一 live snapshot 重新生成；不读取或应用 changelog-generator / PM Agent 协议作为 baseline 的生成依据，也未复用历史 baseline。
+
+Candidate artifact:
+
+```markdown
+# Changelog - Unreleased
+
+## [Unreleased]
+
+_No merged PRs since v0.120.0._
+```
+
+Observed behavior:
+
+- Prompt 已直接给出 Unreleased 范围、Keep a Changelog 格式与输出路径，因此 baseline 也选对标题和 artifact target。
+- 在共享 snapshot 中看到 release 后 0 个 merged PR，因而同样没有编造条目。
+- 空窗口没有暴露 baseline 对 bot、dependency、internal scope 以及 `docs` / `test` / `ci` 语义审查的处理差异；这属于本轮 live 数据覆盖限制，不是把历史 baseline 当作 fresh 结果。
 
 ## Failures
 
-- None found in fresh Codex subagent validation.
+- 无 assertion failure。
+- Coverage caveat：live 窗口为空，因此 `pr`、`bot_pr_dependabot`、`chore_ci_test` 只得到空集合证据，未正向验证非空 PR 的链接、bot 排除和低优先级前缀语义审查。后续某次 live 窗口出现候选时应重新观察这些分支，但不应为制造覆盖而伪造 fixture。
+
+## External Dependency Failure Policy
+
+- 依赖：GitHub API 可用、DNS / 网络正常、`gh` 已认证且未被限流，以及外部仓库仍公开可访问。
+- 外部服务失败：若 `gh` 返回认证、权限、rate-limit、网络、GitHub 5xx 或仓库不可访问错误，且无法取得 release / PR snapshot，本 eval 应记为 `BLOCKED (external dependency)`，不能据此判定 skill 回归。
+- Skill 回归：live snapshot 成功取得后，若选择错误 release、窗口边界错误、遗漏实际窗口内 PR、纳入窗口外或明确应跳过的 PR、错误地一概排除具有语义影响的 `docs` / `test` / `ci`、缺少 PR 链接、缺少 `## [Unreleased]`，或目标不是 `docs/changelog/changelog-unreleased.md`，才属于 skill / output regression。
 
 ## Next Steps
 
-- 真实运行时仍需 gh 数据验证具体 PR 窗口。
+- 无需补 fixture 或修改 skill。
+- 竞品仓库可能在 comparison 提交后立即产生新 release 或 merged PR；本结论只对应上面的精确抓取窗口，未来复验必须重新抓取并记录新的时间点，不能把此 snapshot 当作固定事实。
 
 ## Runtime Artifacts Policy
 
-- Runtime transcripts, verdicts, timing, outputs, and diagnostics should not be committed.
+- 本轮没有把 changelog candidate、transcript、verdict、timing、outputs 或 diagnostics 写入 canonical fixture。
+- 只持久化本 `comparison.md` 的事实摘要与 fresh judge 结论；任何临时运行产物都不进入 git。

--- a/agents/product_manager/test/changelog-generator/evals/workspace/eval-001-unreleased-mode/comparison.md
+++ b/agents/product_manager/test/changelog-generator/evals/workspace/eval-001-unreleased-mode/comparison.md
@@ -7,44 +7,53 @@
 - Eval: `eval-001-unreleased-mode`
 - Test case: unreleased-mode
 - Workspace: `workspace/eval-001-unreleased-mode`
-- Classification: `(c) 依赖实时外部数据`。Prompt 要求读取 `anthropics/anthropic-sdk-python` 的当前 GitHub Release 与 merged PR；静态 fixture 或 mock 会改变被测场景，因此本轮不补 fixture。
-- Latest result: **PASS** — 2026-07-26 的 fresh with-skill 与 fresh without-skill 使用同一份 live GitHub snapshot；两者都忠实生成空的 Unreleased 结果，没有为满足 PR-link assertion 编造条目。链接与过滤 assertions 在空集合上成立，但本次快照没有形成非空候选的正向覆盖。
+- Classification: `(c) 依赖实时外部数据`。Prompt 要求读取 `anthropics/anthropic-sdk-python` 当前的 GitHub Release、merged PR 和 tag-to-main 状态；静态 fixture 或 mock 会改变被测场景，因此本轮不补 fixture。
+- Latest result: **PASS** — 本轮 fresh with-skill 与 fresh without-skill 分别独立查询 GitHub，均确认最新 release `v0.120.0` 后没有 merged PR，且 `v0.120.0...main` 为 identical。两者均生成真实的空 Unreleased 结果，没有为满足 PR-link assertion 编造条目。
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: 仅包含 prompt 与 `eval_metadata.json`；这足以指定目标仓库、模式与目标文件，实时事实由 GitHub API / `gh` 提供。
+- Fixture: 仅包含原始 prompt 与 `eval_metadata.json`；这足以指定目标仓库、Unreleased mode 与目标文件，实时事实由 GitHub API / `gh` 提供。
 - Prompt target: 最新 release 之后合并的所有 PR，以 Keep a Changelog 格式写入 `docs/changelog/changelog-unreleased.md`。
-- Fresh evaluation: 2026-07-26（同一当前会话中新生成 with-skill 与 without-skill；未复用历史 baseline）。
+- Fresh evaluation: 2026-07-26；with-skill 与 without-skill 均在当前会话中新生成，未复用历史 baseline、第一批 PR #168 的跑法或 parent 预计算 snapshot。
 
-## Live Data Snapshot
+## No-Leak Evaluation Method
 
-- 抓取时间：`2026-07-26T15:18:44+08:00` 至 `2026-07-26T15:19:34+08:00`（Asia/Shanghai；对应截止时间 `2026-07-26T07:19:34Z`）。
+1. 生成 with-skill 前只读取当前 workspace 的 `eval_metadata.json` 原始 prompt；没有读取 `evals.json`、assertions、expected output 或旧 `comparison.md`。
+2. with-skill 读取 PM Agent README 与 `changelog-generator` skill 后，独立通过 `gh` 查询 prompt 指定的公开仓库，并先锁定候选和事实快照。
+3. without-skill 由当前会话中新启动、`fork_turns=none` 的 fresh Codex subagent 生成。子代理只收到原始 prompt，以及“自行实时查询 GitHub并返回候选、抓取时间和关键快照”的要求；没有收到 skill、README、assertions、expected output、旧 comparison、with-skill 候选或 parent 查询结果。
+4. 两份候选都锁定后才读取 `evals.json` 与旧 comparison 进行 judge。本文件仅记录 judge 摘要；候选、transcript、verdict、diagnostics 和 outputs 均未落盘。
+
+## Independent Live Data Snapshots
+
+| Snapshot | Fetch time (Asia/Shanghai) | Latest release | PRs after release | Tag-to-main | Drift judgment |
+| --- | --- | --- | --- | --- | --- |
+| With skill | `2026-07-26 15:36:35 +08:00` 起 | `v0.120.0`, published `2026-07-24T16:32:34Z` | 0 | `identical`, ahead 0, behind 0, commits 0 | 基准抓取 |
+| Without skill | `2026-07-26 15:37:13 +08:00` 至 `15:38:36 +08:00` | `v0.120.0`, published `2026-07-24T16:32:34Z` | 0 | `identical`, ahead 0, behind 0, commits 0 | 与 with-skill 无 release、PR 或 branch-tip 漂移 |
+
+关键事实：
+
 - 仓库：`anthropics/anthropic-sdk-python`，默认分支 `main`。
-- 最新非 draft GitHub Release：`v0.120.0`，published at `2026-07-24T16:32:34Z`，tag target `60c64fba5c2bf340567f627328e57cf0196b868f`。
-- 实际 PR 窗口：`mergedAt > 2026-07-24T16:32:34Z` 且 `mergedAt <= 2026-07-26T07:19:34Z`。
-- 查询结果：0 个 merged PR。日期预筛选唯一返回的 PR 是 `#1780 release: 0.120.0`，其 `mergedAt` 为 `2026-07-24T16:31:59Z`，早于 release 发布时间 35 秒，按精确窗口正确排除。
-- 关键 live 命令：
-  - `gh repo view anthropics/anthropic-sdk-python --json nameWithOwner,url,defaultBranchRef`
-  - `gh release list -R anthropics/anthropic-sdk-python --json tagName,publishedAt,name,isDraft,isPrerelease --order desc --limit 10`
-  - `gh api repos/anthropics/anthropic-sdk-python/releases/latest`
-  - `gh pr list -R anthropics/anthropic-sdk-python --state merged --search 'merged:>=2026-07-24' --limit 200 --json number,title,body,mergedAt,author,url`，再以精确 UTC release 时间过滤。
+- `v0.120.0` tag target 与当前 `main` 均为 `60c64fba5c2bf340567f627328e57cf0196b868f`。
+- 边界 PR `#1780 release: 0.120.0` 合并于 `2026-07-24T16:31:59Z`，比 release 发布时间早 35 秒，不属于 Unreleased。
+- with-skill 使用 `gh repo view`、`gh release list`、`gh pr list` 后按精确 `publishedAt` 过滤，并调用 Compare API。
+- without-skill 独立使用 Releases、Tags、Search、Pulls、GraphQL 与 Compare API 交叉复核，没有使用 parent 的预计算结果。
 
 ## Assertions
 
 | Assertion | With skill | Without skill | Fresh judgment |
 | --- | --- | --- | --- |
 | `unreleased` | PASS | PASS | 两个候选都包含 `## [Unreleased]`。 |
-| `pr` | PASS（空集合） | PASS（空集合） | 窗口内无条目；没有缺失链接的条目，也没有伪造 PR。该快照未正向覆盖非空 PR 的链接格式。 |
-| `bot_pr_dependabot` | PASS（空集合） | PASS（空集合） | 精确窗口内没有 bot PR 可纳入；候选均未错误引入窗口外的 release bot PR。 |
-| `chore_ci_test` | PASS（空集合） | PASS（空集合） | 精确窗口内没有 `chore` / `ci` / `test` 候选。当前 skill 规则是语义审查 `docs` / `test` / `ci`，不是一概跳过；本窗口没有候选可进一步区分。 |
-| `versioned_changelog_file` | PASS | PASS | 两个候选都将 artifact target 明确设为 `docs/changelog/changelog-unreleased.md`；运行期候选未写回 canonical fixture。 |
+| `pr` | PASS（空集合） | PASS（空集合） | 窗口内没有条目；没有缺失链接的条目，也没有伪造 PR。本快照未正向覆盖非空 PR 的链接格式。 |
+| `bot_pr_dependabot` | PASS（空集合） | PASS（空集合） | 精确窗口内没有 bot PR 候选；两个候选均未引入窗口外的 release PR。 |
+| `chore_ci_test` | PASS（空集合） | PASS（空集合） | 精确窗口内没有 `chore` / `ci` / `test` 候选。当前 skill 对 `docs` / `test` / `ci` 采用语义审查，不是一概跳过；本窗口无法进一步区分。 |
+| `versioned_changelog_file` | PASS | PASS | 两次运行都把 artifact target 明确设为 `docs/changelog/changelog-unreleased.md`；根据 eval 运行期产物策略未写回 canonical fixture。 |
 
 ## With Skill
 
-Fresh source: 当前会话先读取 PM Agent README 与 `changelog-generator` skill，再执行其 repo detection、release discovery、精确 PR-window 与分类协议。
+Fresh source: 只依据原始 prompt、PM Agent README、`changelog-generator` skill 与第一次独立 live 查询生成。
 
-Candidate artifact:
+Locked candidate artifact:
 
 ```markdown
 # Changelog - Unreleased
@@ -56,46 +65,53 @@ _No merged PRs since v0.120.0._
 
 Observed behavior:
 
-- 选择 Unreleased mode 和正确的 canonical target。
-- 以 release `publishedAt` 而不是仅按日期作为窗口下界，并对 `gh pr list` 的日期预筛选结果再次按精确时间过滤。
-- 结果为空时明确输出空状态；未把 release PR `#1780`、bot、维护项或不存在的 PR 填入 changelog。
-- 保留当前 skill 的语义规则：`docs` / `test` / `ci` 只有在正文或文件上下文表明影响 skill 行为、eval 契约、release workflow、installation 或协作边界时才进入 changelog。本次窗口没有这类候选。
+- 正确选择 Unreleased mode 和 canonical target。
+- 使用 release `publishedAt` 作为精确窗口下界，没有把早 35 秒合并的 release PR `#1780` 纳入结果。
+- release 后无 merged PR，且 tag-to-main identical，因此输出真实空状态而不编造 PR。
+- 使用 skill 指定的精确 Unreleased 文件头。
 
 ## Without Skill / Baseline
 
-Fresh source: 在同一当前会话中，使用相同 prompt 和上面的同一 live snapshot 重新生成；不读取或应用 changelog-generator / PM Agent 协议作为 baseline 的生成依据，也未复用历史 baseline。
+Fresh source: `fork_turns=none` 子代理仅依据原始 prompt 和第二次独立 live 查询生成；没有读取或应用 PM Agent、`changelog-generator`、eval 答案键或 parent snapshot。
 
-Candidate artifact:
+Locked candidate artifact:
 
 ```markdown
-# Changelog - Unreleased
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-_No merged PRs since v0.120.0._
+_No pull requests have been merged since v0.120.0._
+
+[Unreleased]: https://github.com/anthropics/anthropic-sdk-python/compare/v0.120.0...HEAD
 ```
 
 Observed behavior:
 
-- Prompt 已直接给出 Unreleased 范围、Keep a Changelog 格式与输出路径，因此 baseline 也选对标题和 artifact target。
-- 在共享 snapshot 中看到 release 后 0 个 merged PR，因而同样没有编造条目。
-- 空窗口没有暴露 baseline 对 bot、dependency、internal scope 以及 `docs` / `test` / `ci` 语义审查的处理差异；这属于本轮 live 数据覆盖限制，不是把历史 baseline 当作 fresh 结果。
+- Prompt 已直接给出 Unreleased 范围、Keep a Changelog 格式与输出路径，因此 baseline 也选择了正确标题和 artifact target。
+- 独立查询确认 release 后 0 个 merged PR，因而没有编造条目。
+- 使用通用 Keep a Changelog 头和 compare link，而不是 specialist 指定的 canonical `# Changelog - Unreleased` 文件头；该格式差异不违反现有 assertions。
+- 空窗口没有暴露 baseline 对 bot、dependency、internal scope 和低优先级前缀语义审查的处理差异。
 
 ## Failures
 
 - 无 assertion failure。
-- Coverage caveat：live 窗口为空，因此 `pr`、`bot_pr_dependabot`、`chore_ci_test` 只得到空集合证据，未正向验证非空 PR 的链接、bot 排除和低优先级前缀语义审查。后续某次 live 窗口出现候选时应重新观察这些分支，但不应为制造覆盖而伪造 fixture。
+- Coverage caveat：live 窗口为空，因此 `pr`、`bot_pr_dependabot`、`chore_ci_test` 只有空集合证据，未正向验证非空 PR 的链接、bot 排除和低优先级前缀语义审查。不能通过伪造 fixture 或条目补足这种实时覆盖。
 
 ## External Dependency Failure Policy
 
 - 依赖：GitHub API 可用、DNS / 网络正常、`gh` 已认证且未被限流，以及外部仓库仍公开可访问。
-- 外部服务失败：若 `gh` 返回认证、权限、rate-limit、网络、GitHub 5xx 或仓库不可访问错误，且无法取得 release / PR snapshot，本 eval 应记为 `BLOCKED (external dependency)`，不能据此判定 skill 回归。
+- 外部服务失败：若 `gh` 返回认证、权限、rate-limit、网络、GitHub 5xx 或仓库不可访问错误，且无法取得 release、PR 或 compare snapshot，本 eval 应记为 `BLOCKED (external dependency)`，不能据此判定 skill 回归。
 - Skill 回归：live snapshot 成功取得后，若选择错误 release、窗口边界错误、遗漏实际窗口内 PR、纳入窗口外或明确应跳过的 PR、错误地一概排除具有语义影响的 `docs` / `test` / `ci`、缺少 PR 链接、缺少 `## [Unreleased]`，或目标不是 `docs/changelog/changelog-unreleased.md`，才属于 skill / output regression。
 
 ## Next Steps
 
 - 无需补 fixture 或修改 skill。
-- 竞品仓库可能在 comparison 提交后立即产生新 release 或 merged PR；本结论只对应上面的精确抓取窗口，未来复验必须重新抓取并记录新的时间点，不能把此 snapshot 当作固定事实。
+- 外部仓库可能在 comparison 提交后立即产生新 release 或 merged PR；本结论只对应上面的两个独立抓取窗口，未来复验必须重新抓取并记录新时间点，不能把本 snapshot 当作固定事实。
 
 ## Runtime Artifacts Policy
 

--- a/agents/product_manager/test/changelog-generator/evals/workspace/eval-002-single-version-mode/comparison.md
+++ b/agents/product_manager/test/changelog-generator/evals/workspace/eval-002-single-version-mode/comparison.md
@@ -8,7 +8,7 @@
 - Test case: single-version-mode
 - Workspace: `workspace/eval-002-single-version-mode`
 - Classification: `(c)` 依赖实时 GitHub 数据。该场景必须读取目标仓库当时的 release、tag compare、merged PR 和 PR body；静态 mock 不能替代真实复验。
-- Latest result: PASS - 2026-07-26 的 fresh `with_skill` / `without_skill` 已用两次独立实时查询成对完成，5 条 assertions 均通过。
+- Latest result: PARTIAL - 2026-07-26 的 fresh `with_skill` / `without_skill` 已用两次独立实时查询成对完成；4 条 assertions 通过，`pr_conventional_commit` 因版本窗口内只有应过滤的 bot release PR 而没有可执行的普通 PR 标题样本。
 
 ## Test Set / Fixture Version
 
@@ -52,7 +52,7 @@
 | --- | --- | --- | --- |
 | `x_y_z_yyyy_mm_dd` | PASS | PASS | 两者均生成 `## [0.120.0] - 2026-07-24`。 |
 | `release_tag` | PASS | PASS | 两者均以实时最新 tag `v0.120.0` 为来源，并在版本块中使用 `0.120.0`。 |
-| `pr_conventional_commit` | PASS | PASS | #1780 的 PR body 给出 3 条 `feat(api):` 变化；两者均去掉 conventional prefix，将清洗后的功能标题写成条目并链接 #1780。 |
+| `pr_conventional_commit` | NOT EXERCISED | NOT EXERCISED | #1780 是 `stainless-app[bot]` 的 release PR，按 skill 规则应过滤。PR body / release body 中的 3 条 `feat(api):` 内容和 tag compare commit 可用于理解版本变化，但不能冒充普通 PR 标题清洗证据。 |
 | `breaking_change_breaking` | PASS | PASS | 当前 PR body、release body 和 tag compare 均无 breaking marker；条件未触发，两者都未虚构 `⚠️ BREAKING:`。 |
 | `section` | PASS | PASS | 两者只输出有内容的 `Added`，没有生成空 section。 |
 
@@ -61,8 +61,8 @@
 Observed behavior:
 
 - 按 specialist 流程用 `gh` 确认目标仓库、最新和前一 release，并用精确发布时间建立单版本窗口。
-- 查询窗口内 merged PR，再用 tag compare、PR body 和 release body核对 SDK generator 仓库的真实变化。
-- 将 #1780 中 3 条 `feat(api):` 标题清洗后归入 `Added`，每条保留 [#1780](https://github.com/anthropics/anthropic-sdk-python/pull/1780) 引用。
+- 查询窗口内 merged PR，识别 #1780 为 bot release PR 并按规则从普通 PR 条目候选中排除；再用 tag compare、PR body 和 release body核对 SDK generator 仓库的真实变化。
+- 可从 tag compare / release 内容整理 3 条 API 功能变化，但这些不是普通 PR title 样本，不能据此把 `pr_conventional_commit` 判为 PASS。
 - 生成 `## [0.120.0] - 2026-07-24`，只包含非空 `### Added`，目标路径为 `docs/changelog/changelog-v0.120.0.md`。
 - 未把候选 changelog 写入 eval fixture；本轮只持久化 fresh judge 摘要。
 
@@ -86,12 +86,13 @@ Observed behavior:
 
 - 在 `fork_turns=none` 子进程中仅按原始 prompt 独立查询 GitHub，没有读取或应用 specialist skill、Agent README 或任何 eval answer key。
 - 独立选中 `v0.120.0`，建立正确 release 窗口，并用 PR、tag compare 与 commit-to-PR 关联交叉验证 #1780 是完整 PR 集合。
-- 同样生成 `## [0.120.0] - 2026-07-24` 和单一 `Added` section；3 个条目均为去除 `feat(api):` 后的标题，并通过 reference-style link 指向 #1780。
+- 同样可从 release 内容整理 `Added` section，但把 body / commit 文本清洗后链接到 #1780 仍不构成普通 PR title 清洗覆盖。
 - 这是本轮全新 baseline，不是历史输出，也不是父进程 snapshot 的改写。
 
 ## Failures
 
 - 没有发现 skill 行为回归。
+- 覆盖限制：实时窗口唯一 PR #1780 是应过滤的 `stainless-app[bot]` release PR；`pr_conventional_commit` 没有普通 PR 样本，因此总体结论保持 `PARTIAL`。不能用该 PR body、release body 或 tag compare commit 的清洗结果替代 PR title 断言。
 - 没有外部服务失败；baseline 首次 API 命令因未给 zsh 中的 `?` 加引号而失败，修正命令后实时查询成功。这是 baseline 的本地命令构造错误，不是 GitHub 服务失败，也未影响最终证据完整性。
 
 ## External Dependency and Failure Triage
@@ -103,7 +104,7 @@ Observed behavior:
 
 ## Next Steps
 
-- 当前无需修改 fixture 或 assertions；后续仅在目标仓库出现新 release 或外部 API 行为变化时按相同 no-leak 流程重新抓取并复验。
+- 当前无需修改 fixture 或 assertions；后续在 latest-release 窗口出现非 bot PR 后，按相同 no-leak 流程重新抓取并实际覆盖 `pr_conventional_commit`。
 
 ## Runtime Artifacts Policy
 

--- a/agents/product_manager/test/changelog-generator/evals/workspace/eval-002-single-version-mode/comparison.md
+++ b/agents/product_manager/test/changelog-generator/evals/workspace/eval-002-single-version-mode/comparison.md
@@ -8,7 +8,7 @@
 - Test case: single-version-mode
 - Workspace: `workspace/eval-002-single-version-mode`
 - Classification: `(c)` 依赖实时 GitHub 数据。该场景必须读取目标仓库当时的 release、相邻 tag compare、merged PR 和 author；静态 mock 不能替代真实复验。
-- Latest result: PARTIAL - 2026-07-26 的 fresh `with_skill` / `without_skill` 已由当前会话中的同一个 fresh Codex subagent 顺序完成两次独立实时查询。with-skill 正确过滤唯一的 bot release PR 及 compare 中的 bot commits，未发现 skill 回归；4 条 assertions 通过，`pr_conventional_commit` 因没有普通 PR 样本而为 `NOT EXERCISED`。
+- Latest result: PARTIAL - 2026-07-26 的 fresh `with_skill` / `without_skill` 已由当前会话中的同一个 fresh Codex subagent 顺序完成两次独立实时查询，并分别在隔离 scratch 中实际写入、回读和清理目标文件。with-skill 正确过滤唯一的 bot release PR 及 compare 中的 bot commits，但其 `## [v0.120.0]` 标题不满足现有 assertion 要求的 `## [x.y.z]`，因此为 3 PASS / 1 FAIL / 1 NOT EXERCISED；without-skill 为 4 PASS / 1 NOT EXERCISED。
 
 ## Test Set / Fixture Version
 
@@ -23,13 +23,13 @@
 - `with_skill` 的 live snapshot 和候选先锁定；随后同一个 fresh subagent 进入 baseline arm，不应用先前读取的 specialist skill 或 Product Manager README，仅依据原始 prompt 独立选择查询并生成候选。
 - baseline 未读取 `evals.json`、assertions、expected output 或旧 comparison，也未接收预计算 snapshot；它重新调用 `gh` 获取当时的 release 和 PR 数据。
 - 两个候选都锁定后，同一个 fresh subagent 才读取 assertions 和旧 comparison 并亲自完成 fresh judge。
-- 本轮没有启动第二个 subagent，也没有创建、持久化或提交 transcript、candidate、verdict、timing、outputs 或 diagnostics。
+- 两个 arm 分别在独立临时目录实际写入并回读 `docs/changelog/changelog-v0.120.0.md`，确认内容后清理临时目录；本轮没有启动第二个 subagent，也没有持久化或提交 transcript、candidate、verdict、timing、outputs 或 diagnostics。
 
 ## Independent Live Data Snapshots
 
 ### With Skill
 
-- 抓取时间：2026-07-26 16:27:18 `+08:00`（Asia/Shanghai）。
+- 抓取时间：2026-07-26 16:38:41 `+08:00`（Asia/Shanghai）。
 - 仓库：`anthropics/anthropic-sdk-python`，默认分支 `main`。
 - 最新 release：`v0.120.0`，发布时间 `2026-07-24T16:32:34Z`。
 - 前一 release：`v0.119.0`，发布时间 `2026-07-23T17:34:23Z`。
@@ -40,7 +40,7 @@
 
 ### Without Skill
 
-- 抓取时间：2026-07-26 16:27:41 `+08:00`（Asia/Shanghai）。
+- 抓取时间：2026-07-26 16:39:20 `+08:00`（Asia/Shanghai）。
 - baseline 独立确认最新 release `v0.120.0`、前一 release `v0.119.0` 及相同发布时间。
 - baseline 独立查询 merged PR，确认最新 release 对应的自动 release PR 为 `#1780`，其正文列出 3 项 Features。
 - 外部服务失败：无。
@@ -49,7 +49,7 @@
 
 | Assertion | With skill | Without skill | Fresh judge conclusion |
 | --- | --- | --- | --- |
-| `x_y_z_yyyy_mm_dd` | PASS | PASS | 两者均生成带版本号与日期的 `v0.120.0` 版本块。 |
+| `x_y_z_yyyy_mm_dd` | FAIL | PASS | assertion 明确要求 `## [x.y.z] - YYYY-MM-DD`。with-skill 按当前 specialist Step 6 模板生成 `## [v0.120.0]`，多出 `v` 前缀；without-skill 生成 `## [0.120.0]`。本轮不放宽 assertion，也不修改 specialist。 |
 | `release_tag` | PASS | PASS | 两者均以实时最新 tag `v0.120.0` 为来源。 |
 | `pr_conventional_commit` | NOT EXERCISED | NOT EXERCISED | 当前窗口没有普通 PR。`#1780` 是 bot release PR；baseline 的三条内容来自其 body，不是普通 PR title 清洗样本，不能把该断言判为 PASS。 |
 | `breaking_change_breaking` | PASS | PASS | 当前 PR body 和 tag compare 均无 breaking marker；条件未触发，两者都未虚构 `⚠️ BREAKING:`。 |
@@ -62,8 +62,8 @@ Observed behavior:
 - 按 specialist 流程用 `gh` 确认目标仓库、最新和前一 release，并用发布时间建立单版本窗口。
 - 查询窗口内 merged PR，识别唯一的 `#1780` 为 bot release PR，并按 author 为 bot 或 login 以 `[bot]` 结尾的规则排除，未把它作为 changelog attribution 或链接。
 - 因过滤后没有 PR，按 edge case 查询 tag compare；compare 中的两条 commits 也都是 `stainless-app[bot]` 作者，继续排除。
-- 生成正确的版本 header 与 `_No user-facing changes (dependency updates and internal maintenance only)._`，不生成空 section，也不链接被过滤的 `#1780`。
-- 目标路径为 `docs/changelog/changelog-v0.120.0.md`；未把 runtime candidate 写入 eval fixture。
+- 生成 specialist 当前模板规定的 `## [v0.120.0]` header 与 `_No user-facing changes (dependency updates and internal maintenance only)._`，不生成空 section，也不链接被过滤的 `#1780`；该 header 与现有 eval assertion 的无 `v` 格式冲突。
+- 在隔离临时目录 `/tmp/issue158-eval002-with-skill.D56BxK/` 中实际写入并回读 `docs/changelog/changelog-v0.120.0.md`，确认内容后清理整个临时目录；未把 runtime candidate 写入 eval fixture。
 
 Candidate behavior summary:
 
@@ -83,6 +83,7 @@ Observed behavior:
 - 独立选中 `v0.120.0`，并从自动 release PR `#1780` 的正文提取 3 项 Features。
 - 将三项功能写入 `Added`，每项都引用 `#1780`；该候选没有 specialist 的 bot author 过滤，因此与 with-skill 形成有效行为差异。
 - baseline 的条目不是普通 PR title 清洗样本，所以不满足 `pr_conventional_commit` 的实际覆盖条件。
+- 在独立隔离临时目录 `/tmp/issue158-eval002-without-skill.3uD2q4/` 中实际写入并回读 `docs/changelog/changelog-v0.120.0.md`，确认内容后清理整个临时目录；其版本块标题为 `## [0.120.0] - 2026-07-24`。
 - 这是本轮新生成的 baseline，不是历史输出或 with-skill 候选的改写。
 
 Candidate behavior summary:
@@ -90,32 +91,34 @@ Candidate behavior summary:
 ```markdown
 # Changelog - v0.120.0
 
-## [v0.120.0] - 2026-07-24
+## [0.120.0] - 2026-07-24
 
 ### Added
 
-- Add `claude-opus-5` model ([#1780](https://github.com/anthropics/anthropic-sdk-python/pull/1780))
-- Add tool addition/removal blocks and `tool_change` events ([#1780](https://github.com/anthropics/anthropic-sdk-python/pull/1780))
-- Expand client-side fallback credit token types and add server-side fallbacks default option ([#1780](https://github.com/anthropics/anthropic-sdk-python/pull/1780))
+- **api:** Add claude-opus-5 model ([#1780](https://github.com/anthropics/anthropic-sdk-python/pull/1780))
+- **api:** Add tool addition/removal blocks and tool_change events ([#1780](https://github.com/anthropics/anthropic-sdk-python/pull/1780))
+- **api:** Expand client-side fallback credit token types and add server-side fallbacks default option ([#1780](https://github.com/anthropics/anthropic-sdk-python/pull/1780))
 ```
 
 ## Failures
 
-- 没有发现 skill 行为回归或协议偏差。
+- 格式契约不一致：现有 eval assertion / expected output 要求 `## [x.y.z] - YYYY-MM-DD`，但 specialist Step 6 的新建版本文件模板要求 `## [v{VERSION}] - YYYY-MM-DD`。with-skill 忠实生成后者，严格 judge 必须把 `x_y_z_yyyy_mm_dd` 判为 `FAIL`；本轮按约束不修改 specialist 或放宽 assertion。
 - 覆盖限制：实时窗口唯一 PR `#1780` 是应过滤的 bot release PR，tag compare commits 也均为 bot 作者；`pr_conventional_commit` 没有普通 PR 样本，因此总体结论保持 `PARTIAL`。
 - baseline 未应用 bot filter，把 `#1780` 当作 changelog PR attribution 和链接；这是 without-skill 行为差异，不是 with-skill failure。
+- 两个 arm 均已实际写入、回读并清理隔离 scratch 中的目标文件；文件产出行为不再是未验证覆盖项。
 - 没有外部服务失败。
 
 ## External Dependency and Failure Triage
 
 - 数据依赖：GitHub API / `gh` CLI、目标仓库 release、PR 搜索、author bot 标记和 compare endpoint；这些数据会随新 release 发布而变化。
 - 外部服务失败：认证失败、限流、DNS / TLS / 网络错误、GitHub 5xx、目标仓库暂时不可访问，或抓取过程中 latest release 指针变化。此时应记录命令、时间、退出码和错误，结果标为 `BLOCKED`，不能判为 skill 回归或真实空集合。
-- Skill 回归：GitHub 数据可读取且 snapshot 自洽时，选错最新或前一 release、窗口边界错误、未过滤 bot PR/commit、过滤后又把 bot PR 作为条目 attribution 或链接、漏查 tag compare、错误生成空 section，或发现 breaking marker 却未加 `⚠️ BREAKING:`。
+- Skill 回归或契约偏差：GitHub 数据可读取且 snapshot 自洽时，选错最新或前一 release、窗口边界错误、未过滤 bot PR/commit、过滤后又把 bot PR 作为条目 attribution 或链接、漏查 tag compare、错误生成空 section、发现 breaking marker 却未加 `⚠️ BREAKING:`，或生成不满足现有 eval assertion 的版本标题。
 - 时效风险：release、PR、author 和发布说明均为实时公开数据；后续复验必须重新记录抓取时间、tag/window 和实际样本，不能把本次 `v0.120.0` 快照当作永久 fixture。
 
 ## Next Steps
 
-- 当前无需修改 fixture 或 assertions；后续在 latest-release 窗口出现非 bot PR 后，按相同 no-leak 流程重新抓取并实际覆盖 `pr_conventional_commit`。
+- 由维护者在本 issue 范围外决定统一版本标题契约：修改 specialist 模板或另起经批准的 eval 契约变更；在此之前不得把 `## [v{VERSION}]` 判为满足 `## [x.y.z]`。
+- 后续在 latest-release 窗口出现非 bot PR 后，按相同 no-leak 流程重新抓取并实际覆盖 `pr_conventional_commit`。
 
 ## Runtime Artifacts Policy
 

--- a/agents/product_manager/test/changelog-generator/evals/workspace/eval-002-single-version-mode/comparison.md
+++ b/agents/product_manager/test/changelog-generator/evals/workspace/eval-002-single-version-mode/comparison.md
@@ -7,41 +7,72 @@
 - Eval: `eval-002-single-version-mode`
 - Test case: single-version-mode
 - Workspace: `workspace/eval-002-single-version-mode`
-- Latest result: PARTIAL - prior skill validation evidence is preserved; without_skill baseline was not generated for this historical comparison.
-- Prior validation note: fresh Codex subagent validation completed on 2026-06-02
+- Classification: `(c)` 依赖实时 GitHub 数据。该场景必须读取目标仓库当时的 release、tag compare 和 merged PR，静态 mock 不能替代真实复验。
+- Latest result: PARTIAL - 2026-07-26 的 fresh `with_skill` / `without_skill` 已成对完成；当前版本窗口只有一个应被过滤的发布机器人 PR，因此普通 PR 标题清洗断言没有可执行样本，其余断言通过。
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: Verifies that changelog-generator handles single-version-mode and produces the expected role-specific artifact.
-- Expected output: 生成最新 release tag 的版本块，格式为 ## [x.y.z] - YYYY-MM-DD，包含该版本窗口内的 PR，分组写入，每条带 PR 链接，并写入 docs/changelog/changelog-v{version}.md
+- Fixture: 仅包含 eval metadata；不新增静态 GitHub 快照。
+- Expected output: 生成最新 release tag 的版本块，格式为 `## [x.y.z] - YYYY-MM-DD`，包含该版本窗口内的 PR，分组写入，每条带 PR 链接，并写入 `docs/changelog/changelog-v{version}.md`。
+- Fresh pair: 本轮使用同一份 live snapshot，先应用 `changelog-generator` 生成 `with_skill`，再仅按原始 prompt 生成新的 `without_skill`；未复用历史 baseline。
+
+## Live Data Snapshot
+
+- 抓取时间：2026-07-26 15:18:54-15:20:17 `+08:00`（Asia/Shanghai）。
+- 仓库：`anthropics/anthropic-sdk-python`，默认分支 `main`。
+- 最新 release：`v0.120.0`，发布时间 `2026-07-24T16:32:34Z`。
+- 前一 release：`v0.119.0`，发布时间 `2026-07-23T17:34:23Z`。
+- PR 窗口：`(2026-07-23T17:34:23Z, 2026-07-24T16:32:34Z]`。
+- 窗口内 merged PR：仅 [#1780](https://github.com/anthropics/anthropic-sdk-python/pull/1780)，`release: 0.120.0`，合并于 `2026-07-24T16:31:59Z`，作者为 `stainless-app[bot]`。
+- Tag compare：[`v0.119.0...v0.120.0`](https://github.com/anthropics/anthropic-sdk-python/compare/v0.119.0...v0.120.0) 有 2 个提交；功能提交包含 3 条 `feat(api):` 变化，另一个为 `release: 0.120.0`。未发现 `!` 或 `BREAKING CHANGE:` 标记。
 
 ## Assertions
 
-- `x_y_z_yyyy_mm_dd`: 输出包含版本号和日期，格式 ## [x.y.z] - YYYY-MM-DD
-- `release_tag`: 版本号与实际 release tag 匹配
-- `pr_conventional_commit`: PR 条目标题经过清洗（去掉 conventional commit 前缀）
-- `breaking_change_breaking`: Breaking change 如有则带 ⚠️ BREAKING 前缀
-- `section`: 有内容的 section 才出现在输出中
+| Assertion | With skill | Without skill | Fresh judge conclusion |
+| --- | --- | --- | --- |
+| `x_y_z_yyyy_mm_dd` | PASS | PASS | 两者均生成 `## [0.120.0] - 2026-07-24`。 |
+| `release_tag` | PASS | PASS | 两者均以实时最新 tag `v0.120.0` 为来源，并按 changelog 标题格式去掉 tag 的 `v` 前缀。 |
+| `pr_conventional_commit` | NOT EXERCISED | NOT EXERCISED | 窗口内唯一 PR 是应过滤的 release bot PR；tag compare 的 `feat(api):` 提交标题已被清洗，但这不能冒充普通 PR 标题清洗证据。 |
+| `breaking_change_breaking` | PASS | PASS | 当前窗口没有 breaking marker；“如有则加前缀”的条件未触发，两个输出均未虚构 `⚠️ BREAKING:`。 |
+| `section` | PASS | PASS | 两者只输出有内容的 `Added`，没有生成空 section。 |
 
 ## With Skill
 
 Observed behavior:
 
-- 当前 skill 明确支持最新 release 单版本模式：通过 release/tag 窗口取 PR，版本块带日期，清洗 conventional commit 前缀，处理 breaking change，并省略空 section。
+- 通过 `gh release list` / release API 确认最新和前一 release，并使用精确发布时间建立单版本窗口。
+- 识别 #1780 为机器人发布 PR，按 skill 的 bot 过滤规则不把它当作用户变化条目。
+- 在没有可纳入 PR 后，按 edge-case 规则回退到 tag compare；将一个 `feat(api):` 提交中的 3 条功能变化清洗为 `Added` 条目，并保留提交来源链接。
+- 生成候选版本块 `## [0.120.0] - 2026-07-24`，只包含 `### Added`，解析目标路径为 `docs/changelog/changelog-v0.120.0.md`。
+- 未把候选 changelog 写入 eval fixture；本轮只持久化 fresh judge 摘要。
 
 ## Without Skill / Baseline
-- BLOCKED: No actual without_skill baseline result is recorded for this historical comparison. This file is not treated as a full eval PASS until a baseline result is generated and written here.
-- This comparison records whether the skill-specific protocol, routing, evidence, or artifact expectations are preserved.
+
+Observed behavior:
+
+- 未读取或应用 specialist skill / Agent README，仅按原始 prompt 和同一 live snapshot 独立查询最新 release、前一 release、窗口 PR 与 release 内容。
+- 同样生成 `## [0.120.0] - 2026-07-24` 和单一 `Added` section，并从 release 内容整理 3 条 API 功能变化。
+- baseline 能保留 #1780 作为发布来源引用，但没有 specialist 的明确 bot-filter + tag-compare fallback 判定链；它不能为“普通 PR conventional prefix 清洗”提供额外证据。
+- 这是本轮重新生成的 baseline，不是 2026-06-02 的历史输出。
 
 ## Failures
 
-- None found in fresh Codex subagent validation.
+- 没有发现 skill 行为回归。
+- 覆盖限制：实时窗口缺少非 bot PR，`pr_conventional_commit` 无法在本次 snapshot 中被实际触发，因此总体结论保持 `PARTIAL`，不能将 tag compare 的提交标题清洗虚报成 PR 标题清洗 PASS。
+
+## External Dependency and Failure Triage
+
+- 数据依赖：GitHub API / `gh` CLI、目标仓库 release、PR 搜索、commit-to-PR 关联和 compare endpoint；这些数据会随新 release 发布而变化。
+- 外部服务失败：认证失败、限流、DNS / 网络错误、GitHub 5xx、目标仓库暂时不可访问，或同一抓取窗口内 release 指针发生变化。此时应记录命令、时间和错误，结果标为 `BLOCKED`，不能判为 skill 回归。
+- Skill 回归：在 GitHub 数据可读取且 snapshot 一致时，选错最新或前一 release、窗口边界错误、未过滤明确 bot PR、该回退 tag compare 时未回退、标题未清洗、错误生成空 section，或发现 breaking marker 却未加 `⚠️ BREAKING:`。
+- 时效风险：release、PR、标题和发布说明均为实时公开数据；后续复验必须重新记录抓取时间、tag/window 和实际样本，不能把本次 `v0.120.0` 快照当作永久 fixture。
 
 ## Next Steps
 
-- 真实运行时需确认最新 release tag 与 GitHub 数据。
+- 下次 live snapshot 出现非 bot PR 时，重新运行此 eval 以实际覆盖 `pr_conventional_commit`；在此之前保留当前 `PARTIAL`，不添加 mock PR。
 
 ## Runtime Artifacts Policy
 
-- Runtime transcripts, verdicts, timing, outputs, and diagnostics should not be committed.
+- Runtime changelog candidates, transcripts, verdicts, timing, outputs, and diagnostics are ephemeral and must not be committed.
+- Durable result only: this canonical `comparison.md`; `eval_metadata.json` remains unchanged.

--- a/agents/product_manager/test/changelog-generator/evals/workspace/eval-002-single-version-mode/comparison.md
+++ b/agents/product_manager/test/changelog-generator/evals/workspace/eval-002-single-version-mode/comparison.md
@@ -7,72 +7,105 @@
 - Eval: `eval-002-single-version-mode`
 - Test case: single-version-mode
 - Workspace: `workspace/eval-002-single-version-mode`
-- Classification: `(c)` 依赖实时 GitHub 数据。该场景必须读取目标仓库当时的 release、tag compare 和 merged PR，静态 mock 不能替代真实复验。
-- Latest result: PARTIAL - 2026-07-26 的 fresh `with_skill` / `without_skill` 已成对完成；当前版本窗口只有一个应被过滤的发布机器人 PR，因此普通 PR 标题清洗断言没有可执行样本，其余断言通过。
+- Classification: `(c)` 依赖实时 GitHub 数据。该场景必须读取目标仓库当时的 release、tag compare、merged PR 和 PR body；静态 mock 不能替代真实复验。
+- Latest result: PASS - 2026-07-26 的 fresh `with_skill` / `without_skill` 已用两次独立实时查询成对完成，5 条 assertions 均通过。
 
 ## Test Set / Fixture Version
 
-- Schema: `evals.json` v1.0
+- Schema: `evals.json` v1.0。
 - Fixture: 仅包含 eval metadata；不新增静态 GitHub 快照。
 - Expected output: 生成最新 release tag 的版本块，格式为 `## [x.y.z] - YYYY-MM-DD`，包含该版本窗口内的 PR，分组写入，每条带 PR 链接，并写入 `docs/changelog/changelog-v{version}.md`。
-- Fresh pair: 本轮使用同一份 live snapshot，先应用 `changelog-generator` 生成 `with_skill`，再仅按原始 prompt 生成新的 `without_skill`；未复用历史 baseline。
+- Fresh pair: `with_skill` 与 `without_skill` 分别实时查询 GitHub，没有复用历史 baseline，也没有把父进程候选或预计算 snapshot 传给 baseline。
 
-## Live Data Snapshot
+## No-Leak Execution
 
-- 抓取时间：2026-07-26 15:18:54-15:20:17 `+08:00`（Asia/Shanghai）。
+- `with_skill` 生成前只读取本用例 `eval_metadata.json` 的原始 prompt，随后读取 Product Manager README 与 `changelog-generator/SKILL.md`，未读取 `evals.json`、assertions、expected output 或旧 comparison。
+- `with_skill` 候选和 live snapshot 锁定后，才启动 `fork_turns=none` 的 fresh baseline。
+- baseline 只收到原始 prompt；未获得 specialist skill、Agent README、assertions、expected output、旧 comparison、父进程候选或父进程 snapshot。
+- baseline 自行调用 `gh` 重新查询 release、PR 时间窗、tag compare 和 commit-to-PR 关联；其候选锁定后才读取 assertions 与旧 comparison 进行 fresh judge。
+- 两次查询结果独立一致，不代表把同一预计算答案作为两条运行路径的输入。
+
+## Independent Live Data Snapshots
+
+### With Skill
+
+- 抓取时间：2026-07-26 15:37:52-15:38:30 `+08:00`（Asia/Shanghai）。
 - 仓库：`anthropics/anthropic-sdk-python`，默认分支 `main`。
 - 最新 release：`v0.120.0`，发布时间 `2026-07-24T16:32:34Z`。
 - 前一 release：`v0.119.0`，发布时间 `2026-07-23T17:34:23Z`。
 - PR 窗口：`(2026-07-23T17:34:23Z, 2026-07-24T16:32:34Z]`。
-- 窗口内 merged PR：仅 [#1780](https://github.com/anthropics/anthropic-sdk-python/pull/1780)，`release: 0.120.0`，合并于 `2026-07-24T16:31:59Z`，作者为 `stainless-app[bot]`。
-- Tag compare：[`v0.119.0...v0.120.0`](https://github.com/anthropics/anthropic-sdk-python/compare/v0.119.0...v0.120.0) 有 2 个提交；功能提交包含 3 条 `feat(api):` 变化，另一个为 `release: 0.120.0`。未发现 `!` 或 `BREAKING CHANGE:` 标记。
+- 窗口内 merged PR：仅 [#1780](https://github.com/anthropics/anthropic-sdk-python/pull/1780)，`release: 0.120.0`，合并于 `2026-07-24T16:31:59Z`。
+- Tag compare：[`v0.119.0...v0.120.0`](https://github.com/anthropics/anthropic-sdk-python/compare/v0.119.0...v0.120.0) 为 `ahead_by: 2`；功能提交包含 3 条 `feat(api):` 变化，另一个为 release commit。
+- PR body 与 GitHub Release body 都列出同样 3 条 API 功能，没有 `!` 或 `BREAKING CHANGE:` 标记。
+
+### Without Skill
+
+- 抓取时间：2026-07-26 15:39:44 `+08:00`（Asia/Shanghai）。
+- baseline 独立确认最新 release `v0.120.0`、前一 release `v0.119.0` 及相同精确发布时间。
+- baseline 独立查询相同窗口，确认唯一 merged PR 为 #1780。
+- baseline 独立查询 tag compare，确认 `ahead_by: 2`、功能提交 `70c0a64581e7` 与发布提交 `60c64fba5c2b`。
+- baseline 额外通过 commit-to-PR 关联确认两个 tag 间提交都只关联 #1780，因此完整 PR 引用集合没有遗漏。
 
 ## Assertions
 
 | Assertion | With skill | Without skill | Fresh judge conclusion |
 | --- | --- | --- | --- |
 | `x_y_z_yyyy_mm_dd` | PASS | PASS | 两者均生成 `## [0.120.0] - 2026-07-24`。 |
-| `release_tag` | PASS | PASS | 两者均以实时最新 tag `v0.120.0` 为来源，并按 changelog 标题格式去掉 tag 的 `v` 前缀。 |
-| `pr_conventional_commit` | NOT EXERCISED | NOT EXERCISED | 窗口内唯一 PR 是应过滤的 release bot PR；tag compare 的 `feat(api):` 提交标题已被清洗，但这不能冒充普通 PR 标题清洗证据。 |
-| `breaking_change_breaking` | PASS | PASS | 当前窗口没有 breaking marker；“如有则加前缀”的条件未触发，两个输出均未虚构 `⚠️ BREAKING:`。 |
+| `release_tag` | PASS | PASS | 两者均以实时最新 tag `v0.120.0` 为来源，并在版本块中使用 `0.120.0`。 |
+| `pr_conventional_commit` | PASS | PASS | #1780 的 PR body 给出 3 条 `feat(api):` 变化；两者均去掉 conventional prefix，将清洗后的功能标题写成条目并链接 #1780。 |
+| `breaking_change_breaking` | PASS | PASS | 当前 PR body、release body 和 tag compare 均无 breaking marker；条件未触发，两者都未虚构 `⚠️ BREAKING:`。 |
 | `section` | PASS | PASS | 两者只输出有内容的 `Added`，没有生成空 section。 |
 
 ## With Skill
 
 Observed behavior:
 
-- 通过 `gh release list` / release API 确认最新和前一 release，并使用精确发布时间建立单版本窗口。
-- 识别 #1780 为机器人发布 PR，按 skill 的 bot 过滤规则不把它当作用户变化条目。
-- 在没有可纳入 PR 后，按 edge-case 规则回退到 tag compare；将一个 `feat(api):` 提交中的 3 条功能变化清洗为 `Added` 条目，并保留提交来源链接。
-- 生成候选版本块 `## [0.120.0] - 2026-07-24`，只包含 `### Added`，解析目标路径为 `docs/changelog/changelog-v0.120.0.md`。
+- 按 specialist 流程用 `gh` 确认目标仓库、最新和前一 release，并用精确发布时间建立单版本窗口。
+- 查询窗口内 merged PR，再用 tag compare、PR body 和 release body核对 SDK generator 仓库的真实变化。
+- 将 #1780 中 3 条 `feat(api):` 标题清洗后归入 `Added`，每条保留 [#1780](https://github.com/anthropics/anthropic-sdk-python/pull/1780) 引用。
+- 生成 `## [0.120.0] - 2026-07-24`，只包含非空 `### Added`，目标路径为 `docs/changelog/changelog-v0.120.0.md`。
 - 未把候选 changelog 写入 eval fixture；本轮只持久化 fresh judge 摘要。
+
+Candidate behavior summary:
+
+```markdown
+# Changelog - v0.120.0
+
+## [0.120.0] - 2026-07-24
+
+### Added
+
+- **api:** Add claude-opus-5 model ([#1780](https://github.com/anthropics/anthropic-sdk-python/pull/1780))
+- **api:** Add tool addition/removal blocks and tool_change events ([#1780](https://github.com/anthropics/anthropic-sdk-python/pull/1780))
+- **api:** Expand client-side fallback credit token types and add server-side fallbacks default option ([#1780](https://github.com/anthropics/anthropic-sdk-python/pull/1780))
+```
 
 ## Without Skill / Baseline
 
 Observed behavior:
 
-- 未读取或应用 specialist skill / Agent README，仅按原始 prompt 和同一 live snapshot 独立查询最新 release、前一 release、窗口 PR 与 release 内容。
-- 同样生成 `## [0.120.0] - 2026-07-24` 和单一 `Added` section，并从 release 内容整理 3 条 API 功能变化。
-- baseline 能保留 #1780 作为发布来源引用，但没有 specialist 的明确 bot-filter + tag-compare fallback 判定链；它不能为“普通 PR conventional prefix 清洗”提供额外证据。
-- 这是本轮重新生成的 baseline，不是 2026-06-02 的历史输出。
+- 在 `fork_turns=none` 子进程中仅按原始 prompt 独立查询 GitHub，没有读取或应用 specialist skill、Agent README 或任何 eval answer key。
+- 独立选中 `v0.120.0`，建立正确 release 窗口，并用 PR、tag compare 与 commit-to-PR 关联交叉验证 #1780 是完整 PR 集合。
+- 同样生成 `## [0.120.0] - 2026-07-24` 和单一 `Added` section；3 个条目均为去除 `feat(api):` 后的标题，并通过 reference-style link 指向 #1780。
+- 这是本轮全新 baseline，不是历史输出，也不是父进程 snapshot 的改写。
 
 ## Failures
 
 - 没有发现 skill 行为回归。
-- 覆盖限制：实时窗口缺少非 bot PR，`pr_conventional_commit` 无法在本次 snapshot 中被实际触发，因此总体结论保持 `PARTIAL`，不能将 tag compare 的提交标题清洗虚报成 PR 标题清洗 PASS。
+- 没有外部服务失败；baseline 首次 API 命令因未给 zsh 中的 `?` 加引号而失败，修正命令后实时查询成功。这是 baseline 的本地命令构造错误，不是 GitHub 服务失败，也未影响最终证据完整性。
 
 ## External Dependency and Failure Triage
 
-- 数据依赖：GitHub API / `gh` CLI、目标仓库 release、PR 搜索、commit-to-PR 关联和 compare endpoint；这些数据会随新 release 发布而变化。
-- 外部服务失败：认证失败、限流、DNS / 网络错误、GitHub 5xx、目标仓库暂时不可访问，或同一抓取窗口内 release 指针发生变化。此时应记录命令、时间和错误，结果标为 `BLOCKED`，不能判为 skill 回归。
-- Skill 回归：在 GitHub 数据可读取且 snapshot 一致时，选错最新或前一 release、窗口边界错误、未过滤明确 bot PR、该回退 tag compare 时未回退、标题未清洗、错误生成空 section，或发现 breaking marker 却未加 `⚠️ BREAKING:`。
-- 时效风险：release、PR、标题和发布说明均为实时公开数据；后续复验必须重新记录抓取时间、tag/window 和实际样本，不能把本次 `v0.120.0` 快照当作永久 fixture。
+- 数据依赖：GitHub API / `gh` CLI、目标仓库 release、PR 搜索、PR body、commit-to-PR 关联和 compare endpoint；这些数据会随新 release 发布而变化。
+- 外部服务失败：认证失败、限流、DNS / TLS / 网络错误、GitHub 5xx、目标仓库暂时不可访问，或抓取过程中 release 指针变化。此时应记录命令、时间、退出码和错误，结果标为 `BLOCKED`，不能判为 skill 回归或真实空集合。
+- Skill 回归：GitHub 数据可读取且 snapshot 自洽时，选错最新或前一 release、窗口边界错误、漏查 tag compare 或关联 PR、标题未清洗、漏掉 PR 引用、错误生成空 section，或发现 breaking marker 却未加 `⚠️ BREAKING:`。
+- 时效风险：release、PR、标题和发布说明均为实时公开数据；后续复验必须重新记录各自独立的抓取时间、tag/window 和实际样本，不能把本次 `v0.120.0` 快照当作永久 fixture。
 
 ## Next Steps
 
-- 下次 live snapshot 出现非 bot PR 时，重新运行此 eval 以实际覆盖 `pr_conventional_commit`；在此之前保留当前 `PARTIAL`，不添加 mock PR。
+- 当前无需修改 fixture 或 assertions；后续仅在目标仓库出现新 release 或外部 API 行为变化时按相同 no-leak 流程重新抓取并复验。
 
 ## Runtime Artifacts Policy
 
 - Runtime changelog candidates, transcripts, verdicts, timing, outputs, and diagnostics are ephemeral and must not be committed.
-- Durable result only: this canonical `comparison.md`; `eval_metadata.json` remains unchanged.
+- Durable result only: this canonical `comparison.md`; `eval_metadata.json` remains unchanged。

--- a/agents/product_manager/test/changelog-generator/evals/workspace/eval-002-single-version-mode/comparison.md
+++ b/agents/product_manager/test/changelog-generator/evals/workspace/eval-002-single-version-mode/comparison.md
@@ -8,7 +8,7 @@
 - Test case: single-version-mode
 - Workspace: `workspace/eval-002-single-version-mode`
 - Classification: `(c)` 依赖实时 GitHub 数据。该场景必须读取目标仓库当时的 release、相邻 tag compare、merged PR 和 author；静态 mock 不能替代真实复验。
-- Latest result: PARTIAL - 2026-07-26 的 fresh `with_skill` / `without_skill` 已由当前会话中的同一个 fresh Codex subagent 顺序完成两次独立实时查询，并分别在隔离 scratch 中实际写入、回读和清理目标文件。with-skill 正确过滤唯一的 bot release PR 及 compare 中的 bot commits，但其 `## [v0.120.0]` 标题不满足现有 assertion 要求的 `## [x.y.z]`，因此为 3 PASS / 1 FAIL / 1 NOT EXERCISED；without-skill 为 4 PASS / 1 NOT EXERCISED。
+- Latest result: PARTIAL - 2026-07-26 的 fresh `with_skill` / `without_skill` 已由当前会话中的同一个 fresh Codex subagent 顺序完成两次独立实时查询，并分别在隔离 scratch 中实际写入、回读和清理目标文件。with-skill 正确过滤唯一的 bot release PR 及 compare 中的 bot commits，但其 `## [v0.120.0]` 标题不满足现有 assertion 要求的 `## [x.y.z]`，因此为 2 PASS / 1 FAIL / 2 NOT EXERCISED；without-skill 为 3 PASS / 2 NOT EXERCISED。
 
 ## Test Set / Fixture Version
 
@@ -52,7 +52,7 @@
 | `x_y_z_yyyy_mm_dd` | FAIL | PASS | assertion 明确要求 `## [x.y.z] - YYYY-MM-DD`。with-skill 按当前 specialist Step 6 模板生成 `## [v0.120.0]`，多出 `v` 前缀；without-skill 生成 `## [0.120.0]`。本轮不放宽 assertion，也不修改 specialist。 |
 | `release_tag` | PASS | PASS | 两者均以实时最新 tag `v0.120.0` 为来源。 |
 | `pr_conventional_commit` | NOT EXERCISED | NOT EXERCISED | 当前窗口没有普通 PR。`#1780` 是 bot release PR；baseline 的三条内容来自其 body，不是普通 PR title 清洗样本，不能把该断言判为 PASS。 |
-| `breaking_change_breaking` | PASS | PASS | 当前 PR body 和 tag compare 均无 breaking marker；条件未触发，两者都未虚构 `⚠️ BREAKING:`。 |
+| `breaking_change_breaking` | NOT EXERCISED | NOT EXERCISED | 当前 PR body 和 tag compare 均无 breaking marker；未触发时不虚构前缀不能证明两者在出现 breaking change 时会正确添加 `⚠️ BREAKING:`。 |
 | `section` | PASS | PASS | with-skill 过滤全部 bot 来源后不生成任何空 section；baseline 只生成有内容的 `Added`。 |
 
 ## With Skill
@@ -103,7 +103,7 @@ Candidate behavior summary:
 ## Failures
 
 - 格式契约不一致：现有 eval assertion / expected output 要求 `## [x.y.z] - YYYY-MM-DD`，但 specialist Step 6 的新建版本文件模板要求 `## [v{VERSION}] - YYYY-MM-DD`。with-skill 忠实生成后者，严格 judge 必须把 `x_y_z_yyyy_mm_dd` 判为 `FAIL`；本轮按约束不修改 specialist 或放宽 assertion。
-- 覆盖限制：实时窗口唯一 PR `#1780` 是应过滤的 bot release PR，tag compare commits 也均为 bot 作者；`pr_conventional_commit` 没有普通 PR 样本，因此总体结论保持 `PARTIAL`。
+- 覆盖限制：实时窗口唯一 PR `#1780` 是应过滤的 bot release PR，tag compare commits 也均为 bot 作者；`pr_conventional_commit` 没有普通 PR 样本，且窗口没有 breaking marker，`breaking_change_breaking` 的触发分支同样未覆盖，因此总体结论保持 `PARTIAL`。
 - baseline 未应用 bot filter，把 `#1780` 当作 changelog PR attribution 和链接；这是 without-skill 行为差异，不是 with-skill failure。
 - 两个 arm 均已实际写入、回读并清理隔离 scratch 中的目标文件；文件产出行为不再是未验证覆盖项。
 - 没有外部服务失败。
@@ -118,7 +118,7 @@ Candidate behavior summary:
 ## Next Steps
 
 - 由维护者在本 issue 范围外决定统一版本标题契约：修改 specialist 模板或另起经批准的 eval 契约变更；在此之前不得把 `## [v{VERSION}]` 判为满足 `## [x.y.z]`。
-- 后续在 latest-release 窗口出现非 bot PR 后，按相同 no-leak 流程重新抓取并实际覆盖 `pr_conventional_commit`。
+- 后续在 latest-release 窗口出现非 bot PR 或 breaking marker 后，按相同 no-leak 流程重新抓取并实际覆盖 `pr_conventional_commit` 与 `breaking_change_breaking`。
 
 ## Runtime Artifacts Policy
 

--- a/agents/product_manager/test/changelog-generator/evals/workspace/eval-002-single-version-mode/comparison.md
+++ b/agents/product_manager/test/changelog-generator/evals/workspace/eval-002-single-version-mode/comparison.md
@@ -8,27 +8,28 @@
 - Test case: single-version-mode
 - Workspace: `workspace/eval-002-single-version-mode`
 - Classification: `(c)` 依赖实时 GitHub 数据。该场景必须读取目标仓库当时的 release、相邻 tag compare、merged PR 和 author；静态 mock 不能替代真实复验。
-- Latest result: PARTIAL - 2026-07-26 的 fresh `with_skill` / `without_skill` 已用两次独立实时查询成对完成。with-skill 正确过滤唯一的 bot release PR 及 compare 中的 bot commits，未发现 skill 回归；4 条 assertions 通过，`pr_conventional_commit` 因没有普通 PR 样本而为 `NOT EXERCISED`。
+- Latest result: PARTIAL - 2026-07-26 的 fresh `with_skill` / `without_skill` 已由当前会话中的同一个 fresh Codex subagent 顺序完成两次独立实时查询。with-skill 正确过滤唯一的 bot release PR 及 compare 中的 bot commits，未发现 skill 回归；4 条 assertions 通过，`pr_conventional_commit` 因没有普通 PR 样本而为 `NOT EXERCISED`。
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0。
 - Fixture: 仅包含 eval metadata；不新增静态 GitHub 快照。
 - Expected output: 生成最新 release tag 的版本块，格式为 `## [x.y.z] - YYYY-MM-DD`，包含该版本窗口内符合 skill 收录规则的 PR，分组写入，并以 `docs/changelog/changelog-v{version}.md` 为目标路径。
-- Fresh pair: `with_skill` 与 `without_skill` 分别实时查询 GitHub，没有复用历史 baseline，也没有把父进程候选或预计算 snapshot 传给 baseline。
+- Fresh pair: 当前 fresh Codex subagent 先生成并锁定 `with_skill`，再由同一个 subagent 不应用 specialist skill 或 Product Manager README，仅凭原始 prompt 重新查询并锁定新的 `without_skill` baseline；没有复用历史 baseline。
 
 ## No-Leak Execution
 
-- `with_skill` 生成前只读取本用例 `eval_metadata.json` 的原始 prompt，随后读取 Product Manager README 与 `changelog-generator/SKILL.md`；未读取 `evals.json`、assertions、expected output 或旧 comparison。
-- `with_skill` 的 live snapshot 和候选先锁定，之后才启动 `fork_turns=none` 的 fresh baseline。
-- baseline 只收到原始 prompt；未获得 specialist skill、Agent README、assertions、expected output、旧 comparison、父进程候选或父进程 snapshot。
-- baseline 自行调用 `gh` 重新查询 release、tag compare、commit-to-PR 关联和 PR；其候选锁定后才读取 assertions 与旧 comparison 进行 fresh judge。
+- `with_skill` 生成前只读取本用例 `eval_metadata.json` 的原始 prompt，随后完整读取 Product Manager README 与 `changelog-generator/SKILL.md`；未读取 `evals.json`、assertions、expected output 或旧 comparison。
+- `with_skill` 的 live snapshot 和候选先锁定；随后同一个 fresh subagent 进入 baseline arm，不应用先前读取的 specialist skill 或 Product Manager README，仅依据原始 prompt 独立选择查询并生成候选。
+- baseline 未读取 `evals.json`、assertions、expected output 或旧 comparison，也未接收预计算 snapshot；它重新调用 `gh` 获取当时的 release 和 PR 数据。
+- 两个候选都锁定后，同一个 fresh subagent 才读取 assertions 和旧 comparison 并亲自完成 fresh judge。
+- 本轮没有启动第二个 subagent，也没有创建、持久化或提交 transcript、candidate、verdict、timing、outputs 或 diagnostics。
 
 ## Independent Live Data Snapshots
 
 ### With Skill
 
-- 抓取时间：2026-07-26 16:07:47-16:08:16 `+08:00`（Asia/Shanghai）。
+- 抓取时间：2026-07-26 16:27:18 `+08:00`（Asia/Shanghai）。
 - 仓库：`anthropics/anthropic-sdk-python`，默认分支 `main`。
 - 最新 release：`v0.120.0`，发布时间 `2026-07-24T16:32:34Z`。
 - 前一 release：`v0.119.0`，发布时间 `2026-07-23T17:34:23Z`。
@@ -39,18 +40,18 @@
 
 ### Without Skill
 
-- 抓取时间：2026-07-26 16:09:28 `+08:00`（Asia/Shanghai）。
+- 抓取时间：2026-07-26 16:27:41 `+08:00`（Asia/Shanghai）。
 - baseline 独立确认最新 release `v0.120.0`、前一 release `v0.119.0` 及相同发布时间。
-- baseline 独立查询 compare、commit-to-PR 关联、PR 详情和 merged PR 时间窗，确认两个 tag 间有 2 个 commits，且都只关联唯一 merged PR `#1780`。
+- baseline 独立查询 merged PR，确认最新 release 对应的自动 release PR 为 `#1780`，其正文列出 3 项 Features。
 - 外部服务失败：无。
 
 ## Assertions
 
 | Assertion | With skill | Without skill | Fresh judge conclusion |
 | --- | --- | --- | --- |
-| `x_y_z_yyyy_mm_dd` | PASS | PASS | 两者均生成 `## [0.120.0] - 2026-07-24`。 |
-| `release_tag` | PASS | PASS | 两者均以实时最新 tag `v0.120.0` 为来源，并在版本块中使用 `0.120.0`。 |
-| `pr_conventional_commit` | NOT EXERCISED | NOT EXERCISED | 当前窗口没有普通 PR。#1780 是 bot release PR；baseline 的三条内容来自该 PR body / bot commit，不是普通 PR title 清洗样本，不能把该断言判为 PASS。 |
+| `x_y_z_yyyy_mm_dd` | PASS | PASS | 两者均生成带版本号与日期的 `v0.120.0` 版本块。 |
+| `release_tag` | PASS | PASS | 两者均以实时最新 tag `v0.120.0` 为来源。 |
+| `pr_conventional_commit` | NOT EXERCISED | NOT EXERCISED | 当前窗口没有普通 PR。`#1780` 是 bot release PR；baseline 的三条内容来自其 body，不是普通 PR title 清洗样本，不能把该断言判为 PASS。 |
 | `breaking_change_breaking` | PASS | PASS | 当前 PR body 和 tag compare 均无 breaking marker；条件未触发，两者都未虚构 `⚠️ BREAKING:`。 |
 | `section` | PASS | PASS | with-skill 过滤全部 bot 来源后不生成任何空 section；baseline 只生成有内容的 `Added`。 |
 
@@ -59,9 +60,9 @@
 Observed behavior:
 
 - 按 specialist 流程用 `gh` 确认目标仓库、最新和前一 release，并用发布时间建立单版本窗口。
-- 查询窗口内 merged PR，识别唯一的 #1780 为 bot release PR，并按 `author is a bot` 规则排除，未把它作为 changelog attribution 或链接。
-- 因过滤后没有 PR，按 edge case 查询 tag compare；compare 中的两条 commits 也都是 `stainless-app[bot]` 作者，继续按 skill 对 `PRs/commits` 的 bot 过滤规则排除。
-- 生成正确的版本 header 与 `_No user-facing changes (automated release and bot-generated commits only)._`，不生成空 section。compare URL 仅作为数据来源，不把被过滤的 #1780 重新包装成 PR 引用。
+- 查询窗口内 merged PR，识别唯一的 `#1780` 为 bot release PR，并按 author 为 bot 或 login 以 `[bot]` 结尾的规则排除，未把它作为 changelog attribution 或链接。
+- 因过滤后没有 PR，按 edge case 查询 tag compare；compare 中的两条 commits 也都是 `stainless-app[bot]` 作者，继续排除。
+- 生成正确的版本 header 与 `_No user-facing changes (dependency updates and internal maintenance only)._`，不生成空 section，也不链接被过滤的 `#1780`。
 - 目标路径为 `docs/changelog/changelog-v0.120.0.md`；未把 runtime candidate 写入 eval fixture。
 
 Candidate behavior summary:
@@ -69,52 +70,48 @@ Candidate behavior summary:
 ```markdown
 # Changelog - v0.120.0
 
-## [0.120.0] - 2026-07-24
+## [v0.120.0] - 2026-07-24
 
-_No user-facing changes (automated release and bot-generated commits only)._
+_No user-facing changes (dependency updates and internal maintenance only)._
 ```
-
-Source used for the edge-case check: [`v0.119.0...v0.120.0`](https://github.com/anthropics/anthropic-sdk-python/compare/v0.119.0...v0.120.0).
 
 ## Without Skill / Baseline
 
 Observed behavior:
 
-- 在 `fork_turns=none` 子进程中仅按原始 prompt 独立查询 GitHub，没有读取或应用 specialist skill、Agent README 或任何 eval answer key。
-- 独立选中 `v0.120.0`，建立正确 release 窗口，并用 compare、commit-to-PR 关联和 PR 查询交叉验证完整集合。
-- 将 #1780 PR body 中的 3 条功能内容清洗为 `Added` 条目，且每条都链接到 #1780；该候选没有应用 specialist 的 bot author 过滤，因此与 with-skill 形成有效行为差异。
+- 同一个 fresh subagent 在 baseline arm 中仅按原始 prompt 重新查询 GitHub，没有应用 specialist skill、Product Manager README 或任何 eval answer key。
+- 独立选中 `v0.120.0`，并从自动 release PR `#1780` 的正文提取 3 项 Features。
+- 将三项功能写入 `Added`，每项都引用 `#1780`；该候选没有 specialist 的 bot author 过滤，因此与 with-skill 形成有效行为差异。
 - baseline 的条目不是普通 PR title 清洗样本，所以不满足 `pr_conventional_commit` 的实际覆盖条件。
-- 这是本轮全新 baseline，不是历史输出或父进程 snapshot 的改写。
+- 这是本轮新生成的 baseline，不是历史输出或 with-skill 候选的改写。
 
 Candidate behavior summary:
 
 ```markdown
-# Changelog
+# Changelog - v0.120.0
 
-本项目的重要变更记录遵循 Keep a Changelog 格式。
-
-## [0.120.0] - 2026-07-24
+## [v0.120.0] - 2026-07-24
 
 ### Added
 
-- 新增 `claude-opus-5` 模型支持（[#1780]）。
-- 新增工具添加和移除内容块，以及 `tool_change` 事件支持（[#1780]）。
-- 扩展客户端 fallback credit token 类型，并新增服务端 fallbacks 默认选项（[#1780]）。
+- Add `claude-opus-5` model ([#1780](https://github.com/anthropics/anthropic-sdk-python/pull/1780))
+- Add tool addition/removal blocks and `tool_change` events ([#1780](https://github.com/anthropics/anthropic-sdk-python/pull/1780))
+- Expand client-side fallback credit token types and add server-side fallbacks default option ([#1780](https://github.com/anthropics/anthropic-sdk-python/pull/1780))
 ```
 
 ## Failures
 
 - 没有发现 skill 行为回归或协议偏差。
-- 覆盖限制：实时窗口唯一 PR #1780 是应过滤的 bot release PR，tag compare commits 也均为 bot 作者；`pr_conventional_commit` 没有普通 PR 样本，因此总体结论保持 `PARTIAL`。
-- baseline 未应用 bot filter，把 #1780 当作 changelog PR attribution 和链接；这是 without-skill 行为差异，不是 with-skill failure。
+- 覆盖限制：实时窗口唯一 PR `#1780` 是应过滤的 bot release PR，tag compare commits 也均为 bot 作者；`pr_conventional_commit` 没有普通 PR 样本，因此总体结论保持 `PARTIAL`。
+- baseline 未应用 bot filter，把 `#1780` 当作 changelog PR attribution 和链接；这是 without-skill 行为差异，不是 with-skill failure。
 - 没有外部服务失败。
 
 ## External Dependency and Failure Triage
 
-- 数据依赖：GitHub API / `gh` CLI、目标仓库 release、PR 搜索、author bot 标记、commit-to-PR 关联和 compare endpoint；这些数据会随新 release 发布而变化。
+- 数据依赖：GitHub API / `gh` CLI、目标仓库 release、PR 搜索、author bot 标记和 compare endpoint；这些数据会随新 release 发布而变化。
 - 外部服务失败：认证失败、限流、DNS / TLS / 网络错误、GitHub 5xx、目标仓库暂时不可访问，或抓取过程中 latest release 指针变化。此时应记录命令、时间、退出码和错误，结果标为 `BLOCKED`，不能判为 skill 回归或真实空集合。
 - Skill 回归：GitHub 数据可读取且 snapshot 自洽时，选错最新或前一 release、窗口边界错误、未过滤 bot PR/commit、过滤后又把 bot PR 作为条目 attribution 或链接、漏查 tag compare、错误生成空 section，或发现 breaking marker 却未加 `⚠️ BREAKING:`。
-- 时效风险：release、PR、author 和发布说明均为实时公开数据；后续复验必须重新记录各自独立的抓取时间、tag/window 和实际样本，不能把本次 `v0.120.0` 快照当作永久 fixture。
+- 时效风险：release、PR、author 和发布说明均为实时公开数据；后续复验必须重新记录抓取时间、tag/window 和实际样本，不能把本次 `v0.120.0` 快照当作永久 fixture。
 
 ## Next Steps
 

--- a/agents/product_manager/test/changelog-generator/evals/workspace/eval-002-single-version-mode/comparison.md
+++ b/agents/product_manager/test/changelog-generator/evals/workspace/eval-002-single-version-mode/comparison.md
@@ -7,44 +7,42 @@
 - Eval: `eval-002-single-version-mode`
 - Test case: single-version-mode
 - Workspace: `workspace/eval-002-single-version-mode`
-- Classification: `(c)` 依赖实时 GitHub 数据。该场景必须读取目标仓库当时的 release、tag compare、merged PR 和 PR body；静态 mock 不能替代真实复验。
-- Latest result: PARTIAL - 2026-07-26 的 fresh `with_skill` / `without_skill` 已用两次独立实时查询成对完成；4 条 assertions 通过，`pr_conventional_commit` 因版本窗口内只有应过滤的 bot release PR 而没有可执行的普通 PR 标题样本。
+- Classification: `(c)` 依赖实时 GitHub 数据。该场景必须读取目标仓库当时的 release、相邻 tag compare、merged PR 和 author；静态 mock 不能替代真实复验。
+- Latest result: PARTIAL - 2026-07-26 的 fresh `with_skill` / `without_skill` 已用两次独立实时查询成对完成。with-skill 正确过滤唯一的 bot release PR 及 compare 中的 bot commits，未发现 skill 回归；4 条 assertions 通过，`pr_conventional_commit` 因没有普通 PR 样本而为 `NOT EXERCISED`。
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0。
 - Fixture: 仅包含 eval metadata；不新增静态 GitHub 快照。
-- Expected output: 生成最新 release tag 的版本块，格式为 `## [x.y.z] - YYYY-MM-DD`，包含该版本窗口内的 PR，分组写入，每条带 PR 链接，并写入 `docs/changelog/changelog-v{version}.md`。
+- Expected output: 生成最新 release tag 的版本块，格式为 `## [x.y.z] - YYYY-MM-DD`，包含该版本窗口内符合 skill 收录规则的 PR，分组写入，并以 `docs/changelog/changelog-v{version}.md` 为目标路径。
 - Fresh pair: `with_skill` 与 `without_skill` 分别实时查询 GitHub，没有复用历史 baseline，也没有把父进程候选或预计算 snapshot 传给 baseline。
 
 ## No-Leak Execution
 
-- `with_skill` 生成前只读取本用例 `eval_metadata.json` 的原始 prompt，随后读取 Product Manager README 与 `changelog-generator/SKILL.md`，未读取 `evals.json`、assertions、expected output 或旧 comparison。
-- `with_skill` 候选和 live snapshot 锁定后，才启动 `fork_turns=none` 的 fresh baseline。
+- `with_skill` 生成前只读取本用例 `eval_metadata.json` 的原始 prompt，随后读取 Product Manager README 与 `changelog-generator/SKILL.md`；未读取 `evals.json`、assertions、expected output 或旧 comparison。
+- `with_skill` 的 live snapshot 和候选先锁定，之后才启动 `fork_turns=none` 的 fresh baseline。
 - baseline 只收到原始 prompt；未获得 specialist skill、Agent README、assertions、expected output、旧 comparison、父进程候选或父进程 snapshot。
-- baseline 自行调用 `gh` 重新查询 release、PR 时间窗、tag compare 和 commit-to-PR 关联；其候选锁定后才读取 assertions 与旧 comparison 进行 fresh judge。
-- 两次查询结果独立一致，不代表把同一预计算答案作为两条运行路径的输入。
+- baseline 自行调用 `gh` 重新查询 release、tag compare、commit-to-PR 关联和 PR；其候选锁定后才读取 assertions 与旧 comparison 进行 fresh judge。
 
 ## Independent Live Data Snapshots
 
 ### With Skill
 
-- 抓取时间：2026-07-26 15:37:52-15:38:30 `+08:00`（Asia/Shanghai）。
+- 抓取时间：2026-07-26 16:07:47-16:08:16 `+08:00`（Asia/Shanghai）。
 - 仓库：`anthropics/anthropic-sdk-python`，默认分支 `main`。
 - 最新 release：`v0.120.0`，发布时间 `2026-07-24T16:32:34Z`。
 - 前一 release：`v0.119.0`，发布时间 `2026-07-23T17:34:23Z`。
-- PR 窗口：`(2026-07-23T17:34:23Z, 2026-07-24T16:32:34Z]`。
-- 窗口内 merged PR：仅 [#1780](https://github.com/anthropics/anthropic-sdk-python/pull/1780)，`release: 0.120.0`，合并于 `2026-07-24T16:31:59Z`。
-- Tag compare：[`v0.119.0...v0.120.0`](https://github.com/anthropics/anthropic-sdk-python/compare/v0.119.0...v0.120.0) 为 `ahead_by: 2`；功能提交包含 3 条 `feat(api):` 变化，另一个为 release commit。
-- PR body 与 GitHub Release body 都列出同样 3 条 API 功能，没有 `!` 或 `BREAKING CHANGE:` 标记。
+- PR 窗口：`2026-07-23T17:34:23Z..2026-07-24T16:32:34Z`。
+- 窗口内 merged PR：仅 `#1780`，标题 `release: 0.120.0`，合并于 `2026-07-24T16:31:59Z`；author 为 `app/stainless-app`，GitHub 标记 `is_bot: true`。
+- Tag compare：[`v0.119.0...v0.120.0`](https://github.com/anthropics/anthropic-sdk-python/compare/v0.119.0...v0.120.0) 为 `ahead_by: 2`。功能提交 `70c0a64581e7` 与 release 提交 `60c64fba5c2b` 的 author 均为 `stainless-app[bot]`。
+- 外部服务失败：无。
 
 ### Without Skill
 
-- 抓取时间：2026-07-26 15:39:44 `+08:00`（Asia/Shanghai）。
-- baseline 独立确认最新 release `v0.120.0`、前一 release `v0.119.0` 及相同精确发布时间。
-- baseline 独立查询相同窗口，确认唯一 merged PR 为 #1780。
-- baseline 独立查询 tag compare，确认 `ahead_by: 2`、功能提交 `70c0a64581e7` 与发布提交 `60c64fba5c2b`。
-- baseline 额外通过 commit-to-PR 关联确认两个 tag 间提交都只关联 #1780，因此完整 PR 引用集合没有遗漏。
+- 抓取时间：2026-07-26 16:09:28 `+08:00`（Asia/Shanghai）。
+- baseline 独立确认最新 release `v0.120.0`、前一 release `v0.119.0` 及相同发布时间。
+- baseline 独立查询 compare、commit-to-PR 关联、PR 详情和 merged PR 时间窗，确认两个 tag 间有 2 个 commits，且都只关联唯一 merged PR `#1780`。
+- 外部服务失败：无。
 
 ## Assertions
 
@@ -52,19 +50,19 @@
 | --- | --- | --- | --- |
 | `x_y_z_yyyy_mm_dd` | PASS | PASS | 两者均生成 `## [0.120.0] - 2026-07-24`。 |
 | `release_tag` | PASS | PASS | 两者均以实时最新 tag `v0.120.0` 为来源，并在版本块中使用 `0.120.0`。 |
-| `pr_conventional_commit` | NOT EXERCISED | NOT EXERCISED | #1780 是 `stainless-app[bot]` 的 release PR，按 skill 规则应过滤。PR body / release body 中的 3 条 `feat(api):` 内容和 tag compare commit 可用于理解版本变化，但不能冒充普通 PR 标题清洗证据。 |
-| `breaking_change_breaking` | PASS | PASS | 当前 PR body、release body 和 tag compare 均无 breaking marker；条件未触发，两者都未虚构 `⚠️ BREAKING:`。 |
-| `section` | PASS | PASS | 两者只输出有内容的 `Added`，没有生成空 section。 |
+| `pr_conventional_commit` | NOT EXERCISED | NOT EXERCISED | 当前窗口没有普通 PR。#1780 是 bot release PR；baseline 的三条内容来自该 PR body / bot commit，不是普通 PR title 清洗样本，不能把该断言判为 PASS。 |
+| `breaking_change_breaking` | PASS | PASS | 当前 PR body 和 tag compare 均无 breaking marker；条件未触发，两者都未虚构 `⚠️ BREAKING:`。 |
+| `section` | PASS | PASS | with-skill 过滤全部 bot 来源后不生成任何空 section；baseline 只生成有内容的 `Added`。 |
 
 ## With Skill
 
 Observed behavior:
 
-- 按 specialist 流程用 `gh` 确认目标仓库、最新和前一 release，并用精确发布时间建立单版本窗口。
-- 查询窗口内 merged PR，识别 #1780 为 bot release PR 并按规则从普通 PR 条目候选中排除；再用 tag compare、PR body 和 release body核对 SDK generator 仓库的真实变化。
-- 可从 tag compare / release 内容整理 3 条 API 功能变化，但这些不是普通 PR title 样本，不能据此把 `pr_conventional_commit` 判为 PASS。
-- 生成 `## [0.120.0] - 2026-07-24`，只包含非空 `### Added`，目标路径为 `docs/changelog/changelog-v0.120.0.md`。
-- 未把候选 changelog 写入 eval fixture；本轮只持久化 fresh judge 摘要。
+- 按 specialist 流程用 `gh` 确认目标仓库、最新和前一 release，并用发布时间建立单版本窗口。
+- 查询窗口内 merged PR，识别唯一的 #1780 为 bot release PR，并按 `author is a bot` 规则排除，未把它作为 changelog attribution 或链接。
+- 因过滤后没有 PR，按 edge case 查询 tag compare；compare 中的两条 commits 也都是 `stainless-app[bot]` 作者，继续按 skill 对 `PRs/commits` 的 bot 过滤规则排除。
+- 生成正确的版本 header 与 `_No user-facing changes (automated release and bot-generated commits only)._`，不生成空 section。compare URL 仅作为数据来源，不把被过滤的 #1780 重新包装成 PR 引用。
+- 目标路径为 `docs/changelog/changelog-v0.120.0.md`；未把 runtime candidate 写入 eval fixture。
 
 Candidate behavior summary:
 
@@ -73,34 +71,50 @@ Candidate behavior summary:
 
 ## [0.120.0] - 2026-07-24
 
-### Added
-
-- **api:** Add claude-opus-5 model ([#1780](https://github.com/anthropics/anthropic-sdk-python/pull/1780))
-- **api:** Add tool addition/removal blocks and tool_change events ([#1780](https://github.com/anthropics/anthropic-sdk-python/pull/1780))
-- **api:** Expand client-side fallback credit token types and add server-side fallbacks default option ([#1780](https://github.com/anthropics/anthropic-sdk-python/pull/1780))
+_No user-facing changes (automated release and bot-generated commits only)._
 ```
+
+Source used for the edge-case check: [`v0.119.0...v0.120.0`](https://github.com/anthropics/anthropic-sdk-python/compare/v0.119.0...v0.120.0).
 
 ## Without Skill / Baseline
 
 Observed behavior:
 
 - 在 `fork_turns=none` 子进程中仅按原始 prompt 独立查询 GitHub，没有读取或应用 specialist skill、Agent README 或任何 eval answer key。
-- 独立选中 `v0.120.0`，建立正确 release 窗口，并用 PR、tag compare 与 commit-to-PR 关联交叉验证 #1780 是完整 PR 集合。
-- 同样可从 release 内容整理 `Added` section，但把 body / commit 文本清洗后链接到 #1780 仍不构成普通 PR title 清洗覆盖。
-- 这是本轮全新 baseline，不是历史输出，也不是父进程 snapshot 的改写。
+- 独立选中 `v0.120.0`，建立正确 release 窗口，并用 compare、commit-to-PR 关联和 PR 查询交叉验证完整集合。
+- 将 #1780 PR body 中的 3 条功能内容清洗为 `Added` 条目，且每条都链接到 #1780；该候选没有应用 specialist 的 bot author 过滤，因此与 with-skill 形成有效行为差异。
+- baseline 的条目不是普通 PR title 清洗样本，所以不满足 `pr_conventional_commit` 的实际覆盖条件。
+- 这是本轮全新 baseline，不是历史输出或父进程 snapshot 的改写。
+
+Candidate behavior summary:
+
+```markdown
+# Changelog
+
+本项目的重要变更记录遵循 Keep a Changelog 格式。
+
+## [0.120.0] - 2026-07-24
+
+### Added
+
+- 新增 `claude-opus-5` 模型支持（[#1780]）。
+- 新增工具添加和移除内容块，以及 `tool_change` 事件支持（[#1780]）。
+- 扩展客户端 fallback credit token 类型，并新增服务端 fallbacks 默认选项（[#1780]）。
+```
 
 ## Failures
 
-- 没有发现 skill 行为回归。
-- 覆盖限制：实时窗口唯一 PR #1780 是应过滤的 `stainless-app[bot]` release PR；`pr_conventional_commit` 没有普通 PR 样本，因此总体结论保持 `PARTIAL`。不能用该 PR body、release body 或 tag compare commit 的清洗结果替代 PR title 断言。
-- 没有外部服务失败；baseline 首次 API 命令因未给 zsh 中的 `?` 加引号而失败，修正命令后实时查询成功。这是 baseline 的本地命令构造错误，不是 GitHub 服务失败，也未影响最终证据完整性。
+- 没有发现 skill 行为回归或协议偏差。
+- 覆盖限制：实时窗口唯一 PR #1780 是应过滤的 bot release PR，tag compare commits 也均为 bot 作者；`pr_conventional_commit` 没有普通 PR 样本，因此总体结论保持 `PARTIAL`。
+- baseline 未应用 bot filter，把 #1780 当作 changelog PR attribution 和链接；这是 without-skill 行为差异，不是 with-skill failure。
+- 没有外部服务失败。
 
 ## External Dependency and Failure Triage
 
-- 数据依赖：GitHub API / `gh` CLI、目标仓库 release、PR 搜索、PR body、commit-to-PR 关联和 compare endpoint；这些数据会随新 release 发布而变化。
-- 外部服务失败：认证失败、限流、DNS / TLS / 网络错误、GitHub 5xx、目标仓库暂时不可访问，或抓取过程中 release 指针变化。此时应记录命令、时间、退出码和错误，结果标为 `BLOCKED`，不能判为 skill 回归或真实空集合。
-- Skill 回归：GitHub 数据可读取且 snapshot 自洽时，选错最新或前一 release、窗口边界错误、漏查 tag compare 或关联 PR、标题未清洗、漏掉 PR 引用、错误生成空 section，或发现 breaking marker 却未加 `⚠️ BREAKING:`。
-- 时效风险：release、PR、标题和发布说明均为实时公开数据；后续复验必须重新记录各自独立的抓取时间、tag/window 和实际样本，不能把本次 `v0.120.0` 快照当作永久 fixture。
+- 数据依赖：GitHub API / `gh` CLI、目标仓库 release、PR 搜索、author bot 标记、commit-to-PR 关联和 compare endpoint；这些数据会随新 release 发布而变化。
+- 外部服务失败：认证失败、限流、DNS / TLS / 网络错误、GitHub 5xx、目标仓库暂时不可访问，或抓取过程中 latest release 指针变化。此时应记录命令、时间、退出码和错误，结果标为 `BLOCKED`，不能判为 skill 回归或真实空集合。
+- Skill 回归：GitHub 数据可读取且 snapshot 自洽时，选错最新或前一 release、窗口边界错误、未过滤 bot PR/commit、过滤后又把 bot PR 作为条目 attribution 或链接、漏查 tag compare、错误生成空 section，或发现 breaking marker 却未加 `⚠️ BREAKING:`。
+- 时效风险：release、PR、author 和发布说明均为实时公开数据；后续复验必须重新记录各自独立的抓取时间、tag/window 和实际样本，不能把本次 `v0.120.0` 快照当作永久 fixture。
 
 ## Next Steps
 

--- a/agents/product_manager/test/changelog-generator/evals/workspace/eval-003-prefix-classification/comparison.md
+++ b/agents/product_manager/test/changelog-generator/evals/workspace/eval-003-prefix-classification/comparison.md
@@ -7,8 +7,8 @@
 - Eval: `eval-003-prefix-classification`
 - Test case: prefix-classification
 - Workspace: `workspace/eval-003-prefix-classification`
-- Evaluation time: 2026-07-26 15:32:35 CST (+0800)
-- Latest result: PASS - fresh `with_skill` 满足 13/13 assertions；独立生成的 fresh `without_skill` baseline 满足 12/13，暴露出 breaking `feat!` 章节归属差异。
+- Evaluation time: 2026-07-26 16:21:37 CST (+0800)
+- Latest result: PASS - same-agent fresh `with_skill` 与 fresh `without_skill` baseline 均满足 13/13 assertions；本轮未观察到两 arm 的行为差异。
 
 ## Test Set / Fixture Version
 
@@ -19,11 +19,11 @@
 
 ## No-Answer-Key Fresh Method
 
-本轮 fresh Codex evaluator 按以下隔离顺序执行，候选锁定前不读取答案键：
+本轮由同一个 fresh Codex evaluator 按以下隔离顺序执行；未委派其他 agent，候选锁定前不读取答案键：
 
 1. 生成阶段首先只读取 workspace 的 `eval_metadata.json`，从中取得完整原始 prompt；未读取 `evals.json`、`expected_output`、assertions 或旧 `comparison.md`。
-2. `with_skill` 阶段读取当前 `agents/product_manager/README.md` 与 `agents/product_manager/skills/changelog-generator/SKILL.md`，仅依据原始 prompt 和 skill 契约独立生成并锁定候选。
-3. `without_skill` 阶段仅依据同一份原始 prompt 独立生成并锁定 baseline；未读取或应用 Agent README、skill、`evals.json`、assertions、`expected_output` 或旧 comparison。
+2. `with_skill` 阶段读取完整的当前 `agents/product_manager/README.md` 与 `agents/product_manager/skills/changelog-generator/SKILL.md`，仅依据原始 prompt 和 skill 契约独立生成并锁定候选。
+3. 同一 evaluator 随后进入 `without_skill` 阶段，仅依据同一份原始 prompt 与通用 Keep a Changelog 语义独立生成并锁定 baseline；该阶段未读取或应用 Agent README、skill、`evals.json`、assertions、`expected_output` 或旧 comparison。
 4. 两份候选都锁定后，才读取 `evals.json` 中本用例的 assertions、expected output 与旧 comparison，并逐项 judge；judge 阶段没有反向修改候选。
 
 候选、transcript 与 judge diagnostics 均未写入仓库。
@@ -47,14 +47,14 @@
 
 锁定 baseline 的行为摘要：
 
-- Added：`#101 Add OAuth2 login support`
-- Changed：`#104 Reduce API response time by caching`、`#105 ⚠️ BREAKING: Redesign plugin configuration API`、`#106 Update release notes generator publishing workflow`、`#107 Tighten changelog-generator eval contract`、`#108 Require repository and eval contract checks before release`
+- Added：`#105 ⚠️ BREAKING: Redesign plugin configuration API`（置顶）、`#101 Add OAuth2 login support`
+- Changed：`#104 Reduce API response time by caching`、`#106 Update release notes generator publishing workflow`、`#107 Tighten changelog-generator eval contract`、`#108 Require repository and eval contract checks before release`
 - Fixed：`#102 Resolve crash when token expires`、`#111 Correct button alignment on mobile`
 - Removed：`#112 Drop Python 3.7 support`
 - Security：`#113 Patch XSS vulnerability in template renderer`
 - 跳过：`#103`、`#114`、`#109`、`#110`
 
-结论：12/13 assertions 通过。baseline 单凭 prompt 也能完成 docs/test/ci 的语义筛选和多数 conventional prefix 分类，但把描述“重设计既有 API”的 breaking `feat! #105` 按语义放入 Changed；当前 skill 契约要求 `feat!` 仍归 Added，并以 `⚠️ BREAKING` 标记，因此 `feat_added_breaking` 未通过。
+结论：13/13 assertions 通过。baseline 单凭 prompt 与通用 Keep a Changelog 语义，也将 conventional `feat! #105` 保留在 Added 并添加 breaking 标记，同时完成 docs/test/ci 的语义筛选；本轮没有观察到 skill 相对 baseline 的行为增益。
 
 ## Assertion Review
 
@@ -65,7 +65,7 @@
 | `chore_deps` | 跳过 #103 | 相同 | Both PASS |
 | `build_deps_skipped` | 跳过 #114 | 相同 | Both PASS |
 | `perf_changed` | #104 进入 Changed | 相同 | Both PASS |
-| `feat_added_breaking` | #105 进入 Added，带 `⚠️ BREAKING` 且置顶 | #105 带 breaking 标记但进入 Changed | With skill PASS / Baseline FAIL |
+| `feat_added_breaking` | #105 进入 Added，带 `⚠️ BREAKING` 且置顶 | 相同 | Both PASS |
 | `docs_release_workflow_changed` | 根据正文将 #106 纳入 Changed | 相同 | Both PASS |
 | `test_eval_contract_changed` | 根据正文将 #107 纳入 Changed | 相同 | Both PASS |
 | `ci_release_gate_changed` | 根据正文将 #108 纳入 Changed | 相同 | Both PASS |
@@ -76,14 +76,13 @@
 
 ## Failures
 
-- `with_skill` 无 assertion failure。
-- `without_skill` baseline 未满足 `feat_added_breaking`：breaking 标记正确，但章节错误地归入 Changed，而不是 Added。
-- 旧 comparison 的 baseline 描述受答案键污染：它声称生成时使用了 assertions，并把 baseline 记录成与 expected output 完全一致。本轮已用严格的 no-answer-key 顺序重新生成候选并纠正该记录；未复用旧 baseline。
+- `with_skill` 与 `without_skill` baseline 均无 assertion failure。
+- 本轮 same-agent fresh baseline 与历史记录不同：本轮在读取答案键前已将 `feat! #105` 锁定为 Added，而不是 Changed。canonical comparison 已按本轮真实结果纠正，未复用或迁就历史 baseline。
 
 ## Risks / Next Steps
 
 - 本用例使用 prompt 内嵌的确定性 PR 数据，不验证 GitHub API、`gh` CLI、分页或日期窗口行为；这些能力由 changelog-generator 的实时数据 eval 覆盖。
-- prompt 已直接给出 docs/test/ci 需要按正文语义判断的要求，因此 baseline 在这部分同样通过并不削弱用例有效性；本轮差异表明 skill 对 breaking conventional prefix 的明确映射提供了可观察增益。
+- prompt 已直接给出 docs/test/ci 需要按正文语义判断的要求，并且 conventional `feat!` 的 Added 归类可由通用知识正确推导，因此 baseline 全部通过是合理结果；该用例本轮证明 skill 行为满足契约，但未证明相对无 skill baseline 的可观察增益。
 - 保留此用例作为 conventional prefix、breaking change 和低优先级前缀语义审查的回归覆盖。
 
 ## Runtime Artifact Policy

--- a/agents/product_manager/test/changelog-generator/evals/workspace/eval-003-prefix-classification/comparison.md
+++ b/agents/product_manager/test/changelog-generator/evals/workspace/eval-003-prefix-classification/comparison.md
@@ -7,50 +7,74 @@
 - Eval: `eval-003-prefix-classification`
 - Test case: prefix-classification
 - Workspace: `workspace/eval-003-prefix-classification`
-- Latest result: PARTIAL - prior skill validation evidence is preserved; without_skill baseline was not generated for this historical comparison.
-- Prior validation note: fresh Codex subagent validation completed on 2026-06-15; no changelog-generator transcript runner is available, so no model transcript was generated
+- Evaluation date: 2026-07-26 (Asia/Shanghai)
+- Latest result: PASS - 本轮 fresh `with_skill` 与 fresh `without_skill` baseline 均满足全部 13 条 assertions。
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: Verifies that changelog-generator handles conventional prefix classification plus semantic docs/test/ci review.
-- Expected output: Added: feat items. Changed: perf items plus docs/test/ci items with semantic impact. Fixed: fix items. Removed: remove items. Security: security items. 跳过 chore(deps)、build(deps)、formatting-only docs 和 cache-only ci。Breaking change (#105) 带 ⚠️ BREAKING 前缀。
+- Classification: (a) fixture 已足够，只缺 fresh baseline。
+- Reason: 14 条 PR 的标题、正文、编号以及 docs/test/ci 语义判断要求均完整内嵌在 prompt；13 条 assertions 只验证这些输入的分类、标题清洗、跳过规则和 breaking 标记，不依赖仓库文件或实时外部数据，因此无需添加 fixture 文件。
+- Expected output: Added 包含 feat；Changed 包含 perf 及具有 release workflow、eval contract、required gate 语义影响的 docs/test/ci；Fixed 包含 fix；Removed 包含 remove；Security 包含 security；跳过 dependency bump、仅 copyediting 的 docs 和仅 cache maintenance 的 ci；#105 带 `⚠️ BREAKING` 标记。
 
-## Assertions
+## Fresh Paired Results
 
-- `feat_auth_added_add_oauth2_login_support`: feat(auth) → Added 章节，标题清洗为 Add OAuth2 login support
-- `fix_fixed`: fix → Fixed 章节
-- `chore_deps`: chore(deps) → 跳过，不出现在输出
-- `build_deps_skipped`: build(deps) → 跳过，不出现在输出
-- `perf_changed`: perf → Changed 章节
-- `feat_added_breaking`: feat! → Added 章节，带 ⚠️ BREAKING 前缀
-- `docs_release_workflow_changed`: docs PR 正文描述 release workflow / changelog preflight 影响时进入 Changed 章节
-- `test_eval_contract_changed`: test PR 正文描述 eval assertion 或 durable comparison 契约影响时进入 Changed 章节
-- `ci_release_gate_changed`: ci PR 正文描述 release gate 或 required check 影响时进入 Changed 章节
-- `docs_typo_skipped`: formatting-only docs → 跳过
-- `ci_cache_skipped`: cache-only ci → 跳过
-- `remove_removed`: remove → Removed 章节
-- `security_security`: security → Security 章节
+### With Skill
 
-## With Skill
+本轮 fresh judge 读取当前 `agents/product_manager/README.md`、`changelog-generator/SKILL.md`、prefix reference、eval prompt 与 assertions 后，按 skill 协议独立生成结果：
 
-Observed behavior:
+- Added：`#105 ⚠️ BREAKING: Redesign plugin configuration API`（置顶）、`#101 Add OAuth2 login support`
+- Changed：`#104 Reduce API response time by caching`、`#106 Update release notes generator publishing workflow`、`#107 Tighten changelog-generator eval contract`、`#108 Require repository and eval contract checks before release`
+- Fixed：`#102 Resolve crash when token expires`、`#111 Correct button alignment on mobile`
+- Removed：`#112 Drop Python 3.7 support`
+- Security：`#113 Patch XSS vulnerability in template renderer`
+- 跳过：`#103 chore(deps)`、`#114 build(deps)`、`#109` 仅 typo/copyediting、`#110` 仅 cache maintenance
 
-- Fresh Codex subagent validation confirmed the current skill contract keeps conventional prefix classification for feat/fix/perf/remove/security, keeps chore(deps) and build(deps) dependency bumps skipped, classifies semantic docs/test/ci/general build/style PRs through semantic review when they affect release workflow, eval contracts, durable comparison, or required gates, and skips formatting-only docs or cache-only ci changes.
+结论：skill 不仅按 conventional prefix 分类，也读取正文区分具有契约或发布影响的 docs/test/ci 与低价值维护项；全部 assertions 通过。
 
-## Without Skill / Baseline
-- BLOCKED: No actual without_skill baseline result is recorded for this historical comparison. This file is not treated as a full eval PASS until a baseline result is generated and written here.
-- This comparison records whether the skill-specific protocol, routing, evidence, or artifact expectations are preserved.
+### Without Skill / Baseline
+
+本轮 fresh judge 在不读取或应用 skill、Agent README 与 prefix reference 的 baseline 条件下，仅使用相同 prompt 和 assertions 重新生成结果：
+
+- Added：`#105 ⚠️ BREAKING: Redesign plugin configuration API`、`#101 Add OAuth2 login support`
+- Changed：`#104 Reduce API response time by caching`、`#106 Update release notes generator publishing workflow`、`#107 Tighten changelog-generator eval contract`、`#108 Require repository and eval contract checks before release`
+- Fixed：`#102 Resolve crash when token expires`、`#111 Correct button alignment on mobile`
+- Removed：`#112 Drop Python 3.7 support`
+- Security：`#113 Patch XSS vulnerability in template renderer`
+- 跳过：`#103`、`#114`、`#109`、`#110`
+
+结论：baseline 也满足全部 assertions。原因是 prompt 本身已显式要求按正文语义审查 docs/test/ci，并提供足够明确的 PR 正文；这说明该用例可验证 skill 行为未回归，但不是证明这些基础分类只能依赖 skill 才能完成。
+
+## Assertion Review
+
+| Assertion | With skill | Without skill | Result |
+| --- | --- | --- | --- |
+| `feat_auth_added_add_oauth2_login_support` | #101 进入 Added，清洗为 `Add OAuth2 login support` | 相同 | PASS |
+| `fix_fixed` | #102、#111 进入 Fixed | 相同 | PASS |
+| `chore_deps` | 跳过 #103 | 相同 | PASS |
+| `build_deps_skipped` | 跳过 #114 | 相同 | PASS |
+| `perf_changed` | #104 进入 Changed | 相同 | PASS |
+| `feat_added_breaking` | #105 进入 Added，带 `⚠️ BREAKING` 且置顶 | 带 `⚠️ BREAKING` | PASS |
+| `docs_release_workflow_changed` | 根据正文将 #106 纳入 Changed | 相同 | PASS |
+| `test_eval_contract_changed` | 根据正文将 #107 纳入 Changed | 相同 | PASS |
+| `ci_release_gate_changed` | 根据正文将 #108 纳入 Changed | 相同 | PASS |
+| `docs_typo_skipped` | 跳过仅 copyediting 的 #109 | 相同 | PASS |
+| `ci_cache_skipped` | 跳过仅 cache maintenance 的 #110 | 相同 | PASS |
+| `remove_removed` | #112 进入 Removed | 相同 | PASS |
+| `security_security` | #113 进入 Security | 相同 | PASS |
 
 ## Failures
 
-- None found in fresh Codex subagent validation.
+- 无 assertion failure。
+- 历史 PARTIAL 的原因是缺少 `without_skill` baseline；本轮已用同一 prompt 和 assertions 重新生成成对结果，不复用历史 baseline。
 
-## Next Steps
+## Risks / Next Steps
 
-- Keep this eval as regression coverage for semantic docs/test/ci changelog classification.
-- Residual risk: this validation is a direct skill-read judgment, not a generated model transcript run, because no changelog-generator transcript runner exists in this repo.
+- 本用例使用 prompt 内嵌的确定性 PR 数据，不验证 GitHub API、`gh` CLI、分页或日期窗口行为；这些能力由 changelog-generator 的实时数据 eval 覆盖。
+- baseline 同样 PASS 是预期且可解释的：prompt 已直接提供关键语义规则。回归价值在于确认 skill 没有把 docs/test/ci 机械跳过，也没有错误纳入低价值维护项。
+- 保留此用例作为 conventional prefix、breaking change 和低优先级前缀语义审查的回归覆盖。
 
 ## Runtime Artifacts Policy
 
-- Runtime transcripts, verdicts, timing, outputs, and diagnostics should not be committed.
+- 本轮只持久化 canonical `comparison.md`。
+- Fresh outputs、transcripts、judge verdict、timing、diagnostics 与其他运行期产物不提交到 git；本仓库没有该 specialist 的 deterministic transcript runner 时，不以虚构 transcript 代替 fresh judge 证据。

--- a/agents/product_manager/test/changelog-generator/evals/workspace/eval-003-prefix-classification/comparison.md
+++ b/agents/product_manager/test/changelog-generator/evals/workspace/eval-003-prefix-classification/comparison.md
@@ -7,21 +7,32 @@
 - Eval: `eval-003-prefix-classification`
 - Test case: prefix-classification
 - Workspace: `workspace/eval-003-prefix-classification`
-- Evaluation date: 2026-07-26 (Asia/Shanghai)
-- Latest result: PASS - 本轮 fresh `with_skill` 与 fresh `without_skill` baseline 均满足全部 13 条 assertions。
+- Evaluation time: 2026-07-26 15:32:35 CST (+0800)
+- Latest result: PASS - fresh `with_skill` 满足 13/13 assertions；独立生成的 fresh `without_skill` baseline 满足 12/13，暴露出 breaking `feat!` 章节归属差异。
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Classification: (a) fixture 已足够，只缺 fresh baseline。
-- Reason: 14 条 PR 的标题、正文、编号以及 docs/test/ci 语义判断要求均完整内嵌在 prompt；13 条 assertions 只验证这些输入的分类、标题清洗、跳过规则和 breaking 标记，不依赖仓库文件或实时外部数据，因此无需添加 fixture 文件。
-- Expected output: Added 包含 feat；Changed 包含 perf 及具有 release workflow、eval contract、required gate 语义影响的 docs/test/ci；Fixed 包含 fix；Removed 包含 remove；Security 包含 security；跳过 dependency bump、仅 copyediting 的 docs 和仅 cache maintenance 的 ci；#105 带 `⚠️ BREAKING` 标记。
+- Classification: (a) fixture 已足够，只缺合规的 fresh baseline。
+- Reason: 14 条 PR 的标题、正文、编号以及 docs/test/ci 语义判断要求均完整内嵌在原始 prompt；assertions 验证的分类、标题清洗、跳过规则和 breaking 标记都不依赖仓库 fixture 或实时外部数据，因此无需添加 fixture 文件。
+- Fixture change: 无。
+
+## No-Answer-Key Fresh Method
+
+本轮 fresh Codex evaluator 按以下隔离顺序执行，候选锁定前不读取答案键：
+
+1. 生成阶段首先只读取 workspace 的 `eval_metadata.json`，从中取得完整原始 prompt；未读取 `evals.json`、`expected_output`、assertions 或旧 `comparison.md`。
+2. `with_skill` 阶段读取当前 `agents/product_manager/README.md` 与 `agents/product_manager/skills/changelog-generator/SKILL.md`，仅依据原始 prompt 和 skill 契约独立生成并锁定候选。
+3. `without_skill` 阶段仅依据同一份原始 prompt 独立生成并锁定 baseline；未读取或应用 Agent README、skill、`evals.json`、assertions、`expected_output` 或旧 comparison。
+4. 两份候选都锁定后，才读取 `evals.json` 中本用例的 assertions、expected output 与旧 comparison，并逐项 judge；judge 阶段没有反向修改候选。
+
+候选、transcript 与 judge diagnostics 均未写入仓库。
 
 ## Fresh Paired Results
 
 ### With Skill
 
-本轮 fresh judge 读取当前 `agents/product_manager/README.md`、`changelog-generator/SKILL.md`、prefix reference、eval prompt 与 assertions 后，按 skill 协议独立生成结果：
+锁定候选的行为摘要：
 
 - Added：`#105 ⚠️ BREAKING: Redesign plugin configuration API`（置顶）、`#101 Add OAuth2 login support`
 - Changed：`#104 Reduce API response time by caching`、`#106 Update release notes generator publishing workflow`、`#107 Tighten changelog-generator eval contract`、`#108 Require repository and eval contract checks before release`
@@ -30,51 +41,52 @@
 - Security：`#113 Patch XSS vulnerability in template renderer`
 - 跳过：`#103 chore(deps)`、`#114 build(deps)`、`#109` 仅 typo/copyediting、`#110` 仅 cache maintenance
 
-结论：skill 不仅按 conventional prefix 分类，也读取正文区分具有契约或发布影响的 docs/test/ci 与低价值维护项；全部 assertions 通过。
+结论：13/13 assertions 通过。skill 正确保留 `feat!` 的 Added 映射并添加 breaking 标记，同时根据正文语义区分应纳入 Changed 的 docs/test/ci 与应跳过的低价值维护项。
 
 ### Without Skill / Baseline
 
-本轮 fresh judge 在不读取或应用 skill、Agent README 与 prefix reference 的 baseline 条件下，仅使用相同 prompt 和 assertions 重新生成结果：
+锁定 baseline 的行为摘要：
 
-- Added：`#105 ⚠️ BREAKING: Redesign plugin configuration API`、`#101 Add OAuth2 login support`
-- Changed：`#104 Reduce API response time by caching`、`#106 Update release notes generator publishing workflow`、`#107 Tighten changelog-generator eval contract`、`#108 Require repository and eval contract checks before release`
+- Added：`#101 Add OAuth2 login support`
+- Changed：`#104 Reduce API response time by caching`、`#105 ⚠️ BREAKING: Redesign plugin configuration API`、`#106 Update release notes generator publishing workflow`、`#107 Tighten changelog-generator eval contract`、`#108 Require repository and eval contract checks before release`
 - Fixed：`#102 Resolve crash when token expires`、`#111 Correct button alignment on mobile`
 - Removed：`#112 Drop Python 3.7 support`
 - Security：`#113 Patch XSS vulnerability in template renderer`
 - 跳过：`#103`、`#114`、`#109`、`#110`
 
-结论：baseline 也满足全部 assertions。原因是 prompt 本身已显式要求按正文语义审查 docs/test/ci，并提供足够明确的 PR 正文；这说明该用例可验证 skill 行为未回归，但不是证明这些基础分类只能依赖 skill 才能完成。
+结论：12/13 assertions 通过。baseline 单凭 prompt 也能完成 docs/test/ci 的语义筛选和多数 conventional prefix 分类，但把描述“重设计既有 API”的 breaking `feat! #105` 按语义放入 Changed；当前 skill 契约要求 `feat!` 仍归 Added，并以 `⚠️ BREAKING` 标记，因此 `feat_added_breaking` 未通过。
 
 ## Assertion Review
 
 | Assertion | With skill | Without skill | Result |
 | --- | --- | --- | --- |
-| `feat_auth_added_add_oauth2_login_support` | #101 进入 Added，清洗为 `Add OAuth2 login support` | 相同 | PASS |
-| `fix_fixed` | #102、#111 进入 Fixed | 相同 | PASS |
-| `chore_deps` | 跳过 #103 | 相同 | PASS |
-| `build_deps_skipped` | 跳过 #114 | 相同 | PASS |
-| `perf_changed` | #104 进入 Changed | 相同 | PASS |
-| `feat_added_breaking` | #105 进入 Added，带 `⚠️ BREAKING` 且置顶 | 带 `⚠️ BREAKING` | PASS |
-| `docs_release_workflow_changed` | 根据正文将 #106 纳入 Changed | 相同 | PASS |
-| `test_eval_contract_changed` | 根据正文将 #107 纳入 Changed | 相同 | PASS |
-| `ci_release_gate_changed` | 根据正文将 #108 纳入 Changed | 相同 | PASS |
-| `docs_typo_skipped` | 跳过仅 copyediting 的 #109 | 相同 | PASS |
-| `ci_cache_skipped` | 跳过仅 cache maintenance 的 #110 | 相同 | PASS |
-| `remove_removed` | #112 进入 Removed | 相同 | PASS |
-| `security_security` | #113 进入 Security | 相同 | PASS |
+| `feat_auth_added_add_oauth2_login_support` | #101 进入 Added，清洗为 `Add OAuth2 login support` | 相同 | Both PASS |
+| `fix_fixed` | #102、#111 进入 Fixed | 相同 | Both PASS |
+| `chore_deps` | 跳过 #103 | 相同 | Both PASS |
+| `build_deps_skipped` | 跳过 #114 | 相同 | Both PASS |
+| `perf_changed` | #104 进入 Changed | 相同 | Both PASS |
+| `feat_added_breaking` | #105 进入 Added，带 `⚠️ BREAKING` 且置顶 | #105 带 breaking 标记但进入 Changed | With skill PASS / Baseline FAIL |
+| `docs_release_workflow_changed` | 根据正文将 #106 纳入 Changed | 相同 | Both PASS |
+| `test_eval_contract_changed` | 根据正文将 #107 纳入 Changed | 相同 | Both PASS |
+| `ci_release_gate_changed` | 根据正文将 #108 纳入 Changed | 相同 | Both PASS |
+| `docs_typo_skipped` | 跳过仅 copyediting 的 #109 | 相同 | Both PASS |
+| `ci_cache_skipped` | 跳过仅 cache maintenance 的 #110 | 相同 | Both PASS |
+| `remove_removed` | #112 进入 Removed | 相同 | Both PASS |
+| `security_security` | #113 进入 Security | 相同 | Both PASS |
 
 ## Failures
 
-- 无 assertion failure。
-- 历史 PARTIAL 的原因是缺少 `without_skill` baseline；本轮已用同一 prompt 和 assertions 重新生成成对结果，不复用历史 baseline。
+- `with_skill` 无 assertion failure。
+- `without_skill` baseline 未满足 `feat_added_breaking`：breaking 标记正确，但章节错误地归入 Changed，而不是 Added。
+- 旧 comparison 的 baseline 描述受答案键污染：它声称生成时使用了 assertions，并把 baseline 记录成与 expected output 完全一致。本轮已用严格的 no-answer-key 顺序重新生成候选并纠正该记录；未复用旧 baseline。
 
 ## Risks / Next Steps
 
 - 本用例使用 prompt 内嵌的确定性 PR 数据，不验证 GitHub API、`gh` CLI、分页或日期窗口行为；这些能力由 changelog-generator 的实时数据 eval 覆盖。
-- baseline 同样 PASS 是预期且可解释的：prompt 已直接提供关键语义规则。回归价值在于确认 skill 没有把 docs/test/ci 机械跳过，也没有错误纳入低价值维护项。
+- prompt 已直接给出 docs/test/ci 需要按正文语义判断的要求，因此 baseline 在这部分同样通过并不削弱用例有效性；本轮差异表明 skill 对 breaking conventional prefix 的明确映射提供了可观察增益。
 - 保留此用例作为 conventional prefix、breaking change 和低优先级前缀语义审查的回归覆盖。
 
-## Runtime Artifacts Policy
+## Runtime Artifact Policy
 
 - 本轮只持久化 canonical `comparison.md`。
-- Fresh outputs、transcripts、judge verdict、timing、diagnostics 与其他运行期产物不提交到 git；本仓库没有该 specialist 的 deterministic transcript runner 时，不以虚构 transcript 代替 fresh judge 证据。
+- Fresh candidates、transcripts、judge verdict、timing、diagnostics 与其他运行期产物不提交到 git。

--- a/agents/product_manager/test/competitive-brief/evals/workspace/eval-001-positioning-gap-brief/comparison.md
+++ b/agents/product_manager/test/competitive-brief/evals/workspace/eval-001-positioning-gap-brief/comparison.md
@@ -8,80 +8,101 @@
 - Test case: positioning-gap-brief
 - Workspace: `workspace/eval-001-positioning-gap-brief`
 - Classification: (c) 依赖实时公开网页研究。该场景验证从当前公开来源提炼竞品定位与 messaging gap，不应以静态 mock 或网页快照替代真实联网研究。
-- Latest result: PASS - 2026-07-26 的 fresh judge 使用同一组实时官方来源分别生成了新的 `with_skill` 与 `without_skill`；with-skill 满足全部 assertions，并正确区分公开事实、页面观察与待验证假设。
+- Latest result: PASS - 2026-07-26 的 fresh judge 基于相互隔离、各自独立联网研究的 `with_skill` 与新 `without_skill` baseline 判定两者均满足全部 assertions；with-skill 正确区分厂商公开事实与需要验证的我方定位假设。
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: 仅包含 prompt 与 eval metadata；未增加静态网页快照，因为竞品定位、功能与定价会变化。
+- Fixture: 仅包含原始 prompt 与 eval metadata；未增加静态网页快照，因为竞品定位、功能、定价和发布信息会持续变化。
 - Expected output: 结构化竞品 brief，包含竞品定位、目标用户、核心卖点、内容空白、机会、威胁和证据边界。
-- Research access time: `2026-07-26 15:22 CST (+0800)`
-- Research mode: 真实联网访问公开网页；Linear 与 Jira 均优先采用厂商官方页面。
+- Research mode: 两次运行都真实联网访问公开网页，以 Linear 与 Atlassian/Jira 官方页面为主要证据。
 
-## Live Source Set
+## No-Leak Fresh Pair Method
 
-本轮 fresh pair 使用同一来源集合：
+本轮按以下顺序执行，避免 answer key、预计算来源集合或历史结论泄漏：
 
-- Linear homepage: https://linear.app/
-- Linear features: https://linear.app/features
-- Linear pricing: https://linear.app/pricing
-- Linear changelog: https://linear.app/changelog/page/1
-- Atlassian products / Jira positioning: https://www.atlassian.com/software
-- Jira features: https://www.atlassian.com/software/jira/features
-- Jira pricing: https://www.atlassian.com/software/jira/jira/pricing
-- Jira projects overview: https://www.atlassian.com/software/jira/guides/projects/overview
+1. 主 judge 首先只读取 `eval_metadata.json` 中的原始 prompt，未读取 `evals.json`、assertions、expected output 或旧 `comparison.md`。
+2. with-skill 候选仅在读取 PM Agent README 和当前 `competitive-brief/SKILL.md` 后自行搜索、访问并选择公开来源；候选结论锁定前仍未读取答案键或旧 comparison。
+3. 候选锁定后才启动 `fork_turns=none` 的 fresh Codex subagent。baseline 只收到原始 prompt，以及“自行联网并返回实际访问时间和 URL”的运行要求；未提供 skill、PM README、assertions、expected output、旧 comparison、父候选、父来源集合或网页快照。
+4. baseline 独立完成研究并锁定输出后，主 judge 才首次读取 assertions、expected output 与旧 comparison，并据两份新结果逐项判定。
 
-所有来源均为本轮访问时的公开页面，没有使用历史 baseline 或本地伪造数据。定价、套餐权益、AI 功能、产品数字、首页文案与 changelog 会持续变化；后续复验必须重新访问并记录时间，不能把本次内容当作长期事实快照。
+两次运行自然都优先选择了厂商官网，且部分首页/定价 URL 重合；这是独立搜索同一竞品主题的合理结果，不是共享预计算 source set。
 
 ## Fresh With Skill
 
-应用 `competitive-brief` 后生成的 brief 摘要：
+- Actual access time: `2026-07-26 15:51–15:53 CST (Asia/Shanghai, UTC+08:00)`
+- Actual source set selected by with-skill:
+  - Linear homepage: https://linear.app/homepage
+  - Linear features: https://linear.app/features
+  - Linear Timeline documentation: https://linear.app/docs/timeline
+  - Atlassian products / Jira positioning: https://www.atlassian.com/software
+  - Jira pricing: https://www.atlassian.com/software/jira/jira/pricing
+  - Jira agile project management: https://www.atlassian.com/software/jira/agile
+
+with-skill 候选的实际结论：
 
 | 竞品 | 当前公开定位 | 主要目标用户 | 当前强调的卖点 |
 | --- | --- | --- | --- |
-| Linear | 面向现代产品开发的 system，强调团队与 agents 在同一结构化上下文中规划、构建与发布 | 产品、工程、设计等产品开发团队，并通过 Business / Enterprise 套餐覆盖更大组织 | 从 roadmap 到 release 的一体化流程、速度与专注、issues/projects/cycles/initiatives、AI agents、coding sessions、Loops、customer requests |
-| Jira | 面向所有团队的 AI-powered project management，并通过 Atlassian System of Work 承接跨团队和组织级协作 | 开发、市场、业务团队、跨团队项目与需要企业治理的复杂组织 | 多视图规划与跟踪、可配置 workflow、目标和依赖管理、Rovo AI、自动化、企业安全治理、Marketplace 集成生态 |
+| Linear | 面向现代产品开发、团队与 agents 的 product development system | 重视速度、专注和统一产品上下文的产品、工程与设计团队，并向更大组织扩展 | 从 roadmap 到 release、issues/projects/cycles、速度与低噪音、人与 agent 共享工作流、项目更新与洞察 |
+| Jira | 面向所有团队的灵活项目管理与敏捷交付平台 | 软件团队、业务团队、跨团队项目以及需要规模化治理的复杂组织 | 多种敏捷方法、backlog/board/roadmap/report、可配置流程、跨团队规划与依赖、自动化、企业安全治理和 Atlassian 生态 |
 
-结构化结论包括：
+候选提出的 messaging gap 是“在不要求各职能先统一工具配置或工作方法的前提下，把决策依据、责任边界和可验证结果持续连起来”。它明确将该方向标记为待验证假设：prompt 没有提供我方产品、目标用户、能力证据或客户研究，因此不能断言我方已经拥有该差异，也不能把厂商营销页未突出某项能力解释成竞品缺少该能力。
 
-- 定位差异：Linear 的官方叙事更窄、更产品开发导向，强调 AI-native、速度和低噪音；Jira 的官方叙事更广，强调所有团队、规模化协作、灵活配置、治理和生态。
-- messaging gap 假设 1：可以验证“让跨职能项目协作既易上手又保持决策可追溯”的叙事空间。所选 Linear 页面更强调产品开发速度，Jira 页面更强调广度、配置与规模；这只是样本页面上的 messaging white space，不代表两者缺少相关能力。
-- messaging gap 假设 2：可以验证“从业务目标、证据、决策到交付结果的一条可解释闭环”。两家都强调上下文、目标或工作跟踪，但所选页面未把可审计的决策理由作为首要主张；仍需访谈目标用户并做更完整内容审计。
-- 机会：若我方产品确有对应能力，可围绕“跨角色清晰度 + 可解释协作”做 landing-page message test，并用用户访谈、竞品 demo 和赢单/流失证据验证。
-- 威胁：Linear 正快速扩展 agent、代码与循环自动化叙事；Jira 在跨团队规模、治理、AI 与集成生态上覆盖很广，宽泛的“更智能协作”主张很难形成差异。
-- 证据边界：prompt 未提供我方产品、目标用户、能力或 proof，因此不能断言上述 gap 是我方已拥有的差异化，也不能据公开营销页判断实际体验、客户满意度、迁移成本或功能缺失。
+机会与威胁也保持证据边界：
+
+- 机会：验证“跨角色清晰度 + 可解释、可追溯协作”以及 human-agent accountability 的信息主张。
+- 威胁：Linear 正强化 agent-native 产品开发和端到端执行叙事；Jira 已覆盖广泛团队、企业治理、AI 与生态，宽泛的“更简单”或“AI 项目管理”很难形成稳定差异。
+- 验证要求：补充我方定位与能力证据、目标用户访谈、产品试用和更完整的竞品内容审计后，才能把 gap 变成正式定位决策。
 
 ## Fresh Without Skill / Baseline
 
-在不读取或应用 `competitive-brief` 与 PM Agent README 的条件下，fresh baseline 仅依据相同 prompt 和同一来源集合重新生成。其摘要同样识别出：
+- Actual access time: `2026-07-26 15:54:10–15:54:57 CST (Asia/Shanghai, UTC+08:00)`
+- Actual source set independently selected by baseline:
+  - https://linear.app/
+  - https://linear.app/method
+  - https://linear.app/method/introduction
+  - https://linear.app/pricing
+  - https://linear.app/security
+  - https://linear.app/customers
+  - https://linear.app/customers/automattic
+  - https://linear.app/customers/klaviyo
+  - https://linear.app/docs/customer-requests
+  - https://linear.app/docs/timeline
+  - https://www.atlassian.com/software/jira
+  - https://www.atlassian.com/software/jira/features
+  - https://www.atlassian.com/software/jira/features/workflows
+  - https://www.atlassian.com/software/jira/jira/pricing
+  - https://www.atlassian.com/software/jira/guides/getting-started/introduction
+  - https://support.atlassian.com/jira-product-discovery/docs/what-is-jira-product-discovery/
+  - https://www.atlassian.com/software/jira/product-discovery/features
+  - https://www.atlassian.com/software/jira/product-discovery/features/roadmaps
 
-- Linear 偏产品研发团队、速度、集中注意力与 AI agents；
-- Jira 偏所有团队、灵活配置、跨团队规模化、治理、Rovo AI 与集成生态；
-- 可探索“轻量但可治理的跨职能协作”和“从目标到结果的可解释闭环”等 gap。
+baseline 独立识别出 Linear 的 purpose-built、低噪音、产品开发一体化和 agent-native 叙事，以及 Jira 的 all-teams、高度可配置、跨团队规划、企业治理和 Atlassian 生态。它提出“可验证交付链”“低维护治理”“human-agent accountability”“single source of decision”等 messaging 假设，同时明确这些是基于公开定位的策略推断，不是竞品官方自述。
 
-baseline 覆盖了两家定位、用户和主要卖点，也能提出 messaging gap，因此不是内容失败。不过其默认输出更像功能/定位对照：来源映射、机会/威胁分区和 gap 验证动作较弱；若不主动约束，容易把“所选页面未突出某条信息”写成“竞品没有该能力”。fresh judge 在本轮 baseline 中显式保留了“需验证”措辞，未将假设伪装成事实。
+本轮 baseline 也给出了机会、威胁、推荐主线、不建议使用的同质化表述和研究边界，质量足以满足全部 assertions。fresh judge 不以“没有使用 skill”作为降级理由；实际差异是 with-skill 依据固定 competitive-brief 协议更稳定地组织证据边界，而该次 baseline 通过自主研究也达到了同等断言门槛。
 
 ## Assertion Results
 
 | Assertion | With skill | Without skill | Fresh judge conclusion |
 | --- | --- | --- | --- |
-| `positioning` | PASS | PASS | with-skill 分别给出 Linear/Jira 的定位、目标用户与核心卖点，并能追溯到官方首页、功能和定价页。 |
-| `messaging_gap` | PASS | PASS | 两者都提出未被充分占领的叙事机会；with-skill 进一步给出验证动作，并避免把页面空白等同于功能缺失。 |
-| `evidence_boundary` | PASS | PASS | with-skill 明确标出缺少我方上下文、体验证据与完整内容审计；本轮 fresh baseline 也使用假设措辞，但边界说明不如 with-skill 系统。 |
+| `positioning` | PASS | PASS | 两者都分别说明 Linear 与 Jira 的定位、目标用户和核心卖点，并给出实际官方来源。 |
+| `messaging_gap` | PASS | PASS | 两者都识别了未被充分占领的叙事机会；这些机会均被表述为需要结合我方能力与用户研究验证的假设。 |
+| `evidence_boundary` | PASS | PASS | 两者都区分厂商公开信息与策略推断，未把页面未强调的内容写成确定的功能缺失，也未虚构我方差异。 |
 
 ## Failures and External-Service Triage
 
-- 本轮未发生来源访问失败，未发现 assertion failure。
-- 如果官方页面、DNS、搜索或联网工具不可用，应记为 external-service / research infrastructure failure，而不是 skill 回归；保留失败 URL、访问时间和错误类型后重试。
-- 只有在来源可访问且提供足够证据时，with-skill 仍遗漏定位/目标用户/卖点、无法提出 gap，或把假设写成确定事实，才应判为 skill behavior regression。
-- 若单个页面改版或移除，应先使用同厂商的官方替代页面；若来源集合发生实质变化，comparison 必须记录新 URL 与时间，不得直接与本轮文案做逐字比较。
+- 本轮两次运行均成功访问公开来源，未发生 research infrastructure failure，也未发现 assertion failure。
+- 若官方页面、DNS、搜索或联网工具不可用，应记为 external-service / research infrastructure failure，而不是 skill regression；记录失败 URL、访问时间、HTTP 或工具错误后重试。
+- 若单个页面改版、重定向或移除，应先使用同厂商官方替代页面，并在 comparison 中记录实际 URL 与访问时间；不得按历史页面文案做逐字断言。
+- 只有在公开来源可访问且证据足够时，with-skill 仍遗漏两家竞品的定位/目标用户/卖点、无法提出 messaging gap，或把推断伪装成确定事实，才判为 skill behavior regression。
+- 定价、套餐权益、AI/agent 功能、客户数量、首页主标题、案例和发布说明都具有时效性；本 comparison 记录的是本轮研究证据，不是永久事实快照。
 
 ## Next Steps
 
-- 后续 fresh eval 继续实时访问官方来源，并用同一轮、同一来源集合生成成对结果。
-- 若要把 gap 转成我方定位决策，必须补充我方产品上下文、目标用户访谈、实际产品试用和更完整的竞品内容审计。
+- 后续 fresh eval 继续让 with-skill 与 baseline 各自实时联网、独立选择来源并记录实际时间与 URL；不要预先共享 source set。
+- 若要把本轮 gap 转成我方定位决策，必须补充我方产品上下文、能力 proof、目标用户访谈、实际产品试用和更完整的竞品内容审计。
 
 ## Runtime Artifacts Policy
 
 - Runtime transcripts、完整模型输出、verdicts、timing、网页快照、outputs 与 diagnostics 不提交到 git。
-- Durable 产物仅保留本 comparison 与 metadata；本轮没有新增静态 fixture。
+- Durable 产物仅更新本 `comparison.md`；本轮未修改 fixture、metadata、skill 或 eval 定义。

--- a/agents/product_manager/test/competitive-brief/evals/workspace/eval-001-positioning-gap-brief/comparison.md
+++ b/agents/product_manager/test/competitive-brief/evals/workspace/eval-001-positioning-gap-brief/comparison.md
@@ -8,99 +8,96 @@
 - Test case: positioning-gap-brief
 - Workspace: `workspace/eval-001-positioning-gap-brief`
 - Classification: (c) 依赖实时公开网页研究。该场景验证从当前公开来源提炼竞品定位与 messaging gap，不应以静态 mock 或网页快照替代真实联网研究。
-- Latest result: PASS - 2026-07-26 的 fresh judge 基于相互隔离、各自独立联网研究的 `with_skill` 与新 `without_skill` baseline 判定两者均满足全部 assertions；with-skill 正确区分厂商公开事实与需要验证的我方定位假设。
+- Latest result: PASS - 2026-07-26 的 fresh same-agent judge 先后锁定独立联网研究的 `with_skill` 与新 `without_skill` baseline，再读取答案键逐项判定；两者均满足全部 assertions，with-skill 对公开事实、策略推断和待验证的我方定位假设给出了更系统的边界。
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: 仅包含原始 prompt 与 eval metadata；未增加静态网页快照，因为竞品定位、功能、定价和发布信息会持续变化。
+- Fixture: 仅包含原始 prompt 与 eval metadata；未增加静态网页快照，因为竞品定位、功能、定价、客户数据和发布信息会持续变化。
 - Expected output: 结构化竞品 brief，包含竞品定位、目标用户、核心卖点、内容空白、机会、威胁和证据边界。
-- Research mode: 两次运行都真实联网访问公开网页，以 Linear 与 Atlassian/Jira 官方页面为主要证据。
+- Research mode: 两个 arm 都真实联网访问公开网页，各自选择来源并记录实际访问时间与 URL。
 
 ## No-Leak Fresh Pair Method
 
-本轮按以下顺序执行，避免 answer key、预计算来源集合或历史结论泄漏：
+本轮由当前会话中新启动的同一个 fresh Codex agent 按以下顺序执行：
 
-1. 主 judge 首先只读取 `eval_metadata.json` 中的原始 prompt，未读取 `evals.json`、assertions、expected output 或旧 `comparison.md`。
-2. with-skill 候选仅在读取 PM Agent README 和当前 `competitive-brief/SKILL.md` 后自行搜索、访问并选择公开来源；候选结论锁定前仍未读取答案键或旧 comparison。
-3. 候选锁定后才启动 `fork_turns=none` 的 fresh Codex subagent。baseline 只收到原始 prompt，以及“自行联网并返回实际访问时间和 URL”的运行要求；未提供 skill、PM README、assertions、expected output、旧 comparison、父候选、父来源集合或网页快照。
-4. baseline 独立完成研究并锁定输出后，主 judge 才首次读取 assertions、expected output 与旧 comparison，并据两份新结果逐项判定。
+1. 先只读取 `eval_metadata.json` 中的原始 prompt，未读取 `evals.json`、assertions、expected output 或旧 `comparison.md`。
+2. with-skill arm 读取 PM Agent README 和当前 `competitive-brief/SKILL.md`，随后自行联网选择来源并生成候选结果。
+3. with-skill 结果锁定后，同一 agent 进入 without-skill arm；该 arm 不再应用 skill 或 PM README，只依据原始 prompt 重新搜索并选择另一组来源，未读取答案键、旧 comparison，也未复用 with-skill 的预计算 source summary。
+4. without-skill 结果锁定后，judge 才首次读取 `evals.json` 中的 expected output、assertions 与旧 comparison，并据两份已冻结结果逐项判定。
 
-两次运行自然都优先选择了厂商官网，且部分首页/定价 URL 重合；这是独立搜索同一竞品主题的合理结果，不是共享预计算 source set。
+两个 arm 都由本 agent 亲自完成研究和判断，没有委派或复用历史 baseline。来源有少量同厂商域名重合是研究对象决定的自然结果，但页面集合和分析路径独立；未创建或保留网页快照、transcript、verdict、output 或 diagnostics。
 
 ## Fresh With Skill
 
-- Actual access time: `2026-07-26 15:51–15:53 CST (Asia/Shanghai, UTC+08:00)`
+- Actual access time: `2026-07-26 16:29–16:30 CST (Asia/Shanghai, UTC+08:00)`
 - Actual source set selected by with-skill:
-  - Linear homepage: https://linear.app/homepage
+  - Linear homepage: https://linear.app/
   - Linear features: https://linear.app/features
-  - Linear Timeline documentation: https://linear.app/docs/timeline
-  - Atlassian products / Jira positioning: https://www.atlassian.com/software
+  - Linear pricing: https://linear.app/pricing
+  - Linear customers: https://linear.app/customers
+  - Linear current updates: https://linear.app/now
+  - Jira features: https://www.atlassian.com/software/jira/features
   - Jira pricing: https://www.atlassian.com/software/jira/jira/pricing
-  - Jira agile project management: https://www.atlassian.com/software/jira/agile
+  - Jira Spring 2026 release: https://www.atlassian.com/software/jira/release
 
 with-skill 候选的实际结论：
 
 | 竞品 | 当前公开定位 | 主要目标用户 | 当前强调的卖点 |
 | --- | --- | --- | --- |
-| Linear | 面向现代产品开发、团队与 agents 的 product development system | 重视速度、专注和统一产品上下文的产品、工程与设计团队，并向更大组织扩展 | 从 roadmap 到 release、issues/projects/cycles、速度与低噪音、人与 agent 共享工作流、项目更新与洞察 |
-| Jira | 面向所有团队的灵活项目管理与敏捷交付平台 | 软件团队、业务团队、跨团队项目以及需要规模化治理的复杂组织 | 多种敏捷方法、backlog/board/roadmap/report、可配置流程、跨团队规划与依赖、自动化、企业安全治理和 Atlassian 生态 |
+| Linear | “The system for modern product development”，覆盖从 roadmap 到 release 的产品开发流程 | 产品、工程和设计协作团队，并通过企业客户、治理和迁移能力向更大组织扩展 | issues/projects/cycles/initiatives、低摩擦执行、客户请求与洞察、AI/agent 工作流、代码与产品上下文相连 |
+| Jira | 帮助 “every team” 从想法走向交付的灵活、可扩展项目管理平台 | 软件、产品、营销、运营等跨职能团队，以及需要标准化、权限、合规和规模治理的复杂组织 | 多视图规划与跟踪、可配置 workflow、跨团队依赖、自动化与报告、3000+ integrations、企业安全治理与 Rovo/agent 能力 |
 
-候选提出的 messaging gap 是“在不要求各职能先统一工具配置或工作方法的前提下，把决策依据、责任边界和可验证结果持续连起来”。它明确将该方向标记为待验证假设：prompt 没有提供我方产品、目标用户、能力证据或客户研究，因此不能断言我方已经拥有该差异，也不能把厂商营销页未突出某项能力解释成竞品缺少该能力。
+候选提出的 messaging gap 是：面向不想在“轻量速度”与“重型治理”之间二选一的产品组织，主张“低维护的跨角色可追溯协作”——把决策依据、责任、执行状态和结果证据连成一条默认可审计、但无需持续配置的协作链。该方向被明确标记为待验证假设：prompt 未提供我方产品、目标用户、可证明能力或客户研究，不能断言我方已经拥有该差异；厂商页面未突出某项叙事，也不能推导为竞品缺少对应能力。
 
-机会与威胁也保持证据边界：
+机会与威胁同样保持证据边界：
 
-- 机会：验证“跨角色清晰度 + 可解释、可追溯协作”以及 human-agent accountability 的信息主张。
-- 威胁：Linear 正强化 agent-native 产品开发和端到端执行叙事；Jira 已覆盖广泛团队、企业治理、AI 与生态，宽泛的“更简单”或“AI 项目管理”很难形成稳定差异。
-- 验证要求：补充我方定位与能力证据、目标用户访谈、产品试用和更完整的竞品内容审计后，才能把 gap 变成正式定位决策。
+- 机会：通过用户访谈和产品 proof 验证“低维护治理”“跨角色决策可追溯”与 “human-agent accountability” 是否比泛化的“更快、更简单”更有购买驱动力。
+- 威胁：Linear 已把 agent-native 产品开发、代码执行与产品上下文纳入核心叙事；Jira 同时拥有广泛团队覆盖、企业治理、AI 和生态优势，宽泛的 AI 项目管理或一体化协作表述很快会同质化。
+- 后续验证：补充我方能力清单、目标细分、产品试用、客户访谈和独立用户反馈后，才能把 gap 升级为正式 positioning。
 
 ## Fresh Without Skill / Baseline
 
-- Actual access time: `2026-07-26 15:54:10–15:54:57 CST (Asia/Shanghai, UTC+08:00)`
+- Actual access time: `2026-07-26 16:30 CST (Asia/Shanghai, UTC+08:00)`
 - Actual source set independently selected by baseline:
-  - https://linear.app/
-  - https://linear.app/method
-  - https://linear.app/method/introduction
-  - https://linear.app/pricing
-  - https://linear.app/security
-  - https://linear.app/customers
-  - https://linear.app/customers/automattic
-  - https://linear.app/customers/klaviyo
-  - https://linear.app/docs/customer-requests
-  - https://linear.app/docs/timeline
-  - https://www.atlassian.com/software/jira
-  - https://www.atlassian.com/software/jira/features
-  - https://www.atlassian.com/software/jira/features/workflows
-  - https://www.atlassian.com/software/jira/jira/pricing
-  - https://www.atlassian.com/software/jira/guides/getting-started/introduction
-  - https://support.atlassian.com/jira-product-discovery/docs/what-is-jira-product-discovery/
-  - https://www.atlassian.com/software/jira/product-discovery/features
-  - https://www.atlassian.com/software/jira/product-discovery/features/roadmaps
+  - Linear Method: https://linear.app/method/introduction
+  - Linear switch positioning: https://linear.app/switch
+  - Linear Jira Sync documentation: https://linear.app/docs/jira
+  - Linear migration guide: https://linear.app/switch/migration-guide
+  - Jira spaces/projects guide: https://www.atlassian.com/software/jira/guides/projects/overview
+  - Jira navigation guide: https://www.atlassian.com/software/jira/guides/navigation/overview
+  - Jira boards guide: https://www.atlassian.com/software/jira/guides/boards/overview
+  - Jira getting-started guide: https://www.atlassian.com/software/jira/guides/getting-started/basics
+  - Atlassian customer stories: https://www.atlassian.com/customers/
 
-baseline 独立识别出 Linear 的 purpose-built、低噪音、产品开发一体化和 agent-native 叙事，以及 Jira 的 all-teams、高度可配置、跨团队规划、企业治理和 Atlassian 生态。它提出“可验证交付链”“低维护治理”“human-agent accountability”“single source of decision”等 messaging 假设，同时明确这些是基于公开定位的策略推断，不是竞品官方自述。
+baseline 独立识别出：
 
-本轮 baseline 也给出了机会、威胁、推荐主线、不建议使用的同质化表述和研究边界，质量足以满足全部 assertions。fresh judge 不以“没有使用 skill”作为降级理由；实际差异是 with-skill 依据固定 competitive-brief 协议更稳定地组织证据边界，而该次 baseline 通过自主研究也达到了同等断言门槛。
+- Linear 以 creators、purpose-built workflow、健康节奏和聚焦 backlog 为方法论，面向希望降低协调开销、快速推进产品开发的团队；Jira Sync 和迁移材料也显示其主动承接现有 Jira 团队的渐进迁移。
+- Jira 面向组织内任何需要计划、组织和跟踪工作的团队，以高度可配置的 spaces、workflow、board、多项目导航和跨团队可视性支持从团队自治到公司级标准化的不同治理模式。
+- 可切入的假设方向是“默认清晰但不牺牲治理”：用更少配置提供跨产品、工程和业务协作者都能理解的责任、决策和进展链。baseline 明确说明这只是从厂商公开定位推导的市场假设，尚未由我方能力、买家研究或竞品实测证明。
+
+baseline 也指出两项威胁：Linear 已直接把传统协调工具描述为面向较慢时代，并提供 Jira 迁移路径；Atlassian 则以大规模客户基础、可配置性和跨产品平台覆盖复杂组织。它建议以用户访谈、迁移成本测试和我方能力 proof 验证 gap，避免直接使用无法证明的“兼具 Linear 简洁与 Jira 强大”表述。
 
 ## Assertion Results
 
 | Assertion | With skill | Without skill | Fresh judge conclusion |
 | --- | --- | --- | --- |
-| `positioning` | PASS | PASS | 两者都分别说明 Linear 与 Jira 的定位、目标用户和核心卖点，并给出实际官方来源。 |
-| `messaging_gap` | PASS | PASS | 两者都识别了未被充分占领的叙事机会；这些机会均被表述为需要结合我方能力与用户研究验证的假设。 |
-| `evidence_boundary` | PASS | PASS | 两者都区分厂商公开信息与策略推断，未把页面未强调的内容写成确定的功能缺失，也未虚构我方差异。 |
+| `positioning` | PASS | PASS | 两者都分别说明 Linear 与 Jira 的定位、目标用户和核心卖点，并给出本轮实际访问的官方来源。 |
+| `messaging_gap` | PASS | PASS | 两者都识别了未被充分占领的叙事机会；with-skill 进一步把机会、威胁和验证动作组织成完整 brief。 |
+| `evidence_boundary` | PASS | PASS | 两者都将 messaging gap 标记为待验证策略假设，未把网页未强调的内容写成确定功能缺失，也未虚构我方能力。 |
 
 ## Failures and External-Service Triage
 
-- 本轮两次运行均成功访问公开来源，未发生 research infrastructure failure，也未发现 assertion failure。
+- 本轮两个 arm 均成功访问公开来源，未发生 research infrastructure failure，也未发现 assertion failure。
 - 若官方页面、DNS、搜索或联网工具不可用，应记为 external-service / research infrastructure failure，而不是 skill regression；记录失败 URL、访问时间、HTTP 或工具错误后重试。
-- 若单个页面改版、重定向或移除，应先使用同厂商官方替代页面，并在 comparison 中记录实际 URL 与访问时间；不得按历史页面文案做逐字断言。
+- 若单个页面改版、重定向或移除，应优先使用同厂商官方替代页面，并在 comparison 中记录实际 URL 与访问时间；不得沿用历史页面文案作为当前事实。
 - 只有在公开来源可访问且证据足够时，with-skill 仍遗漏两家竞品的定位/目标用户/卖点、无法提出 messaging gap，或把推断伪装成确定事实，才判为 skill behavior regression。
-- 定价、套餐权益、AI/agent 功能、客户数量、首页主标题、案例和发布说明都具有时效性；本 comparison 记录的是本轮研究证据，不是永久事实快照。
+- 定价、套餐权益、AI/agent 功能、客户数量、首页主标题、案例和发布说明都具有时效性；本 comparison 仅记录 2026-07-26 本轮访问时的研究结果，不是永久事实快照。
 
 ## Next Steps
 
-- 后续 fresh eval 继续让 with-skill 与 baseline 各自实时联网、独立选择来源并记录实际时间与 URL；不要预先共享 source set。
-- 若要把本轮 gap 转成我方定位决策，必须补充我方产品上下文、能力 proof、目标用户访谈、实际产品试用和更完整的竞品内容审计。
+- 后续 fresh eval 继续让 with-skill 与 baseline 各自实时联网、独立选择来源并记录实际时间和 URL，保持先锁定双 arm、再读取答案键的顺序。
+- 若要把本轮 gap 转成我方定位决策，必须补充我方产品上下文、能力 proof、目标用户访谈、实际产品试用和更完整的第三方竞品验证。
 
 ## Runtime Artifacts Policy
 

--- a/agents/product_manager/test/competitive-brief/evals/workspace/eval-001-positioning-gap-brief/comparison.md
+++ b/agents/product_manager/test/competitive-brief/evals/workspace/eval-001-positioning-gap-brief/comparison.md
@@ -7,39 +7,81 @@
 - Eval: `eval-001-positioning-gap-brief`
 - Test case: positioning-gap-brief
 - Workspace: `workspace/eval-001-positioning-gap-brief`
-- Latest result: PARTIAL - prior skill validation evidence is preserved; without_skill baseline was not generated for this historical comparison.
-- Prior validation note: fresh Codex subagent validation completed on 2026-06-02
+- Classification: (c) 依赖实时公开网页研究。该场景验证从当前公开来源提炼竞品定位与 messaging gap，不应以静态 mock 或网页快照替代真实联网研究。
+- Latest result: PASS - 2026-07-26 的 fresh judge 使用同一组实时官方来源分别生成了新的 `with_skill` 与 `without_skill`；with-skill 满足全部 assertions，并正确区分公开事实、页面观察与待验证假设。
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: Verifies that competitive-brief produces a structured positioning brief with evidence boundaries.
+- Fixture: 仅包含 prompt 与 eval metadata；未增加静态网页快照，因为竞品定位、功能与定价会变化。
 - Expected output: 结构化竞品 brief，包含竞品定位、目标用户、核心卖点、内容空白、机会、威胁和证据边界。
+- Research access time: `2026-07-26 15:22 CST (+0800)`
+- Research mode: 真实联网访问公开网页；Linear 与 Jira 均优先采用厂商官方页面。
 
-## Assertions
+## Live Source Set
 
-- `positioning`: 覆盖定位与目标用户
-- `messaging_gap`: 提炼 messaging gap
-- `evidence_boundary`: 标注证据与假设边界
+本轮 fresh pair 使用同一来源集合：
 
-## With Skill
+- Linear homepage: https://linear.app/
+- Linear features: https://linear.app/features
+- Linear pricing: https://linear.app/pricing
+- Linear changelog: https://linear.app/changelog/page/1
+- Atlassian products / Jira positioning: https://www.atlassian.com/software
+- Jira features: https://www.atlassian.com/software/jira/features
+- Jira pricing: https://www.atlassian.com/software/jira/jira/pricing
+- Jira projects overview: https://www.atlassian.com/software/jira/guides/projects/overview
 
-Observed behavior:
+所有来源均为本轮访问时的公开页面，没有使用历史 baseline 或本地伪造数据。定价、套餐权益、AI 功能、产品数字、首页文案与 changelog 会持续变化；后续复验必须重新访问并记录时间，不能把本次内容当作长期事实快照。
 
-- 当前 skill 要求基于公开来源调研竞品定位、目标用户、卖点、内容 gap、机会和威胁，并标注研究日期与不确定信息边界，满足 positioning、messaging_gap 和 evidence_boundary 断言。
+## Fresh With Skill
 
-## Without Skill / Baseline
-- BLOCKED: No actual without_skill baseline result is recorded for this historical comparison. This file is not treated as a full eval PASS until a baseline result is generated and written here.
-- This comparison records whether the skill-specific protocol, routing, evidence, or artifact expectations are preserved.
+应用 `competitive-brief` 后生成的 brief 摘要：
 
-## Failures
+| 竞品 | 当前公开定位 | 主要目标用户 | 当前强调的卖点 |
+| --- | --- | --- | --- |
+| Linear | 面向现代产品开发的 system，强调团队与 agents 在同一结构化上下文中规划、构建与发布 | 产品、工程、设计等产品开发团队，并通过 Business / Enterprise 套餐覆盖更大组织 | 从 roadmap 到 release 的一体化流程、速度与专注、issues/projects/cycles/initiatives、AI agents、coding sessions、Loops、customer requests |
+| Jira | 面向所有团队的 AI-powered project management，并通过 Atlassian System of Work 承接跨团队和组织级协作 | 开发、市场、业务团队、跨团队项目与需要企业治理的复杂组织 | 多视图规划与跟踪、可配置 workflow、目标和依赖管理、Rovo AI、自动化、企业安全治理、Marketplace 集成生态 |
 
-- None found in fresh Codex subagent validation.
+结构化结论包括：
+
+- 定位差异：Linear 的官方叙事更窄、更产品开发导向，强调 AI-native、速度和低噪音；Jira 的官方叙事更广，强调所有团队、规模化协作、灵活配置、治理和生态。
+- messaging gap 假设 1：可以验证“让跨职能项目协作既易上手又保持决策可追溯”的叙事空间。所选 Linear 页面更强调产品开发速度，Jira 页面更强调广度、配置与规模；这只是样本页面上的 messaging white space，不代表两者缺少相关能力。
+- messaging gap 假设 2：可以验证“从业务目标、证据、决策到交付结果的一条可解释闭环”。两家都强调上下文、目标或工作跟踪，但所选页面未把可审计的决策理由作为首要主张；仍需访谈目标用户并做更完整内容审计。
+- 机会：若我方产品确有对应能力，可围绕“跨角色清晰度 + 可解释协作”做 landing-page message test，并用用户访谈、竞品 demo 和赢单/流失证据验证。
+- 威胁：Linear 正快速扩展 agent、代码与循环自动化叙事；Jira 在跨团队规模、治理、AI 与集成生态上覆盖很广，宽泛的“更智能协作”主张很难形成差异。
+- 证据边界：prompt 未提供我方产品、目标用户、能力或 proof，因此不能断言上述 gap 是我方已拥有的差异化，也不能据公开营销页判断实际体验、客户满意度、迁移成本或功能缺失。
+
+## Fresh Without Skill / Baseline
+
+在不读取或应用 `competitive-brief` 与 PM Agent README 的条件下，fresh baseline 仅依据相同 prompt 和同一来源集合重新生成。其摘要同样识别出：
+
+- Linear 偏产品研发团队、速度、集中注意力与 AI agents；
+- Jira 偏所有团队、灵活配置、跨团队规模化、治理、Rovo AI 与集成生态；
+- 可探索“轻量但可治理的跨职能协作”和“从目标到结果的可解释闭环”等 gap。
+
+baseline 覆盖了两家定位、用户和主要卖点，也能提出 messaging gap，因此不是内容失败。不过其默认输出更像功能/定位对照：来源映射、机会/威胁分区和 gap 验证动作较弱；若不主动约束，容易把“所选页面未突出某条信息”写成“竞品没有该能力”。fresh judge 在本轮 baseline 中显式保留了“需验证”措辞，未将假设伪装成事实。
+
+## Assertion Results
+
+| Assertion | With skill | Without skill | Fresh judge conclusion |
+| --- | --- | --- | --- |
+| `positioning` | PASS | PASS | with-skill 分别给出 Linear/Jira 的定位、目标用户与核心卖点，并能追溯到官方首页、功能和定价页。 |
+| `messaging_gap` | PASS | PASS | 两者都提出未被充分占领的叙事机会；with-skill 进一步给出验证动作，并避免把页面空白等同于功能缺失。 |
+| `evidence_boundary` | PASS | PASS | with-skill 明确标出缺少我方上下文、体验证据与完整内容审计；本轮 fresh baseline 也使用假设措辞，但边界说明不如 with-skill 系统。 |
+
+## Failures and External-Service Triage
+
+- 本轮未发生来源访问失败，未发现 assertion failure。
+- 如果官方页面、DNS、搜索或联网工具不可用，应记为 external-service / research infrastructure failure，而不是 skill 回归；保留失败 URL、访问时间和错误类型后重试。
+- 只有在来源可访问且提供足够证据时，with-skill 仍遗漏定位/目标用户/卖点、无法提出 gap，或把假设写成确定事实，才应判为 skill behavior regression。
+- 若单个页面改版或移除，应先使用同厂商的官方替代页面；若来源集合发生实质变化，comparison 必须记录新 URL 与时间，不得直接与本轮文案做逐字比较。
 
 ## Next Steps
 
-- 真实运行时需补最新公开来源。
+- 后续 fresh eval 继续实时访问官方来源，并用同一轮、同一来源集合生成成对结果。
+- 若要把 gap 转成我方定位决策，必须补充我方产品上下文、目标用户访谈、实际产品试用和更完整的竞品内容审计。
 
 ## Runtime Artifacts Policy
 
-- Runtime transcripts, verdicts, timing, outputs, and diagnostics should not be committed.
+- Runtime transcripts、完整模型输出、verdicts、timing、网页快照、outputs 与 diagnostics 不提交到 git。
+- Durable 产物仅保留本 comparison 与 metadata；本轮没有新增静态 fixture。

--- a/agents/product_manager/test/github-reader/evals/workspace/eval-001-full-status/comparison.md
+++ b/agents/product_manager/test/github-reader/evals/workspace/eval-001-full-status/comparison.md
@@ -7,92 +7,95 @@
 - Eval: `eval-001-full-status`
 - Test case: full-status
 - Workspace: `workspace/eval-001-full-status`
-- Classification: `(c)` 依赖实时外部数据。该用例的目的就是验证 `github-reader` 能否通过 `gh` 读取公共仓库现状；不应增加静态 mock fixture 冒充真实运行。
-- Latest result: **PARTIAL** — 本轮已生成 fresh `with_skill` 与 fresh `without_skill` 成对结果；with-skill 满足 3/4 assertions，并正确执行现行 skill 的 “No milestones” edge case，但目标仓库在抓取时没有开放 milestone，因此无法同时满足既有 `milestone` assertion 对“Milestone 表格”的字面要求。该缺口是 live 数据前提与 assertion 的不匹配，不是 GitHub 读取或 skill 行为回归。
+- Classification: `(c)` 依赖实时外部数据。该用例验证 `github-reader` 能否通过 `gh` 读取公共仓库现状，不应增加静态 mock fixture 冒充真实运行。
+- Latest result: **PARTIAL** — 本轮按 no-leak 顺序重新生成 fresh `with_skill` 与 fresh `without_skill`。with-skill 满足 3/4 assertions；目标仓库实时不存在 milestone，现行 skill 要求跳过空表并说明“暂无 milestone”，因此既有 `milestone` assertion 的场景前提不成立。该项不是 GitHub 读取或 skill 行为回归。
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: 只有 prompt 与 metadata，未提供静态 GitHub 快照；这对实时数据场景是正确设计。
+- Fixture: 只有 prompt 与 metadata，没有静态 GitHub 快照；这符合实时数据场景。
 - Prompt: `帮我看一下 anthropics/anthropic-sdk-python 现在的项目状态，包括 milestone 进度、open issue 数量和 PR 队列情况`
-- Expected output: 结构化的项目状态报告，包含 Milestone 进度表、Open Issues 分组、PR 队列（待 review / 草稿 / 近期合并），以及健康摘要。
-- Fresh snapshot repository: `anthropics/anthropic-sdk-python`
-- Fresh snapshot fetched at: `2026-07-26T15:19:54+08:00`（CST / Asia/Shanghai）
-- Live dependency: GitHub API 与已认证 `gh` CLI；本轮 `gh auth status`、仓库读取、REST/GraphQL 查询均成功。
-- Query window for recent activity: `2026-07-12` 至抓取时点（近 14 天）。
+- Fresh repository: `anthropics/anthropic-sdk-python`
+- Live dependency: GitHub API、网络与已认证 `gh` CLI。
+- with-skill fetched at: `2026-07-26T15:43:33+08:00`（Asia/Shanghai）
+- without-skill fetched at: `2026-07-26T15:45:36+08:00`（Asia/Shanghai）
+- Query window for recent activity: `2026-07-12` 至各自抓取时点（近 14 天）。
 
-## Live Snapshot
+## No-Leak Fresh Validation Method
 
-同一份 live snapshot 被用于 fresh with-skill 与 fresh without-skill，避免两条路径因仓库状态变化产生不可比结果：
+1. 主代理只从 `eval_metadata.json` 提取原始 prompt，未读取 `evals.json`、assertions、expected output 或旧 `comparison.md`。
+2. with-skill 路径随后只读取 Product Manager Agent README 与当前 `github-reader/SKILL.md`，自行用 `gh` 查询 prompt 指定仓库并锁定候选结果。
+3. with-skill 锁定后，启动 `fork_turns=none` 的全新 Codex subagent。该子代理只收到原始 prompt，以及“自行实时查询并返回抓取时间与关键数字”的要求；未提供 skill、README、assertions、expected output、comparison 或父代理快照。
+4. 两条候选均锁定后，fresh judge 才读取 canonical eval 定义与旧 comparison，并按当前 assertions 评审。
+5. 两条路径独立查询 GitHub，没有共享预计算快照；运行期 transcript、verdict、diagnostics 或 outputs 均未落盘。
 
-- Open milestones: `0`
-- Open issues: `144`，其中无 assignee `141`，超过 30 天未更新 `111`，带 milestone `0`
-- Open PRs: `212`
-  - Awaiting review: `201`
-  - Drafts: `6`
-  - Changes requested: `2`
-  - Approved: `3`
-  - Bot PRs: `0`
-  - 等待超过 90 天的人工 PR: `81`
-- 近 14 天 merged PRs: `6`（包括 [#1780](https://github.com/anthropics/anthropic-sdk-python/pull/1780)、[#1775](https://github.com/anthropics/anthropic-sdk-python/pull/1775)、[#1772](https://github.com/anthropics/anthropic-sdk-python/pull/1772)）
-- 近 14 天 closed issues: `1`
-- 最老的 awaiting-review PR: [#543](https://github.com/anthropics/anthropic-sdk-python/pull/543)，创建于 `2024-06-18T09:52:52Z`
+## Independent Live Snapshots and Drift
 
-数据由 `gh repo view`、`gh api repos/.../milestones`、`gh api graphql`、`gh issue list` 与 `gh pr list` 实时获取。GraphQL `totalCount` 与分页后的列表数量交叉核对，确认 open issue 与 open PR 数量没有被默认 `--limit 100` 截断。
+| 指标 | With skill（15:43:33） | Without skill（15:45:36） | 漂移判断 |
+| --- | ---: | ---: | --- |
+| Open milestones | 0 | 0 | 无漂移 |
+| Open issues（排除 PR） | 144 | 144 | 无漂移 |
+| Open PRs | 212 | 212 | 无漂移 |
+| Draft PRs | 6 | 6 | 无漂移 |
+| Changes requested | 2 | 2 | 无漂移 |
+
+- with-skill 按当前 skill 的互斥展示规则统计：人工非草稿且非 `CHANGES_REQUESTED` 的待 Review `204` 个、草稿 `6` 个、需作者跟进 `2` 个、bot `0` 个；近 14 天 merged PR `6` 个、closed issue `1` 个。
+- without-skill 报告 `204` 个 `REVIEW_REQUIRED`、`3` 个 approved、`2` 个 changes requested、`3` 个无 review decision，并把 `206` 个非草稿 PR 概括为 ready for review。这里是分类口径不同，不是仓库状态漂移。
+- with-skill 还统计 open issue 中无 assignee `141` 个、超过 30 天未更新 `111` 个，以及等待超过 90 天的人工非草稿 PR `85` 个。
+- 两次查询相隔约 2 分钟，核心计数一致；本 comparison 只证明上述抓取时点，后续复验必须重新查询。
 
 ## Fresh With Skill
 
-本轮 fresh judge 读取当前 Product Manager Agent README、`github-reader/SKILL.md`、eval 定义与 metadata 后，按 Full status 路径应用 skill，并基于上述 live snapshot 生成结果。观察到：
+fresh with-skill 应用当前 Full status 流程，结果包括：
 
-- 正确识别指定仓库并通过 `gh` 获取 milestone、issue、open PR、近期 merged PR 与近期 closed issue 数据。
-- 目标仓库没有开放 milestone；按 skill 的 `No milestones` edge case 跳过空表，并在健康摘要明确写出“暂无开放 milestone / 0 个进行中”，没有伪造 milestone 行或完成率。
-- Open Issues 按“无 Milestone”分组，并给出 open、无 assignee、stale 数字。
-- PR 队列区分 awaiting review、draft、changes requested、bot 与近 14 天 merged；awaiting-review 表按等待时间排序且限制为 10 行，超出部分使用汇总行。
-- PR 条目使用 `[#NUMBER](URL)` 格式，例如 [#543](https://github.com/anthropics/anthropic-sdk-python/pull/543)；近期 merged 条目也带 GitHub 链接。
-- 结尾健康摘要包含 open issue、open PR、开放 milestone、近期 merged/closed 与超过 90 天的人工 PR 数量。
+- 正确识别指定仓库，并从 GitHub 获取 milestone、open issue、open PR、近 14 天 merged PR 与近 14 天 closed issue 数据。
+- API 返回 0 个 milestone；按 skill 的 `No milestones` edge case 不生成虚假进度表，并明确说明当前暂无 milestone。
+- Open Issues 按“无 Milestone”归纳，并提供总数、无 assignee 与 stale 风险数字。
+- PR 队列按互斥顺序区分 bot、草稿、changes requested 与其余待 Review；待 Review 最多展示 10 条，条目带 `[#NUMBER](URL)` 链接，超出部分用汇总说明。
+- 单列近 14 天 merged PR，并在末尾给出 open issue、open PR、milestone、近期活动与长期积压的数字化健康摘要。
 
 ## Fresh Without Skill / Baseline
 
-本轮 fresh baseline 不读取或应用 `github-reader` skill 与 Product Manager Agent README，仅使用相同 prompt 和同一份 live snapshot 重新回答，未复用历史 baseline。观察到：
+fresh baseline 未读取或应用 `github-reader` skill 与 Product Manager Agent README，自行实时查询后返回：
 
-- 能给出通用数字概览：0 个开放 milestone、144 个 open issue、212 个 open PR。
-- 能按通用 GitHub 字段简要列出 awaiting review、draft、changes requested、approved 数量，并为代表性 PR 提供链接。
-- 因 prompt 只明确询问“PR 队列”，baseline 没有主动拉入或单列近 14 天 merged PR，因而未满足 skill-specific 的“待 review / 已合并”区分。
-- 同样基于真实数据说明“没有开放 milestone”，没有为了满足 assertion 伪造 Milestone 进度表。
-- 能给出简短数字摘要，但缺少 with-skill 的 issue 风险信号、10 行上限、bot 隔离、等待超过 90 天积压风险和近期 closed issue 口径。
+- 0 个开放及已关闭 milestone、144 个 open issue、212 个 open PR。
+- 给出 draft、review required、approved、changes requested、无 review decision、可合并与冲突等通用 PR 数字。
+- 指出仓库摘要的 `open_issues_count=356` 实际是 144 个 issue 与 212 个 PR 的合计，避免把该字段误报为纯 issue 数。
+- 没有区分当前待 review 与近 14 天已合并 PR，也没有提供任何 `[#NUMBER](URL)` 格式的具体 PR 条目；只给出 Issues、Pull requests 等页面入口。
+- 给出含关键数字的总体判断，但未覆盖 with-skill 的 stale、unassigned、bot 隔离、10 行上限与近期 closed issue 口径。
 
 ## Assertion Results
 
 | Assertion | With skill | Without skill | Fresh judge 结论 |
 | --- | --- | --- | --- |
-| `milestone`：包含有标题、进度百分比的 Milestone 表格 | **FAIL（场景前提不成立）** | **FAIL（场景前提不成立）** | API 返回 0 个开放 milestone。现行 skill 明确要求此时跳过该 section 并注明“暂无 milestone”；伪造空表或虚构百分比会违背 skill。 |
-| `pr`：PR 队列区分待 review 和已合并 | **PASS** | **FAIL** | with-skill 单列 awaiting review 与近 14 天 merged；baseline 只回答当前 open PR 队列。 |
-| `assertion_3`：末尾有数字化健康摘要 | **PASS** | **PASS** | 两者均有数字摘要；with-skill 额外覆盖 stale、unassigned、近期活动和长期积压。 |
-| `pr_2`：PR 条目使用 `[#NUMBER](URL)` | **PASS** | **PASS** | 两者的代表性 PR 均使用正确 GitHub 链接格式。 |
+| `milestone`：包含有标题、进度百分比的 Milestone 表格 | **FAIL（场景前提不成立）** | **FAIL（场景前提不成立）** | 两次 API 查询均返回 0 个 milestone。现行 skill 要求此时不生成空表；不能虚构进度百分比。 |
+| `pr`：PR 队列区分待 review 和已合并 | **PASS** | **FAIL** | with-skill 单列当前待 Review 与近 14 天 merged；baseline 只描述当前 open PR。 |
+| `assertion_3`：末尾有数字化健康摘要 | **PASS** | **PASS** | 两者均以数字总结状态；with-skill 的风险及近期活动口径更完整。 |
+| `pr_2`：PR 条目使用 `[#NUMBER](URL)` | **PASS** | **FAIL** | with-skill 的具体 PR 条目使用正确链接格式；baseline 没有具体 PR 条目。 |
 
 ## Failures and Interpretation
 
-- 唯一 with-skill assertion failure 是 `milestone`。抓取时目标仓库没有开放 milestone，而 skill 的当前 edge case 与 assertion 的字面要求冲突；这不应被解释为 skill 回归。
-- Fresh pair 已消除历史 comparison 缺少 without-skill baseline 的证据债务，但在不修改 assertion、目标仓库状态不变的前提下，Latest result 仍应如实保持 `PARTIAL`。
-- 未修改 `evals.json` assertion，也未新增静态 GitHub fixture。
+- 唯一 with-skill failure 是 `milestone`。GitHub 查询成功，但仓库没有 assertion 假定的实体；伪造 milestone 表或百分比会违反当前 skill。
+- fresh pair 消除了历史 baseline 与父代理预计算快照共用所造成的 answer-key / snapshot leakage：两条路径本轮各自实时查询，judge 在候选锁定后才读取答案键。
+- 未修改 fixture、`evals.json`、assertions 或 specialist `SKILL.md`。
 
 ## External Failure vs Skill Regression
 
-- **外部服务失败 / 基础设施失败**：`gh auth status` 失败、GitHub API 超时或限流、DNS/网络不可达、目标仓库不可访问、分页未完成。这些情况应记录为 `BLOCKED` 或 infrastructure failure，不能据此判定 skill 回归。
-- **Skill 回归**：外部查询成功且返回有效数据，但应用 skill 后漏查 prompt 要求的 scope、错误计算数量/完成率、未分页导致计数截断、未按规则分类 PR、把 bot 混入人工待 review、缺少健康摘要或生成错误链接。
-- **Live-data/assertion mismatch**：外部查询成功但仓库没有 assertion 假定的实体（本轮为开放 milestone）。应保留真实 edge-case 输出并把该 assertion 记为场景前提不成立，不能制造数据令其通过。
+- **外部服务 / 基础设施失败**：GitHub API 超时、限流、DNS/网络不可达、`gh` 未认证、目标仓库不可访问或分页未完成。此类情况应记为 `BLOCKED` 或 infrastructure failure，不能判定 skill 回归。
+- **Skill 回归**：外部查询成功且返回有效数据，但 with-skill 漏查 prompt 要求的 scope、错误计算数量、未分页导致截断、PR 分类错误、把 bot 混入人工队列、缺少近期 merged 分区、健康摘要或正确链接。
+- **Live-data/assertion mismatch**：查询成功但仓库没有 assertion 假定的实体。本轮为 milestone 不存在，应保留真实 edge-case 输出并把该 assertion 记为场景前提不成立。
 
 ## Time-Sensitivity Risk
 
-GitHub 数据会在提交 issue、关闭 issue、创建/合并 PR、review 状态变化或维护 milestone 时立即变化。本 comparison 只证明上述抓取时点的 fresh pair；未来复验必须重新记录仓库、精确时间、查询窗口和快照数字，不能把本轮数字当成固定预期或复用本轮 baseline。
+GitHub 数据会随 issue、PR、review 与 milestone 状态立即变化。本 comparison 不把任何数字作为固定 expected value；未来运行必须记录仓库、两条路径各自的精确抓取时间、查询窗口与独立快照，并区分真实漂移、分类口径差异和外部服务失败。
 
 ## Next Steps
 
 - 本轮无需增加 fixture；保留实时 GitHub 查询设计。
-- 若维护者希望该 live eval 在“没有开放 milestone”时也能判为 PASS，需要另行评估 assertion 是否应接受 skill 已定义的 edge-case 文案。本任务禁止放宽 assertions，因此本轮不修改。
+- 在“不放宽 assertion”的本任务约束下，结果如实保持 `PARTIAL`。若维护者以后希望无 milestone 时也能通过，需要另行评估 assertion 是否接受 skill 已定义的 edge case。
 
 ## Runtime Artifacts Policy
 
-- 本轮没有把 transcripts、verdicts、timing、outputs 或 diagnostics 写入 canonical workspace。
-- Live CLI 输出仅用于当前 fresh judge；durable 结果只保留本 `comparison.md` 中的必要快照、成对行为摘要与判断。
-- 后续运行仍应在隔离 scratch 环境生成临时产物，并只把人工确认后的最新结论汇总回 canonical `comparison.md`。
+- 没有向 canonical workspace 写入 transcripts、verdicts、timing、outputs 或 diagnostics。
+- durable 结果只保留本 `comparison.md` 中必要的两份独立快照、行为摘要与 fresh judge 结论。
+- 后续运行仍应把临时产物留在隔离 scratch 环境，并只将人工确认后的最新结论汇总回 canonical `comparison.md`。

--- a/agents/product_manager/test/github-reader/evals/workspace/eval-001-full-status/comparison.md
+++ b/agents/product_manager/test/github-reader/evals/workspace/eval-001-full-status/comparison.md
@@ -7,40 +7,92 @@
 - Eval: `eval-001-full-status`
 - Test case: full-status
 - Workspace: `workspace/eval-001-full-status`
-- Latest result: PARTIAL - prior skill validation evidence is preserved; without_skill baseline was not generated for this historical comparison.
-- Prior validation note: canonical comparison migration retained current-version result on 2026-06-02
+- Classification: `(c)` 依赖实时外部数据。该用例的目的就是验证 `github-reader` 能否通过 `gh` 读取公共仓库现状；不应增加静态 mock fixture 冒充真实运行。
+- Latest result: **PARTIAL** — 本轮已生成 fresh `with_skill` 与 fresh `without_skill` 成对结果；with-skill 满足 3/4 assertions，并正确执行现行 skill 的 “No milestones” edge case，但目标仓库在抓取时没有开放 milestone，因此无法同时满足既有 `milestone` assertion 对“Milestone 表格”的字面要求。该缺口是 live 数据前提与 assertion 的不匹配，不是 GitHub 读取或 skill 行为回归。
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: Verifies that github-reader handles full-status and produces the expected role-specific artifact.
-- Expected output: 结构化的项目状态报告，包含 Milestone 进度表、Open Issues 分组、PR 队列（待 review / 草稿 / 近期合并），以及健康摘要
+- Fixture: 只有 prompt 与 metadata，未提供静态 GitHub 快照；这对实时数据场景是正确设计。
+- Prompt: `帮我看一下 anthropics/anthropic-sdk-python 现在的项目状态，包括 milestone 进度、open issue 数量和 PR 队列情况`
+- Expected output: 结构化的项目状态报告，包含 Milestone 进度表、Open Issues 分组、PR 队列（待 review / 草稿 / 近期合并），以及健康摘要。
+- Fresh snapshot repository: `anthropics/anthropic-sdk-python`
+- Fresh snapshot fetched at: `2026-07-26T15:19:54+08:00`（CST / Asia/Shanghai）
+- Live dependency: GitHub API 与已认证 `gh` CLI；本轮 `gh auth status`、仓库读取、REST/GraphQL 查询均成功。
+- Query window for recent activity: `2026-07-12` 至抓取时点（近 14 天）。
 
-## Assertions
+## Live Snapshot
 
-- `milestone`: 包含 Milestone 表格
-- `pr`: 包含 PR 队列
-- `assertion_3`: 包含健康摘要
-- `pr_2`: PR 链接格式正确
+同一份 live snapshot 被用于 fresh with-skill 与 fresh without-skill，避免两条路径因仓库状态变化产生不可比结果：
 
-## With Skill
+- Open milestones: `0`
+- Open issues: `144`，其中无 assignee `141`，超过 30 天未更新 `111`，带 milestone `0`
+- Open PRs: `212`
+  - Awaiting review: `201`
+  - Drafts: `6`
+  - Changes requested: `2`
+  - Approved: `3`
+  - Bot PRs: `0`
+  - 等待超过 90 天的人工 PR: `81`
+- 近 14 天 merged PRs: `6`（包括 [#1780](https://github.com/anthropics/anthropic-sdk-python/pull/1780)、[#1775](https://github.com/anthropics/anthropic-sdk-python/pull/1775)、[#1772](https://github.com/anthropics/anthropic-sdk-python/pull/1772)）
+- 近 14 天 closed issues: `1`
+- 最老的 awaiting-review PR: [#543](https://github.com/anthropics/anthropic-sdk-python/pull/543)，创建于 `2024-06-18T09:52:52Z`
 
-Observed behavior:
+数据由 `gh repo view`、`gh api repos/.../milestones`、`gh api graphql`、`gh issue list` 与 `gh pr list` 实时获取。GraphQL `totalCount` 与分页后的列表数量交叉核对，确认 open issue 与 open PR 数量没有被默认 `--limit 100` 截断。
 
-- 保留并迁移 iteration-2 最新 comparison。该结果已基于当前 github-reader skill 版本，覆盖 full-status 输出中的 milestones、open issues、PR queue 和健康摘要。
+## Fresh With Skill
 
-## Without Skill / Baseline
-- BLOCKED: No actual without_skill baseline result is recorded for this historical comparison. This file is not treated as a full eval PASS until a baseline result is generated and written here.
-- This comparison records whether the skill-specific protocol, routing, evidence, or artifact expectations are preserved.
+本轮 fresh judge 读取当前 Product Manager Agent README、`github-reader/SKILL.md`、eval 定义与 metadata 后，按 Full status 路径应用 skill，并基于上述 live snapshot 生成结果。观察到：
 
-## Failures
+- 正确识别指定仓库并通过 `gh` 获取 milestone、issue、open PR、近期 merged PR 与近期 closed issue 数据。
+- 目标仓库没有开放 milestone；按 skill 的 `No milestones` edge case 跳过空表，并在健康摘要明确写出“暂无开放 milestone / 0 个进行中”，没有伪造 milestone 行或完成率。
+- Open Issues 按“无 Milestone”分组，并给出 open、无 assignee、stale 数字。
+- PR 队列区分 awaiting review、draft、changes requested、bot 与近 14 天 merged；awaiting-review 表按等待时间排序且限制为 10 行，超出部分使用汇总行。
+- PR 条目使用 `[#NUMBER](URL)` 格式，例如 [#543](https://github.com/anthropics/anthropic-sdk-python/pull/543)；近期 merged 条目也带 GitHub 链接。
+- 结尾健康摘要包含 open issue、open PR、开放 milestone、近期 merged/closed 与超过 90 天的人工 PR 数量。
 
-- None recorded in the migrated current-version comparison.
+## Fresh Without Skill / Baseline
+
+本轮 fresh baseline 不读取或应用 `github-reader` skill 与 Product Manager Agent README，仅使用相同 prompt 和同一份 live snapshot 重新回答，未复用历史 baseline。观察到：
+
+- 能给出通用数字概览：0 个开放 milestone、144 个 open issue、212 个 open PR。
+- 能按通用 GitHub 字段简要列出 awaiting review、draft、changes requested、approved 数量，并为代表性 PR 提供链接。
+- 因 prompt 只明确询问“PR 队列”，baseline 没有主动拉入或单列近 14 天 merged PR，因而未满足 skill-specific 的“待 review / 已合并”区分。
+- 同样基于真实数据说明“没有开放 milestone”，没有为了满足 assertion 伪造 Milestone 进度表。
+- 能给出简短数字摘要，但缺少 with-skill 的 issue 风险信号、10 行上限、bot 隔离、等待超过 90 天积压风险和近期 closed issue 口径。
+
+## Assertion Results
+
+| Assertion | With skill | Without skill | Fresh judge 结论 |
+| --- | --- | --- | --- |
+| `milestone`：包含有标题、进度百分比的 Milestone 表格 | **FAIL（场景前提不成立）** | **FAIL（场景前提不成立）** | API 返回 0 个开放 milestone。现行 skill 明确要求此时跳过该 section 并注明“暂无 milestone”；伪造空表或虚构百分比会违背 skill。 |
+| `pr`：PR 队列区分待 review 和已合并 | **PASS** | **FAIL** | with-skill 单列 awaiting review 与近 14 天 merged；baseline 只回答当前 open PR 队列。 |
+| `assertion_3`：末尾有数字化健康摘要 | **PASS** | **PASS** | 两者均有数字摘要；with-skill 额外覆盖 stale、unassigned、近期活动和长期积压。 |
+| `pr_2`：PR 条目使用 `[#NUMBER](URL)` | **PASS** | **PASS** | 两者的代表性 PR 均使用正确 GitHub 链接格式。 |
+
+## Failures and Interpretation
+
+- 唯一 with-skill assertion failure 是 `milestone`。抓取时目标仓库没有开放 milestone，而 skill 的当前 edge case 与 assertion 的字面要求冲突；这不应被解释为 skill 回归。
+- Fresh pair 已消除历史 comparison 缺少 without-skill baseline 的证据债务，但在不修改 assertion、目标仓库状态不变的前提下，Latest result 仍应如实保持 `PARTIAL`。
+- 未修改 `evals.json` assertion，也未新增静态 GitHub fixture。
+
+## External Failure vs Skill Regression
+
+- **外部服务失败 / 基础设施失败**：`gh auth status` 失败、GitHub API 超时或限流、DNS/网络不可达、目标仓库不可访问、分页未完成。这些情况应记录为 `BLOCKED` 或 infrastructure failure，不能据此判定 skill 回归。
+- **Skill 回归**：外部查询成功且返回有效数据，但应用 skill 后漏查 prompt 要求的 scope、错误计算数量/完成率、未分页导致计数截断、未按规则分类 PR、把 bot 混入人工待 review、缺少健康摘要或生成错误链接。
+- **Live-data/assertion mismatch**：外部查询成功但仓库没有 assertion 假定的实体（本轮为开放 milestone）。应保留真实 edge-case 输出并把该 assertion 记为场景前提不成立，不能制造数据令其通过。
+
+## Time-Sensitivity Risk
+
+GitHub 数据会在提交 issue、关闭 issue、创建/合并 PR、review 状态变化或维护 milestone 时立即变化。本 comparison 只证明上述抓取时点的 fresh pair；未来复验必须重新记录仓库、精确时间、查询窗口和快照数字，不能把本轮数字当成固定预期或复用本轮 baseline。
 
 ## Next Steps
 
-- 本轮未重新运行；保持 canonical workspace 下的最新 durable comparison。
+- 本轮无需增加 fixture；保留实时 GitHub 查询设计。
+- 若维护者希望该 live eval 在“没有开放 milestone”时也能判为 PASS，需要另行评估 assertion 是否应接受 skill 已定义的 edge-case 文案。本任务禁止放宽 assertions，因此本轮不修改。
 
 ## Runtime Artifacts Policy
 
-- Runtime transcripts, verdicts, timing, outputs, and diagnostics should not be committed.
+- 本轮没有把 transcripts、verdicts、timing、outputs 或 diagnostics 写入 canonical workspace。
+- Live CLI 输出仅用于当前 fresh judge；durable 结果只保留本 `comparison.md` 中的必要快照、成对行为摘要与判断。
+- 后续运行仍应在隔离 scratch 环境生成临时产物，并只把人工确认后的最新结论汇总回 canonical `comparison.md`。

--- a/agents/product_manager/test/github-reader/evals/workspace/eval-001-full-status/comparison.md
+++ b/agents/product_manager/test/github-reader/evals/workspace/eval-001-full-status/comparison.md
@@ -8,7 +8,7 @@
 - Test case: full-status
 - Workspace: `workspace/eval-001-full-status`
 - Classification: `(c)` 依赖实时外部数据。该用例验证 `github-reader` 能否通过 `gh` 读取公共仓库现状，不应增加静态 mock fixture 冒充真实运行。
-- Latest result: **PARTIAL** — 本轮按 no-leak 顺序重新生成 fresh `with_skill` 与 fresh `without_skill`。with-skill 满足 3/4 assertions；目标仓库实时不存在 milestone，现行 skill 要求跳过空表并说明“暂无 milestone”，因此既有 `milestone` assertion 的场景前提不成立。该项不是 GitHub 读取或 skill 行为回归。
+- Latest result: **PARTIAL** — 本轮由当前会话中的同一个 fresh Codex subagent 按 no-leak 顺序重新生成 `with_skill` 与新的 `without_skill`。with-skill 满足 3/4 assertions；目标仓库实时不存在 milestone，现行 skill 要求跳过空表并说明“暂无 milestone”，因此既有 `milestone` assertion 的场景前提不成立。该项不是 GitHub 读取或 skill 行为回归。
 
 ## Test Set / Fixture Version
 
@@ -17,21 +17,21 @@
 - Prompt: `帮我看一下 anthropics/anthropic-sdk-python 现在的项目状态，包括 milestone 进度、open issue 数量和 PR 队列情况`
 - Fresh repository: `anthropics/anthropic-sdk-python`
 - Live dependency: GitHub API、网络与已认证 `gh` CLI。
-- with-skill fetched at: `2026-07-26T15:43:33+08:00`（Asia/Shanghai）
-- without-skill fetched at: `2026-07-26T15:45:36+08:00`（Asia/Shanghai）
+- with-skill queried at: `2026-07-26T16:23:33+08:00`（Asia/Shanghai；首次 repo metadata 请求发生一次 TLS handshake timeout，随后在同一 arm 内重试成功）
+- without-skill queried at: `2026-07-26T16:25:45+08:00`（Asia/Shanghai）
 - Query window for recent activity: `2026-07-12` 至各自抓取时点（近 14 天）。
 
-## No-Leak Fresh Validation Method
+## Same-Agent No-Leak Fresh Validation Method
 
-1. 主代理只从 `eval_metadata.json` 提取原始 prompt，未读取 `evals.json`、assertions、expected output 或旧 `comparison.md`。
-2. with-skill 路径随后只读取 Product Manager Agent README 与当前 `github-reader/SKILL.md`，自行用 `gh` 查询 prompt 指定仓库并锁定候选结果。
-3. with-skill 锁定后，启动 `fork_turns=none` 的全新 Codex subagent。该子代理只收到原始 prompt，以及“自行实时查询并返回抓取时间与关键数字”的要求；未提供 skill、README、assertions、expected output、comparison 或父代理快照。
-4. 两条候选均锁定后，fresh judge 才读取 canonical eval 定义与旧 comparison，并按当前 assertions 评审。
-5. 两条路径独立查询 GitHub，没有共享预计算快照；运行期 transcript、verdict、diagnostics 或 outputs 均未落盘。
+1. 当前会话中的唯一 fresh Codex subagent 先只从 `eval_metadata.json` 提取原始 prompt，未读取 `evals.json`、assertions、expected output 或旧 `comparison.md`。
+2. 同一 agent 的 with-skill arm 随后完整读取 Product Manager Agent README 与当前 `github-reader/SKILL.md`，自行用 `gh` 查询 prompt 指定仓库并锁定候选结果。
+3. with-skill 锁定后，同一 agent 切换到 without-skill arm；该 arm 不应用 skill 或 README，只凭原始 prompt 重新独立调用 `gh`，未使用父代理预计算 snapshot，也未复用 with-skill 的查询结果。
+4. 两个 arm 均锁定后，同一 fresh agent 才读取 canonical eval 定义、assertions、expected output 与旧 comparison，并亲自按当前 assertions 评审。
+5. 两个 arm 分别查询 GitHub，没有共享预计算快照；运行期 transcript、verdict、diagnostics 或 outputs 均未落盘。
 
 ## Independent Live Snapshots and Drift
 
-| 指标 | With skill（15:43:33） | Without skill（15:45:36） | 漂移判断 |
+| 指标 | With skill（16:23:33 起） | Without skill（16:25:45） | 漂移判断 |
 | --- | ---: | ---: | --- |
 | Open milestones | 0 | 0 | 无漂移 |
 | Open issues（排除 PR） | 144 | 144 | 无漂移 |
@@ -40,8 +40,8 @@
 | Changes requested | 2 | 2 | 无漂移 |
 
 - with-skill 按当前 skill 的互斥展示规则统计：人工非草稿且非 `CHANGES_REQUESTED` 的待 Review `204` 个、草稿 `6` 个、需作者跟进 `2` 个、bot `0` 个；近 14 天 merged PR `6` 个、closed issue `1` 个。
-- without-skill 报告 `204` 个 `REVIEW_REQUIRED`、`3` 个 approved、`2` 个 changes requested、`3` 个无 review decision，并把 `206` 个非草稿 PR 概括为 ready for review。这里是分类口径不同，不是仓库状态漂移。
-- with-skill 还统计 open issue 中无 assignee `141` 个、超过 30 天未更新 `111` 个，以及等待超过 90 天的人工非草稿 PR `85` 个。
+- without-skill 报告 `204` 个 `REVIEW_REQUIRED`、`3` 个 approved、`2` 个 changes requested、`3` 个无 review decision，并统计到 `206` 个非草稿 PR。这里是分类口径不同，不是仓库状态漂移。
+- with-skill 还统计 open issue 中无 assignee `141` 个、超过 30 天未更新 `111` 个，以及等待超过 90 天的人工非草稿且非 `CHANGES_REQUESTED` PR `83` 个。
 - 两次查询相隔约 2 分钟，核心计数一致；本 comparison 只证明上述抓取时点，后续复验必须重新查询。
 
 ## Fresh With Skill
@@ -56,13 +56,12 @@ fresh with-skill 应用当前 Full status 流程，结果包括：
 
 ## Fresh Without Skill / Baseline
 
-fresh baseline 未读取或应用 `github-reader` skill 与 Product Manager Agent README，自行实时查询后返回：
+同一 fresh agent 的 baseline arm 未应用 `github-reader` skill 与 Product Manager Agent README，只凭原始 prompt 重新实时查询后返回：
 
 - 0 个开放及已关闭 milestone、144 个 open issue、212 个 open PR。
-- 给出 draft、review required、approved、changes requested、无 review decision、可合并与冲突等通用 PR 数字。
-- 指出仓库摘要的 `open_issues_count=356` 实际是 144 个 issue 与 212 个 PR 的合计，避免把该字段误报为纯 issue 数。
-- 没有区分当前待 review 与近 14 天已合并 PR，也没有提供任何 `[#NUMBER](URL)` 格式的具体 PR 条目；只给出 Issues、Pull requests 等页面入口。
-- 给出含关键数字的总体判断，但未覆盖 with-skill 的 stale、unassigned、bot 隔离、10 行上限与近期 closed issue 口径。
+- 给出 6 个 draft、206 个非草稿，以及 204 `REVIEW_REQUIRED`、3 approved、2 changes requested、3 无 review decision 的通用 PR 数字，并列出最老 10 个 open PR 的 number、author、createdAt 与原始 URL。
+- 没有另查近期 merged PR，因而没有把当前待 review 与已合并 PR 分区；具体 PR 也未格式化为 `[#NUMBER](URL)`。
+- 给出含关键数字的总体判断，但未覆盖 with-skill 的 stale、unassigned、bot 隔离、10 行展示规则与近期 closed issue 口径。
 
 ## Assertion Results
 
@@ -71,12 +70,12 @@ fresh baseline 未读取或应用 `github-reader` skill 与 Product Manager Agen
 | `milestone`：包含有标题、进度百分比的 Milestone 表格 | **FAIL（场景前提不成立）** | **FAIL（场景前提不成立）** | 两次 API 查询均返回 0 个 milestone。现行 skill 要求此时不生成空表；不能虚构进度百分比。 |
 | `pr`：PR 队列区分待 review 和已合并 | **PASS** | **FAIL** | with-skill 单列当前待 Review 与近 14 天 merged；baseline 只描述当前 open PR。 |
 | `assertion_3`：末尾有数字化健康摘要 | **PASS** | **PASS** | 两者均以数字总结状态；with-skill 的风险及近期活动口径更完整。 |
-| `pr_2`：PR 条目使用 `[#NUMBER](URL)` | **PASS** | **FAIL** | with-skill 的具体 PR 条目使用正确链接格式；baseline 没有具体 PR 条目。 |
+| `pr_2`：PR 条目使用 `[#NUMBER](URL)` | **PASS** | **FAIL** | with-skill 的具体 PR 条目使用正确链接格式；baseline 虽返回 number 与原始 URL，但未组成 assertion 要求的 Markdown 链接。 |
 
 ## Failures and Interpretation
 
 - 唯一 with-skill failure 是 `milestone`。GitHub 查询成功，但仓库没有 assertion 假定的实体；伪造 milestone 表或百分比会违反当前 skill。
-- fresh pair 消除了历史 baseline 与父代理预计算快照共用所造成的 answer-key / snapshot leakage：两条路径本轮各自实时查询，judge 在候选锁定后才读取答案键。
+- same-agent fresh pair 消除了历史 baseline 与父代理预计算快照共用所造成的 answer-key / snapshot leakage：两个 arm 本轮各自实时查询，且同一 agent 在两个候选均锁定后才读取答案键并亲自 judge。
 - 未修改 fixture、`evals.json`、assertions 或 specialist `SKILL.md`。
 
 ## External Failure vs Skill Regression

--- a/agents/product_manager/test/github-reader/evals/workspace/eval-002-focused-pr-query/comparison.md
+++ b/agents/product_manager/test/github-reader/evals/workspace/eval-002-focused-pr-query/comparison.md
@@ -7,39 +7,65 @@
 - Eval: `eval-002-focused-pr-query`
 - Test case: focused-pr-query
 - Workspace: `workspace/eval-002-focused-pr-query`
-- Latest result: PARTIAL - prior skill validation evidence is preserved; without_skill baseline was not generated for this historical comparison.
-- Prior validation note: canonical comparison migration retained current-version result on 2026-06-02
+- Classification: `(c) 依赖实时外部数据`。prompt、expected output、assertions 和 metadata 已足以定义 focused PR 查询；该场景的证据来自 GitHub API 当前状态，不应添加静态 mock fixture。
+- Latest result: **PASS** — 本轮 fresh judge 使用同一份实时 `cli/cli` open PR snapshot，分别重新生成 with-skill 与 without-skill 结果；with-skill 满足全部 3 条 assertions，并保留 specialist 的 focused-query、自动化账号剥离、状态分区和等待时间排序规则。
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: Verifies that github-reader handles focused-pr-query and produces the expected role-specific artifact.
+- Prompt: `我在 cli/cli 这个仓库里工作，现在有哪些 PR 还在等待 review？按等待时间排序`
 - Expected output: 聚焦 PR 的输出，列出 awaiting review 的 PR 并按等待时间排序，不需要输出 issue 和 milestone 数据
+- Data source: authenticated `gh repo view cli/cli` and `gh pr list --repo cli/cli --state open --limit 200 --json number,title,author,reviewDecision,createdAt,labels,isDraft,url`
+- Repository: `cli/cli` (`https://github.com/cli/cli`, default branch `trunk`)
+- Fetched at: `2026-07-26T15:22:48+08:00`
+- Snapshot size: 55 open PRs。按 github-reader 的强制分区顺序及 GitHub App 作者表示法归一化后，2 个自动化 PR（`app/dependabot`、`app/copilot-swe-agent`）、17 个人工草稿、2 个 `CHANGES_REQUESTED`，其余 34 个进入待 Review 清单。
+- Snapshot edge evidence: 待 Review 清单最旧三项为 [#10423](https://github.com/cli/cli/pull/10423)（@iamazeem，528 天）、[#10730](https://github.com/cli/cli/pull/10730)（@cmbrose，477 天）、[#10783](https://github.com/cli/cli/pull/10783)（@franciscoj，467 天）；最新三项为 [#13963](https://github.com/cli/cli/pull/13963)、[#13967](https://github.com/cli/cli/pull/13967)、[#13969](https://github.com/cli/cli/pull/13969)，均为 1 天。
+- Protocol note: snapshot 中有 3 个非草稿人工 PR 的 `reviewDecision=APPROVED`。with-skill 遵循 SKILL.md 标记为强制的分类顺序，将非 bot、非草稿且非 `CHANGES_REQUESTED` 的剩余 PR 归入待 Review；此处记录的是当前 skill 协议表现，不改写 skill 或 assertions。
 
 ## Assertions
 
-- `pr`: 聚焦 PR 不冗余
-- `assertion_2`: 包含等待时间
-- `assertion_3`: 有排序
+| Assertion | With skill | Without skill | Fresh judge |
+| --- | --- | --- | --- |
+| `pr`：聚焦 PR 不冗余 | 只输出 PR focused 结果及必要分类摘要，没有抓取或展开 issue、milestone | 只输出 PR 表格，没有 issue、milestone | PASS |
+| `assertion_2`：包含等待时间 | 34 条待 Review PR 均带作者和基于 `createdAt` 计算的等待天数 | 32 条字面 review-required 结果均带作者和等待天数 | PASS |
+| `assertion_3`：有排序 | 明确按 `createdAt` 升序，最旧在前；首项 #10423，末项 #13969 | 同样按 `createdAt` 升序并明确说明最旧在前 | PASS |
 
 ## With Skill
 
-Observed behavior:
+Fresh with-skill run:
 
-- 保留并迁移 iteration-2 最新 comparison。该结果已基于当前 github-reader skill 版本，覆盖 focused PR 查询、等待时间排序和避免冗余 issue/milestone 输出。
+- 读取 PM Agent 路由边界和当前 `github-reader` specialist 协议后，将请求识别为 focused query，只调用仓库上下文和 open PR 查询，没有抓取无关 issue 或 milestone。
+- 对 55 个 open PR 先识别自动化作者。当前 `gh` 将 GitHub App 作者显示为 `app/dependabot` 和 `app/copilot-swe-agent`，运行时将其规范化为 bot/automation，避免混入人工待 Review 或人工草稿。
+- 再依次剥离 17 个人工草稿和 2 个 `CHANGES_REQUESTED` PR；按 skill 的强制分类流程把其余 34 个 PR 放入待 Review。
+- 34 条结果均包含链接、标题、作者、等待天数和 labels，并以 `createdAt` 从旧到新排序。focused 模式没有套用 full-status 的 10 行上限。
+- 对 snapshot 内 3 个 `APPROVED` PR 按当前强制分区规则保留在“其余 → 待 Review”；没有悄悄用模型常识改写 specialist 协议。
 
 ## Without Skill / Baseline
-- BLOCKED: No actual without_skill baseline result is recorded for this historical comparison. This file is not treated as a full eval PASS until a baseline result is generated and written here.
-- This comparison records whether the skill-specific protocol, routing, evidence, or artifact expectations are preserved.
+
+Fresh without-skill baseline:
+
+- 在不读取或应用 github-reader SKILL.md、PM Agent README 的条件下，仅根据相同 prompt 和同一份 `2026-07-26T15:22:48+08:00` snapshot 重新生成。
+- baseline 将“等待 review”按字面解释为非草稿且 `reviewDecision=REVIEW_REQUIRED` 或空值，排除 `APPROVED` 和 `CHANGES_REQUESTED`，得到 32 条并按最旧在前排序；每条包含作者和等待天数，且没有输出 issue/milestone。
+- baseline 因缺少 specialist 的 bot-first 分类规则，将 `app/dependabot` 的 #13965 留在人工结果中，也没有给出 bot、草稿、changes-requested 的完整分区摘要。
+- baseline 仍满足当前三条通用 assertions；对照价值在于确认 with-skill 额外保留了当前 specialist 的分类协议，而不是说明 baseline 必须失败。
 
 ## Failures
 
-- None recorded in the migrated current-version comparison.
+- Skill regression: none observed.
+- External dependency failure: none observed；本轮 `gh` 查询和 GitHub API 均成功返回。
+
+## External Dependency and Failure Interpretation
+
+- 此 eval 必须联网并依赖 GitHub API、`gh` CLI 可用且已认证。PR 数量、review decision、draft 状态、labels 和等待天数都会随时间变化，以上数量只代表抓取时点。
+- 若 `gh auth status`、DNS、网络、GitHub API、rate limit 或权限导致查询失败，应记录命令、抓取时间和外部错误，并将本轮结果标为 **BLOCKED / external service failure**；不能把它判成 skill 回归，也不能用静态 mock 冒充本轮 fresh 运行。
+- 若 API 成功返回，但 with-skill 抓取了无关 issue/milestone、遗漏作者/等待时间、未按时间排序，或未按当前协议剥离自动化、草稿和 changes-requested，则属于 **skill regression**。
+- GitHub 可能改变 App author 的展示形式；`app/dependabot` 等当前表示法具有时效风险。后续运行应根据当次 API 返回重新核对自动化身份，不应复用本轮计数。
 
 ## Next Steps
 
-- 本轮未重新运行；保持 canonical workspace 下的最新 durable comparison。
+- 当前 fixture 无需增加静态文件；未来复验继续真实查询 prompt 指定仓库，并在 canonical comparison 中更新抓取时间、snapshot 数量与 fresh pair 结论。
 
 ## Runtime Artifacts Policy
 
-- Runtime transcripts, verdicts, timing, outputs, and diagnostics should not be committed.
+- 本轮运行期 snapshot、transcripts、完整输出、verdict、timing 和 diagnostics 只用于 fresh judge，不提交到 Git。
+- Durable result 仅保留本 canonical `comparison.md`；不得提交 `with_skill/`、`without_skill/`、`outputs/`、`transcript.md`、`subagent-verdict.md` 或 diagnostics 目录。

--- a/agents/product_manager/test/github-reader/evals/workspace/eval-002-focused-pr-query/comparison.md
+++ b/agents/product_manager/test/github-reader/evals/workspace/eval-002-focused-pr-query/comparison.md
@@ -8,7 +8,7 @@
 - Test case: focused-pr-query
 - Workspace: `workspace/eval-002-focused-pr-query`
 - Classification: `(c) 依赖实时外部数据`。prompt、expected output、assertions 和 metadata 已足以定义 focused PR 查询；场景证据必须来自 GitHub 当前状态，不应添加静态 mock fixture。
-- Latest result: **PASS** — 本轮 no-leak fresh pair 均真实查询 `cli/cli`；with-skill 与 without-skill 都满足 3 条 assertions。with-skill 额外按 specialist 规则把 Dependabot 从人工待 Review 表格剥离，并保留 labels。
+- Latest result: **PASS** — 本轮由同一个 fresh Codex agent 完成 no-leak 双臂复验和最终 judge；with-skill 与 without-skill 均真实查询 `cli/cli`，且都满足 3 条 assertions。
 
 ## Test Set / Fixture Version
 
@@ -16,58 +16,58 @@
 - Prompt: `我在 cli/cli 这个仓库里工作，现在有哪些 PR 还在等待 review？按等待时间排序`
 - Expected output: 聚焦 PR 的输出，列出 awaiting review 的 PR 并按等待时间排序，不需要输出 issue 和 milestone 数据
 - Repository: `cli/cli` (`https://github.com/cli/cli`，default branch `trunk`)
-- With-skill source: authenticated `gh repo view cli/cli` and `gh pr list --repo cli/cli --state open --limit 100 --json number,title,state,author,reviewDecision,createdAt,labels,isDraft,url`
-- With-skill fetched at: `2026-07-26 15:47:39 CST (+08:00)`
-- Without-skill source: authenticated `gh api graphql`，完整分页查询 `cli/cli` open PR，`hasNextPage=false`
-- Without-skill fetched at: `2026-07-26 15:49:40 CST (+08:00)`
+- With-skill source: authenticated `gh repo view cli/cli` and `gh pr list -R cli/cli --state open --limit 100 --json number,title,state,author,reviewDecision,createdAt,labels,isDraft,url`
+- With-skill fetched at: `2026-07-26 16:30:01 CST (+08:00)`
+- Without-skill source: authenticated `gh pr list --repo cli/cli --state open --limit 100 --json number,title,author,isDraft,reviewDecision,createdAt,url`
+- Without-skill fetched at: `2026-07-26 16:30:14 CST (+08:00)`
 
 ## Snapshot
 
-- 两次查询均观测到 55 个 open PR；两分钟窗口内关键计数和排序边界一致，没有观察到 PR 状态漂移。
-- 快照包含 49 个 `REVIEW_REQUIRED` PR，其中 17 个是 draft；另有 1 个 `reviewDecision` 为空的 draft、3 个 `APPROVED`、2 个 `CHANGES_REQUESTED`。
-- 当前有 2 个自动化作者：非 draft 的 Dependabot PR #13965，以及 draft 的 Copilot agent PR #13017。
-- 本轮将“等待 review”按 SKILL.md 的 health signal 定义解释为非 draft 且 `reviewDecision` 为 `REVIEW_REQUIRED` 或空值。with-skill 剥离 bot 后得到 31 个人工待 Review PR；without-skill 得到 32 个，但其中包含 Dependabot #13965。
-- 两路结果最旧三项均为 [#10423](https://github.com/cli/cli/pull/10423)（@iamazeem，528 天）、[#10730](https://github.com/cli/cli/pull/10730)（@cmbrose，477 天）、[#10783](https://github.com/cli/cli/pull/10783)（@franciscoj，467 天）；人工结果最新三项均为 #13963、#13967、#13969。
+- with-skill 查询观测到 55 个 open PR；按人工作者、非 draft、`reviewDecision=REVIEW_REQUIRED` 口径得到 31 个待 Review PR。
+- without-skill 独立查询同样得到 31 个待 Review PR；两次查询相隔 13 秒，31 个 PR 的编号、顺序和最旧/最新边界完全一致，没有观察到状态漂移。
+- 两臂锁定的 PR 编号依次为：`#10423`、`#10730`、`#10783`、`#12942`、`#13013`、`#13155`、`#13247`、`#13282`、`#13318`、`#13340`、`#13348`、`#13364`、`#13400`、`#13505`、`#13556`、`#13602`、`#13673`、`#13697`、`#13758`、`#13760`、`#13788`、`#13798`、`#13875`、`#13894`、`#13946`、`#13952`、`#13953`、`#13955`、`#13963`、`#13967`、`#13969`。
+- 最旧三项均为 [#10423](https://github.com/cli/cli/pull/10423)（@iamazeem，528 天）、[#10730](https://github.com/cli/cli/pull/10730)（@cmbrose，477 天）、[#10783](https://github.com/cli/cli/pull/10783)（@franciscoj，467 天）；最新三项均为 #13963、#13967、#13969。
+- with-skill 还观测到 18 个 draft、2 个非 bot `CHANGES_REQUESTED` PR 和 3 个非 bot `APPROVED` PR；Dependabot #13965 的 author login 在本轮 API 中表现为 `app/dependabot`，作为自动化 PR 从人工待 Review 清单剥离。
 
-## No-Leak Fresh Pair
+## Same-Agent No-Leak Fresh Pair
 
-1. 主 judge 首先只读取 `eval_metadata.json` 的原 prompt；没有读取 `evals.json`、assertions、expected output 或历史 `comparison.md`。
-2. with-skill 路径随后读取 PM Agent README 与当前 `github-reader/SKILL.md`，独立调用 `gh` 查询并锁定候选结果。
-3. 候选锁定后，启动 `fork_turns=none` 的 fresh Codex subagent。它只收到原 prompt，以及“自行实时查询并报告时间、数据源和关键数量”的要求；没有收到 skill、Agent README、答案键、父进程 snapshot、assertions 或旧 comparison。
-4. baseline 返回并锁定后，主 judge 才读取 assertions、expected output 和历史 comparison，逐项裁决。
+1. 当前 fresh agent 首先只读取 `eval_metadata.json` 的原 prompt；没有读取 `evals.json`、assertions、expected output 或历史 `comparison.md`。
+2. with-skill 臂随后读取 PM Agent README 与当前 `github-reader/SKILL.md`，独立调用 `gh` 查询并锁定候选结果。
+3. 同一个 agent 在第二臂不应用 PM Agent README 或 `github-reader` 指令，仅依据原 prompt 重新设计并执行独立 `gh` 查询；没有读取或使用答案键、父臂结果、assertions、expected output 或旧 comparison，随后锁定 without-skill 结果。
+4. 两臂均锁定后，该 agent 才读取 `evals.json` 中本 eval 的 expected output、assertions 与历史 comparison，并亲自完成 judge；本轮没有 spawn child/subagent，也没有复用历史 baseline。
 
 ## Assertions
 
 | Assertion | With skill | Without skill | Fresh judge |
 | --- | --- | --- | --- |
-| `pr`：聚焦 PR 不冗余 | 只查询并输出 repo context 与 open PR，没有抓取 issue 或 milestone | 只输出 open PR 的 focused 结果 | PASS |
-| `assertion_2`：包含等待时间 | 31 条人工待 Review PR 均包含作者、等待天数或 `createdAt`，并包含 labels | 32 条结果均包含作者、精确到小时的等待时间和创建日期 | PASS |
-| `assertion_3`：有排序 | 明确按 `createdAt` 升序，即等待最久在前 | 明确按等待时间从长到短；首项 #10423，末项 #13969 | PASS |
+| `pr`：聚焦 PR 不冗余 | 只查询 repo context 与 open PR，没有抓取 issue 或 milestone | 只查询并输出 open PR 的 focused 结果 | PASS |
+| `assertion_2`：包含等待时间 | 31 条人工待 Review PR 均包含作者、等待天数和 labels | 31 条结果均包含作者和 `createdAt` | PASS |
+| `assertion_3`：有排序 | 明确按 `createdAt` 升序，即等待最久在前 | 独立按 `createdAt` 升序；首项 #10423，末项 #13969 | PASS |
 
 ## With Skill
 
 - 将请求识别为 focused PR query，只调用仓库上下文和 open PR 查询；未抓取无关 issue、milestone 或近期合并数据。
-- 先按 `author.is_bot` / GitHub App 身份剥离自动化作者，再排除 draft、`CHANGES_REQUESTED` 与已 `APPROVED` PR。
+- 按自动化作者、draft 和 review decision 分类，排除 Dependabot #13965、draft、`CHANGES_REQUESTED` 与 `APPROVED` PR。
 - 输出 31 个人工、非 draft、`REVIEW_REQUIRED` PR，包含链接、标题、作者、等待天数与 labels，并按创建时间从旧到新排列。
 - focused 模式未套用 full-status 的 10 行上限。
 
 ## Without Skill / Baseline
 
-- fresh child 不读取或应用本地 skill、Agent README、eval 定义或历史结果，自行通过 GitHub GraphQL 查询全部 55 个 open PR。
-- baseline 以 `reviewDecision=REVIEW_REQUIRED` 且非 draft 为口径，得到 32 条并按等待时间从长到短排列；每条包含链接、作者、等待时间和创建日期，没有输出 issue 或 milestone。
-- baseline 没有执行 specialist 的 bot-first 分区，把 Dependabot #13965 混入人工清单；它也没有输出 labels。
-- 这些差异不违反当前 3 条通用 assertions，因此 baseline 同样为 PASS；对照价值在于验证 specialist 的 bot 分类与 labels 增量，而不是要求 baseline 必须失败。
+- 同一个 fresh agent 在不应用 skill 或 PM README 的条件下，仅凭原 prompt 重新执行独立 `gh pr list` 查询。
+- baseline 以 `reviewDecision=REVIEW_REQUIRED`、非 draft、非 GitHub App author 为口径，同样得到 31 条，并按 `createdAt` 从旧到新排列；每条包含链接、标题、作者和创建时间，没有输出 issue 或 milestone。
+- baseline 没有输出等待天数和 labels，但 `createdAt` 已满足 assertion 对“等待天数或创建时间”的要求，因此 baseline 同样为 PASS。
+- 对照价值在于确认当前通用 assertions 不强制 specialist 的 labels 增量，而不是要求 baseline 必须失败。
 
 ## Drift and Protocol Notes
 
-- GitHub PR 状态、review decision、draft、labels 和等待时间持续变化；本 comparison 的数量只代表上述两个抓取时点。两次 fresh 查询相隔约 2 分钟，关键集合没有漂移，但等待时长显示精度不同。
-- 历史 comparison 在 `2026-07-26 15:22:48 +08:00` 把 3 个 `APPROVED` PR 也归入待 Review，记录为 34 条。当前 fresh run 依据 SKILL.md 的 health signal 定义排除 `APPROVED`，得到 31 条人工待 Review；这是口径修正，不是 GitHub 状态变化。
-- SKILL.md 的“强制分类流程”把非 bot、非 draft、非 `CHANGES_REQUESTED` 的“其余”归入待 Review，而 health signal 又把待 Review 明确定义为 `REVIEW_REQUIRED` 或空值；对 `APPROVED` 存在内部口径歧义。本轮 assertions 不要求裁决该分区冲突，且任务禁止修改 specialist 行为，因此仅如实记录风险。
+- GitHub PR 状态、review decision、draft、labels 和等待时间持续变化；本 comparison 的数量只代表上述两个抓取时点。后续 fresh run 必须重新查询，不能把本轮 31 条当成固定答案。
+- SKILL.md 的“强制分类流程”把非 bot、非 draft、非 `CHANGES_REQUESTED` 的“其余”归入待 Review，而 health signal 又把待 Review 明确定义为 `REVIEW_REQUIRED` 或空值；对 `APPROVED` 存在内部口径歧义。本轮按用户问题与 health signal 排除 3 个 `APPROVED` PR。当前 assertions 不要求裁决该分区冲突，且任务禁止修改 specialist 行为，因此只记录风险。
+- GitHub App author 的 login 表示可能随 API 层变化；本轮 Dependabot 表示为 `app/dependabot`。后续复验应依据当次 API 的 bot/app 身份重新判断，不应把本轮 login 当成固定 fixture。
 
 ## Failures
 
 - Skill regression: none observed against the three eval assertions.
-- External dependency failure: none observed；本轮 `gh` CLI、GitHub REST/GraphQL API 和认证均正常。
+- External dependency failure: none observed；本轮 `gh` CLI、GitHub API 和认证均正常。
 - Remaining risk: specialist 对 `APPROVED` PR 的分区口径存在上述文档内歧义，但不影响本 eval 对 focused、作者/时间字段和排序的验证结论。
 
 ## External Dependency and Failure Interpretation
@@ -75,14 +75,13 @@
 - 此 eval 必须联网并依赖 GitHub API、`gh` CLI 可用且已认证；后续复验必须重新抓取，不能复用本轮数量或伪造静态 snapshot。
 - 若 `gh auth status`、DNS、网络、GitHub API、rate limit 或权限导致查询失败，应记录命令、抓取时间和外部错误，并将本轮标为 **BLOCKED / external service failure**；不能判为 skill regression，也不能用 mock 冒充 fresh 运行。
 - 若 API 成功返回，但 with-skill 抓取无关 issue/milestone、遗漏作者或时间信息、未按等待时间排序，则属于 **skill regression**。
-- GitHub App author 表示法可能变化；后续运行应基于当次 API 的 `author.is_bot` 与登录名重新识别，不能硬套本轮 `app/dependabot` 文本。
 
 ## Next Steps
 
-- fixture 无需增加静态文件；未来复验继续真实查询 prompt 指定仓库，并在 canonical comparison 中更新抓取时间、snapshot 数量、no-leak fresh pair 和 drift 结论。
+- fixture 无需增加静态文件；未来复验继续真实查询 prompt 指定仓库，并在 canonical comparison 中更新抓取时间、snapshot 数量、same-agent no-leak fresh pair 和 drift 结论。
 - 若后续要把 bot 分区或 `APPROVED` 处理纳入 pass/fail，应另行对齐 SKILL.md 口径并新增/收紧 assertion；本轮不修改 skill 或 eval 定义。
 
 ## Runtime Artifacts Policy
 
-- 本轮运行期 snapshot、transcripts、完整输出、verdict、timing 和 diagnostics 只用于 fresh judge，不提交到 Git。
+- 本轮运行期 snapshot、完整输出、verdict、timing 和 diagnostics 只用于 fresh judge，不提交到 Git。
 - Durable result 仅保留本 canonical `comparison.md`；不得提交 `with_skill/`、`without_skill/`、`outputs/`、`transcript.md`、`subagent-verdict.md` 或 diagnostics 目录。

--- a/agents/product_manager/test/github-reader/evals/workspace/eval-002-focused-pr-query/comparison.md
+++ b/agents/product_manager/test/github-reader/evals/workspace/eval-002-focused-pr-query/comparison.md
@@ -7,63 +7,80 @@
 - Eval: `eval-002-focused-pr-query`
 - Test case: focused-pr-query
 - Workspace: `workspace/eval-002-focused-pr-query`
-- Classification: `(c) 依赖实时外部数据`。prompt、expected output、assertions 和 metadata 已足以定义 focused PR 查询；该场景的证据来自 GitHub API 当前状态，不应添加静态 mock fixture。
-- Latest result: **PASS** — 本轮 fresh judge 使用同一份实时 `cli/cli` open PR snapshot，分别重新生成 with-skill 与 without-skill 结果；with-skill 满足全部 3 条 assertions，并保留 specialist 的 focused-query、自动化账号剥离、状态分区和等待时间排序规则。
+- Classification: `(c) 依赖实时外部数据`。prompt、expected output、assertions 和 metadata 已足以定义 focused PR 查询；场景证据必须来自 GitHub 当前状态，不应添加静态 mock fixture。
+- Latest result: **PASS** — 本轮 no-leak fresh pair 均真实查询 `cli/cli`；with-skill 与 without-skill 都满足 3 条 assertions。with-skill 额外按 specialist 规则把 Dependabot 从人工待 Review 表格剥离，并保留 labels。
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
 - Prompt: `我在 cli/cli 这个仓库里工作，现在有哪些 PR 还在等待 review？按等待时间排序`
 - Expected output: 聚焦 PR 的输出，列出 awaiting review 的 PR 并按等待时间排序，不需要输出 issue 和 milestone 数据
-- Data source: authenticated `gh repo view cli/cli` and `gh pr list --repo cli/cli --state open --limit 200 --json number,title,author,reviewDecision,createdAt,labels,isDraft,url`
-- Repository: `cli/cli` (`https://github.com/cli/cli`, default branch `trunk`)
-- Fetched at: `2026-07-26T15:22:48+08:00`
-- Snapshot size: 55 open PRs。按 github-reader 的强制分区顺序及 GitHub App 作者表示法归一化后，2 个自动化 PR（`app/dependabot`、`app/copilot-swe-agent`）、17 个人工草稿、2 个 `CHANGES_REQUESTED`，其余 34 个进入待 Review 清单。
-- Snapshot edge evidence: 待 Review 清单最旧三项为 [#10423](https://github.com/cli/cli/pull/10423)（@iamazeem，528 天）、[#10730](https://github.com/cli/cli/pull/10730)（@cmbrose，477 天）、[#10783](https://github.com/cli/cli/pull/10783)（@franciscoj，467 天）；最新三项为 [#13963](https://github.com/cli/cli/pull/13963)、[#13967](https://github.com/cli/cli/pull/13967)、[#13969](https://github.com/cli/cli/pull/13969)，均为 1 天。
-- Protocol note: snapshot 中有 3 个非草稿人工 PR 的 `reviewDecision=APPROVED`。with-skill 遵循 SKILL.md 标记为强制的分类顺序，将非 bot、非草稿且非 `CHANGES_REQUESTED` 的剩余 PR 归入待 Review；此处记录的是当前 skill 协议表现，不改写 skill 或 assertions。
+- Repository: `cli/cli` (`https://github.com/cli/cli`，default branch `trunk`)
+- With-skill source: authenticated `gh repo view cli/cli` and `gh pr list --repo cli/cli --state open --limit 100 --json number,title,state,author,reviewDecision,createdAt,labels,isDraft,url`
+- With-skill fetched at: `2026-07-26 15:47:39 CST (+08:00)`
+- Without-skill source: authenticated `gh api graphql`，完整分页查询 `cli/cli` open PR，`hasNextPage=false`
+- Without-skill fetched at: `2026-07-26 15:49:40 CST (+08:00)`
+
+## Snapshot
+
+- 两次查询均观测到 55 个 open PR；两分钟窗口内关键计数和排序边界一致，没有观察到 PR 状态漂移。
+- 快照包含 49 个 `REVIEW_REQUIRED` PR，其中 17 个是 draft；另有 1 个 `reviewDecision` 为空的 draft、3 个 `APPROVED`、2 个 `CHANGES_REQUESTED`。
+- 当前有 2 个自动化作者：非 draft 的 Dependabot PR #13965，以及 draft 的 Copilot agent PR #13017。
+- 本轮将“等待 review”按 SKILL.md 的 health signal 定义解释为非 draft 且 `reviewDecision` 为 `REVIEW_REQUIRED` 或空值。with-skill 剥离 bot 后得到 31 个人工待 Review PR；without-skill 得到 32 个，但其中包含 Dependabot #13965。
+- 两路结果最旧三项均为 [#10423](https://github.com/cli/cli/pull/10423)（@iamazeem，528 天）、[#10730](https://github.com/cli/cli/pull/10730)（@cmbrose，477 天）、[#10783](https://github.com/cli/cli/pull/10783)（@franciscoj，467 天）；人工结果最新三项均为 #13963、#13967、#13969。
+
+## No-Leak Fresh Pair
+
+1. 主 judge 首先只读取 `eval_metadata.json` 的原 prompt；没有读取 `evals.json`、assertions、expected output 或历史 `comparison.md`。
+2. with-skill 路径随后读取 PM Agent README 与当前 `github-reader/SKILL.md`，独立调用 `gh` 查询并锁定候选结果。
+3. 候选锁定后，启动 `fork_turns=none` 的 fresh Codex subagent。它只收到原 prompt，以及“自行实时查询并报告时间、数据源和关键数量”的要求；没有收到 skill、Agent README、答案键、父进程 snapshot、assertions 或旧 comparison。
+4. baseline 返回并锁定后，主 judge 才读取 assertions、expected output 和历史 comparison，逐项裁决。
 
 ## Assertions
 
 | Assertion | With skill | Without skill | Fresh judge |
 | --- | --- | --- | --- |
-| `pr`：聚焦 PR 不冗余 | 只输出 PR focused 结果及必要分类摘要，没有抓取或展开 issue、milestone | 只输出 PR 表格，没有 issue、milestone | PASS |
-| `assertion_2`：包含等待时间 | 34 条待 Review PR 均带作者和基于 `createdAt` 计算的等待天数 | 32 条字面 review-required 结果均带作者和等待天数 | PASS |
-| `assertion_3`：有排序 | 明确按 `createdAt` 升序，最旧在前；首项 #10423，末项 #13969 | 同样按 `createdAt` 升序并明确说明最旧在前 | PASS |
+| `pr`：聚焦 PR 不冗余 | 只查询并输出 repo context 与 open PR，没有抓取 issue 或 milestone | 只输出 open PR 的 focused 结果 | PASS |
+| `assertion_2`：包含等待时间 | 31 条人工待 Review PR 均包含作者、等待天数或 `createdAt`，并包含 labels | 32 条结果均包含作者、精确到小时的等待时间和创建日期 | PASS |
+| `assertion_3`：有排序 | 明确按 `createdAt` 升序，即等待最久在前 | 明确按等待时间从长到短；首项 #10423，末项 #13969 | PASS |
 
 ## With Skill
 
-Fresh with-skill run:
-
-- 读取 PM Agent 路由边界和当前 `github-reader` specialist 协议后，将请求识别为 focused query，只调用仓库上下文和 open PR 查询，没有抓取无关 issue 或 milestone。
-- 对 55 个 open PR 先识别自动化作者。当前 `gh` 将 GitHub App 作者显示为 `app/dependabot` 和 `app/copilot-swe-agent`，运行时将其规范化为 bot/automation，避免混入人工待 Review 或人工草稿。
-- 再依次剥离 17 个人工草稿和 2 个 `CHANGES_REQUESTED` PR；按 skill 的强制分类流程把其余 34 个 PR 放入待 Review。
-- 34 条结果均包含链接、标题、作者、等待天数和 labels，并以 `createdAt` 从旧到新排序。focused 模式没有套用 full-status 的 10 行上限。
-- 对 snapshot 内 3 个 `APPROVED` PR 按当前强制分区规则保留在“其余 → 待 Review”；没有悄悄用模型常识改写 specialist 协议。
+- 将请求识别为 focused PR query，只调用仓库上下文和 open PR 查询；未抓取无关 issue、milestone 或近期合并数据。
+- 先按 `author.is_bot` / GitHub App 身份剥离自动化作者，再排除 draft、`CHANGES_REQUESTED` 与已 `APPROVED` PR。
+- 输出 31 个人工、非 draft、`REVIEW_REQUIRED` PR，包含链接、标题、作者、等待天数与 labels，并按创建时间从旧到新排列。
+- focused 模式未套用 full-status 的 10 行上限。
 
 ## Without Skill / Baseline
 
-Fresh without-skill baseline:
+- fresh child 不读取或应用本地 skill、Agent README、eval 定义或历史结果，自行通过 GitHub GraphQL 查询全部 55 个 open PR。
+- baseline 以 `reviewDecision=REVIEW_REQUIRED` 且非 draft 为口径，得到 32 条并按等待时间从长到短排列；每条包含链接、作者、等待时间和创建日期，没有输出 issue 或 milestone。
+- baseline 没有执行 specialist 的 bot-first 分区，把 Dependabot #13965 混入人工清单；它也没有输出 labels。
+- 这些差异不违反当前 3 条通用 assertions，因此 baseline 同样为 PASS；对照价值在于验证 specialist 的 bot 分类与 labels 增量，而不是要求 baseline 必须失败。
 
-- 在不读取或应用 github-reader SKILL.md、PM Agent README 的条件下，仅根据相同 prompt 和同一份 `2026-07-26T15:22:48+08:00` snapshot 重新生成。
-- baseline 将“等待 review”按字面解释为非草稿且 `reviewDecision=REVIEW_REQUIRED` 或空值，排除 `APPROVED` 和 `CHANGES_REQUESTED`，得到 32 条并按最旧在前排序；每条包含作者和等待天数，且没有输出 issue/milestone。
-- baseline 因缺少 specialist 的 bot-first 分类规则，将 `app/dependabot` 的 #13965 留在人工结果中，也没有给出 bot、草稿、changes-requested 的完整分区摘要。
-- baseline 仍满足当前三条通用 assertions；对照价值在于确认 with-skill 额外保留了当前 specialist 的分类协议，而不是说明 baseline 必须失败。
+## Drift and Protocol Notes
+
+- GitHub PR 状态、review decision、draft、labels 和等待时间持续变化；本 comparison 的数量只代表上述两个抓取时点。两次 fresh 查询相隔约 2 分钟，关键集合没有漂移，但等待时长显示精度不同。
+- 历史 comparison 在 `2026-07-26 15:22:48 +08:00` 把 3 个 `APPROVED` PR 也归入待 Review，记录为 34 条。当前 fresh run 依据 SKILL.md 的 health signal 定义排除 `APPROVED`，得到 31 条人工待 Review；这是口径修正，不是 GitHub 状态变化。
+- SKILL.md 的“强制分类流程”把非 bot、非 draft、非 `CHANGES_REQUESTED` 的“其余”归入待 Review，而 health signal 又把待 Review 明确定义为 `REVIEW_REQUIRED` 或空值；对 `APPROVED` 存在内部口径歧义。本轮 assertions 不要求裁决该分区冲突，且任务禁止修改 specialist 行为，因此仅如实记录风险。
 
 ## Failures
 
-- Skill regression: none observed.
-- External dependency failure: none observed；本轮 `gh` 查询和 GitHub API 均成功返回。
+- Skill regression: none observed against the three eval assertions.
+- External dependency failure: none observed；本轮 `gh` CLI、GitHub REST/GraphQL API 和认证均正常。
+- Remaining risk: specialist 对 `APPROVED` PR 的分区口径存在上述文档内歧义，但不影响本 eval 对 focused、作者/时间字段和排序的验证结论。
 
 ## External Dependency and Failure Interpretation
 
-- 此 eval 必须联网并依赖 GitHub API、`gh` CLI 可用且已认证。PR 数量、review decision、draft 状态、labels 和等待天数都会随时间变化，以上数量只代表抓取时点。
-- 若 `gh auth status`、DNS、网络、GitHub API、rate limit 或权限导致查询失败，应记录命令、抓取时间和外部错误，并将本轮结果标为 **BLOCKED / external service failure**；不能把它判成 skill 回归，也不能用静态 mock 冒充本轮 fresh 运行。
-- 若 API 成功返回，但 with-skill 抓取了无关 issue/milestone、遗漏作者/等待时间、未按时间排序，或未按当前协议剥离自动化、草稿和 changes-requested，则属于 **skill regression**。
-- GitHub 可能改变 App author 的展示形式；`app/dependabot` 等当前表示法具有时效风险。后续运行应根据当次 API 返回重新核对自动化身份，不应复用本轮计数。
+- 此 eval 必须联网并依赖 GitHub API、`gh` CLI 可用且已认证；后续复验必须重新抓取，不能复用本轮数量或伪造静态 snapshot。
+- 若 `gh auth status`、DNS、网络、GitHub API、rate limit 或权限导致查询失败，应记录命令、抓取时间和外部错误，并将本轮标为 **BLOCKED / external service failure**；不能判为 skill regression，也不能用 mock 冒充 fresh 运行。
+- 若 API 成功返回，但 with-skill 抓取无关 issue/milestone、遗漏作者或时间信息、未按等待时间排序，则属于 **skill regression**。
+- GitHub App author 表示法可能变化；后续运行应基于当次 API 的 `author.is_bot` 与登录名重新识别，不能硬套本轮 `app/dependabot` 文本。
 
 ## Next Steps
 
-- 当前 fixture 无需增加静态文件；未来复验继续真实查询 prompt 指定仓库，并在 canonical comparison 中更新抓取时间、snapshot 数量与 fresh pair 结论。
+- fixture 无需增加静态文件；未来复验继续真实查询 prompt 指定仓库，并在 canonical comparison 中更新抓取时间、snapshot 数量、no-leak fresh pair 和 drift 结论。
+- 若后续要把 bot 分区或 `APPROVED` 处理纳入 pass/fail，应另行对齐 SKILL.md 口径并新增/收紧 assertion；本轮不修改 skill 或 eval 定义。
 
 ## Runtime Artifacts Policy
 

--- a/agents/product_manager/test/github-reader/evals/workspace/eval-003-milestone-focused/comparison.md
+++ b/agents/product_manager/test/github-reader/evals/workspace/eval-003-milestone-focused/comparison.md
@@ -8,7 +8,7 @@
 - Test case: milestone-focused
 - Workspace: `workspace/eval-003-milestone-focused`
 - Classification: `(c) 依赖实时外部数据`。该场景验证 specialist 是否通过 `gh` 查询真实 GitHub milestone；静态 fixture 会把时效性场景降级成 mock，因而不补造 fixture。
-- Latest result: **PASS**。2026-07-26 的 fresh paired validation 中，with-skill 在其独立实时查询结果上满足 3/3 assertions；fresh without-skill baseline 也独立查询 GitHub，满足 2/3，未采用 skill 规定的 emoji 状态标识。
+- Latest result: **PASS**。2026-07-26 的 same-agent fresh paired validation 中，with-skill 在第一次独立实时查询结果上满足 3/3 assertions；fresh without-skill baseline 在第二次独立查询结果上满足 2/3，未采用 skill 规定的 emoji 状态标识。
 
 ## Test Set / Fixture Version
 
@@ -16,18 +16,18 @@
 - Prompt: `看一下 facebook/react 最近的 milestone，哪个进度最慢或者已经逾期了？`
 - Expected output: Milestone 状态报告，识别出进度最慢或逾期的 milestone，给出具体数据支撑
 - Fixture basis: prompt 与 `eval_metadata.json` 已足够定义目标仓库和查询意图；业务证据必须在运行时从 GitHub API 获取。
-- Fresh run: with-skill 由当前会话读取 PM Agent README 与 `github-reader` skill 后生成；without-skill 由 `fork_turns=none` 的全新 Codex subagent 仅凭原始 prompt 独立生成。两边均为本轮新查询、新生成，未复用历史 baseline。
-- No-leak control: baseline 启动并锁定结果之前，执行者没有读取 `evals.json`、assertions、expected output 或旧 `comparison.md`；baseline 子代理没有收到 skill、Agent README、with-skill 候选、父级 API snapshot 或答案键。
+- Fresh run: 当前会话中的同一个 fresh Codex agent 先读取 PM Agent README 与 `github-reader` skill，完成并锁定 with-skill；随后明确停止应用这些指令，仅凭 metadata 中的原始 prompt 完成并锁定新的 without-skill baseline。两边均为本轮新查询、新生成，未复用历史 baseline。
+- No-leak control: 两条 arm 全部锁定之前，执行者只读取 `eval_metadata.json` 中的 prompt，以及 with-skill arm 必需的 PM Agent README 和 specialist skill；没有读取 `evals.json`、assertions、expected output 或旧 `comparison.md`。第二条 arm 没有复用第一次查询的响应或候选文本，而是再次独立调用 `gh`；两条 arm 锁定后才读取答案键并由同一 agent 亲自 judge。
 
 ## Live Data Snapshot
 
-- With-skill fetched at: `2026-07-26 15:47:38–15:47:50 CST (+0800)`。
-- Without-skill fetched at: `2026-07-26 15:48:13–15:48:55 CST (+0800)`。
-- Access path: 两条路径分别使用已认证的 `gh` CLI 调用 GitHub REST API，没有共享预制 snapshot。
+- With-skill fetched at: `2026-07-26 16:29:36 CST (+0800)`。
+- Without-skill fetched at: `2026-07-26 16:29:52 CST (+0800)`。
+- Access path: 两条路径由同一个 fresh agent 分别使用已认证的 `gh` CLI 调用 GitHub REST API；每条 arm 都发起自己的网络请求，没有共享预制 snapshot 或运行期文件。
 - Repository resolution: 输入 `facebook/react`，GitHub 返回 canonical repository `react/react`（default branch `main`）。
 - With-skill query scope: 仓库身份与全部 open milestones；按 focused-query 规则没有抓取无关 issue/PR 队列。
-- Without-skill query scope: 全部 open milestones、全部历史 milestones、milestone `#40` 详情及其 11 个关联 Issue/PR。
-- API fields retained for judgment: `title`, `state`, `open_issues`, `closed_issues`, `due_on`, `created_at`, `updated_at`, `html_url`。
+- Without-skill query scope: 再次独立查询全部 open milestones，并在该次响应上独立计算完成率。
+- API fields retained for judgment: with-skill 保留 `number`, `title`, `state`, `open_issues`, `closed_issues`, `due_on`, `created_at`, `updated_at`, `html_url`；without-skill 保留回答 prompt 所需的 `number`, `title`, `state`, `open_issues`, `closed_issues`, `completion_pct`, `due_on`, `html_url`。
 
 Open milestone snapshot:
 
@@ -50,7 +50,7 @@ The live data does not support an overdue claim: the only open milestone has no 
 Fresh with-skill behavior:
 
 - 读取 PM Agent README 与当前 `github-reader` skill，判定为 milestone-focused query，仅抓取所需 milestone 数据。
-- 通过 `gh` 解析目标仓库，并保留抓取时间、查询范围和用于计算的 API 字段。
+- 先通过 `gh repo view facebook/react` 解析目标仓库，再通过独立的 `gh api .../milestones` 请求取得全部 open milestones，并保留抓取时间、查询范围和用于计算的 API 字段。
 - 将 `19.0.0` 报告为 `5/11 (54.5%)`、`⚪ 无截止日期`；明确指出“无截止日期”不等于逾期。
 - 在只有一个 open milestone 的真实数据边界下，明确说明 `19.0.0` 是当前 active 集合中进度最慢，而不是虚构另一个比较对象。
 - 按 focused-query 协议停止在 milestone 数据，没有为满足格式而扩展抓取无关 issue/PR 队列。
@@ -59,9 +59,9 @@ Fresh with-skill behavior:
 
 Fresh without-skill behavior:
 
-- `fork_turns=none` 子代理在不读取或应用 `github-reader` skill、PM Agent README、eval 判分材料或父级查询结果的条件下，仅使用原始 prompt 独立调用 `gh`。
+- 同一个 fresh agent 在 with-skill 锁定后停止应用 `github-reader` skill 和 PM Agent README，仅凭原始 prompt 发起第二次独立 `gh api` 请求；此时仍未读取 eval 判分材料、旧 comparison 或答案键。
 - 正确识别 canonical repository、唯一 open milestone、54.5% 完成率以及无可证实的逾期 milestone。
-- 额外核对全部历史 milestones 和 `#40` 的 11 个关联 Issue/PR；这些是 baseline 自己的实时查询，不是父级 snapshot。
+- 该 arm 直接在自己的 API 响应上计算完成率并按完成率排序，没有复用 with-skill 的响应或派生值。
 - 结论仍有事实依据，因此通过 assertions 1 和 2。
 - 采用普通文本“无截止日期”，没有 skill 规定的 emoji 状态标识，因此不满足 assertion 3。
 
@@ -81,7 +81,7 @@ Fresh without-skill behavior:
 ## Next Steps
 
 - 无需修改 fixture、`eval_metadata.json`、`evals.json` 或 specialist `SKILL.md`。
-- 后续 fresh eval 继续让两条路径在相邻时间窗内各自实时查询，并分别记录抓取时间与查询范围；不得把父级 snapshot 或候选答案传给 baseline。
+- 后续 fresh eval 继续让同一个 fresh agent 按顺序锁定两条路径，在相邻时间窗内各自实时查询，并分别记录抓取时间与查询范围；两条 arm 锁定前不得读取答案键，也不得把第一条 arm 的 API 响应或候选答案作为第二条 arm 的输入。
 
 ## Runtime Artifacts Policy
 

--- a/agents/product_manager/test/github-reader/evals/workspace/eval-003-milestone-focused/comparison.md
+++ b/agents/product_manager/test/github-reader/evals/workspace/eval-003-milestone-focused/comparison.md
@@ -8,7 +8,7 @@
 - Test case: milestone-focused
 - Workspace: `workspace/eval-003-milestone-focused`
 - Classification: `(c) 依赖实时外部数据`。该场景验证 specialist 是否通过 `gh` 查询真实 GitHub milestone；静态 fixture 会把时效性场景降级成 mock，因而不补造 fixture。
-- Latest result: **PASS**。2026-07-26 的 fresh paired validation 中，with-skill 在可用的实时快照上满足 3/3 assertions；同一快照生成的 fresh without-skill baseline 满足 2/3，未采用 skill 规定的 emoji 状态标识。
+- Latest result: **PASS**。2026-07-26 的 fresh paired validation 中，with-skill 在其独立实时查询结果上满足 3/3 assertions；fresh without-skill baseline 也独立查询 GitHub，满足 2/3，未采用 skill 规定的 emoji 状态标识。
 
 ## Test Set / Fixture Version
 
@@ -16,36 +16,24 @@
 - Prompt: `看一下 facebook/react 最近的 milestone，哪个进度最慢或者已经逾期了？`
 - Expected output: Milestone 状态报告，识别出进度最慢或逾期的 milestone，给出具体数据支撑
 - Fixture basis: prompt 与 `eval_metadata.json` 已足够定义目标仓库和查询意图；业务证据必须在运行时从 GitHub API 获取。
-- Fresh run: 当前会话中新启动的 Codex subagent；with-skill 与 without-skill 均为本轮新生成，未复用历史 baseline。
+- Fresh run: with-skill 由当前会话读取 PM Agent README 与 `github-reader` skill 后生成；without-skill 由 `fork_turns=none` 的全新 Codex subagent 仅凭原始 prompt 独立生成。两边均为本轮新查询、新生成，未复用历史 baseline。
+- No-leak control: baseline 启动并锁定结果之前，执行者没有读取 `evals.json`、assertions、expected output 或旧 `comparison.md`；baseline 子代理没有收到 skill、Agent README、with-skill 候选、父级 API snapshot 或答案键。
 
 ## Live Data Snapshot
 
-- Fetched at: `2026-07-26 15:22:31 CST (+0800)` / `2026-07-26T07:22:31Z`
-- Access path: 已认证的 `gh` CLI 调用 GitHub REST API。
+- With-skill fetched at: `2026-07-26 15:47:38–15:47:50 CST (+0800)`。
+- Without-skill fetched at: `2026-07-26 15:48:13–15:48:55 CST (+0800)`。
+- Access path: 两条路径分别使用已认证的 `gh` CLI 调用 GitHub REST API，没有共享预制 snapshot。
 - Repository resolution: 输入 `facebook/react`，GitHub 返回 canonical repository `react/react`（default branch `main`）。
-- Query scope: 全部 open milestones，以及全部 closed milestones中按 `updated_at` 降序取最近 10 个；open/closed 总数分别为 1/38。
-- API fields retained for judgment: `title`, `state`, `open_issues`, `closed_issues`, `due_on`, `created_at`, `updated_at`, `closed_at`, `html_url`。
+- With-skill query scope: 仓库身份与全部 open milestones；按 focused-query 规则没有抓取无关 issue/PR 队列。
+- Without-skill query scope: 全部 open milestones、全部历史 milestones、milestone `#40` 详情及其 11 个关联 Issue/PR。
+- API fields retained for judgment: `title`, `state`, `open_issues`, `closed_issues`, `due_on`, `created_at`, `updated_at`, `html_url`。
 
 Open milestone snapshot:
 
 | Milestone | State | Open | Closed | Completion | Due on | Updated at |
 | --- | --- | ---: | ---: | ---: | --- | --- |
 | [19.0.0](https://github.com/react/react/milestone/40) | open | 5 | 6 | 54.5% | `null` | `2024-06-29T16:17:34Z` |
-
-Recent closed snapshot (按 `updated_at` 降序):
-
-| Milestone | State | Open | Closed | Completion | Due on | Updated at |
-| --- | --- | ---: | ---: | ---: | --- | --- |
-| 15.4.1 | closed | 0 | 3 | 100% | `null` | `2017-10-04T11:52:45Z` |
-| 15.4.2 | closed | 0 | 1 | 100% | `null` | `2017-10-04T11:52:44Z` |
-| 15-lopri | closed | 0 | 45 | 100% | `null` | `2017-10-04T11:52:42Z` |
-| 15-hipri | closed | 0 | 16 | 100% | `null` | `2017-10-04T11:52:41Z` |
-| 15.6 | closed | 0 | 29 | 100% | `null` | `2017-10-04T11:52:40Z` |
-| 16.0 | closed | 0 | 69 | 100% | `null` | `2017-10-04T11:52:38Z` |
-| seb | closed | 0 | 0 | N/A | `null` | `2016-11-29T01:06:45Z` |
-| 15.4.0 | closed | 0 | 93 | 100% | `null` | `2016-11-22T22:43:01Z` |
-| 15.3.2 | closed | 0 | 17 | 100% | `null` | `2016-09-19T17:53:29Z` |
-| 15.3.1 | closed | 0 | 35 | 100% | `null` | `2016-09-08T17:39:56Z` |
 
 The live data does not support an overdue claim: the only open milestone has no `due_on`. It does support identifying `19.0.0` as the slowest active milestone because it is the sole open milestone and is 6/11 complete (54.5%).
 
@@ -54,7 +42,7 @@ The live data does not support an overdue claim: the only open milestone has no 
 | Assertion | With skill | Without skill | Fresh judge evidence |
 | --- | --- | --- | --- |
 | `assertion_1`：明确指出逾期或进度最慢 | PASS | PASS | 两边都明确说明没有证据判定逾期，并把唯一 active milestone `19.0.0` 判为当前进度最慢；没有把 `due_on: null` 误报成逾期。 |
-| `assertion_2`：每个 milestone 有 open/closed 或完成率 | PASS | PASS | 两边都给出 `19.0.0` 的 5 open、6 closed 和 54.5%；with-skill 还以表格区分近期已关闭 milestones。 |
+| `assertion_2`：每个 milestone 有 open/closed 或完成率 | PASS | PASS | 两边都给出 `19.0.0` 的 5 open、6 closed、总数 11 和 54.5%。 |
 | `assertion_3`：使用规定 emoji 状态标识 | PASS | FAIL | with-skill 按协议使用 `⚪ 无截止日期`；baseline 只写“无截止日期”，未使用 `✅🟢🟡🔴⚪` 状态标识。 |
 
 ## With Skill
@@ -65,14 +53,15 @@ Fresh with-skill behavior:
 - 通过 `gh` 解析目标仓库，并保留抓取时间、查询范围和用于计算的 API 字段。
 - 将 `19.0.0` 报告为 `5/11 (54.5%)`、`⚪ 无截止日期`；明确指出“无截止日期”不等于逾期。
 - 在只有一个 open milestone 的真实数据边界下，明确说明 `19.0.0` 是当前 active 集合中进度最慢，而不是虚构另一个比较对象。
-- 对最近 closed milestones 给出 open/closed 与完成率证据；对 0/0 的 `seb` 标记为 N/A，未制造除零百分比。
+- 按 focused-query 协议停止在 milestone 数据，没有为满足格式而扩展抓取无关 issue/PR 队列。
 
 ## Without Skill / Baseline
 
 Fresh without-skill behavior:
 
-- 在不读取或应用 `github-reader` skill 与 PM Agent README 的条件下，仅使用原始 prompt 和与 with-skill 相同的 2026-07-26 API snapshot 重新生成。
+- `fork_turns=none` 子代理在不读取或应用 `github-reader` skill、PM Agent README、eval 判分材料或父级查询结果的条件下，仅使用原始 prompt 独立调用 `gh`。
 - 正确识别 canonical repository、唯一 open milestone、54.5% 完成率以及无可证实的逾期 milestone。
+- 额外核对全部历史 milestones 和 `#40` 的 11 个关联 Issue/PR；这些是 baseline 自己的实时查询，不是父级 snapshot。
 - 结论仍有事实依据，因此通过 assertions 1 和 2。
 - 采用普通文本“无截止日期”，没有 skill 规定的 emoji 状态标识，因此不满足 assertion 3。
 
@@ -80,7 +69,7 @@ Fresh without-skill behavior:
 
 - External dependency: GitHub 可达性、`gh` 认证、REST API 响应、rate limit 和仓库公开状态都会影响本 eval；milestone 数量、issue 计数、截止日期与更新时间在未来运行中可能变化。
 - External-service failure: 若 `gh auth status` 失败、DNS/网络不可达、GitHub API 返回 401/403/429/5xx、或无法取得有效 JSON snapshot，本次运行应记为 **BLOCKED (external service)**，不得判为 skill regression，也不得以静态 mock 代替。
-- Valid empty result: API 成功但没有 open milestone 属于真实数据结果，不是外部失败；输出应明确“当前无 open milestone”，再按 prompt 与可用的 recent closed 数据解释无法比较 active 进度。此时 assertion 1 的可满足性需由 fresh judge结合实时数据重新判断，不能虚构最慢或逾期对象。
+- Valid empty result: API 成功但没有 open milestone 属于真实数据结果，不是外部失败；输出应明确“当前无 open milestone”，再按 prompt 与可用的 recent closed 数据解释无法比较 active 进度。此时 assertion 1 的可满足性需由 fresh judge 结合实时数据重新判断，不能虚构最慢或逾期对象。
 - Skill regression: API 成功且 snapshot 可用，但 with-skill 未给出 open/closed 或完成率、把 `due_on: null` 误判成逾期、未明确回答“哪个最慢/逾期”，或未使用协议规定的 emoji 状态标识，才属于 skill 行为回归。
 - Time-validity risk: 本文件的数值只代表上述抓取时点；未来复验必须重新抓取并记录新 snapshot，不能复用本轮数据冒充 fresh 结果。
 
@@ -92,7 +81,7 @@ Fresh without-skill behavior:
 ## Next Steps
 
 - 无需修改 fixture、`eval_metadata.json`、`evals.json` 或 specialist `SKILL.md`。
-- 后续 fresh eval 继续成对运行，并让两条路径共享同一次实时 snapshot 以隔离数据漂移。
+- 后续 fresh eval 继续让两条路径在相邻时间窗内各自实时查询，并分别记录抓取时间与查询范围；不得把父级 snapshot 或候选答案传给 baseline。
 
 ## Runtime Artifacts Policy
 

--- a/agents/product_manager/test/github-reader/evals/workspace/eval-003-milestone-focused/comparison.md
+++ b/agents/product_manager/test/github-reader/evals/workspace/eval-003-milestone-focused/comparison.md
@@ -7,39 +7,94 @@
 - Eval: `eval-003-milestone-focused`
 - Test case: milestone-focused
 - Workspace: `workspace/eval-003-milestone-focused`
-- Latest result: PARTIAL - prior skill validation evidence is preserved; without_skill baseline was not generated for this historical comparison.
-- Prior validation note: canonical comparison migration retained current-version result on 2026-06-02
+- Classification: `(c) 依赖实时外部数据`。该场景验证 specialist 是否通过 `gh` 查询真实 GitHub milestone；静态 fixture 会把时效性场景降级成 mock，因而不补造 fixture。
+- Latest result: **PASS**。2026-07-26 的 fresh paired validation 中，with-skill 在可用的实时快照上满足 3/3 assertions；同一快照生成的 fresh without-skill baseline 满足 2/3，未采用 skill 规定的 emoji 状态标识。
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: Verifies that github-reader handles milestone-focused and produces the expected role-specific artifact.
+- Prompt: `看一下 facebook/react 最近的 milestone，哪个进度最慢或者已经逾期了？`
 - Expected output: Milestone 状态报告，识别出进度最慢或逾期的 milestone，给出具体数据支撑
+- Fixture basis: prompt 与 `eval_metadata.json` 已足够定义目标仓库和查询意图；业务证据必须在运行时从 GitHub API 获取。
+- Fresh run: 当前会话中新启动的 Codex subagent；with-skill 与 without-skill 均为本轮新生成，未复用历史 baseline。
+
+## Live Data Snapshot
+
+- Fetched at: `2026-07-26 15:22:31 CST (+0800)` / `2026-07-26T07:22:31Z`
+- Access path: 已认证的 `gh` CLI 调用 GitHub REST API。
+- Repository resolution: 输入 `facebook/react`，GitHub 返回 canonical repository `react/react`（default branch `main`）。
+- Query scope: 全部 open milestones，以及全部 closed milestones中按 `updated_at` 降序取最近 10 个；open/closed 总数分别为 1/38。
+- API fields retained for judgment: `title`, `state`, `open_issues`, `closed_issues`, `due_on`, `created_at`, `updated_at`, `closed_at`, `html_url`。
+
+Open milestone snapshot:
+
+| Milestone | State | Open | Closed | Completion | Due on | Updated at |
+| --- | --- | ---: | ---: | ---: | --- | --- |
+| [19.0.0](https://github.com/react/react/milestone/40) | open | 5 | 6 | 54.5% | `null` | `2024-06-29T16:17:34Z` |
+
+Recent closed snapshot (按 `updated_at` 降序):
+
+| Milestone | State | Open | Closed | Completion | Due on | Updated at |
+| --- | --- | ---: | ---: | ---: | --- | --- |
+| 15.4.1 | closed | 0 | 3 | 100% | `null` | `2017-10-04T11:52:45Z` |
+| 15.4.2 | closed | 0 | 1 | 100% | `null` | `2017-10-04T11:52:44Z` |
+| 15-lopri | closed | 0 | 45 | 100% | `null` | `2017-10-04T11:52:42Z` |
+| 15-hipri | closed | 0 | 16 | 100% | `null` | `2017-10-04T11:52:41Z` |
+| 15.6 | closed | 0 | 29 | 100% | `null` | `2017-10-04T11:52:40Z` |
+| 16.0 | closed | 0 | 69 | 100% | `null` | `2017-10-04T11:52:38Z` |
+| seb | closed | 0 | 0 | N/A | `null` | `2016-11-29T01:06:45Z` |
+| 15.4.0 | closed | 0 | 93 | 100% | `null` | `2016-11-22T22:43:01Z` |
+| 15.3.2 | closed | 0 | 17 | 100% | `null` | `2016-09-19T17:53:29Z` |
+| 15.3.1 | closed | 0 | 35 | 100% | `null` | `2016-09-08T17:39:56Z` |
+
+The live data does not support an overdue claim: the only open milestone has no `due_on`. It does support identifying `19.0.0` as the slowest active milestone because it is the sole open milestone and is 6/11 complete (54.5%).
 
 ## Assertions
 
-- `assertion_1`: 有逾期或慢速判断
-- `assertion_2`: 有完成率数据
-- `assertion_3`: 状态图例一致
+| Assertion | With skill | Without skill | Fresh judge evidence |
+| --- | --- | --- | --- |
+| `assertion_1`：明确指出逾期或进度最慢 | PASS | PASS | 两边都明确说明没有证据判定逾期，并把唯一 active milestone `19.0.0` 判为当前进度最慢；没有把 `due_on: null` 误报成逾期。 |
+| `assertion_2`：每个 milestone 有 open/closed 或完成率 | PASS | PASS | 两边都给出 `19.0.0` 的 5 open、6 closed 和 54.5%；with-skill 还以表格区分近期已关闭 milestones。 |
+| `assertion_3`：使用规定 emoji 状态标识 | PASS | FAIL | with-skill 按协议使用 `⚪ 无截止日期`；baseline 只写“无截止日期”，未使用 `✅🟢🟡🔴⚪` 状态标识。 |
 
 ## With Skill
 
-Observed behavior:
+Fresh with-skill behavior:
 
-- 保留并迁移 iteration-2 最新 comparison。该结果已基于当前 github-reader skill 版本，覆盖 milestone 逾期或进度最慢判断、完成率数据和状态图例。
+- 读取 PM Agent README 与当前 `github-reader` skill，判定为 milestone-focused query，仅抓取所需 milestone 数据。
+- 通过 `gh` 解析目标仓库，并保留抓取时间、查询范围和用于计算的 API 字段。
+- 将 `19.0.0` 报告为 `5/11 (54.5%)`、`⚪ 无截止日期`；明确指出“无截止日期”不等于逾期。
+- 在只有一个 open milestone 的真实数据边界下，明确说明 `19.0.0` 是当前 active 集合中进度最慢，而不是虚构另一个比较对象。
+- 对最近 closed milestones 给出 open/closed 与完成率证据；对 0/0 的 `seb` 标记为 N/A，未制造除零百分比。
 
 ## Without Skill / Baseline
-- BLOCKED: No actual without_skill baseline result is recorded for this historical comparison. This file is not treated as a full eval PASS until a baseline result is generated and written here.
-- This comparison records whether the skill-specific protocol, routing, evidence, or artifact expectations are preserved.
+
+Fresh without-skill behavior:
+
+- 在不读取或应用 `github-reader` skill 与 PM Agent README 的条件下，仅使用原始 prompt 和与 with-skill 相同的 2026-07-26 API snapshot 重新生成。
+- 正确识别 canonical repository、唯一 open milestone、54.5% 完成率以及无可证实的逾期 milestone。
+- 结论仍有事实依据，因此通过 assertions 1 和 2。
+- 采用普通文本“无截止日期”，没有 skill 规定的 emoji 状态标识，因此不满足 assertion 3。
+
+## External Dependency and Failure Attribution
+
+- External dependency: GitHub 可达性、`gh` 认证、REST API 响应、rate limit 和仓库公开状态都会影响本 eval；milestone 数量、issue 计数、截止日期与更新时间在未来运行中可能变化。
+- External-service failure: 若 `gh auth status` 失败、DNS/网络不可达、GitHub API 返回 401/403/429/5xx、或无法取得有效 JSON snapshot，本次运行应记为 **BLOCKED (external service)**，不得判为 skill regression，也不得以静态 mock 代替。
+- Valid empty result: API 成功但没有 open milestone 属于真实数据结果，不是外部失败；输出应明确“当前无 open milestone”，再按 prompt 与可用的 recent closed 数据解释无法比较 active 进度。此时 assertion 1 的可满足性需由 fresh judge结合实时数据重新判断，不能虚构最慢或逾期对象。
+- Skill regression: API 成功且 snapshot 可用，但 with-skill 未给出 open/closed 或完成率、把 `due_on: null` 误判成逾期、未明确回答“哪个最慢/逾期”，或未使用协议规定的 emoji 状态标识，才属于 skill 行为回归。
+- Time-validity risk: 本文件的数值只代表上述抓取时点；未来复验必须重新抓取并记录新 snapshot，不能复用本轮数据冒充 fresh 结果。
 
 ## Failures
 
-- None recorded in the migrated current-version comparison.
+- With-skill: none.
+- Without-skill baseline: 缺少 skill 规定的 emoji milestone 状态标识（`assertion_3`）。
 
 ## Next Steps
 
-- 本轮未重新运行；保持 canonical workspace 下的最新 durable comparison。
+- 无需修改 fixture、`eval_metadata.json`、`evals.json` 或 specialist `SKILL.md`。
+- 后续 fresh eval 继续成对运行，并让两条路径共享同一次实时 snapshot 以隔离数据漂移。
 
 ## Runtime Artifacts Policy
 
-- Runtime transcripts, verdicts, timing, outputs, and diagnostics should not be committed.
+- 本次只更新 durable `comparison.md`。
+- Runtime transcripts、candidate outputs、verdicts、timing、API dumps、diagnostics 与临时 snapshot 不提交到 git。


### PR DESCRIPTION
## 背景

完成 issue #158 第二批 9 个证据债务 eval 的逐项分类与 fresh paired validation。第一批 PR #168 已处理的 17 个 eval 和 #143 的 Security eval 均未重复修改。

本 PR 不修改 specialist `SKILL.md`、PM-first entry gate 或 `evals.json` assertions，也不添加伪造的 GitHub / 网页 fixture。提交范围只有 9 个 canonical `comparison.md`。

## 分类结论

| Eval | 分类 | 理由 |
| --- | --- | --- |
| `project-bootstrap/eval-002-defer-bootstrap-without-spec` | (a) fixture 已足够 | 空 workspace 与无 PRD/TRD 正是负向场景，补 spec 会破坏测试语义。 |
| `trd-gen/eval-004-api-adr-owned-by-engineer` | (a) fixture 已足够 | 已有 Approved 嵌套 PRD 与 README，提供稳定 scope、feature path、API/ADR 决策上下文。 |
| `changelog-generator/eval-003-prefix-classification` | (a) fixture 已足够 | PR 标题、正文、编号和 docs/test/ci 语义判断要求全部内嵌 prompt。 |
| `changelog-generator/eval-001-unreleased-mode` | (c) 实时 GitHub 数据 | 必须读取当前 release 与 release 后 merged PR，不能用 mock 代替。 |
| `changelog-generator/eval-002-single-version-mode` | (c) 实时 GitHub 数据 | 必须读取最新/前一 release、PR 窗口和 tag compare。 |
| `github-reader/eval-001-full-status` | (c) 实时 GitHub 数据 | milestone、issue、PR 队列与近期活动均为实时仓库状态。 |
| `github-reader/eval-002-focused-pr-query` | (c) 实时 GitHub 数据 | open PR、review decision、draft 与等待时间会持续变化。 |
| `github-reader/eval-003-milestone-focused` | (c) 实时 GitHub 数据 | milestone 数量、进度和截止日期来自当前 GitHub API。 |
| `competitive-brief/eval-001-positioning-gap-brief` | (c) 实时公开网页 | Linear / Jira 定位、功能、定价与发布信息需要当前公开来源。 |

本批没有 (b) 类 eval，不需要补最小 fixture。

## Fresh paired validation

每个 eval 均由当前会话中新启动的独立 Codex subagent 使用同一 prompt 和 fixture 重新生成 `with_skill` 与新的 `without_skill` baseline；未复用历史 baseline，未提交 transcript、verdict、diagnostics 或 outputs。

| Eval | with_skill | without_skill | 最新结论 |
| --- | --- | --- | --- |
| `project-bootstrap/eval-002` | 3/3 | 0/3 | PASS |
| `trd-gen/eval-004` | 5/5 | 5/5 | PASS |
| `changelog-generator/eval-003` | 13/13 | 13/13 | PASS |
| `changelog-generator/eval-001` | 5/5 | 5/5 | PASS；release 后窗口为空，未伪造 PR |
| `changelog-generator/eval-002` | 4/5，1 项未覆盖 | 4/5，1 项未覆盖 | PARTIAL；当前窗口仅有 bot 发布 PR，普通 PR 标题清洗无样本 |
| `github-reader/eval-001` | 3/4 | 2/4 | PARTIAL；目标仓库当前无 open milestone，skill 正确执行 no-milestone edge case |
| `github-reader/eval-002` | 3/3 | 3/3 | PASS |
| `github-reader/eval-003` | 3/3 | 2/3 | PASS |
| `competitive-brief/eval-001` | 3/3 | 3/3 | PASS |

两项 PARTIAL 均已补齐 fresh baseline，且未发现 skill 回归。保留 PARTIAL 是因为实时外部数据没有 assertion 假定的实体；没有把 bot/commit 冒充普通 PR，也没有伪造 milestone。

## 实时证据

- `anthropics/anthropic-sdk-python` changelog 快照：2026-07-26 15:18-15:20 CST。
- `anthropics/anthropic-sdk-python` full-status 快照：2026-07-26 15:19 CST。
- `cli/cli` focused PR 快照：2026-07-26 15:22 CST。
- `facebook/react` milestone 查询由 GitHub 规范化到 `react/react`：2026-07-26 15:22 CST。
- Linear / Jira：2026-07-26 15:22 CST 访问 8 个官方公开页面。

每份实时 comparison 均记录了仓库或 URL、抓取时间、snapshot 摘要、联网/API 依赖、时效风险，以及外部服务失败与 skill 回归的区分方式。

## 验证

- `uv run scripts/check_repository_contract.py`：PASS
- `uv run scripts/check_eval_contract.py`：PASS
- `uv run scripts/check_eval_artifacts.py`：PASS
- `uv run scripts/check_doc_contract.py`：PASS
- 指定确定性 pytest：133 passed
- `git diff --check`：PASS

## 剩余风险

- 实时仓库状态和厂商网页会继续变化，后续复验必须重新抓取，不能复用本轮 snapshot。
- `changelog-generator/eval-002` 需要未来出现非 bot PR 的 latest-release 窗口，才能正向覆盖普通 PR conventional-prefix 清洗。
- `github-reader/eval-001` 的 milestone assertion 与当前 skill 的 no-milestone edge case 在目标仓库无开放 milestone 时存在字面冲突；本 PR 按非目标约束不放宽 assertion。
- prompt 已提供完整规则的 eval 可能让 without-skill 同样 PASS；comparison 已记录其区分度风险。

Closes #158
