### PR TITLE
fix: github-reader 查询协议增加数据完整性声明与计算集合上限

### DIFF
--- a/agents/product_manager/skills/github-reader/SKILL.md
+++ b/agents/product_manager/skills/github-reader/SKILL.md
@@ -56,10 +56,12 @@ Focused query 可按需只获取相关集合的 `total_count`。
 > 2. 任一集合的获取数小于 `total_count` 时，必须在该集合小节和健康摘要中显式声明：`⚠️ 数据截断：已获取 {fetched}/{total} 条，分类统计基于已获取部分`
 > 3. 禁止在未声明截断的情况下，把部分集合的分类统计或健康信号呈现为完整状态
 > 4. **展示限行**仅控制报告展示数量（例如待 Review 表格最多 10 行并附汇总行）；**计算集合限行**控制用于分类和健康信号的获取集合（上限 1000）。两者互不影响
+> 5. Milestones 集合必须通过 `--paginate` 获取完整集合；若分页获取失败或集合不完整，必须在 Milestones 小节和健康摘要中声明数据不完整，不得呈现为完整状态
 
 ### Milestones
 ```bash
 gh api repos/{OWNER}/{REPO}/milestones \
+  --paginate \
   --jq '.[] | {title, state, open_issues, closed_issues, due_on, html_url}' \
   -X GET -f state=open
 ```
@@ -219,6 +221,6 @@ This lets downstream skills parse state without re-fetching.
 ## Edge cases
 
 - **No milestones**: skip that section, note "暂无 milestone" in the summary
-- **Large repos**: open issues、open PR 队列和近期 merged PR 的计算集合上限均为 1000；超出时优先用 `--milestone`、`--label` 或时间窗收窄。收窄后仍超出上限时，按 Step 3a 的数据完整性规则显式声明截断
+- **Large repos**: milestones 通过 `--paginate` 获取完整集合；open issues、open PR 队列和近期 merged PR 的计算集合上限均为 1000，超出时优先用 `--milestone`、`--label` 或时间窗收窄。收窄后仍超出上限时，按 Step 3a 的数据完整性规则显式声明截断
 - **No GitHub auth**: `gh auth status` will fail — surface the error clearly and tell the user to run `gh auth login`
 - **Focused query shortcut**: if the user only asks about PRs, skip issue fetching entirely to save time

--- a/agents/product_manager/skills/github-reader/SKILL.md
+++ b/agents/product_manager/skills/github-reader/SKILL.md
@@ -43,20 +43,21 @@ Run only what the scope requires. Commands below are the full toolkit — use se
 Full status / Feed mode 下，在获取各计算集合前，必须先通过 search API 取得精确总数。先计算近 14 天窗口的 `{DATE}`，再执行：
 
 ```bash
-gh api search/issues -X GET -f q='repo:{OWNER}/{REPO} is:issue is:open' --jq '.total_count'
-gh api search/issues -X GET -f q='repo:{OWNER}/{REPO} is:pr is:open' --jq '.total_count'
-gh api search/issues -X GET -f q='repo:{OWNER}/{REPO} is:pr is:merged merged:>{DATE}' --jq '.total_count'
-gh api search/issues -X GET -f q='repo:{OWNER}/{REPO} is:issue is:closed closed:>{DATE}' --jq '.total_count'
+gh api search/issues -X GET -f q='repo:{OWNER}/{REPO} is:issue is:open' --jq '{total_count, incomplete_results}'
+gh api search/issues -X GET -f q='repo:{OWNER}/{REPO} is:pr is:open' --jq '{total_count, incomplete_results}'
+gh api search/issues -X GET -f q='repo:{OWNER}/{REPO} is:pr is:merged merged:>{DATE}' --jq '{total_count, incomplete_results}'
+gh api search/issues -X GET -f q='repo:{OWNER}/{REPO} is:issue is:closed closed:>{DATE}' --jq '{total_count, incomplete_results}'
 ```
 
 Focused query 可按需只获取相关集合的 `total_count`。
 
 > **[强制规则] 数据完整性声明：**
 > 1. 健康摘要与汇总数字一律以 Step 3a 的 `total_count` 为准，不得用获取集合长度冒充总数
