### PR TITLE
chore: 发布 v0.3.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "PM-first agent skill marketplace with one public pm-agent entry and downstream PM-orchestrated engineering, QA, DevOps, design, security, and documentation capabilities",
-    "version": "0.3.3"
+    "version": "0.3.4"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 仓库级发布变更记录按版本归档到 `docs/changelog/`。
 
+- [v0.3.4](./docs/changelog/changelog-v0.3.4.md)
 - [v0.3.3](./docs/changelog/changelog-v0.3.3.md)
 - [v0.3.2](./docs/changelog/changelog-v0.3.2.md)
 - [v0.3.1](./docs/changelog/changelog-v0.3.1.md)

--- a/agents/designer/.claude-plugin/plugin.json
+++ b/agents/designer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "designer-agent",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Downstream design capability invoked after pm-agent handoff for confirmed UX flows, information architecture, wireframes, reference-pattern analysis, and reference-backed visual system work.",
   "author": {
     "name": "Neplich"

--- a/agents/devops/.claude-plugin/plugin.json
+++ b/agents/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops-agent",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Downstream DevOps capability invoked after pm-agent handoff for confirmed deployment planning, CI/CD automation, environment audits, release readiness, rollback, and runbook preparation.",
   "author": {
     "name": "Neplich"

--- a/agents/docs/.claude-plugin/plugin.json
+++ b/agents/docs/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "docs-agent",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Downstream documentation capability invoked after pm-agent handoff for confirmed formal documentation bootstrap, synchronization, backfill, and release audit.",
   "author": {
     "name": "Neplich"

--- a/agents/engineer/.claude-plugin/plugin.json
+++ b/agents/engineer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "engineer-agent",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Downstream engineering capability invoked after pm-agent handoff for confirmed codebase analysis, TRDs, bootstrapping, implementation, tests, debugging, and delivery. Skills remain available for PM-orchestrated execution, not as standalone starting points.",
   "author": {
     "name": "Neplich"

--- a/agents/product_manager/.claude-plugin/plugin.json
+++ b/agents/product_manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pm-agent",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Default entry plugin for new user requests. Use when the user describes product ideas, feature requests, requirement changes, bugs, build/test/deploy/review/status requests, feature catalogs, competitive research, release communication, roadmaps, or GitHub project status. Classifies scope first, then routes to PM specialists or hands off to downstream role agents.",
   "author": {
     "name": "Neplich"

--- a/agents/product_manager/test/idea-to-spec/evals/workspace/eval-008-mapped-notification-update/comparison.md
+++ b/agents/product_manager/test/idea-to-spec/evals/workspace/eval-008-mapped-notification-update/comparison.md
@@ -2,36 +2,44 @@
 
 ## Evaluation Target
 
+- Agent: `product_manager`
 - Skill: `idea-to-spec`
 - Eval: `eval-008-mapped-notification-update`
+- Workspace: `workspace/eval-008-mapped-notification-update`
 
 ## Test Set / Fixture Version
 
-- Fixture: `ws1-consumption-v1`
-- Commit: `0b000b9`
+- Evaluation date: `2026-07-28`
+- Schema: `evals.json` v1.0
+- Fixture: mapped notification source, `change-map.yaml`, an `unverified` notification API page, and `channels.txt` with email as the only enabled channel.
+- Run: fresh Codex evaluator with a separately isolated, newly generated `without_skill` baseline.
 
 ## Latest Result
 
-**PASS** — with-skill 以代码证据确认仅 email 启用，把文档声称的 webhook 支持结构化记录为分歧，按 standard 分级推进现有功能更新并回用户确认关键决策。
+**PASS** — all 3 assertions passed. With-skill precisely followed the change map, verified the current channel from code, reported the webhook documentation drift, and treated `unverified` documentation as lowest trust.
 
 ## With-Skill Behavior
 
-- 命中映射文档后以 src 代码核证渠道能力，明确区分'代码已证实 / 文档声称但无证据'。
-- 分歧以文档声明/代码事实/影响结构化记录；未虚构供应商、接口与数据模型；正确停在 PM 决策点。
+- 从 `src/notifications/` 反查 `change-map.yaml`，只读取命中的 `docs/site/api/notifications.md`。
+- 以 `src/notifications/channels.txt` 的 email-only 事实作为 ground truth，没有用文档覆盖代码。
+- 结构化说明 webhook 分歧、SMS delta 与影响范围，不虚构供应商、接口或数据模型。
+- 正确停在一个产品范围决策点。
 
 ## Without-Skill Baseline
 
-- 来源：本次 fresh `codex exec` 独立子进程，同一原始 prompt 与 fixture，未接触 skill 或消费契约提示。
-- baseline 走了合理的 PM 澄清流程，但未结构化记录文档与代码的渠道能力分歧，对文档声明的采信边界不明确。
+- 来源：本次 fresh 严格隔离子代理，使用相同 prompt 与 fixture，未读取或应用目标 skill、PM Agent README、内部指令或历史 comparison。
+- baseline 也正确使用映射、降低 `unverified` 文档信任并回代码核证；fixture 的事实线索本身较强。baseline 仅作为对照，不影响 with-skill 对三条 assertions 的直接满足。
 
 ## Failures
 
-- 无。
+- 无 assertion failure 或 baseline blocker。
+- PR #163 新增的部署完整性收尾在本场景不触发：这里只消费 `docs/site` 证据，没有完成 Docs content batch、bootstrap、Release Notes 或构建入口变更；未发现回归。
 
 ## Next Steps
 
-- 保留本结果；后续 fixture 可增加干扰文档以放大行为差距。
+- 保留本用例作为 change-map、代码 ground truth 与文档信任模型的回归覆盖。
+- 后续可加入无关站点页面，进一步验证精准读取边界。
 
 ## Runtime Artifact Policy
 
-- 运行期产物只存放于 `tmp/eval-runs/`，不提交到 git。
+- with/without responses、verdict、timing 与 diagnostics 仅保留在 `tmp/eval-runs/idea-to-spec-v0.3.4/`，不提交到 git。

--- a/agents/product_manager/test/idea-to-spec/workspace/iteration-1/eval-1-existing-project-feature/comparison.md
+++ b/agents/product_manager/test/idea-to-spec/workspace/iteration-1/eval-1-existing-project-feature/comparison.md
@@ -7,43 +7,40 @@
 - Eval: `eval-001-existing-project-feature-design`
 - Test case: existing-project-feature-design
 - Workspace: `workspace/iteration-1/eval-1-existing-project-feature`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
+- Evaluation date: `2026-07-28`
 - Schema: `evals.json` v1.0
-- Fixture: existing web app with partial docs, app catalog TRD, and working app-tags PM draft / DECISIONS docs
-- Expected output: start with context summary, advance one decision point, present 2-3 options and trade-offs, progress by section, and use `DECISIONS.md` / feature docs as durable memory.
+- Fixture: cleaned existing Web app workspace with Next.js markers and an app-catalog TRD; stale `docs/pm/app-tags/` output was excluded through `execution_cleanup`.
+- Run: fresh Codex evaluator with a separately isolated, newly generated `without_skill` baseline.
 
-## Assertions
+## Latest Result
 
-- `assertion_1`: context detection first
-- `assertion_2`: one decision point at a time
-- `assertion_3`: key trade-offs include 2-3 options
-- `section`: section-based confirmation
-- `assertion_5`: durable memory through `DECISIONS.md` or feature docs
+**PASS** — all 5 assertions passed. The with-skill response starts with context detection, advances one section and one decision point, presents three options with trade-offs, and names `DECISIONS.md` / PM feature docs as durable memory.
 
-## With Skill
+## With-Skill Behavior
 
-- `idea-to-spec` requires Phase 0 workspace and document context detection before formal design, then selects `existing-project-feature` for an existing repo adding app tags.
-- The non-negotiable protocol requires one decision point per turn, 2-3 options with trade-offs when choices matter, and section-based progression.
-- The fixture has an existing app catalog TRD plus `docs/pm/app-tags/DECISIONS.md` and `design.md`; with skill, those documents are treated as durable memory rather than ignored or overwritten.
-- New or updated formal PM docs must preserve `feature_path=app-tags`, `feature=app-tags`, `parent_feature=N/A`, and `feature_level=1`.
+- Identified the lane as `existing-project-feature` and used the cleaned workspace state rather than prior output.
+- Compared discovery/filtering, admin classification, and combined scope with explicit benefits, costs, and a recommendation.
+- Required confirmation of Section 1 before moving to the next decision.
+- Reserved `docs/pm/app-tags/DECISIONS.md`, `design.md`, and `PRD.md` for confirmed decisions.
 
-## Without Skill / without_skill Baseline
+## Without-Skill Baseline
 
-- The baseline read the eval item and fixture before target skill docs. A generic PM response could jump straight to a full design or implementation plan before context detection and confirmation.
-- It may not enforce one decision per turn, section confirmation, or durable decision logging in `DECISIONS.md`.
+- Source: fresh isolated subagent run using the same prompt and cleaned fixture; it did not read or apply the target skill, PM Agent README, internal instructions, or historical comparison.
+- The baseline also inspected context and offered three options, but did not explicitly use the section protocol or name `DECISIONS.md`; the with-skill response follows the tested protocol and memory contract more completely.
 
 ## Failures
 
-- None. The current `idea-to-spec` protocol satisfies all first-turn and durable-memory assertions.
+- No assertion failures or baseline blockers.
+- PR #163's conditional Documentation Site Deployment Completeness closeout was not triggered and caused no regression.
 
 ## Next Steps
 
 - Keep this eval focused on first-turn PM design discipline.
-- Add a separate multi-turn artifact eval only if final PRD / DECISIONS generation needs automated content validation.
+- Re-run fresh validation when conversation protocol, durable-memory rules, or Docs closeout routing changes.
 
 ## Runtime Artifacts Policy
 
-- No runtime artifacts were created or committed. Transcripts, verdicts, timing, outputs, and diagnostics must remain outside git.
+- Responses, verdicts, timing, and diagnostics remain under `tmp/eval-runs/idea-to-spec-v0.3.4/` and are not committed.

--- a/agents/product_manager/test/idea-to-spec/workspace/iteration-1/eval-2-existing-project-update/comparison.md
+++ b/agents/product_manager/test/idea-to-spec/workspace/iteration-1/eval-2-existing-project-update/comparison.md
@@ -7,42 +7,40 @@
 - Eval: `eval-002-existing-project-update`
 - Test case: existing-project-update
 - Workspace: `workspace/iteration-1/eval-2-existing-project-update`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
+- Evaluation date: `2026-07-28`
 - Schema: `evals.json` v1.0
-- Fixture: approved notification-center PRD, DECISIONS, and Engineer TRD covering a polling baseline and event-driven migration direction
-- Expected output: recognize `existing-project-update`, summarize delta and blast radius first, prefer `change-impactor` / iteration over full regeneration, and name affected docs.
+- Fixture: approved notification-center PRD, DECISIONS, and Engineer TRD covering polling plus the confirmed event-driven migration direction.
+- Run: fresh Codex evaluator with a separately isolated, newly generated `without_skill` baseline.
 
-## Assertions
+## Latest Result
 
-- `update`: recognize existing update
-- `delta_blast_radius`: start with delta and blast radius
-- `assertion_3`: prefer iteration over rewrite
-- `assertion_4`: name affected feature docs or document types
+**PASS** — all 4 assertions passed. The response recognizes an `existing-project-update`, explains the delta and blast radius first, prefers `change-impactor` plus targeted iteration, and names every affected document path.
 
-## With Skill
+## With-Skill Behavior
 
-- `idea-to-spec` selects `existing-project-update` when approved behavior, rollout, or scope changes.
-- The shared skill map requires `change-impactor` first when blast radius is unclear, then targeted iteration rather than full regeneration.
-- The fixture docs establish the affected paths: `docs/pm/notification-center/PRD.md`, `docs/pm/notification-center/DECISIONS.md`, and `docs/engineer/notification-center/TRD.md`.
-- The current docs preserve the hybrid event-driven transition and rejected permanent polling-only option, so the update path can describe delta, impacted docs, and revision order without reopening unrelated decisions.
+- Preserved the confirmed `hybrid transition` and the rejected permanent polling-only option instead of silently reopening decision history.
+- Mapped impact to `DECISIONS.md`, PM PRD, Engineer TRD, and later QA coverage.
+- Routed Engineer TRD revision to `engineer-agent:trd-gen` and avoided full regeneration.
+- Advanced only the fallback user-behavior decision.
 
-## Without Skill / without_skill Baseline
+## Without-Skill Baseline
 
-- The baseline read the eval item and fixture before target skill docs. A generic response could treat the request as a net-new design or rewrite the PRD/TRD wholesale.
-- It may miss the decision-history requirement to revise or retire the prior polling decision instead of silently replacing it.
+- Source: fresh isolated subagent run using the same prompt and fixture without the target skill, PM Agent README, internal instructions, or historical comparison.
+- The baseline also identified a targeted update and the three main documents, but did not name `change-impactor`, `prd-iteration`, or the dependency-ordered lifecycle route.
 
 ## Failures
 
-- None. The current `idea-to-spec` and `change-impactor` routing satisfy all update assertions.
+- No assertion failures or baseline blockers.
+- PR #163's Docs deployment-completeness closeout did not apply to this feature update and caused no regression.
 
 ## Next Steps
 
-- Keep this eval as existing-project update coverage.
-- Re-run fresh validation if change impact, iteration ordering, or document-memory rules change.
+- Keep this eval as coverage for decision-history preservation and targeted update routing.
+- Re-run when impact analysis, iteration ownership, or Docs closeout rules change.
 
 ## Runtime Artifacts Policy
 
-- No runtime artifacts were created or committed. Transcripts, verdicts, timing, outputs, and diagnostics must remain outside git.
+- Responses, verdicts, timing, and diagnostics remain under `tmp/eval-runs/idea-to-spec-v0.3.4/` and are not committed.

--- a/agents/product_manager/test/idea-to-spec/workspace/iteration-1/eval-3-greenfield-discovery/comparison.md
+++ b/agents/product_manager/test/idea-to-spec/workspace/iteration-1/eval-3-greenfield-discovery/comparison.md
@@ -7,41 +7,39 @@
 - Eval: `eval-003-greenfield-discovery`
 - Test case: greenfield-discovery
 - Workspace: `workspace/iteration-1/eval-3-greenfield-discovery`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
+- Evaluation date: `2026-07-28`
 - Schema: `evals.json` v1.0
-- Fixture: vague team knowledge Q&A idea with minimal notes and no formal docs or technical stack
-- Expected output: stay in `greenfield-discovery`, avoid full PRD/TRD generation, use one-decision discovery, and recommend document generation only after direction stabilizes.
+- Fixture: near-empty team knowledge Q&A workspace with minimal notes, no formal PM docs, and no selected stack.
+- Run: fresh Codex evaluator with a separately isolated, newly generated `without_skill` baseline.
 
-## Assertions
+## Latest Result
 
-- `assertion_1`: no complete document on the first turn
-- `assertion_2`: use exploratory single-decision protocol
-- `assertion_3`: recommend documentation after the direction stabilizes
+**PASS** — all 3 assertions passed. The response stays in `greenfield-discovery`, avoids premature PRD/TRD generation, advances one discovery decision, and defers durable documentation until the direction stabilizes.
 
-## With Skill
+## With-Skill Behavior
 
-- `idea-to-spec` maps vague ideas and near-empty workspaces to `greenfield-discovery`.
-- Its non-negotiable protocol blocks immediate full PRD/TRD generation and advances one decision point at a time.
-- It keeps the feature path unresolved until problem, users, scope, constraints, and assumptions are stable enough to document.
-- It can recommend future PRD / DECISIONS documentation, but only after the discovery direction is confirmed.
+- Reported the near-empty context and avoided assumptions about knowledge sources, permissions, or answer-quality metrics.
+- Compared three primary use cases with trade-offs and asked only for the first scenario decision.
+- Deferred `feature_path`, `DECISIONS.md`, and PRD creation until problem, user, and MVP boundaries are stable.
 
-## Without Skill / without_skill Baseline
+## Without-Skill Baseline
 
-- The baseline read the eval item and fixture before target skill docs. A generic PM response could produce a premature PRD outline or implementation plan from the vague idea.
-- It may ask several broad questions at once rather than using a single focused decision point.
+- Source: fresh isolated subagent run using the same prompt and fixture without the target skill, PM Agent README, internal instructions, or historical comparison.
+- The baseline also avoided a premature PRD and asked one target-user question; the with-skill response additionally makes the lane, feature-path timing, and durable-memory contract explicit.
 
 ## Failures
 
-- None. The current `idea-to-spec` protocol satisfies all greenfield discovery assertions.
+- No assertion failures or baseline blockers.
+- PR #163's conditional Docs closeout was not triggered during discovery and caused no regression.
 
 ## Next Steps
 
-- Keep this eval as first-turn discovery discipline coverage.
-- Re-run fresh validation if greenfield lane selection or document timing changes.
+- Keep this eval as first-turn greenfield discovery coverage.
+- Re-run when lane selection, single-decision progression, or document timing changes.
 
 ## Runtime Artifacts Policy
 
-- No runtime artifacts were created or committed. Transcripts, verdicts, timing, outputs, and diagnostics must remain outside git.
+- Responses, verdicts, timing, and diagnostics remain under `tmp/eval-runs/idea-to-spec-v0.3.4/` and are not committed.

--- a/agents/product_manager/test/idea-to-spec/workspace/iteration-2/eval-4-greenfield-bootstrap-routing/comparison.md
+++ b/agents/product_manager/test/idea-to-spec/workspace/iteration-2/eval-4-greenfield-bootstrap-routing/comparison.md
@@ -7,42 +7,40 @@
 - Eval: `eval-004-greenfield-bootstrap-routing`
 - Test case: greenfield-bootstrap-routing
 - Workspace: `workspace/iteration-2/eval-4-greenfield-bootstrap-routing`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
+- Evaluation date: `2026-07-28`
 - Schema: `evals.json` v1.0
-- Fixture: empty-workspace AI chat assistant request; `eval_metadata.json` lists `PRD.md` as execution cleanup for stale runtime output
-- Expected output: Phase 0 empty-workspace context summary, PM-first `greenfield-discovery` or `greenfield-bootstrap`, no code scaffold, and PM documentation next step.
+- Fixture: empty-workspace AI chat assistant request; stale root `PRD.md` was excluded through `execution_cleanup`.
+- Run: fresh Codex evaluator with a separately isolated, newly generated `without_skill` baseline.
 
-## Assertions
+## Latest Result
 
-- `assertion_1`: empty workspace / docs context first
-- `pm_first_lane`: PM-first lane selection
-- `pm_first`: no direct engineering scaffold
-- `assertion_4`: document-oriented next step
+**PASS** — all 4 assertions passed. The response starts with the empty-workspace context, selects a PM-first `greenfield-bootstrap` lane, explicitly rejects engineering scaffolding, and names durable PM documents as the next step.
 
-## With Skill
+## With-Skill Behavior
 
-- `idea-to-spec` requires Phase 0 context detection and keeps empty product requests in PM lanes unless the user explicitly opts out.
-- Because the user asks for PRD shaping rather than code, the correct lane is `greenfield-bootstrap` or a `greenfield-discovery` first step that may load `project-init` for durable docs.
-- `project-init` creates documentation scaffolding only when appropriate and records API / ADR needs as Engineer handoff, not immediate code scaffolding.
-- The stale `PRD.md` listed in `execution_cleanup` does not weaken the expected behavior; fresh validation treats cleanup metadata as a signal not to reuse prior runtime output as the answer.
+- Did not reuse the stale root PRD or infer an existing stack.
+- Explicitly avoided `npm create vite`, `create-next-app`, and equivalent scaffolds.
+- Proposed `project-init`, `DECISIONS.md`, and `PRD.md` only after the first product-positioning decision is confirmed.
+- Kept the proposed `feature_path` provisional.
 
-## Without Skill / without_skill Baseline
+## Without-Skill Baseline
 
-- The baseline read the eval item and fixture before target skill docs. A generic response could run or recommend `create-next-app`, `npm create vite`, or another scaffold because the layout is concrete.
-- It could also accept stale `PRD.md` content without first stating empty-workspace context or PM-first routing.
+- Source: fresh isolated subagent run using the same prompt and cleaned fixture without the target skill, PM Agent README, internal instructions, or historical comparison.
+- The baseline also avoided engineering setup, but immediately produced a broad PRD skeleton and multiple unresolved questions; the with-skill response follows the single-decision and durable-doc gate more strictly.
 
 ## Failures
 
-- None. The current `idea-to-spec` and `project-init` contract satisfies all greenfield bootstrap routing assertions.
+- No assertion failures or baseline blockers.
+- PR #163's post-Docs deployment completeness check did not apply because no docs-site bootstrap or confirmed commit occurred.
 
 ## Next Steps
 
-- Keep this eval as PM-first coverage for empty-workspace app requests.
-- Re-run fresh validation if project-init or stale runtime cleanup behavior changes.
+- Keep this eval as PM-first empty-workspace routing coverage.
+- Re-run when `project-init`, execution cleanup, or Docs completion routing changes.
 
 ## Runtime Artifacts Policy
 
-- No runtime artifacts were created or committed. Transcripts, verdicts, timing, outputs, and diagnostics must remain outside git.
+- Responses, verdicts, timing, and diagnostics remain under `tmp/eval-runs/idea-to-spec-v0.3.4/` and are not committed.

--- a/agents/product_manager/test/idea-to-spec/workspace/iteration-2/eval-5-pm-agent-direct-delegation/comparison.md
+++ b/agents/product_manager/test/idea-to-spec/workspace/iteration-2/eval-5-pm-agent-direct-delegation/comparison.md
@@ -7,41 +7,40 @@
 - Eval: `eval-005-pm-agent-direct-delegation`
 - Test case: pm-agent-direct-delegation
 - Workspace: `workspace/iteration-2/eval-5-pm-agent-direct-delegation`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
+- Evaluation date: `2026-07-28`
 - Schema: `evals.json` v1.0
-- Fixture: `/pm-agent` entry command for a greenfield AI chat assistant idea
-- Expected output: route through PM entry, immediately continue into `idea-to-spec` requirement shaping, and avoid dispatcher-only meta-answer.
+- Fixture: `/pm-agent` entry command for a near-empty AI chat assistant product request.
+- Run: fresh Codex evaluator with a separately isolated, newly generated `without_skill` baseline.
 
-## Assertions
+## Latest Result
 
-- `dispatcher`: dispatcher directly drills into `idea-to-spec`
-- `skill`: no "do you want me to invoke" handoff question
-- `pm`: same response continues product positioning, MVP, scope, or requirement shaping
+**PASS** — all 3 assertions passed. The PM dispatcher immediately continues into `idea-to-spec` context detection and requirement shaping instead of stopping at a routing answer or asking whether to invoke the specialist.
 
-## With Skill
+## With-Skill Behavior
 
-- `pm-agent` treats the request as a PM-first new product idea and selects `idea-to-spec`.
-- The downstream execution contract says the dispatcher must immediately continue with the selected PM skill in the same response.
-- It must not stop at a meta-routing answer, ask whether to invoke `idea-to-spec`, or tell the user to run a manual sub-skill command.
-- The expected next behavior is `idea-to-spec` Phase 0 context summary and requirement-shaping prompt for the left-history / right-chat product.
+- Explicitly classified the request through the PM entry and directly entered `idea-to-spec`.
+- Selected `greenfield-discovery` despite the concrete two-column layout.
+- Continued in the same response with three product-positioning options and one confirmation point.
+- Did not request a manual `/pm-agent:idea-to-spec` invocation.
 
-## Without Skill / without_skill Baseline
+## Without-Skill Baseline
 
-- The baseline read the eval item and fixture before target skill docs. A generic dispatcher could only recommend `idea-to-spec` and wait for user confirmation.
-- It may not continue into product positioning, MVP scope, or requirement questions in the same turn.
+- Source: fresh isolated subagent run using the same prompt and fixture without the target skill, PM Agent README, internal instructions, or historical comparison.
+- The baseline also produced reasonable PM content, but did not demonstrate the tested PM dispatcher-to-specialist direct-delegation contract.
 
 ## Failures
 
-- None. The current `pm-agent` downstream execution contract and `idea-to-spec` entry behavior satisfy all delegation assertions.
+- No assertion failures or baseline blockers.
+- PR #163's Docs deployment-completeness closeout did not apply and did not interrupt same-turn PM routing.
 
 ## Next Steps
 
-- Keep this eval as coverage for PM dispatcher direct delegation.
-- Re-run fresh validation if `pm-agent` routing output behavior changes.
+- Keep this eval as coverage for direct PM dispatcher delegation.
+- Re-run when PM downstream execution or Docs closeout routing changes.
 
 ## Runtime Artifacts Policy
 
-- No runtime artifacts were created or committed. Transcripts, verdicts, timing, outputs, and diagnostics must remain outside git.
+- Responses, verdicts, timing, and diagnostics remain under `tmp/eval-runs/idea-to-spec-v0.3.4/` and are not committed.

--- a/agents/product_manager/test/idea-to-spec/workspace/iteration-3/eval-6-nested-feature-path/comparison.md
+++ b/agents/product_manager/test/idea-to-spec/workspace/iteration-3/eval-6-nested-feature-path/comparison.md
@@ -7,42 +7,41 @@
 - Eval: `eval-006-nested-feature-path`
 - Test case: nested-feature-path
 - Workspace: `workspace/iteration-3/eval-6-nested-feature-path`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
+- Evaluation date: `2026-07-28`
 - Schema: `evals.json` v1.0
-- Fixture: approved PM PRDs for `chat-interface`, `chat-interface/messages`, and `chat-interface/messages/history`
-- Expected output: scan existing PRDs, resolve search under `chat-interface/messages/history/search`, avoid parallel / truncated paths, and include feature path fields in the handoff packet.
+- Fixture: approved PRDs for `chat-interface`, `chat-interface/messages`, and `chat-interface/messages/history`; all candidate stale child paths were excluded through `execution_cleanup`.
+- Run: fresh Codex evaluator with a separately isolated, newly generated `without_skill` baseline.
 
-## Assertions
+## Latest Result
 
-- `scan_existing_prds`: scan or read existing PM PRDs first
-- `nested_feature_path`: resolve to `chat-interface/messages/history/search`
-- `no_parallel_top_level`: do not choose `docs/pm/history-search/PRD.md` or `docs/pm/chat-interface/history-search/PRD.md`
-- `handoff_fields`: include `feature_path`, `feature`, `parent_feature`, `feature_level`, and `feature_path_evidence`
+**PASS** — all 4 assertions passed. The response scans the existing PRD chain, resolves `chat-interface/messages/history/search`, rejects parallel or truncated paths, and supplies all required feature-path fields with structured evidence.
 
-## With Skill
+## With-Skill Behavior
 
-- `idea-to-spec` requires scanning `docs/pm/**/PRD.md` before choosing or writing a feature folder.
-- The fixture establishes an approved parent chain: `chat-interface` -> `chat-interface/messages` -> `chat-interface/messages/history`.
-- Message history search is a child under the confirmed history feature, so the correct `feature_path` is `chat-interface/messages/history/search`, with `feature=search`, `parent_feature=chat-interface/messages/history`, and `feature_level=4`.
-- The handoff packet must include the feature path fields and `{source, reason}` evidence from the existing PRDs.
+- Read the complete three-level parent chain before choosing a child path.
+- Produced `feature=search`, `parent_feature=chat-interface/messages/history`, and `feature_level=4`.
+- Used `{source, reason}` entries for `feature_path_evidence`.
+- Kept the handoff not ready until search scope is confirmed and asked only one scope question.
 
-## Without Skill / without_skill Baseline
+## Without-Skill Baseline
 
-- The baseline read the eval item and fixture before target skill docs. A generic response could choose the shorter display-name path `docs/pm/history-search/PRD.md` or reuse the older two-level `docs/pm/chat-interface/history-search/PRD.md`.
-- It may also omit `parent_feature`, `feature_level`, or structured `feature_path_evidence`.
+- Source: fresh isolated subagent run using the same prompt and cleaned fixture without the target skill, PM Agent README, internal instructions, or historical comparison.
+- The baseline found the correct four-level path, but used plain path strings instead of `{source, reason}` evidence and non-standard route / owner fields.
 
 ## Failures
 
-- None. The current `idea-to-spec` feature document memory rules satisfy all nested feature path assertions.
+- No assertion failures or baseline blockers.
+- Non-blocking observation: the with-skill response formatted a not-ready PM continuation like a cross-role packet and used `downstream_owner: PM`, which is outside the cross-role owner enum. Because it explicitly marked the handoff not ready and all declared assertions passed, the result remains PASS.
+- PR #163's Docs deployment-completeness closeout was not triggered and caused no feature-path regression.
 
 ## Next Steps
 
-- Keep this eval as issue #37 coverage for multi-level PM feature ownership.
-- Re-run fresh validation if feature path inheritance or handoff fields change.
+- Keep this eval as multi-level feature ownership and handoff-evidence coverage.
+- Consider tightening a future assertion for not-ready PM packet shape and the `downstream_owner` enum.
 
 ## Runtime Artifacts Policy
 
-- No runtime artifacts were created or committed. Transcripts, verdicts, timing, outputs, and diagnostics must remain outside git.
+- Responses, verdicts, timing, and diagnostics remain under `tmp/eval-runs/idea-to-spec-v0.3.4/` and are not committed.

--- a/agents/product_manager/test/idea-to-spec/workspace/iteration-3/eval-7-api-adr-engineer-handoff/comparison.md
+++ b/agents/product_manager/test/idea-to-spec/workspace/iteration-3/eval-7-api-adr-engineer-handoff/comparison.md
@@ -7,42 +7,40 @@
 - Eval: `eval-007-api-adr-engineer-handoff`
 - Test case: api-adr-engineer-handoff
 - Workspace: `workspace/iteration-3/eval-7-api-adr-engineer-handoff`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
 
 ## Test Set / Fixture Version
 
+- Evaluation date: `2026-07-28`
 - Schema: `evals.json` v1.0
-- Fixture: confirmed PM PRD at `docs/pm/chat-interface/history-search/PRD.md`
-- Expected output: PM does not generate Engineer API or ADR docs directly; it hands a feature path packet to `engineer-agent:trd-gen` and mirrors output paths under `docs/engineer/chat-interface/history-search/`.
+- Fixture: confirmed PM PRD at `docs/pm/chat-interface/history-search/PRD.md`; stale Engineer output paths were excluded through `execution_cleanup`.
+- Run: fresh Codex evaluator with a separately isolated, newly generated `without_skill` baseline.
 
-## Assertions
+## Latest Result
 
-- `does_not_use_pm_api_adr_generators`: API and ADR are Engineer-owned
-- `routes_to_trd_gen`: next owner is `engineer-agent:trd-gen`
-- `engineer_paths_mirror_feature_path`: Engineer outputs mirror `chat-interface/history-search`
-- `handoff_contains_feature_path_evidence`: handoff packet includes feature path fields, PRD path, and API / ADR context
+**PASS** — all 4 assertions passed. The response keeps API and ADR Engineer-owned, routes them to `engineer-agent:trd-gen`, mirrors the complete feature path, and includes the required evidence and decision context.
 
-## With Skill
+## With-Skill Behavior
 
-- The shared `idea-to-spec` skill map routes API and ADR generation to `engineer-agent:trd-gen`; PM internal API / ADR resources are not used to create Engineer-owned documents.
-- The confirmed PRD provides `feature_path=chat-interface/history-search`, `parent_feature=chat-interface`, and `feature_level=2`.
-- The required Engineer-owned outputs are under `docs/engineer/chat-interface/history-search/`, including `API.md` and `ADR-*.md`, not `docs/engineer/history-search/`.
-- The handoff packet carries `feature_path`, `parent_feature`, `feature_level`, PRD source path, API goals, and search-index decision background.
+- Explicitly prohibited PM internal `api-gen` / `adr-gen` from creating Engineer artifacts.
+- Required `docs/engineer/chat-interface/history-search/API.md` and same-directory `ADR-*.md`.
+- Included standard cross-role packet fields, the approved PRD path, API scope, ADR decision background, and unresolved technical evidence.
+- Did not fabricate scale, latency, storage, or index-selection facts.
 
-## Without Skill / without_skill Baseline
+## Without-Skill Baseline
 
-- The baseline read the eval item and fixture before target skill docs. A generic PM response could directly draft API and ADR documents from the PRD.
-- It may also choose a terminal-only Engineer path such as `docs/engineer/history-search/`, losing the confirmed feature-path mirror.
+- Source: fresh isolated subagent run using the same prompt and cleaned fixture without the target skill, PM Agent README, internal instructions, or historical comparison.
+- The baseline retained Engineer ownership and the parent path, but did not route to `engineer-agent:trd-gen` and proposed an `ADR/` subdirectory instead of the canonical same-directory `ADR-*.md` shape.
 
 ## Failures
 
-- None. The current `idea-to-spec` ownership and handoff rules satisfy all API / ADR assertions.
+- No assertion failures or baseline blockers.
+- PR #163's Docs deployment-completeness closeout did not apply to this PM-to-Engineer handoff and caused no ownership regression.
 
 ## Next Steps
 
-- Keep this eval as PM coverage for Engineer-owned API / ADR handoff and path mirroring.
-- Re-run fresh validation if API / ADR ownership or Engineer handoff paths change.
+- Keep this eval as API / ADR ownership and full-path mirroring coverage.
+- Re-run when Engineer handoff ownership, canonical filenames, or Docs closeout routing changes.
 
 ## Runtime Artifacts Policy
 
-- No runtime artifacts were created or committed. Transcripts, verdicts, timing, outputs, and diagnostics must remain outside git.
+- Responses, verdicts, timing, and diagnostics remain under `tmp/eval-runs/idea-to-spec-v0.3.4/` and are not committed.

--- a/agents/qa/.claude-plugin/plugin.json
+++ b/agents/qa/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qa-agent",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Downstream QA capability invoked after pm-agent handoff for confirmed acceptance, exploratory testing, bug analysis, and regression verification. Requirement or implementation gaps return through the PM-orchestrated handoff path.",
   "author": {
     "name": "Neplich"

--- a/agents/security/.claude-plugin/plugin.json
+++ b/agents/security/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "security-agent",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Downstream security capability invoked after pm-agent handoff for confirmed AppSec, auth/authz, dependency risk, privacy, and data-flow reviews, with remediation routed through the PM handoff path.",
   "author": {
     "name": "Neplich"

--- a/docs/changelog/changelog-v0.3.4.md
+++ b/docs/changelog/changelog-v0.3.4.md
@@ -1,0 +1,83 @@
+---
+feature: release-changelog
+version: 0.3.4
+date: 2026-07-28
+last_updated: 2026-07-28
+---
+
+# Changelog - v0.3.4
+
+## [v0.3.4] - 2026-07-28
+
+本版本集中完善 docs-agent 正式文档契约：API 与数据库、Product 与 Design、Ops 部署三分类的信息架构分层落地，文档站侧边栏升级为任意深度递归嵌套，并新增文档站部署完整性安全网（Docs → PM → DevOps 条件式 handoff）；同时修复实施计划归档门禁的 status 触发检测与双态审计 handoff 门禁对无文档站宿主失效的问题，将 docs-site 模板 VitePress 依赖精确固定到已验证版本；并补齐两批共 26 个薄 fixture / 证据债务 eval 的确认上下文与 fresh 成对复验。本版本覆盖 v0.3.3 之后合并到 `main` 的全部变更（#156、#157、#163、#164、#165、#166、#167、#168、#171、#174、#179、#180）。
+
+### Added
+
+- **文档站部署完整性安全网**：在既有 Safety-Net Closeout 中建立 Docs → PM → DevOps 条件式 handoff，统一 `integrated` / `partial` / `not_integrated` / `not_applicable` / `unknown` 五态判定与逐构建变体证据要求；Docs 只读识别和报告，commit、镜像发布与部署保持独立授权边界。([#163](https://github.com/Neplich/dev-agent-skills/pull/163))
+- **API 与数据库文档信息架构**：完善 API 文档「功能域 → 子功能 → 接口叶子页」与 Database 文档「数据库 / schema → 数据域 → 关系总览 → 实体页」层级契约，关系页与实体页双向链接，并明确区分物理外键与逻辑引用。([#164](https://github.com/Neplich/dev-agent-skills/pull/164))
+- **Product 与 Design 分层文档契约**：Product 建立「产品域 → 功能 / 子功能 → 用户任务 / 场景」层级，Design 建立「系统 → 领域 → 子系统 / 组件 → 流程与边界」层级，落实组件/流程双向链接、跨领域唯一权威页与 API / Database contract 引用边界。([#165](https://github.com/Neplich/dev-agent-skills/pull/165))
+- **Ops 部署文档三分类契约**：Ops 部署正式文档拆分为 Development、Docker、Kubernetes/Helm 三类，统一入口 `docs/site/ops/deployment/`，新增共享 `environment-reference.md` 证据规则，要求交叉核对 `.env.example`、配置读取与 Compose/Helm 映射。([#166](https://github.com/Neplich/dev-agent-skills/pull/166))
+- **文档站侧边栏任意深度递归嵌套**：侧边栏生成器从固定层级升级为基于树结构的递归构建，支撑 Product / Design 文档的多级子功能、子系统结构，非叶子节点可递归嵌套并生成独立 `index.md`。([#167](https://github.com/Neplich/dev-agent-skills/pull/167))
+
+### Changed
+
+- **跨角色薄 fixture eval 确认上下文**：为 11 个 specialist 的 17 个高风险薄 fixture eval 按各自当前 entry gate 补齐最小确认上下文（PM handoff、已确认文档链、真实部署样本、竞品资料等），全部经 fresh `with_skill` / `without_skill` 成对复验并更新 durable `comparison.md`。([#168](https://github.com/Neplich/dev-agent-skills/pull/168))
+- **跨角色证据债务 eval 复现策略判定**：完成第二批 9 个证据债务 eval 的逐项分类与 fresh paired validation，不修改 specialist 行为与 assertions，仅更新 canonical `comparison.md`。([#171](https://github.com/Neplich/dev-agent-skills/pull/171))
+- **发版流程说明**：明确每次 tag 发版后由 `pm-agent → github-release-generator` 自动创建 GitHub Release draft 交维护者审批，draft 发布仍需维护者显式批准；并明确双态审计 handoff 门禁不适用于本仓库自身发版。([764dc2f](https://github.com/Neplich/dev-agent-skills/commit/764dc2f)、[ca1535c](https://github.com/Neplich/dev-agent-skills/commit/ca1535c))
+
+### Fixed
+
+- **实施计划归档门禁 status 触发检测**：活跃 `IMPLEMENTATION_PLAN.md` 的 `status` 设为 repository contract 无条件必填字段，以 merge-base 上 active plan 的 `status: Implemented` 触发 `previous_plan_archive` 校验，保留 base ref 容错与同提交 closeout 归档例外。([#179](https://github.com/Neplich/dev-agent-skills/pull/179))
+- **双态审计 handoff 门禁**：修复门禁对无文档站宿主不生效的问题。([#156](https://github.com/Neplich/dev-agent-skills/pull/156))
+- **docs-site 模板 VitePress 依赖固定**：模板依赖从 caret 范围精确固定为已验证版本 `1.6.4`，避免上游 minor 漂移破坏脚手架；resolved URL、integrity 及其余依赖均无漂移。([#157](https://github.com/Neplich/dev-agent-skills/pull/157))
+- **changelog-generator 版本标题 eval assertion**：修正 `eval-002-single-version-mode` 的版本标题期望，统一为既定的 `## [v{VERSION}] - YYYY-MM-DD` 格式约定，不修改 specialist 行为。([#174](https://github.com/Neplich/dev-agent-skills/pull/174))
+
+## Skill Eval 汇总（v0.3.4 发版前）
+
+本节按 marketplace 当前注册的 **40 个 skill** 逐一汇总最新结论。与 v0.3.3 不同，本次按各 skill `evals.json` 的 `workspace` 契约路径定位每份 durable `comparison.md`（同时覆盖 canonical `evals/workspace/` 与仍在使用的当前 workspace 路径），共核对 **185** 份当前结论：**176 PASS、9 PARTIAL**。份数较 v0.3.3（155 份）增长来自各 PR 新增的 eval 定义，以及 `idea-to-spec` 7 个既有 eval 本次补齐 fresh 结论后纳入汇总。
+
+| Agent | Skill（eval 范围） | 纳入汇总的 durable comparison 数 | 最新结论 |
+| --- | --- | ---: | --- |
+| Designer | `designer-agent` | 3 | 3 PASS |
+| Designer | `ui-ux-design` | 5 | 3 PASS、2 PARTIAL |
+| Designer | `visual-design` | 3 | 2 PASS、1 PARTIAL |
+| DevOps | `cicd-bootstrap` | 3 | 3 PASS |
+| DevOps | `deployment-planner` | 4 | 4 PASS |
+| DevOps | `devops-agent` | 2 | 2 PASS |
+| DevOps | `env-config-auditor` | 4 | 3 PASS、1 PARTIAL |
+| DevOps | `incident-playbook-writer` | 2 | 2 PASS |
+| Docs | `docs-agent` | 6 | 6 PASS |
+| Docs | `docs-audit` | 14 | 14 PASS |
+| Docs | `docs-site-bootstrap` | 4 | 4 PASS |
+| Docs | `formal-docs-sync` | 14 | 14 PASS |
+| Docs | `release-notes-generator` | 4 | 4 PASS |
+| Engineer | `codebase-analyzer` | 3 | 3 PASS |
+| Engineer | `debugger` | 5 | 5 PASS |
+| Engineer | `delivery` | 1 | 1 PASS |
+| Engineer | `engineer-agent` | 4 | 4 PASS |
+| Engineer | `feature-implementor` | 17 | 15 PASS、2 PARTIAL |
+| Engineer | `project-bootstrap` | 2 | 2 PASS |
+| Engineer | `test-writer` | 2 | 2 PASS |
+| Engineer | `trd-gen` | 5 | 5 PASS |
+| Product Manager | `changelog-generator` | 3 | 1 PASS、2 PARTIAL |
+| Product Manager | `competitive-brief` | 1 | 1 PASS |
+| Product Manager | `competitive-intelligence` | 1 | 1 PASS |
+| Product Manager | `feature-catalog` | 4 | 4 PASS |
+| Product Manager | `github-reader` | 4 | 3 PASS、1 PARTIAL |
+| Product Manager | `github-release-generator` | 6 | 6 PASS |
+| Product Manager | `idea-to-spec` | 8 | 8 PASS |
+| Product Manager | `pm-agent` | 15 | 15 PASS |
+| Product Manager | `roadmap-generator` | 3 | 3 PASS |
+| QA | `bug-analyzer` | 3 | 3 PASS |
+| QA | `exploratory-tester` | 3 | 3 PASS |
+| QA | `qa-agent` | 3 | 3 PASS |
+| QA | `regression-suite` | 3 | 3 PASS |
+| QA | `spec-based-tester` | 3 | 3 PASS |
+| Security | `appsec-checklist` | 5 | 5 PASS |
+| Security | `authz-reviewer` | 4 | 4 PASS |
+| Security | `dependency-risk-auditor` | 4 | 4 PASS |
+| Security | `privacy-surface-mapper` | 4 | 4 PASS |
+| Security | `security-agent` | 1 | 1 PASS |
+| **合计** | **40 个 marketplace skill 分组** | **185** | **176 PASS、9 PARTIAL** |
+
+本版本直接涉及的复验结果为：`idea-to-spec` 全部 8 个 eval 经 fresh Codex subagent 成对复验（全新 `without_skill` baseline）**30/30 assertions PASS**，覆盖 PR #163 新增「Documentation Site Deployment Completeness」契约节后的行为确认；`docs-site-bootstrap`、`formal-docs-sync`、`docs-audit`、`feature-implementor`、`changelog-generator` 等 skill 的新增或受影响 eval 已在各自 PR（#157、#163–#168、#171、#174、#179）合并时完成 fresh 复验并更新 durable `comparison.md`。本次汇总由 `scripts/summarize_eval_results.py` 按 `evals.json` workspace 契约路径机械提取，不重跑其余 skill eval。表中 **9 个 PARTIAL** 沿用各 skill 既有 durable 结论，主要记录历史 comparison 的证据缺口，不是本版回归。

--- a/scripts/summarize_eval_results.py
+++ b/scripts/summarize_eval_results.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""汇总各 skill 最新 eval 结论，输出 changelog 的 Skill Eval 汇总表。
+
+按每个 skill 的 evals.json 中 workspace 字段定位 durable comparison.md，
+提取 Latest result 结论（PASS / PARTIAL / BLOCKED），按 skill 分组统计。
+"""
+import glob
+import json
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def find_comparison(test_dir, workspace):
+    """按 eval workspace 字段定位 comparison.md，兼容 test/{skill}/ 与 test/{skill}/evals/ 两种基准。"""
+    for base in (test_dir, os.path.join(test_dir, "evals")):
+        candidate = os.path.join(base, workspace, "comparison.md")
+        if os.path.isfile(candidate):
+            return candidate
+    return None
+
+
+def extract_result(path):
+    text = open(path, encoding="utf-8").read()
+    m = re.search(r"Latest [Rr]esult[：:]\s*\**\s*(PASS|PARTIAL|BLOCKED)", text)
+    if m:
+        return m.group(1)
+    m = re.search(r"^##\s*Latest [Rr]esult\s*$([\s\S]{0,400})", text, re.M)
+    if m:
+        m2 = re.search(r"(PASS|PARTIAL|BLOCKED)", m.group(1))
+        if m2:
+            return m2.group(1)
+    return None
+
+
+def main():
+    rows = []
+    total_files = 0
+    total_stat = {"PASS": 0, "PARTIAL": 0, "BLOCKED": 0, "UNKNOWN": 0}
+    missing = []
+    for evals_path in sorted(glob.glob(os.path.join(ROOT, "agents/*/test/*/evals/evals.json"))):
+        test_dir = os.path.dirname(os.path.dirname(evals_path))
+        rel = os.path.relpath(test_dir, ROOT)
+        agent = rel.split(os.sep)[1]
+        skill = os.path.basename(test_dir)
+        data = json.load(open(evals_path, encoding="utf-8"))
+        stat = {"PASS": 0, "PARTIAL": 0, "BLOCKED": 0, "UNKNOWN": 0}
+        n = 0
+        for ev in data["evals"]:
+            comp = find_comparison(test_dir, ev["workspace"])
+            if not comp:
+                missing.append(f"{agent}/{skill} {ev['id']} ws={ev['workspace']}")
+                stat["UNKNOWN"] += 1
+            else:
+                r = extract_result(comp) or "UNKNOWN"
+                stat[r] += 1
+            n += 1
+        for k in total_stat:
+            total_stat[k] += stat[k]
+        total_files += n
+        parts = [f"{stat[k]} {k}" for k in ("PASS", "PARTIAL", "BLOCKED", "UNKNOWN") if stat[k]]
+        rows.append((agent, skill, n, "、".join(parts) if parts else "-"))
+    for agent, skill, n, summary in rows:
+        print(f"| {agent} | `{skill}` | {n} | {summary} |")
+    print(f"\n共 {len(rows)} 个 skill 分组、{total_files} 份 comparison："
+          + "、".join(f"{v} {k}" for k, v in total_stat.items() if v))
+    if missing:
+        print("\n缺 comparison.md:", file=sys.stderr)
+        for m in missing:
+            print(f"  {m}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 概要

发布 v0.3.4 版本准备，包含三部分变更：

1. **版本 bump**：`.claude-plugin/marketplace.json` 与 7 个 `agents/*/.claude-plugin/plugin.json` 从 `0.3.3` 升级到 `0.3.4`。
2. **changelog**：新增 `docs/changelog/changelog-v0.3.4.md`（含 Skill Eval 汇总节），根 `CHANGELOG.md` 索引同步。
3. **eval 债务补齐**：`idea-to-spec` 全部 8 个 eval 经 fresh Codex subagent 成对复验（全新 `without_skill` baseline），**8/8 PASS、30/30 assertions PASS**，8 份 durable `comparison.md` 已更新。背景：PR #163 给 `skill-map.md` 新增 63 行契约节后，该 skill 的 comparison 停在 2026-07-16，本次发版前按 Fresh Sub-Agent 门禁补齐；PR #163 新增契约在 8 个场景均未触发，未发现行为回归。
4. **新增工具**：`scripts/summarize_eval_results.py` 按各 skill `evals.json` 的 `workspace` 契约路径机械提取 comparison 结论，用于 changelog 的 Skill Eval 汇总（本次：40 个 skill、185 份 comparison、176 PASS、9 PARTIAL）。

## v0.3.3 以来变更概览

- 5 个 feat：文档站部署完整性安全网（#163）、API/数据库文档信息架构（#164）、Product/Design 分层文档契约（#165）、Ops 部署文档三分类契约（#166）、侧边栏任意深度递归嵌套（#167）
- 4 个 fix：实施计划归档门禁 status 触发检测（#179）、双态审计 handoff 门禁（#156）、VitePress 依赖固定（#157）、changelog-generator eval assertion（#174）
- 2 个 test：跨角色 17 + 9 个薄 fixture / 证据债务 eval 补齐（#168、#171）

## Test plan

- [x] `uv run scripts/check_repository_contract.py` PASS
- [x] `uv run scripts/check_eval_contract.py` PASS
- [x] `uv run scripts/check_eval_artifacts.py` PASS
- [x] `uv run scripts/check_doc_contract.py` PASS
- [x] `uv run --with pytest pytest <CI 同款清单>`：194 passed
- [x] `idea-to-spec` fresh 成对复验：8/8 PASS、30/30 assertions（baseline 全部本轮新生成，未复用历史）

## 合并后动作

合并后由维护者打 annotated tag `v0.3.4`，再由 `pm-agent → github-release-generator` 创建 GitHub Release draft 交维护者审批。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