-> 2. 任一集合的获取数小于 `total_count` 时，必须在该集合小节和健康摘要中显式声明：`⚠️ 数据截断：已获取 {fetched}/{total} 条，分类统计基于已获取部分`
-> 3. 禁止在未声明截断的情况下，把部分集合的分类统计或健康信号呈现为完整状态
-> 4. **展示限行**仅控制报告展示数量（例如待 Review 表格最多 10 行并附汇总行）；**计算集合限行**控制用于分类和健康信号的获取集合（上限 1000）。两者互不影响
-> 5. Milestones 集合必须通过 `--paginate` 获取完整集合；若分页获取失败或集合不完整，必须在 Milestones 小节和健康摘要中声明数据不完整，不得呈现为完整状态
+> 2. 任一 search 查询返回 `incomplete_results: true` 时，对应集合的总数必须标注「GitHub 标记结果不完整（incomplete_results），总数为参考值」，不得呈现为精确总数；健康摘要中相关数字带同样限定
+> 3. 任一集合的获取数小于 `total_count` 时，必须在该集合小节和健康摘要中显式声明：`⚠️ 数据截断：已获取 {fetched}/{total} 条，分类统计基于已获取部分`
+> 4. 禁止在未声明截断的情况下，把部分集合的分类统计或健康信号呈现为完整状态
+> 5. **展示限行**仅控制报告展示数量（例如待 Review 表格最多 10 行并附汇总行）；**计算集合限行**控制用于分类和健康信号的获取集合（上限 1000）。两者互不影响
+> 6. Milestones 集合必须通过 `--paginate` 获取完整集合；若分页获取失败或集合不完整，必须在 Milestones 小节和健康摘要中声明数据不完整，不得呈现为完整状态
 
 ### Milestones
 ```bash

--- a/agents/product_manager/skills/github-reader/SKILL.md
+++ b/agents/product_manager/skills/github-reader/SKILL.md
@@ -38,6 +38,25 @@ Default to **Full status** if the intent is ambiguous.
 
 Run only what the scope requires. Commands below are the full toolkit — use selectively.
 
+### Step 3a — Count collections before fetching
+
+Full status / Feed mode 下，在获取各计算集合前，必须先通过 search API 取得精确总数。先计算近 14 天窗口的 `{DATE}`，再执行：
+
+```bash
+gh api search/issues -X GET -f q='repo:{OWNER}/{REPO} is:issue is:open' --jq '.total_count'
+gh api search/issues -X GET -f q='repo:{OWNER}/{REPO} is:pr is:open' --jq '.total_count'
+gh api search/issues -X GET -f q='repo:{OWNER}/{REPO} is:pr is:merged merged:>{DATE}' --jq '.total_count'
+gh api search/issues -X GET -f q='repo:{OWNER}/{REPO} is:issue is:closed closed:>{DATE}' --jq '.total_count'
+```
+
+Focused query 可按需只获取相关集合的 `total_count`。
+
+> **[强制规则] 数据完整性声明：**
+> 1. 健康摘要与汇总数字一律以 Step 3a 的 `total_count` 为准，不得用获取集合长度冒充总数
+> 2. 任一集合的获取数小于 `total_count` 时，必须在该集合小节和健康摘要中显式声明：`⚠️ 数据截断：已获取 {fetched}/{total} 条，分类统计基于已获取部分`
+> 3. 禁止在未声明截断的情况下，把部分集合的分类统计或健康信号呈现为完整状态
+> 4. **展示限行**仅控制报告展示数量（例如待 Review 表格最多 10 行并附汇总行）；**计算集合限行**控制用于分类和健康信号的获取集合（上限 1000）。两者互不影响
+
 ### Milestones
 ```bash
 gh api repos/{OWNER}/{REPO}/milestones \
@@ -49,23 +68,29 @@ gh api repos/{OWNER}/{REPO}/milestones \
 ```bash
 gh issue list \
   --json number,title,state,labels,milestone,assignees,createdAt,updatedAt \
-  --state open --limit 100
+  --state open --limit 1000
 ```
+
+上述 `--limit 1000` 是计算集合限行；open issue 分类与健康信号基于该获取集合计算。
 
 ### Recently closed issues (last 14 days)
 ```bash
 gh issue list \
   --json number,title,closedAt,milestone \
-  --state closed --limit 50 \
+  --state closed --limit 1000 \
   --search "closed:>$(date -d '14 days ago' +%Y-%m-%d 2>/dev/null || date -v-14d +%Y-%m-%d)"
 ```
+
+上述 `--limit 1000` 是计算集合限行；近期 closed issue 分类与健康信号基于该获取集合计算。
 
 ### PR queue
 ```bash
 gh pr list \
   --json number,title,state,author,reviewDecision,createdAt,labels,isDraft \
-  --state open --limit 100
+  --state open --limit 1000
 ```
+
+上述 `--limit 1000` 是计算集合限行；open PR 分类与健康信号基于该获取集合计算。
 
 > **[强制规则] PR 分类处理流程：**
 > 1. 先按 `author.login` 过滤 bot（含 `[bot]` 后缀）→ 归入 Bot 区域
@@ -78,11 +103,15 @@ gh pr list \
 ```bash
 gh pr list \
   --json number,title,mergedAt,author \
-  --state merged --limit 30 \
+  --state merged --limit 1000 \
   --search "merged:>$(date -d '14 days ago' +%Y-%m-%d 2>/dev/null || date -v-14d +%Y-%m-%d)"
 ```
 
+上述 `--limit 1000` 是计算集合限行；近期 merged PR 分类与健康信号基于该获取集合计算。
+
 ## Step 4 — Compute health signals
+
+各信号基于 Step 3 获取的计算集合；总数类数字来自 Step 3a 的 `total_count`。
 
 From the fetched data, derive:
 
@@ -166,6 +195,10 @@ github_reader_data:
   repo: owner/repo
   fetched_at: 2024-03-20
   open_issues_total: 15
+  open_prs_total: 8
+  merged_prs_14d_total: 4
+  closed_issues_14d_total: 3
+  truncated_collections: []
   milestones:
     - title: v2.0
       completion_pct: 60
@@ -179,11 +212,13 @@ github_reader_data:
   stale_issues: 2
 ```
 
+健康数字字段（如 `open_issues_total`、`open_prs_total`、`merged_prs_14d_total`、`closed_issues_14d_total`）必须使用 Step 3a 的 `total_count`。任一计算集合被截断时，必须把集合名加入 `truncated_collections`（例如 `[open_issues, open_prs]`），让下游消费方能识别数据完整性。
+
 This lets downstream skills parse state without re-fetching.
 
 ## Edge cases
 
 - **No milestones**: skip that section, note "暂无 milestone" in the summary
-- **Large repos (100+ issues)**: paginate with `--limit 200` or narrow by `--milestone` / `--label`
+- **Large repos**: open issues、open PR 队列和近期 merged PR 的计算集合上限均为 1000；超出时优先用 `--milestone`、`--label` 或时间窗收窄。收窄后仍超出上限时，按 Step 3a 的数据完整性规则显式声明截断
 - **No GitHub auth**: `gh auth status` will fail — surface the error clearly and tell the user to run `gh auth login`
 - **Focused query shortcut**: if the user only asks about PRs, skip issue fetching entirely to save time

--- a/agents/product_manager/skills/github-reader/SKILL.md
+++ b/agents/product_manager/skills/github-reader/SKILL.md
@@ -202,6 +202,7 @@ github_reader_data:
   merged_prs_14d_total: 4
   closed_issues_14d_total: 3
   truncated_collections: []
+  incomplete_totals: []
   milestones:
     - title: v2.0
       completion_pct: 60
@@ -215,7 +216,7 @@ github_reader_data:
   stale_issues: 2
 ```
 
-健康数字字段（如 `open_issues_total`、`open_prs_total`、`merged_prs_14d_total`、`closed_issues_14d_total`）必须使用 Step 3a 的 `total_count`。任一计算集合被截断时，必须把集合名加入 `truncated_collections`（例如 `[open_issues, open_prs]`），让下游消费方能识别数据完整性。
+健康数字字段（如 `open_issues_total`、`open_prs_total`、`merged_prs_14d_total`、`closed_issues_14d_total`）必须使用 Step 3a 的 `total_count`。任一计算集合被截断时，必须把集合名加入 `truncated_collections`（例如 `[open_issues, open_prs]`）；任一 search 返回 `incomplete_results: true`，或 milestones 分页失败/集合不完整时，必须把对应集合名加入 `incomplete_totals`（例如 `[open_issues, milestones]`），告知下游对应总数为参考值。两个字段在无触发时均可省略。
 
 This lets downstream skills parse state without re-fetching.
 

--- a/agents/product_manager/test/github-reader/evals/evals.json
+++ b/agents/product_manager/test/github-reader/evals/evals.json
@@ -112,6 +112,31 @@
           "text": "将 `last_verified_version: unverified` 按最低信任处理，不把文档中的 JSON 支持直接作为已交付状态。"
         }
       ]
+    },
+    {
+      "id": "eval-005-feed-mode-completeness",
+      "name": "feed-mode-completeness",
+      "description": "验证 Feed mode 输出机器可读 YAML 块且完整性信号与报告声明一致",
+      "prompt": "我是 roadmap-generator，需要 anthropics/anthropic-sdk-python 的当前仓库状态作为结构化输入，请给我完整状态数据",
+      "workspace": "workspace/eval-005-feed-mode-completeness",
+      "expected_output": "Markdown 报告后附 `---` 分隔的 `github_reader_data` YAML 块，包含总数类字段；若报告声明了截断或总数不完整，YAML 必须有对应 `truncated_collections` / `incomplete_totals` 字段",
+      "assertions": [
+        {
+          "id": "feed_yaml_present",
+          "description": "包含 Feed mode YAML 数据块",
+          "text": "输出在 Markdown 报告后包含 `github_reader_data` YAML 块，并提供 open issue 总数等关键字段"
+        },
+        {
+          "id": "completeness_signals_consistent",
+          "description": "完整性信号与报告声明一致",
+          "text": "YAML 中的总数类字段与报告声明的数据基础一致；报告声明截断或不完整时，YAML 必须出现对应 `truncated_collections` / `incomplete_totals` 字段"
+        },
+        {
+          "id": "totals_not_fabricated",
+          "description": "总数来自实际查询",
+          "text": "YAML 总数来自实际查询的 search `total_count`，不以获取集合长度冒充"
+        }
+      ]
     }
   ]
 }

--- a/agents/product_manager/test/github-reader/evals/evals.json
+++ b/agents/product_manager/test/github-reader/evals/evals.json
@@ -30,6 +30,11 @@
           "id": "pr_2",
           "description": "PR 链接格式正确",
           "text": "PR 条目带有 GitHub 链接，格式为 [#NUMBER](URL)"
+        },
+        {
+          "id": "data_completeness",
+          "description": "声明数据完整性",
+          "text": "输出中各集合的总数与分类统计有明确的数据基础声明；若任何集合的获取数小于实际总数，必须显式标注截断，不得把部分数据呈现为完整状态"
         }
       ]
     },

--- a/agents/product_manager/test/github-reader/evals/workspace/eval-001-full-status/comparison.md
+++ b/agents/product_manager/test/github-reader/evals/workspace/eval-001-full-status/comparison.md
@@ -5,96 +5,92 @@
 - Agent: `product_manager`
 - Skill: `github-reader`
 - Eval: `eval-001-full-status`
-- Test case: full-status
+- Test case: Full status
 - Workspace: `workspace/eval-001-full-status`
-- Classification: `(c)` 依赖实时外部数据。该用例验证 `github-reader` 能否通过 `gh` 读取公共仓库现状，不应增加静态 mock fixture 冒充真实运行。
-- Latest result: **PARTIAL** — 本轮由当前会话中的同一个 fresh Codex subagent 按 no-leak 顺序重新生成 `with_skill` 与新的 `without_skill`。with-skill 满足 3/4 assertions；目标仓库实时不存在 milestone，现行 skill 要求跳过空表并说明“暂无 milestone”，因此既有 `milestone` assertion 的场景前提不成立。该项不是 GitHub 读取或 skill 行为回归。
+- Classification: `(c)` 依赖实时外部数据；验证 `github-reader` 是否通过已认证 `gh` 获取真实仓库状态。
+- Latest result: **PARTIAL** — 当前会话中的 fresh validator 严格按 no-leak 顺序生成并锁定两个独立 live arm 后才读取 assertions。with-skill 满足 4/5 assertions，without-skill 满足 3/5。唯一 with-skill failure 是目标仓库没有 open milestone，因而无法生成 assertion 要求的“有标题、进度百分比”的表格；skill 正确执行了“暂无 milestone” edge case，没有虚构数据。
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: 只有 prompt 与 metadata，没有静态 GitHub 快照；这符合实时数据场景。
+- Fixture: `eval-001-full-status` 当前 prompt 与 metadata；不包含静态 GitHub 快照。
 - Prompt: `帮我看一下 anthropics/anthropic-sdk-python 现在的项目状态，包括 milestone 进度、open issue 数量和 PR 队列情况`
-- Fresh repository: `anthropics/anthropic-sdk-python`
-- Live dependency: GitHub API、网络与已认证 `gh` CLI。
-- with-skill queried at: `2026-07-26T16:23:33+08:00`（Asia/Shanghai；首次 repo metadata 请求发生一次 TLS handshake timeout，随后在同一 arm 内重试成功）
-- without-skill queried at: `2026-07-26T16:25:45+08:00`（Asia/Shanghai）
-- Query window for recent activity: `2026-07-12` 至各自抓取时点（近 14 天）。
+- Live repository: `anthropics/anthropic-sdk-python`
+- Live dependency: GitHub API、网络、已认证 `gh` CLI。
+- Fixture/eval revision: 2026-07-28 工作树中的当前 `eval_metadata.json` 与 `evals.json`。
+- with-skill query: 2026-07-28 17:58:04–17:58:50 CST。
+- without-skill query: 2026-07-28 18:00:11–18:00:40 CST。
+- with-skill recent-activity window: `>2026-07-14` 至查询时点。
 
-## Same-Agent No-Leak Fresh Validation Method
+## Fresh Validation Method
 
-1. 当前会话中的唯一 fresh Codex subagent 先只从 `eval_metadata.json` 提取原始 prompt，未读取 `evals.json`、assertions、expected output 或旧 `comparison.md`。
-2. 同一 agent 的 with-skill arm 随后完整读取 Product Manager Agent README 与当前 `github-reader/SKILL.md`，自行用 `gh` 查询 prompt 指定仓库并锁定候选结果。
-3. with-skill 锁定后，同一 agent 切换到 without-skill arm；该 arm 不应用 skill 或 README，只凭原始 prompt 重新独立调用 `gh`，未使用父代理预计算 snapshot，也未复用 with-skill 的查询结果。
-4. 两个 arm 均锁定后，同一 fresh agent 才读取 canonical eval 定义、assertions、expected output 与旧 comparison，并亲自按当前 assertions 评审。
-5. 两个 arm 分别查询 GitHub，没有共享预计算快照；运行期 transcript、verdict、diagnostics 或 outputs 均未落盘。
+1. 先只读取 `eval_metadata.json` 提取原始 prompt；未读取 `evals.json`、旧 comparison 或 assertions。
+2. with-skill arm 完整读取当前 `github-reader/SKILL.md` 与 Product Manager Agent README，使用已认证 `gh` 独立查询，并把命令、时间、原始 JSON、最终报告保存到隔离 runtime 目录后以 SHA-256 锁定。
+3. 锁定 with-skill 后，without-skill arm 不读取或应用 skill/README，只凭原始 prompt 重新调用 `gh`，保存独立命令、时间、原始 JSON、报告并锁定；没有复用 with-skill 查询结果。
+4. 两个 arm 均锁定并通过 checksum 复核后，才读取 eval-001 当前 5 条 assertions 与旧 comparison，逐条判定。
+5. canonical fixture 中只更新本 `comparison.md`；运行期证据未纳入 git。
 
-## Independent Live Snapshots and Drift
+## Independent Live Snapshots
 
-| 指标 | With skill（16:23:33 起） | Without skill（16:25:45） | 漂移判断 |
+| 指标 | With skill | Without skill | 漂移判断 |
 | --- | ---: | ---: | --- |
 | Open milestones | 0 | 0 | 无漂移 |
-| Open issues（排除 PR） | 144 | 144 | 无漂移 |
-| Open PRs | 212 | 212 | 无漂移 |
+| Open issues | 143 | 143 | 无漂移 |
+| Open PRs | 213 | 213 | 无漂移 |
 | Draft PRs | 6 | 6 | 无漂移 |
-| Changes requested | 2 | 2 | 无漂移 |
+| Changes Requested | 2 | 2 | 无漂移 |
 
-- with-skill 按当前 skill 的互斥展示规则统计：人工非草稿且非 `CHANGES_REQUESTED` 的待 Review `204` 个、草稿 `6` 个、需作者跟进 `2` 个、bot `0` 个；近 14 天 merged PR `6` 个、closed issue `1` 个。
-- without-skill 报告 `204` 个 `REVIEW_REQUIRED`、`3` 个 approved、`2` 个 changes requested、`3` 个无 review decision，并统计到 `206` 个非草稿 PR。这里是分类口径不同，不是仓库状态漂移。
-- with-skill 还统计 open issue 中无 assignee `141` 个、超过 30 天未更新 `111` 个，以及等待超过 90 天的人工非草稿且非 `CHANGES_REQUESTED` PR `83` 个。
-- 两次查询相隔约 2 分钟，核心计数一致；本 comparison 只证明上述抓取时点，后续复验必须重新查询。
+with-skill 通过 Search API `total_count` 与独立计算集合确认：
 
-## Fresh With Skill
+- Open issues 143/143、open PRs 213/213。
+- 近 14 天 merged PRs 6/6、closed issues 1/1。
+- 所有集合均未截断。
+- Open issues 中无 assignee 140 个、30 天未更新 111 个。
+- PR 互斥分类为：bot 0、draft 6、Changes Requested 2、其余人工待 Review 205；其中等待超过 90 天 87 个。
 
-fresh with-skill 应用当前 Full status 流程，结果包括：
+without-skill 从独立 `gh list --limit 1000` 返回集合统计 143 个 open issue 与 213 个 open PR；PR 原始 review 分布为非草稿 Review Required 198、Changes Requested 2、Approved 3、无 decision 4，另有 draft 6。两个集合的返回量均小于 1000 上限。
 
-- 正确识别指定仓库，并从 GitHub 获取 milestone、open issue、open PR、近 14 天 merged PR 与近 14 天 closed issue 数据。
-- API 返回 0 个 milestone；按 skill 的 `No milestones` edge case 不生成虚假进度表，并明确说明当前暂无 milestone。
-- Open Issues 按“无 Milestone”归纳，并提供总数、无 assignee 与 stale 风险数字。
-- PR 队列按互斥顺序区分 bot、草稿、changes requested 与其余待 Review；待 Review 最多展示 10 条，条目带 `[#NUMBER](URL)` 链接，超出部分用汇总说明。
-- 单列近 14 天 merged PR，并在末尾给出 open issue、open PR、milestone、近期活动与长期积压的数字化健康摘要。
+## With-Skill Behavior
 
-## Fresh Without Skill / Baseline
+- 正确识别 Full status scope，并查询 repo metadata、精确集合总数、open milestones、open issues、open PRs、近 14 天 merged PRs 与 closed issues。
+- 仓库没有 open milestone；报告明确写“暂无 open milestone”，未虚构进度百分比。
+- Open Issues 给出 143 的精确总数、milestone 分组、无 assignee 与 stale 风险。
+- PR 按 bot → draft → Changes Requested → 待 Review 的互斥顺序分类；待 Review 表格限制为 10 条且包含标签列，具体条目使用 `[#NUMBER](URL)`。
+- 单列近 14 天已合并 PR，并在末尾给出数字化健康摘要、截断状态及长期积压风险。
 
-同一 fresh agent 的 baseline arm 未应用 `github-reader` skill 与 Product Manager Agent README，只凭原始 prompt 重新实时查询后返回：
+## Without-Skill Baseline
 
-- 0 个开放及已关闭 milestone、144 个 open issue、212 个 open PR。
-- 给出 6 个 draft、206 个非草稿，以及 204 `REVIEW_REQUIRED`、3 approved、2 changes requested、3 无 review decision 的通用 PR 数字，并列出最老 10 个 open PR 的 number、author、createdAt 与原始 URL。
-- 没有另查近期 merged PR，因而没有把当前待 review 与已合并 PR 分区；具体 PR 也未格式化为 `[#NUMBER](URL)`。
-- 给出含关键数字的总体判断，但未覆盖 with-skill 的 stale、unassigned、bot 隔离、10 行展示规则与近期 closed issue 口径。
+baseline 只依据原始 prompt 重新查询 GitHub：
+
+- 报告 0 个 open milestone、143 个 open issue、213 个 open PR，并指出 140 个 issue 未分配。
+- 把 open PR 按原始 review decision 与 draft 状态分类，列出最老 5 个 PR，具体条目使用正确 Markdown 链接。
+- 提供包含关键数字的风险判断，并声明查询使用最多 1000 条的集合且实际返回均小于上限。
+- 没有查询近期 merged PR，因此没有把“待 review”与“已合并”分区；也没有 with-skill 的 Search API 精确总数、stale issue、bot 隔离、10 行展示和近期 closed issue 口径。
 
 ## Assertion Results
 
 | Assertion | With skill | Without skill | Fresh judge 结论 |
 | --- | --- | --- | --- |
-| `milestone`：包含有标题、进度百分比的 Milestone 表格 | **FAIL（场景前提不成立）** | **FAIL（场景前提不成立）** | 两次 API 查询均返回 0 个 milestone。现行 skill 要求此时不生成空表；不能虚构进度百分比。 |
-| `pr`：PR 队列区分待 review 和已合并 | **PASS** | **FAIL** | with-skill 单列当前待 Review 与近 14 天 merged；baseline 只描述当前 open PR。 |
-| `assertion_3`：末尾有数字化健康摘要 | **PASS** | **PASS** | 两者均以数字总结状态；with-skill 的风险及近期活动口径更完整。 |
-| `pr_2`：PR 条目使用 `[#NUMBER](URL)` | **PASS** | **FAIL** | with-skill 的具体 PR 条目使用正确链接格式；baseline 虽返回 number 与原始 URL，但未组成 assertion 要求的 Markdown 链接。 |
+| `milestone`：包含有标题、进度百分比的 Milestone 表格 | **FAIL（场景前提不成立）** | **FAIL（场景前提不成立）** | 两个独立查询均返回 0 个 open milestone。现行 skill 要求此时说明“暂无 milestone”而不是虚构表格。 |
+| `pr`：PR 队列区分待 review 和已合并 | **PASS** | **FAIL** | with-skill 单列人工待 Review 和近 14 天 merged；baseline 只报告 open PR 队列。 |
+| `assertion_3`：末尾有数字化健康摘要 | **PASS** | **PASS** | with-skill 有独立健康摘要；baseline 的总体判断也用 open issue、open PR 与等待时长数字归纳风险。 |
+| `pr_2`：PR 条目使用 `[#NUMBER](URL)` | **PASS** | **PASS** | 两份报告的具体 PR 条目都符合要求。 |
+| `data_completeness`：总数、分类及截断有明确数据基础 | **PASS** | **PASS** | with-skill 明确给出四组 fetched/total 且均无截断；baseline 明确说明集合上限与实际返回均小于上限，分类基于该完整返回集合。 |
 
-## Failures and Interpretation
+## Failures
 
-- 唯一 with-skill failure 是 `milestone`。GitHub 查询成功，但仓库没有 assertion 假定的实体；伪造 milestone 表或百分比会违反当前 skill。
-- same-agent fresh pair 消除了历史 baseline 与父代理预计算快照共用所造成的 answer-key / snapshot leakage：两个 arm 本轮各自实时查询，且同一 agent 在两个候选均锁定后才读取答案键并亲自 judge。
-- 未修改 fixture、`evals.json`、assertions 或 specialist `SKILL.md`。
-
-## External Failure vs Skill Regression
-
-- **外部服务 / 基础设施失败**：GitHub API 超时、限流、DNS/网络不可达、`gh` 未认证、目标仓库不可访问或分页未完成。此类情况应记为 `BLOCKED` 或 infrastructure failure，不能判定 skill 回归。
-- **Skill 回归**：外部查询成功且返回有效数据，但 with-skill 漏查 prompt 要求的 scope、错误计算数量、未分页导致截断、PR 分类错误、把 bot 混入人工队列、缺少近期 merged 分区、健康摘要或正确链接。
-- **Live-data/assertion mismatch**：查询成功但仓库没有 assertion 假定的实体。本轮为 milestone 不存在，应保留真实 edge-case 输出并把该 assertion 记为场景前提不成立。
-
-## Time-Sensitivity Risk
-
-GitHub 数据会随 issue、PR、review 与 milestone 状态立即变化。本 comparison 不把任何数字作为固定 expected value；未来运行必须记录仓库、两条路径各自的精确抓取时间、查询窗口与独立快照，并区分真实漂移、分类口径差异和外部服务失败。
+- with-skill 唯一 failure 为 `milestone` live-data/assertion mismatch：查询成功，但仓库没有 assertion 假定的实体。生成虚假 milestone 或百分比会违反 skill。
+- without-skill 额外失败 `pr`：没有查询或展示 merged PR，无法区分待 review 与已合并。
+- GitHub、网络、认证和仓库访问均成功，本轮不是 infrastructure failure，也没有发现 Full status 数据完整性回归。
 
 ## Next Steps
 
-- 本轮无需增加 fixture；保留实时 GitHub 查询设计。
-- 在“不放宽 assertion”的本任务约束下，结果如实保持 `PARTIAL`。若维护者以后希望无 milestone 时也能通过，需要另行评估 assertion 是否接受 skill 已定义的 edge case。
+- 保持 **PARTIAL**，不为满足 `milestone` assertion 而虚构数据。
+- 若维护者希望“无 milestone”也是成功场景，应另行调整 assertion，使其接受明确的 edge-case 声明；本轮不修改 eval 定义。
+- 后续 fresh run 必须重新查询 live GitHub，不复用本轮快照。
 
-## Runtime Artifacts Policy
+## Runtime Artifact Policy
 
-- 没有向 canonical workspace 写入 transcripts、verdicts、timing、outputs 或 diagnostics。
-- durable 结果只保留本 `comparison.md` 中必要的两份独立快照、行为摘要与 fresh judge 结论。
-- 后续运行仍应把临时产物留在隔离 scratch 环境，并只将人工确认后的最新结论汇总回 canonical `comparison.md`。
+- runtime 命令、时间、原始 JSON、两个报告、checksums 与 verdict 保存在 `tmp/eval-runs/github-reader-eval-001-2026-07-28/`，不纳入 git。
+- canonical workspace 不保存 transcripts、raw outputs、timing、diagnostics 或 verdict；durable 结果仅更新本 `comparison.md`。
+- fresh validation 过程未修改 canonical fixture、`evals.json` 或 specialist `SKILL.md`；本 issue 的协议与 assertion 修改由主流程维护。

--- a/agents/product_manager/test/github-reader/evals/workspace/eval-005-feed-mode-completeness/comparison.md
+++ b/agents/product_manager/test/github-reader/evals/workspace/eval-005-feed-mode-completeness/comparison.md
@@ -1,0 +1,83 @@
+# Eval Result: eval-005-feed-mode-completeness
+
+## Evaluation Target
+
+- Agent: `product_manager`
+- Skill: `github-reader`
+- Eval: `eval-005-feed-mode-completeness`
+- Test case: Feed mode completeness
+- Workspace: `workspace/eval-005-feed-mode-completeness`
+- Classification: `(c)` 依赖实时外部数据；验证下游 skill 调用时是否产出机器可读 Feed YAML，并使完整性信号与 Markdown 声明一致。
+- Latest result: **PASS** — 当前会话中的 fresh validator 按 no-leak 顺序独立执行两个 live arm。with-skill 满足 3/3 assertions，without-skill 满足 0/3。
+
+## Test Set / Fixture Version
+
+- Schema: `evals.json` v1.0。
+- Fixture: 无静态 fixture；实时查询目标为 `anthropics/anthropic-sdk-python`。
+- Prompt: `我是 roadmap-generator，需要 anthropics/anthropic-sdk-python 的当前仓库状态作为结构化输入，请给我完整状态数据`
+- Live dependency: GitHub API、网络、已认证 `gh` CLI。
+- Validation date: 2026-07-28（Asia/Shanghai）。
+- with-skill query: 2026-07-28 18:41:20–18:42:11 CST。
+- without-skill query: 2026-07-28 18:44:56–18:45:30 CST。
+- 两个 arm 的近 14 天窗口均为 `>2026-07-14`。
+
+## Fresh Validation Method
+
+1. validator 开始时只获得原始 prompt，未读取 `evals.json`、旧 comparison 或 assertions。
+2. with-skill arm 完整读取当前 `github-reader/SKILL.md` 与 Product Manager Agent README，使用已认证 `gh` 独立查询，把命令、时间、原始 JSON 和最终报告保存到隔离 runtime 目录并以 SHA-256 锁定。
+3. 锁定 with-skill 后，without-skill arm 不读取或应用 skill 与 Agent README，仅凭原始 prompt 重新执行独立 GitHub 查询，没有复用 with-skill 查询结果。
+4. 两个 arm 均锁定并复核 checksum 后，validator 才读取 eval-005 的 3 条 assertions 并逐条裁决。
+5. canonical workspace 仅保存本 `comparison.md`；transcript、原始查询、checksum 和 verdict 不纳入 git。
+
+## Independent Live Snapshots
+
+| 集合 | With skill total / fetched | Without skill total / fetched | With skill 完整性 |
+| --- | ---: | ---: | --- |
+| Open issues | 143 / 143 | 143 / 143 | Search `incomplete_results=false`，未截断 |
+| Open PRs | 213 / 213 | 213 / 213 | Search `incomplete_results=false`，未截断 |
+| 近 14 天 merged PRs | 6 / 6 | 未查 total / 6 | Search `incomplete_results=false`，未截断 |
+| 近 14 天 closed issues | 1 / 1 | 未查 total / 1 | Search `incomplete_results=false`，未截断 |
+| Open milestones | 0（分页完成） | 0（分页完成） | 完整 |
+
+with-skill Feed 数据中的 `truncated_collections` 与 `incomplete_totals` 均为空数组。
+
+## With-Skill Behavior
+
+- 正确识别下游 skill 调用并进入 Feed mode。
+- 在 Markdown 报告后使用 `---` 分隔，输出可解析的 `github_reader_data` YAML。
+- Feed 包含 open issues、open PRs、近 14 天 merged PRs 与 closed issues 的 total 和 fetched 字段，以及健康信号。
+- 四个总数均来自独立执行的 Search API `total_count`，没有用获取集合长度冒充总数。
+- Markdown 完整性表与 YAML 一致：143/143、213/213、6/6、1/1；所有 Search 查询均为 `incomplete_results=false`，milestones 分页完成，因此两个完整性信号数组均为空。
+
+## Without-Skill Baseline
+
+- baseline 仅依据原始 prompt 独立查询，并输出 Markdown 报告和 fenced JSON 结构化块。
+- Open issue 与 open PR 总数来自 GraphQL `totalCount`；近 14 天 merged PR 与 closed issue 只报告获取集合长度，没有查询 Search API `total_count`。
+- 报告声明 release 明细截断为 20/213，但结构化 JSON 只有局部 `releases.truncated: true`，没有 Feed 契约要求的 `truncated_collections` / `incomplete_totals`。
+- baseline 首次因 `gh release list` 使用不支持的 `url` 字段失败；validator 保留错误证据，修正字段后重新独立执行整套 baseline 查询并成功锁定，未复用 with-skill 数据。
+
+## Assertion Results
+
+| Assertion | With skill | Without skill | Fresh judge 结论 |
+| --- | --- | --- | --- |
+| `feed_yaml_present`：Markdown 后包含关键总数字段的 `github_reader_data` YAML | **PASS** | **FAIL** | with-skill 提供并成功解析 YAML；baseline 只有 fenced JSON，没有 Feed YAML。 |
+| `completeness_signals_consistent`：结构化完整性信号与报告声明一致 | **PASS** | **FAIL** | with-skill 的 totals、fetched 和两个完整性数组与 Markdown 完全一致；baseline 没有规定的 Feed 完整性字段。 |
+| `totals_not_fabricated`：YAML 总数来自 Search API `total_count` | **PASS** | **FAIL** | with-skill 保存了四个 Search API 原始响应；baseline 未使用 Search API totals，近期活动仅使用集合长度。 |
+
+## Failures
+
+- with-skill 无 assertion failure，也没有 GitHub、网络或认证失败。
+- without-skill 失败 3 条 assertions，说明原始 prompt 本身不足以稳定触发 Feed YAML、统一完整性字段和 Search API count-first 契约。
+- baseline 的首次命令兼容错误已显式记录；完整重跑成功，因此不构成本轮 infrastructure blocker。
+
+## Next Steps
+
+- 保持 **PASS**；eval-005 已覆盖本次新增的 Feed mode `truncated_collections` / `incomplete_totals` 契约。
+- 后续 fresh run 必须重新查询 live GitHub，并重新生成 without-skill baseline，不复用本轮快照。
+- 若目标仓库未来超过计算集合上限或 GitHub 返回 `incomplete_results=true`，应继续验证非空完整性数组与 Markdown 声明一致。
+
+## Runtime Artifact Policy
+
+- runtime 命令、时间、原始 JSON、两个报告、checksums、查询事件与 verdict 保存在 `tmp/eval-runs/github-reader-eval-005-2026-07-28/`，不纳入 git。
+- canonical workspace 不保存 transcripts、raw outputs、timing、diagnostics 或 verdict；durable 结果仅为本 `comparison.md`。
+- 本轮 fresh validation 未修改 canonical fixture、specialist `SKILL.md` 或 Agent README。

--- a/agents/product_manager/test/github-reader/evals/workspace/eval-005-feed-mode-completeness/eval_metadata.json
+++ b/agents/product_manager/test/github-reader/evals/workspace/eval-005-feed-mode-completeness/eval_metadata.json
@@ -1,0 +1,7 @@
+{
+  "eval_id": "eval-005-feed-mode-completeness",
+  "eval_name": "feed-mode-completeness",
+  "workspace_root": "agents/product_manager/test/github-reader/evals/workspace/eval-005-feed-mode-completeness",
+  "skill_availability_goal": "验证 Feed mode 输出机器可读 YAML 块且完整性信号与报告声明一致",
+  "prompt": "我是 roadmap-generator，需要 anthropics/anthropic-sdk-python 的当前仓库状态作为结构化输入，请给我完整状态数据"
+}

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -49,7 +49,7 @@
     "github-reader": {
       "source": "agents/product_manager/skills/github-reader",
       "sourceType": "local",
-      "computedHash": "73b3736b5bfd8e5a33ee6e2abe577c5c0a04449f083eb142c958472c29fccc44"
+      "computedHash": "2f465349cdd5b3e7eed4884f403c4122b8ef78135e6112510fc76e1f51f6cb08"
     },
     "engineer-agent": {
       "source": "agents/engineer/skills/engineer-agent",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -49,7 +49,7 @@
     "github-reader": {
       "source": "agents/product_manager/skills/github-reader",
       "sourceType": "local",
-      "computedHash": "258c86bd73dc1872a2cccbec74bcaa641494a6862260872340e3ee9edfe59b7e"
+      "computedHash": "b4686f9e76aeb4001a6d456d18d834bf4b04ef07d9b8431638374a31e27651be"
     },
     "engineer-agent": {
       "source": "agents/engineer/skills/engineer-agent",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -49,7 +49,7 @@
     "github-reader": {
       "source": "agents/product_manager/skills/github-reader",
       "sourceType": "local",
-      "computedHash": "4b8b4a57357c6ff769276412675ecd3884ac45db295d476b930b44713aee41af"
+      "computedHash": "73b3736b5bfd8e5a33ee6e2abe577c5c0a04449f083eb142c958472c29fccc44"
     },
     "engineer-agent": {
       "source": "agents/engineer/skills/engineer-agent",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -49,7 +49,7 @@
     "github-reader": {
       "source": "agents/product_manager/skills/github-reader",
       "sourceType": "local",
-      "computedHash": "2f465349cdd5b3e7eed4884f403c4122b8ef78135e6112510fc76e1f51f6cb08"
+      "computedHash": "258c86bd73dc1872a2cccbec74bcaa641494a6862260872340e3ee9edfe59b7e"
     },
     "engineer-agent": {
       "source": "agents/engineer/skills/engineer-agent",


### PR DESCRIPTION
## 修改摘要

- 为 Full status / Feed mode 增加 count-first 查询，使用 Search API `total_count` 提供精确总数。
- 将 open issue、open PR、近 14 天 merged PR、近 14 天 closed issue 的计算集合上限统一为 1000。
- 当 `fetched < total` 时，强制在集合小节和健康摘要中声明数据截断，禁止把部分集合呈现为完整状态。
- 明确区分展示限行与计算集合限行：展示行数不影响分类和健康信号的计算范围。
- Feed mode 的结构化输出增加总数字段与 `truncated_collections` 截断标记。

## Fresh eval-001

- with-skill：4/5。
- without-skill：3/5。
- `milestone`：FAIL / FAIL。目标仓库没有 open milestone，场景前提不成立；skill 按 edge case 如实声明“暂无 milestone”，未虚构表格或百分比。
- `pr`：PASS / FAIL。
- `assertion_3`：PASS / PASS。
- `pr_2`：PASS / PASS。
- `data_completeness`：PASS / PASS。
- with-skill 的四个计算集合均为 `fetched = total`：open issues 143/143、open PRs 213/213、近 14 天 merged PRs 6/6、近 14 天 closed issues 1/1，均无截断。
- durable 结果已更新到 `comparison.md`，运行期产物未提交。

## 验证

- `uv run scripts/check_repository_contract.py`：PASS
- `uv run scripts/check_eval_contract.py`：PASS
- `uv run scripts/check_eval_artifacts.py`：PASS
- `uv run scripts/check_doc_contract.py`：PASS
- `uv run --with pytest pytest -q`：194 passed，3 subtests passed

Closes #175
