### PR TITLE
fix: QA 输出路径与 qa-agent router 收敛及 eval 对齐 (#196)

### DIFF
--- a/agents/qa/skills/bug-analyzer/SKILL.md
+++ b/agents/qa/skills/bug-analyzer/SKILL.md
@@ -122,7 +122,7 @@ Pick the durable output that matches the repo workflow and the user request.
 - For E2E-related defects, prefer the function-tree report path:
   `docs/qa/e2e/{feature_path}/_reports/{platform-version}/test-reports-{test-time}.md`
 - For non-E2E defects where the repo has no stronger convention, use
-  `docs/qa-reports/YYYY-MM-DD-<feature>-bug-<short-slug>.md`
+  `docs/qa/{feature_path}/bug-<short-slug>.md`
 - Use a GitHub issue only when the repository workflow explicitly wants issue tracking or the user requested an issue
 
 Do not assume GitHub issue creation is the primary output. Do not mutate code, commit changes, or invent a delivery workflow as part of this skill.

--- a/agents/qa/skills/exploratory-tester/SKILL.md
+++ b/agents/qa/skills/exploratory-tester/SKILL.md
@@ -220,7 +220,7 @@ Report paths:
   `docs/qa/e2e/_reports/{platform-version}/test-reports-{test-time}.md`
 
 For non-E2E exploratory reports where the repo has no stronger convention, use
-`docs/qa-reports/YYYY-MM-DD-<feature>-exploratory-report.md`.
+`docs/qa/{feature_path}/exploratory-report.md`.
 
 The report must be concise, handoff-ready, and clearly separate these sections:
 

--- a/agents/qa/skills/qa-agent/SKILL.md
+++ b/agents/qa/skills/qa-agent/SKILL.md
@@ -106,30 +106,15 @@ When routing is complete:
 
 - state which QA skill should handle the request
 - state the expected evidence artifact for the route
-- for E2E, list the complete QA memory read set before any execution:
-  `TEST_SUITE.md`, `FLOW_INDEX.md`, `cases/*.md`, `scripts/*.spec.md`, prior
-  `results/`, and `_reports/`
-- for E2E, state scenario, function-tree scope, platform version status,
-  subagent execution plan, selected execution entry, and why the selected entry
-  follows repo harness > Chrome plugin / browser connector > Playwright fallback
-- for E2E, state the credential handling reference
-  `references/e2e-credential-store.md`, the local
-  store `.qa/e2e/accounts.local.json`, and the summary report reference
-  `references/e2e-test-report.md`
-- for existing-feature changes, bug fixes, or code-complete E2E documentation
-  updates, state the same-path PRD, TRD, and confirmed
-  `IMPLEMENTATION_PLAN.md` gate explicitly; expectation changes return to PM,
-  TRD gaps return to `engineer-agent:trd-gen`, and missing implementation plans
-  return to `engineer-agent:feature-implementor`; state the resolved
-  `change_tier` and the gate strength it selects per the `AGENTS.md`
-  变更分级契约
-- if E2E is blocked by missing platform version, credentials, environment,
-  unclear `feature_path`, PRD/TRD alignment, or confirmed
-  `IMPLEMENTATION_PLAN.md`, report the blocker and next owner instead of
-  creating or executing TC
+- state that the selected QA specialist's authoritative E2E memory,
+  feature-path, platform-version, credential, execution-entry,
+  PRD/TRD/implementation-plan, and blocked-condition gates apply
 - after the routed skill or role stage completes, apply the cross-role
   safety-net closeout defined in
   `agents/product_manager/skills/idea-to-spec/_internal/_shared/skill-map.md`
   (`Safety-Net Closeout and Auto-Continue`): suggest the collaboration-chain
   next step, request confirmation before continuing, and honor user-enabled
   `auto-continue`
+
+Do not expand these pointers into duplicated specialist protocols inside this
+router.

--- a/agents/qa/skills/regression-suite/SKILL.md
+++ b/agents/qa/skills/regression-suite/SKILL.md
@@ -232,7 +232,7 @@ Use a durable output path that matches repo context.
   `docs/qa/e2e/_reports/{platform-version}/test-reports-{test-time}.md` for
   `release`
 - For non-E2E regression where the repo has no stronger convention, use
-  `docs/qa-reports/YYYY-MM-DD-<feature>-regression-verification.md`
+  `docs/qa/{feature_path}/regression-verification.md`
 - Use a GitHub issue only when the repo workflow or user request explicitly wants issue tracking
 
 Do not commit changes, do not mutate code, and do not assume a GitHub-first workflow.

--- a/agents/qa/skills/spec-based-tester/SKILL.md
+++ b/agents/qa/skills/spec-based-tester/SKILL.md
@@ -271,7 +271,7 @@ Report paths:
   `docs/qa/e2e/_reports/{platform-version}/test-reports-{test-time}.md`
 
 For non-E2E spec validation where the repo has no stronger reporting path, use
-`docs/qa-reports/YYYY-MM-DD-<feature>-spec-validation.md`.
+`docs/qa/{feature_path}/spec-validation.md`.
 
 The report should include:
 

--- a/agents/qa/test/bug-analyzer/evals/evals.json
+++ b/agents/qa/test/bug-analyzer/evals/evals.json
@@ -40,6 +40,11 @@
           "id": "assertion_6",
           "description": "影响说明",
           "text": "报告要包含 implementation impact 或 release impact，并保留 evidence references 以便后续追踪"
+        },
+        {
+          "id": "non_e2e_report_path",
+          "description": "非 E2E 报告路径",
+          "text": "该场景没有 E2E 用例树或版本化 E2E 执行要求，fallback Bug 报告必须落在 docs/qa/{feature_path}/ 下，文件名不得包含日期，并且不得使用 docs/qa-reports/。"
         }
       ]
     },

--- a/agents/qa/test/bug-analyzer/evals/workspace/eval-1-analyze-test-failure/comparison.md
+++ b/agents/qa/test/bug-analyzer/evals/workspace/eval-1-analyze-test-failure/comparison.md
@@ -9,47 +9,57 @@
 ## Test Set / Fixture Version
 
 - Eval schema: `evals.json` v1.0
-- Fixture version: repository commit `778b042`
-- Fresh run: `2026-07-30 19:26:38 +0800`
-- Runtime directory: `tmp/eval-runs/issue-196-pr-b-20260730-192638/qa/agents/qa/test/bug-analyzer/evals/workspace/eval-1-analyze-test-failure/`
+- Fixture version: repository commit `cdfc879` + current PR-B `evals.json` assertion update
+- Fresh run: `2026-07-30 19:56:59 +0800`
+- Runtime directory: `tmp/eval-runs/issue-196-pr-b-bug-explore-20260730-195659/bug-analyzer/eval-001/`
 - `eval_metadata.json` 未声明 `execution_cleanup`。
 
 ## Latest Result
 
-- Behavior result: **FAIL**
+- Behavior result: **PASS**
 - Coverage result: **FULL**
-- 所有 assertion 场景均已判定；无外部实时样本缺口。
-- 非 E2E 路径变更检查：`assertion_4` 已触发 durable output 选择，但候选只给出报告正文，没有声明 `docs/qa/{feature_path}/bug-<short-slug>.md`；因此本轮未证明新路径行为。
+- 当前 7 条 assertion 全部被新 with-skill 候选直接覆盖，无 `NOT EXERCISED`。
+- 本轮按新增 `non_e2e_report_path` 判定非 E2E fallback：候选明确使用
+  `docs/qa/authentication/login/bug-login-form-500.md`，文件名无日期且不使用
+  `docs/qa-reports/`。
 
-Overall result: FAIL
+Overall result: PASS
 
 ## Assertion Results
 
-- FAIL `assertion_1`: 已读取 failing scenario、500、console 与 build context，并注明 trace 不可用；但未明确记录截图、服务端 stack、完整 network output 等证据的存在/缺失，摄取清单不完整。
+- PASS `assertion_1`: 摄取 failing scenario、500、console、branch/commit/environment，并逐项标明 server stack、response body、截图、trace、runtime、flags 等证据缺口。
 - PASS `assertion_2`: 使用 `confirmed but environment-sensitive`，并将 evidence status 与 confidence 分开。
 - PASS `assertion_3`: severity 有影响理由，confidence 独立陈述。
-- FAIL `assertion_4`: 正确避免 GitHub-first，但没有给出可审计的本地 durable 文件路径，未覆盖 PR-B 新的非 E2E 路径。
-- FAIL `assertion_5`: 当前 feature_path 与 plan 对齐材料不足时，应明确把 reusable E2E TC 沉淀标为 blocked；候选既未创建/引用 TC+script，也未记录该 blocker。
+- PASS `assertion_4`: 选择 repo 内本地 Markdown artifact，明确不做 GitHub-first。
+- PASS `assertion_5`: 当前不满足 reusable E2E 沉淀条件；候选明确将 TC/script 创建标为 blocked，并列出缺失的 feature path、PRD/TRD/plan、platform 与用例树。
 - PASS `assertion_6`: 包含 release impact 与 evidence references。
+- PASS `non_e2e_report_path`: 使用 `docs/qa/{feature_path}/bug-<short-slug>.md`
+  形态，文件名无日期且未使用旧 `docs/qa-reports/`。
 
 ## With-Skill Behavior
 
-候选对分类、严重度、置信度和发布影响处理正确，但证据缺口、durable 路径和 reusable E2E coverage blocker 不完整，故 Behavior FAIL。
+候选完整分离 evidence status、confidence 与 severity，保留可追踪 fixture 引用，
+对证据缺口、release impact、reusable E2E blocker 和 PR-B 新非 E2E 路径均给出
+直接证据，Behavior PASS。
 
 ## Fresh Without-Skill Baseline
 
-同一 prompt/fixture 的全新 baseline 已在隔离目录生成，未读取 skill、QA README 或历史 baseline。candidate/verdict 均成功；baseline 过度判断为 `confirmed and reproducible`，且同样未处理 reusable TC，semantic verdict 为 FAIL。
+同一 prompt/fixture 在本轮隔离目录重新生成 baseline，未读取或应用
+`bug-analyzer`、QA README 或历史 baseline。它把一次 fixture 直接写成已确认缺陷，
+GitHub-first，未分离 evidence status / confidence，未声明 repo durable path，也未处理
+reusable E2E gate；baseline 仅作为 comparison 输入，不决定 with-skill Behavior。
 
 ## Failures
 
-- 未给出 `docs/qa/{feature_path}/bug-<short-slug>.md`。
-- 未完整记录证据缺口与 reusable E2E coverage blocker。
+- 无 with-skill assertion failure。
 
 ## Next Steps
 
-- 后续 fixture 应提供明确 `feature_path` 并把非 E2E 路径设为显式 assertion，以直接覆盖 PR-B 路径变更。
+- 可在后续 fixture 中提供正式 handoff `feature_path`，使报告路径无需从登录场景收敛为
+  `authentication/login`；这不影响本轮路径契约判定。
 
 ## Runtime Artifact Policy
 
-- 两条 candidate、两条 verdict、diagnostics 与 `comparison.auto.md` 均在上述 `tmp/eval-runs/`，返回码均为 0、无 timeout。
+- 新 `with_skill.md`、`without_skill.md` 与 `verdict.md` 仅保存在上述
+  `tmp/eval-runs/`；未复用历史 candidate 或 baseline。
 - Runtime 不提交；durable 结果仅为本文件。

--- a/agents/qa/test/bug-analyzer/evals/workspace/eval-1-analyze-test-failure/comparison.md
+++ b/agents/qa/test/bug-analyzer/evals/workspace/eval-1-analyze-test-failure/comparison.md
@@ -1,48 +1,55 @@
-# Eval Result: bug-analyzer-analyze-test-failure
+# Eval Result: eval-001-analyze-test-failure
 
 ## Evaluation Target
 
-- Agent: `qa`
 - Skill: `bug-analyzer`
 - Eval: `eval-001-analyze-test-failure`
-- Test case: analyze-test-failure
-- Workspace: `workspace/eval-1-analyze-test-failure`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
-- Validation method: fresh Codex subagent review; baseline was derived before reading `bug-analyzer` or QA README, then with-skill behavior was checked against `SKILL.md`, `agents/qa/README.md`, direct shared references, eval assertions, and fixture evidence.
+- Prompt target: 从登录 500 测试失败形成证据化 Bug 报告。
 
 ## Test Set / Fixture Version
 
-- Schema: `evals.json` v1.0
-- Prompt: 分析测试失败：登录表单提交后返回 500 错误，生成 Bug 报告
-- Fixture context: `logs/test-failure.log` and `environment/build.md`
-- Evidence present: `POST /api/login 500`, login-form test name, Chromium console error, trace unavailable, branch `login-refresh`, commit `fixture-only`, and local acceptance harness environment.
+- Eval schema: `evals.json` v1.0
+- Fixture version: repository commit `778b042`
+- Fresh run: `2026-07-30 19:26:38 +0800`
+- Runtime directory: `tmp/eval-runs/issue-196-pr-b-20260730-192638/qa/agents/qa/test/bug-analyzer/evals/workspace/eval-1-analyze-test-failure/`
+- `eval_metadata.json` 未声明 `execution_cleanup`。
 
-## Without Skill Baseline
+## Latest Result
 
-- A generic QA response would likely turn the HTTP 500 into a confirmed bug report immediately, with weaker separation between reproducibility, evidence completeness, and severity.
-- It might omit explicit gaps such as missing stack trace, screenshot, network payload, trace file, release channel, and repeated reproduction proof.
-- It could choose GitHub issue creation by default instead of first selecting the repo-appropriate durable Markdown artifact.
-- It would be less likely to gate reusable E2E regression coverage behind `docs/qa/e2e/{feature_path}/cases/TC-NNN-<short-slug>.md`, matching `scripts/`, PRD/TRD alignment, and a confirmed implementation plan when the TC becomes acceptance coverage.
+- Behavior result: **FAIL**
+- Coverage result: **FULL**
+- 所有 assertion 场景均已判定；无外部实时样本缺口。
+- 非 E2E 路径变更检查：`assertion_4` 已触发 durable output 选择，但候选只给出报告正文，没有声明 `docs/qa/{feature_path}/bug-<short-slug>.md`；因此本轮未证明新路径行为。
 
-## With Skill Behavior
+Overall result: FAIL
 
-- PASS: `bug-analyzer` accepts the test failure log plus build context as enough QA evidence for a defect intake, while still recording missing trace and supporting artifacts as evidence gaps.
-- PASS: The skill requires failing scenario, source evidence, console/network/test output, and environment/build context before classification.
-- PASS: The classification vocabulary separates evidence status from confidence: `confirmed and reproducible`, `confirmed but environment-sensitive`, and `suspected / needs more evidence` are distinct from severity.
-- PASS: The report contract includes severity rationale, confidence statement, reproduction steps, expected/actual behavior, evidence references, and implementation or release impact.
-- PASS: Durable output defaults to a local Markdown artifact unless repo workflow or the user explicitly requires GitHub issue tracking.
-- PASS: Confirmed E2E reproduction that should become reusable regression coverage must use `docs/qa/e2e/{feature_path}/cases/TC-NNN-<short-slug>.md` plus matching `scripts/TC-NNN-<short-slug>.spec.md`; acceptance-style TC creation or update requires same-path PRD/TRD expectation alignment and a confirmed `docs/engineer/{feature_path}/IMPLEMENTATION_PLAN.md`.
+## Assertion Results
+
+- FAIL `assertion_1`: 已读取 failing scenario、500、console 与 build context，并注明 trace 不可用；但未明确记录截图、服务端 stack、完整 network output 等证据的存在/缺失，摄取清单不完整。
+- PASS `assertion_2`: 使用 `confirmed but environment-sensitive`，并将 evidence status 与 confidence 分开。
+- PASS `assertion_3`: severity 有影响理由，confidence 独立陈述。
+- FAIL `assertion_4`: 正确避免 GitHub-first，但没有给出可审计的本地 durable 文件路径，未覆盖 PR-B 新的非 E2E 路径。
+- FAIL `assertion_5`: 当前 feature_path 与 plan 对齐材料不足时，应明确把 reusable E2E TC 沉淀标为 blocked；候选既未创建/引用 TC+script，也未记录该 blocker。
+- PASS `assertion_6`: 包含 release impact 与 evidence references。
+
+## With-Skill Behavior
+
+候选对分类、严重度、置信度和发布影响处理正确，但证据缺口、durable 路径和 reusable E2E coverage blocker 不完整，故 Behavior FAIL。
+
+## Fresh Without-Skill Baseline
+
+同一 prompt/fixture 的全新 baseline 已在隔离目录生成，未读取 skill、QA README 或历史 baseline。candidate/verdict 均成功；baseline 过度判断为 `confirmed and reproducible`，且同样未处理 reusable TC，semantic verdict 为 FAIL。
 
 ## Failures
 
-- None identified. The current skill contract satisfies all eval assertions for evidence intake, classification, severity/confidence separation, durable output choice, reusable E2E path rules, and impact framing.
+- 未给出 `docs/qa/{feature_path}/bug-<short-slug>.md`。
+- 未完整记录证据缺口与 reusable E2E coverage blocker。
 
 ## Next Steps
 
-- No fixture or skill change is required from this eval.
-- If a real report is produced later, keep the current missing artifacts visible instead of inflating confidence.
+- 后续 fixture 应提供明确 `feature_path` 并把非 E2E 路径设为显式 assertion，以直接覆盖 PR-B 路径变更。
 
 ## Runtime Artifact Policy
 
-- No runtime artifacts were created for this validation.
-- Do not commit transcripts, verdicts, timing files, diagnostics, `with_skill/`, `without_skill/`, `outputs/`, or `comparison.auto.md`.
+- 两条 candidate、两条 verdict、diagnostics 与 `comparison.auto.md` 均在上述 `tmp/eval-runs/`，返回码均为 0、无 timeout。
+- Runtime 不提交；durable 结果仅为本文件。

--- a/agents/qa/test/bug-analyzer/evals/workspace/eval-2-thin-evidence-suspected-bug/comparison.md
+++ b/agents/qa/test/bug-analyzer/evals/workspace/eval-2-thin-evidence-suspected-bug/comparison.md
@@ -1,45 +1,52 @@
-# Eval Result: bug-analyzer-thin-evidence-suspected-bug
+# Eval Result: eval-002-thin-evidence-suspected-bug
 
 ## Evaluation Target
 
-- Agent: `qa`
 - Skill: `bug-analyzer`
 - Eval: `eval-002-thin-evidence-suspected-bug`
-- Test case: thin-evidence-suspected-bug
-- Workspace: `workspace/eval-2-thin-evidence-suspected-bug`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
-- Validation method: fresh Codex subagent review; baseline was derived before reading `bug-analyzer` or QA README, then with-skill behavior was checked against `SKILL.md`, `agents/qa/README.md`, direct shared references, eval assertions, and fixture evidence.
+- Prompt target: 薄证据用户反馈不得升级为 confirmed bug。
 
 ## Test Set / Fixture Version
 
-- Schema: `evals.json` v1.0
-- Prompt: 用户只提供一句反馈：偶尔点击保存后页面好像没反应，没有截图、日志、复现步骤、环境信息或版本号。请分析是否能生成 Bug 报告。
-- Fixture context: `feedback/customer-note.md`
-- Evidence present: one customer note describing intermittent save non-response, with no screenshot or exact steps.
+- Eval schema: `evals.json` v1.0
+- Fixture version: repository commit `778b042`
+- Fresh run: `2026-07-30 19:26:38 +0800`
+- Runtime directory: `tmp/eval-runs/issue-196-pr-b-20260730-192638/qa/agents/qa/test/bug-analyzer/evals/workspace/eval-2-thin-evidence-suspected-bug/`
+- `eval_metadata.json` 未声明 `execution_cleanup`。
 
-## Without Skill Baseline
+## Latest Result
 
-- A generic response could prematurely write a confirmed bug report from the customer note.
-- It might fail to separate an observed customer complaint from a reproducible failing scenario.
-- It would likely omit a structured missing-evidence list and could recommend issue creation before confidence is high enough.
+- Behavior result: **PASS**
+- Coverage result: **FULL**
+- 无 `NOT EXERCISED` assertion。
+- 非 E2E 路径变更检查：该场景只允许调查 note/补证清单，不生成正式非 E2E Bug 报告，因此 `docs/qa/{feature_path}/bug-*.md` 分支未触发。
 
-## With Skill Behavior
+Overall result: PASS
 
-- PASS: `bug-analyzer` explicitly classifies thin reports as `suspected / needs more evidence`; it must not label this fixture `confirmed and reproducible` or `confirmed but environment-sensitive`.
-- PASS: The skill requires missing evidence to be stated rather than guessed, including exact failing scenario, reproduction steps, environment/version, console output, network output, screenshot, trace, and build context.
-- PASS: The report structure covers classification, evidence status, confidence statement, missing evidence, and recommended next evidence.
-- PASS: The output boundary is an investigation note or evidence request. It avoids creating a confirmed bug artifact or GitHub issue from this fixture.
+## Assertion Results
+
+- PASS `assertion_1`: 分类为 `suspected / needs more evidence`。
+- PASS `assertion_2`: 完整列出 failing scenario、步骤、环境/版本、console/network、截图与 trace 缺口。
+- PASS `assertion_3`: 包含 classification、evidence status、confidence、missing evidence、recommended evidence。
+- PASS `assertion_4`: 未创建 GitHub issue 或 confirmed bug，只建议本地调查 note。
+
+## With-Skill Behavior
+
+候选保持低置信度与证据门槛，清楚说明当前只能形成调查型分析，未越权生成 confirmed bug。
+
+## Fresh Without-Skill Baseline
+
+同一 prompt/fixture 的全新 baseline 已生成，未读取 skill、QA README 或历史 baseline。candidate/verdict 均成功；baseline 也满足四条 assertions，semantic verdict 为 PASS。
 
 ## Failures
 
-- None identified. The current skill contract satisfies all eval assertions for thin-evidence handling, evidence gaps, structured output, and persistence boundaries.
+- 无。
 
 ## Next Steps
 
-- No fixture or skill change is required from this eval.
-- If this scenario is handled in production, collect steps, version, environment, console/network output, screenshot or trace before escalating.
+- 保留为薄证据边界回归用例；正式非 E2E 输出路径需由另一 fixture 覆盖。
 
 ## Runtime Artifact Policy
 
-- No runtime artifacts were created for this validation.
-- Do not commit transcripts, verdicts, timing files, diagnostics, `with_skill/`, `without_skill/`, `outputs/`, or `comparison.auto.md`.
+- 两条 candidate、两条 verdict、diagnostics 与 `comparison.auto.md` 均在上述 `tmp/eval-runs/`，返回码均为 0、无 timeout。
+- Runtime 不提交；durable 结果仅为本文件。

--- a/agents/qa/test/bug-analyzer/evals/workspace/eval-3-mapped-doc-bug-analysis/comparison.md
+++ b/agents/qa/test/bug-analyzer/evals/workspace/eval-3-mapped-doc-bug-analysis/comparison.md
@@ -1,37 +1,51 @@
-# Consumption Regression Comparison
+# Eval Result: eval-003-mapped-doc-bug-analysis
 
 ## Evaluation Target
 
 - Skill: `bug-analyzer`
 - Eval: `eval-003-mapped-doc-bug-analysis`
+- Prompt target: 通过 change-map 定位通知重试文档并回到代码核证。
 
 ## Test Set / Fixture Version
 
-- Fixture: `ws1-consumption-v1`
-- Commit: `0b000b9`
+- Eval schema: `evals.json` v1.0
+- Fixture version: repository commit `778b042`
+- Fresh run: `2026-07-30 19:26:38 +0800`
+- Runtime directory: `tmp/eval-runs/issue-196-pr-b-20260730-192638/qa/agents/qa/test/bug-analyzer/evals/workspace/eval-3-mapped-doc-bug-analysis/`
+- `eval_metadata.json` 未声明 `execution_cleanup`。
 
 ## Latest Result
 
-**PASS** — with-skill 确认文档 3 次与规则 2 次的静态冲突，运行时未证实部分诚实分类为 suspected / needs more evidence，并遵守 E2E 前置门禁不越权建用例。
+- Behavior result: **PASS**
+- Coverage result: **FULL**
+- 无 `NOT EXERCISED` assertion。
+- 非 E2E 路径变更检查：prompt/assertions 只要求证据化静态分析，没有要求持久化报告路径；`docs/qa/{feature_path}/bug-*.md` 未被覆盖。
+
+Overall result: PASS
+
+## Assertion Results
+
+- PASS `reads_mapped_docs_first`: 通过 change-map 精准读取 `notification-retry.md`，未遍历无关文档。
+- PASS `verifies_against_code`: 分别记录文档 3 次与代码 2 次，并以代码事实影响缺陷分类。
+- PASS `treats_unverified_as_low_trust`: 识别 `unverified`，文档仅作低信任线索，关键结论由代码支撑。
 
 ## With-Skill Behavior
 
-- 命中映射文档后回规则配置核证重试次数，产出结构化缺陷分析报告（severity/confidence 显式分级）。
-- 证据边界清晰：静态冲突与运行时行为分开陈述，缺 feature_path 与 PRD/TRD 时不创建 E2E 用例。
+候选形成了清楚的文档声明、代码事实、证据边界和影响说明；静态冲突确认与运行时影响未验证被正确分开。
 
-## Without-Skill Baseline
+## Fresh Without-Skill Baseline
 
-- 来源：本次 fresh `codex exec` 独立子进程，同一原始 prompt 与 fixture，未接触 skill 或消费契约提示。
-- baseline 结论方向一致且同样保持证据谨慎，но分歧证据组织与门禁引用由临场推断承担，协议化程度低于 with-skill。
+同一 prompt/fixture 的全新 baseline 已生成，未读取 skill、QA README 或历史 baseline。candidate/verdict 均成功；baseline 同样满足三条 assertions，semantic verdict 为 PASS。
 
 ## Failures
 
-- 无。
+- 无 assertion failure。
 
 ## Next Steps
 
-- 保留本结果；后续 fixture 可增加干扰文档以放大行为差距。
+- 若要验证 PR-B 非 E2E 路径，应新增明确要求持久化报告且提供 `feature_path` 的 eval；本次不改 fixture。
 
 ## Runtime Artifact Policy
 
-- 运行期产物只存放于 `tmp/eval-runs/`，不提交到 git。
+- 两条 candidate、两条 verdict、diagnostics 与 `comparison.auto.md` 均在上述 `tmp/eval-runs/`，返回码均为 0、无 timeout。
+- Runtime 不提交；durable 结果仅为本文件。

--- a/agents/qa/test/exploratory-tester/evals/workspace/eval-1-explore-web-app/comparison.md
+++ b/agents/qa/test/exploratory-tester/evals/workspace/eval-1-explore-web-app/comparison.md
@@ -9,47 +9,56 @@
 ## Test Set / Fixture Version
 
 - Eval schema: `evals.json` v1.0
-- Fixture version: repository commit `778b042`
-- Fresh run: `2026-07-30 19:26:38 +0800`
-- Runtime directory: `tmp/eval-runs/issue-196-pr-b-20260730-192638/qa/agents/qa/test/exploratory-tester/evals/workspace/eval-1-explore-web-app/`
+- Fixture version: repository commit `cdfc879`
+- Fresh run: `2026-07-30 19:56:59 +0800`
+- Runtime directory: `tmp/eval-runs/issue-196-pr-b-bug-explore-20260730-195659/exploratory-tester/eval-001/`
 - `eval_metadata.json` 未声明 `execution_cleanup`。
 
 ## Latest Result
 
-- Behavior result: **FAIL**
+- Behavior result: **PASS**
 - Coverage result: **FULL**
-- 所有 assertions 均可由静态 preflight/blocked 输出判定；无 `NOT EXERCISED`。
-- 非 E2E 路径变更检查：该 fixture 是 E2E `feature-update` 场景，未触发 `docs/qa/{feature_path}/exploratory-report.md`。
+- 当前 7 条 assertion 均可由 fresh blocked-preflight 候选直接判定，无
+  `NOT EXERCISED`。
+- fixture 已提供 `docs/qa/e2e/search/results/filtering/` 用例树、`feature-update`
+  场景与 `v0.9.0-dev`；这是纯 E2E eval，因此不包含非 E2E fallback 路径断言。
 
-Overall result: FAIL
+Overall result: PASS
 
 ## Assertion Results
 
-- FAIL `assertion_1`: charter 有 surface、heuristics、escalation signals，但缺少上下文给出的 timebox，且未说明重试时由何来源确定 timebox。
+- PASS `assertion_1`: charter 包含 surface、heuristics、escalation signals，并明确本轮未启动 timebox；重试 duration 必须来自用户或 PM/QA handoff。
 - PASS `assertion_2`: 读取 suite、flow、既有 TC，复用同义流程并避免重复 TC。
-- FAIL `assertion_3`: changed surface 与 nearby risks 正确，但 timebox 来源未闭环。
+- PASS `assertion_3`: 围绕 `SearchPanel`、`FilterPills`、`ResultsList` 与 keyboard-focus nearby risk 组织探索；没有套用固定默认时长，并闭环重试 timebox 来源。
 - PASS `assertion_4`: observed、unconfirmed、gaps 三层清楚，未把风险当缺陷。
 - PASS `assertion_5`: 输出是 chartered exploration，不是随机点击日志。
-- PASS `assertion_6`: 含 charter、timebox 状态、covered path、evidence 与 next actions。
-- PASS `deduplicates_existing_flows`: 复用 `TC-001-filter-results`，只建议增量更新。
+- PASS `assertion_6`: 含 charter、timebox 状态、covered path、evidence used 与 next actions。
+- PASS `deduplicates_existing_flows`: 识别既有 `TC-001-filter-results`，只允许增量更新同一 TC、匹配 script 与 `FLOW_INDEX.md`，一次性观察留在报告。
 
 ## With-Skill Behavior
 
-缺少 `QA_BASE_URL` 时停止浏览器执行是正确 blocked 行为；FAIL 仅来自 timebox 契约未闭环，而非“没有实跑”。
+缺少 `QA_BASE_URL`、同路径 TRD 和 confirmed plan 时停止 E2E 执行；同时完整输出
+memory read set、scenario/platform、入口顺序、subagent 执行边界、charter 和去重策略。
+blocked 不妨碍当前静态协议 assertion 的完整判定，Behavior PASS。
 
 ## Fresh Without-Skill Baseline
 
-同一 prompt/fixture 的全新 baseline 已生成，未读取 skill、QA README 或历史 baseline。candidate/verdict 均成功；baseline 同样缺 timebox 来源，semantic verdict 为 FAIL。
+同一 prompt/fixture 在本轮隔离目录重新生成 baseline，未读取或应用
+`exploratory-tester`、QA README 或历史 baseline。它使用固定 30 分钟默认值，包含随机
+点击，没有 QA memory、scenario/platform、执行入口、subagent、证据分层和 TC 去重；
+baseline 仅作为 comparison 输入，不决定 with-skill Behavior。
 
 ## Failures
 
-- 未给出上下文驱动 timebox，也未指出重试时确定 timebox 的来源。
+- 无 with-skill assertion failure。
 
 ## Next Steps
 
-- 后续候选在执行被 URL 阻塞时仍应声明“未启动执行 timebox”，并指出由用户或 handoff 提供的时长决定重试 timebox。
+- 提供 `QA_BASE_URL`、同路径 TRD、confirmed implementation plan 和明确 duration 后，
+  才能开始 `TC-001` 与相邻风险的运行时探索。
 
 ## Runtime Artifact Policy
 
-- 两条 candidate、两条 verdict、diagnostics 与 `comparison.auto.md` 均在上述 `tmp/eval-runs/`，返回码均为 0、无 timeout。
+- 新 `with_skill.md`、`without_skill.md` 与 `verdict.md` 仅保存在上述
+  `tmp/eval-runs/`；未复用历史 candidate 或 baseline。
 - Runtime 不提交；durable 结果仅为本文件。

--- a/agents/qa/test/exploratory-tester/evals/workspace/eval-1-explore-web-app/comparison.md
+++ b/agents/qa/test/exploratory-tester/evals/workspace/eval-1-explore-web-app/comparison.md
@@ -2,46 +2,54 @@
 
 ## Evaluation Target
 
-- Agent: `qa`
 - Skill: `exploratory-tester`
 - Eval: `eval-001-explore-web-app`
-- Test case: explore-web-app
-- Workspace: `workspace/eval-1-explore-web-app`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
-- Validation method: fresh Codex subagent review; baseline was derived before reading `exploratory-tester` or QA README, then with-skill behavior was checked against `SKILL.md`, `agents/qa/README.md`, direct shared references, eval assertions, and fixture evidence.
+- Prompt target: 基于搜索刷新上下文制定并执行探索协议。
 
 ## Test Set / Fixture Version
 
-- Schema: `evals.json` v1.0
-- Expected output: 探索测试报告，包含发现的问题列表和复现路径
-- Fixture context: search-refresh PRD, `SearchPanel`, `FilterPills`, `ResultsList`, QA environment note, `TEST_SUITE.md`, `FLOW_INDEX.md`, and `cases/TC-001-filter-results.md`.
-- Scenario and version: `feature-update`, platform version `v0.9.0-dev`.
+- Eval schema: `evals.json` v1.0
+- Fixture version: repository commit `778b042`
+- Fresh run: `2026-07-30 19:26:38 +0800`
+- Runtime directory: `tmp/eval-runs/issue-196-pr-b-20260730-192638/qa/agents/qa/test/exploratory-tester/evals/workspace/eval-1-explore-web-app/`
+- `eval_metadata.json` 未声明 `execution_cleanup`。
 
-## Without Skill Baseline
+## Latest Result
 
-- A generic exploratory answer would likely begin browser probing or list ad hoc checks without first building a charter from PM context, changed surface, known risks, and environment constraints.
-- It could skip the existing `docs/qa/e2e/search/results/filtering/` memory and create a duplicate filter-results TC instead of updating `TC-001-filter-results`.
-- It might not separate observed defects, suspicious unconfirmed signals, and gaps not explored.
-- It could ignore that browser execution depends on `QA_BASE_URL`, and it would be less likely to state repo harness > Chrome plugin / browser connector > Playwright fallback as the execution-entry order.
+- Behavior result: **FAIL**
+- Coverage result: **FULL**
+- 所有 assertions 均可由静态 preflight/blocked 输出判定；无 `NOT EXERCISED`。
+- 非 E2E 路径变更检查：该 fixture 是 E2E `feature-update` 场景，未触发 `docs/qa/{feature_path}/exploratory-report.md`。
 
-## With Skill Behavior
+Overall result: FAIL
 
-- PASS: `exploratory-tester` requires a charter before interaction, including surface, timebox source, heuristics, and escalation signals. The fixture supplies the changed search surfaces and keyboard-focus risk needed for that charter.
-- PASS: Existing QA memory is primary. The skill requires reading `TEST_SUITE.md`, `FLOW_INDEX.md`, `cases/*.md`, `scripts/*.spec.md`, prior `results/`, and `_reports/`; absent scripts/results/reports must be recorded instead of silently skipped.
-- PASS: The fixture's existing `TC-001-filter-results` covers the filter-results flow. The skill requires updating the existing TC, script, or `FLOW_INDEX.md` when the same flow is found, and keeps one-off observations in the exploratory report.
-- PASS: For existing-feature exploration, reusable TC creation/update/execution remains gated by same-path PRD/TRD expectation alignment and a confirmed `IMPLEMENTATION_PLAN.md`; fixture-level browser execution is also blocked unless `QA_BASE_URL` is present.
-- PASS: The report contract separates observed issues, suspicious but unconfirmed signals, gaps not explored, exploration path covered, evidence used, and recommended next actions.
+## Assertion Results
+
+- FAIL `assertion_1`: charter 有 surface、heuristics、escalation signals，但缺少上下文给出的 timebox，且未说明重试时由何来源确定 timebox。
+- PASS `assertion_2`: 读取 suite、flow、既有 TC，复用同义流程并避免重复 TC。
+- FAIL `assertion_3`: changed surface 与 nearby risks 正确，但 timebox 来源未闭环。
+- PASS `assertion_4`: observed、unconfirmed、gaps 三层清楚，未把风险当缺陷。
+- PASS `assertion_5`: 输出是 chartered exploration，不是随机点击日志。
+- PASS `assertion_6`: 含 charter、timebox 状态、covered path、evidence 与 next actions。
+- PASS `deduplicates_existing_flows`: 复用 `TC-001-filter-results`，只建议增量更新。
+
+## With-Skill Behavior
+
+缺少 `QA_BASE_URL` 时停止浏览器执行是正确 blocked 行为；FAIL 仅来自 timebox 契约未闭环，而非“没有实跑”。
+
+## Fresh Without-Skill Baseline
+
+同一 prompt/fixture 的全新 baseline 已生成，未读取 skill、QA README 或历史 baseline。candidate/verdict 均成功；baseline 同样缺 timebox 来源，semantic verdict 为 FAIL。
 
 ## Failures
 
-- None identified. The current skill contract satisfies all eval assertions for chartering, QA memory reuse, scope/timebox discipline, evidence layering, chartered exploration, handoff-ready output, and duplicate TC avoidance.
+- 未给出上下文驱动 timebox，也未指出重试时确定 timebox 的来源。
 
 ## Next Steps
 
-- No fixture or skill change is required from this eval.
-- A real execution should record any missing `scripts/`, prior `results/`, `_reports/`, `QA_BASE_URL`, TRD, or implementation-plan gates as blocked before browser or E2E execution.
+- 后续候选在执行被 URL 阻塞时仍应声明“未启动执行 timebox”，并指出由用户或 handoff 提供的时长决定重试 timebox。
 
 ## Runtime Artifact Policy
 
-- No runtime artifacts were created for this validation.
-- Do not commit transcripts, verdicts, timing files, diagnostics, `with_skill/`, `without_skill/`, `outputs/`, or `comparison.auto.md`.
+- 两条 candidate、两条 verdict、diagnostics 与 `comparison.auto.md` 均在上述 `tmp/eval-runs/`，返回码均为 0、无 timeout。
+- Runtime 不提交；durable 结果仅为本文件。

--- a/agents/qa/test/exploratory-tester/evals/workspace/eval-2-explore-with-custom-duration/comparison.md
+++ b/agents/qa/test/exploratory-tester/evals/workspace/eval-2-explore-with-custom-duration/comparison.md
@@ -2,48 +2,53 @@
 
 ## Evaluation Target
 
-- Agent: `qa`
 - Skill: `exploratory-tester`
 - Eval: `eval-002-explore-with-custom-duration`
-- Test case: explore-with-custom-duration
-- Workspace: `workspace/eval-2-explore-with-custom-duration`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
-- Validation method: fresh Codex subagent review; baseline was derived before reading `exploratory-tester` or QA README, then with-skill behavior was checked against `SKILL.md`, `agents/qa/README.md`, direct shared references, eval assertions, and fixture evidence.
+- Prompt target: 使用用户给定 5 分钟 timebox 探索 settings 变更面。
 
 ## Test Set / Fixture Version
 
-- Schema: `evals.json` v1.0
-- Expected output: 5 分钟探索测试报告
-- Fixture context: settings-panel PRD, `SettingsPanel`, `EmailPreferenceForm`, shared toast notifications, QA environment note, `TEST_SUITE.md`, and `FLOW_INDEX.md`.
-- Target and timebox: `https://qa.example.test/settings`, 5 minutes.
-- Scenario and version: `feature-update`, platform version missing.
+- Eval schema: `evals.json` v1.0
+- Fixture version: repository commit `778b042`
+- Fresh run: `2026-07-30 19:26:38 +0800`
+- Runtime directory: `tmp/eval-runs/issue-196-pr-b-20260730-192638/qa/agents/qa/test/exploratory-tester/evals/workspace/eval-2-explore-with-custom-duration/`
+- `eval_metadata.json` 未声明 `execution_cleanup`。
 
-## Without Skill Baseline
+## Latest Result
 
-- A generic exploratory answer might honor the 5-minute phrase but skip the function-tree QA memory and platform-version gate.
-- It could start browser automation against the URL before confirming reachability, execution entry, platform version, or subagent delegation.
-- It might create a new save/cancel TC without first updating `FLOW_INDEX.md` or checking for existing equivalent cases.
-- It would be less likely to keep console/network anomalies as unconfirmed signals unless reproduction evidence is strong enough.
+- Behavior result: **PASS**
+- Coverage result: **FULL**
+- 平台版本缺失触发预期 blocker；没有 assertion 因该 blocker 被遗漏。
+- 非 E2E 路径变更检查：这是 E2E `feature-update` 场景，未触发 `docs/qa/{feature_path}/exploratory-report.md`。
 
-## With Skill Behavior
+Overall result: PASS
 
-- PASS: `exploratory-tester` uses the user-provided 5-minute timebox exactly and builds the charter from URL, changed surface, environment note, and toast-risk context.
-- PASS: The skill requires reading `TEST_SUITE.md`, `FLOW_INDEX.md`, `cases/*.md`, `scripts/*.spec.md`, prior `results/`, and `_reports/`; absent cases/scripts/results/reports are recorded as gaps.
-- PASS: The fixture explicitly lacks a platform version. The correct with-skill result is blocked before E2E execution, never an `unknown` archive path.
-- PASS: Execution-entry precedence is repo harness > Chrome plugin / browser connector > Playwright fallback, and executable E2E TC are delegated to subagents by default while the main agent owns scope and summary.
-- PASS: Because this is an existing-feature exploration, reusable TC creation/update/execution also remains blocked until same-path PRD/TRD expectation alignment and a confirmed implementation plan are available.
-- PASS: The report must separate observed issues, suspicious but unconfirmed signals, gaps not explored, evidence references, risk notes, and recommended next actions.
+## Assertion Results
+
+- PASS `assertion_1`: 使用 URL 与 5 分钟建立 charter，记录 changed surface、环境和未验证的实际加载/登录/交互前提。
+- PASS `assertion_2`: 完整记录 suite、flow、缺失 cases/scripts/results/reports，确认 `feature-update`，并说明扩充路径。
+- PASS `version_entry_and_subagent`: 平台版本缺失时 blocked，列出执行入口顺序、未选择入口原因和 subagent 默认。
+- PASS `assertion_3`: confirmed blocker、unconfirmed signals、uncovered areas 分层，未伪造 console/network/page-crash 结果。
+- PASS `assertion_4`: 明确实际路径停在只读 preflight，并提供 evidence references；合法 blocked 不要求虚构浏览器步骤。
+- PASS `assertion_5`: 风险 notes 与后续 QA/bug-analyzer 条件清楚。
+
+## With-Skill Behavior
+
+候选完整执行了 blocked preflight；没有平台版本时不开始 5 分钟执行是正确行为，不应因缺少实际 UI 证据判为行为失败。
+
+## Fresh Without-Skill Baseline
+
+同一 prompt/fixture 的全新 baseline 已生成，未读取 skill、QA README 或历史 baseline。candidate/verdict 均成功；baseline 缺完整 memory、entry 和 subagent 协议，semantic verdict 为 FAIL。
 
 ## Failures
 
-- None identified. The current skill contract satisfies all eval assertions for context-driven scope, E2E memory confirmation, platform-version blocking, execution-entry precedence, subagent default, anomaly layering, evidence output, and risk handoff.
+- 无。
 
 ## Next Steps
 
-- No fixture or skill change is required from this eval.
-- A real execution should ask for platform version before any E2E run and keep URL reachability, TRD, implementation-plan, and missing TC/script gaps visible.
+- 提供平台版本后才可开始真实 5 分钟探索；本 eval 保留为 blocked-preflight 回归。
 
 ## Runtime Artifact Policy
 
-- No runtime artifacts were created for this validation.
-- Do not commit transcripts, verdicts, timing files, diagnostics, `with_skill/`, `without_skill/`, `outputs/`, or `comparison.auto.md`.
+- 两条 candidate、两条 verdict、diagnostics 与 `comparison.auto.md` 均在上述 `tmp/eval-runs/`，返回码均为 0、无 timeout。
+- Runtime 不提交；durable 结果仅为本文件。

--- a/agents/qa/test/exploratory-tester/evals/workspace/eval-3-mapped-doc-exploration/comparison.md
+++ b/agents/qa/test/exploratory-tester/evals/workspace/eval-3-mapped-doc-exploration/comparison.md
@@ -1,37 +1,51 @@
-# Consumption Regression Comparison
+# Eval Result: eval-003-mapped-doc-exploration
 
 ## Evaluation Target
 
 - Skill: `exploratory-tester`
 - Eval: `eval-003-mapped-doc-exploration`
+- Prompt target: 以 change-map 缩小结账超时探索范围并由代码核证。
 
 ## Test Set / Fixture Version
 
-- Fixture: `ws1-consumption-v1`
-- Commit: `0b000b9`
+- Eval schema: `evals.json` v1.0
+- Fixture version: repository commit `778b042`
+- Fresh run: `2026-07-30 19:26:38 +0800`
+- Runtime directory: `tmp/eval-runs/issue-196-pr-b-20260730-192638/qa/agents/qa/test/exploratory-tester/evals/workspace/eval-3-mapped-doc-exploration/`
+- `eval_metadata.json` 未声明 `execution_cleanup`。
 
 ## Latest Result
 
-**PASS** — with-skill 发现文档 15 分钟与代码 10 分钟的超时分歧并结构化记录，探索章程以代码事实为主探针、文档值为兼容探针，同时正确识别 E2E 持久化资产缺失。
+- Behavior result: **PASS**
+- Coverage result: **FULL**
+- 无 `NOT EXERCISED` assertion。
+- 非 E2E 路径变更检查：prompt 只要求探索章程与边界，没有要求持久化报告；`docs/qa/{feature_path}/exploratory-report.md` 未覆盖。
+
+Overall result: PASS
+
+## Assertion Results
+
+- PASS `reads_mapped_docs_first`: 通过 change-map 只读取 checkout session 文档。
+- PASS `verifies_against_code`: 明确文档 15 分钟、代码 10 分钟，并以 10 分钟设计边界。
+- PASS `treats_unverified_as_low_trust`: `unverified` 文档仅作低信任线索，关键假设回到代码。
 
 ## With-Skill Behavior
 
-- 命中映射文档后回代码规则核证超时值，分歧以文档声明/代码事实/影响表结构化输出。
-- 探索设计不把 unverified 文档值当预期，PM 确认前只作为兼容性探针；并按 QA 契约说明 E2E 资产沉淀路径与执行入口优先级。
+候选覆盖 9:59、10:00、10:01 等直接边界，并把文档冲突、运行时未验证与推荐下一步清楚分开。
 
-## Without-Skill Baseline
+## Fresh Without-Skill Baseline
 
-- 来源：本次 fresh `codex exec` 独立子进程，同一原始 prompt 与 fixture，未接触 skill 或消费契约提示。
-- baseline 也识别了 10/15 分钟差异并建议确认预期，但分歧记录为叙述式，未形成契约格式的证据结构。
+同一 prompt/fixture 的全新 baseline 已生成，未读取 skill、QA README 或历史 baseline。candidate/verdict 均成功；baseline 也满足三条 assertions，semantic verdict 为 PASS。
 
 ## Failures
 
-- 无。
+- 无 assertion failure。
 
 ## Next Steps
 
-- 保留本结果；后续 fixture 可增加干扰文档以放大行为差距。
+- PR-B 非 E2E 报告路径需要独立的持久化报告 fixture；本次不改现有 eval。
 
 ## Runtime Artifact Policy
 
-- 运行期产物只存放于 `tmp/eval-runs/`，不提交到 git。
+- 两条 candidate、两条 verdict、diagnostics 与 `comparison.auto.md` 均在上述 `tmp/eval-runs/`，返回码均为 0、无 timeout。
+- Runtime 不提交；durable 结果仅为本文件。

--- a/agents/qa/test/qa-agent/evals/evals.json
+++ b/agents/qa/test/qa-agent/evals/evals.json
@@ -22,24 +22,9 @@
           "text": "必须列出下游 skill 需要先读取的 PM/spec、实现变更、CI 失败信息、环境说明和测试命令，而不是直接假设浏览器或端口"
         },
         {
-          "id": "qa",
-          "description": "QA 用例记忆",
-          "text": "如果是独立 QA 或 E2E 请求，必须要求下游先读取 docs/qa/e2e/{feature_path}/TEST_SUITE.md、FLOW_INDEX.md、cases/*.md、scripts/*.spec.md、历史 results/ 和 _reports/，而不是旧的单层 QA 目录。"
-        },
-        {
-          "id": "e2e_execution_protocol",
-          "description": "E2E 执行协议",
-          "text": "E2E 路由必须要求先确认测试场景和平台版本；版本缺失时 blocked 且不得写入 unknown；执行入口按 repo harness > Chrome plugin / browser connector > Playwright fallback 选择；单个 E2E TC 也默认由 subagent 执行，主 agent 负责拆分和汇总。"
-        },
-        {
-          "id": "credential_and_report_refs",
-          "description": "账号与报告 reference",
-          "text": "如果用户提供平台账号、SSH 账号或其他凭据，输出必须要求按本 skill 目录下的 references/e2e-credential-store.md upsert 到 .qa/e2e/accounts.local.json，测试文档只引用账号 ID；主 agent 汇总报告必须使用 e2e-test-report.md reference 的固定字段和路径。"
-        },
-        {
-          "id": "alignment_and_plan_gate",
-          "description": "PRD/TRD 与实施计划门禁",
-          "text": "如果请求来自现有功能变更、bug 修复或代码完成后的 E2E 文档补充，必须先检查同一 feature_path 下的 PRD/TRD、存在的产品决策记录和已确认的 IMPLEMENTATION_PLAN.md；预期变化回 PM，TRD gap 回 trd-gen，缺 plan 回 feature-implementor，文档缺失 blocked。"
+          "id": "specialist_gate_pointer",
+          "description": "Specialist 权威门禁指针",
+          "text": "路由输出必须声明选中的 specialist，并指出该 specialist 的权威 E2E memory、platform version、credential、execution entry、PRD/TRD/implementation plan 与 blocked-condition 门禁适用；不得在 qa-agent 路由输出中展开或复述这些门禁的具体协议，展开复述应判 FAIL。"
         },
         {
           "id": "assertion_4",
@@ -72,24 +57,9 @@
           "text": "因为用户已确认有新功能更新并授权探索，必须要求下游主动读取目标项目文件、环境说明和测试命令来扩充用例，而不是再次询问是否可以探索或直接返回 blocked"
         },
         {
-          "id": "assertion_3",
-          "description": "探索记录沉淀",
-          "text": "必须要求更新 docs/qa/e2e/account/profile-settings/profile-form/TEST_SUITE.md 和 FLOW_INDEX.md，记录探索过的文件、发现的路由/表单/命令、覆盖含义和待确认假设。"
-        },
-        {
-          "id": "e2e",
-          "description": "E2E 用例创建",
-          "text": "必须将每个新增 E2E 测试用例单独保存为 docs/qa/e2e/account/profile-settings/profile-form/cases/TC-NNN-<short-slug>.md，并把对应可执行或半可执行流程脚本保存为 scripts/TC-NNN-<short-slug>.spec.md；脚本不得包含明文账号、密码、token、cookie、session、SSH 密码或 SSH key。"
-        },
-        {
-          "id": "assertion_5",
-          "description": "用例驱动执行",
-          "text": "必须声明执行验证要基于新建的 TC 和 script；feature-update 场景只覆盖更新功能和直接影响路径；执行入口必须先判断 repo harness，无法覆盖时使用 Chrome 插件 / browser connector，Chrome 不可用时才使用 Playwright 兜底。"
-        },
-        {
-          "id": "version_and_subagent_gate",
-          "description": "版本与 subagent 门禁",
-          "text": "执行前必须确认测试平台版本；缺失时 blocked 并询问用户，不得使用 unknown 目录；所有 E2E TC 默认交给 subagent 执行，主 agent 最终按 e2e-test-report.md 生成 feature-update 报告到功能目录 _reports/{platform-version}/test-reports-{test-time}.md。"
+          "id": "specialist_gate_pointer",
+          "description": "Specialist 权威门禁指针",
+          "text": "路由输出必须声明选中的 specialist，并指出该 specialist 的权威 E2E memory、platform version、credential、execution entry、PRD/TRD/implementation plan 与 blocked-condition 门禁适用；不得在 qa-agent 路由输出中展开或复述这些门禁的具体协议，展开复述应判 FAIL。"
         },
         {
           "id": "assertion_6",
@@ -112,19 +82,14 @@
           "text": "必须把 `account/profile/preferences` 作为 feature_path，读取同路径 PRD 和 TRD，并保留 QA E2E 功能树 `docs/qa/e2e/account/profile/preferences/`。"
         },
         {
-          "id": "blocks_missing_plan",
-          "description": "缺实施计划 blocked",
-          "text": "缺少 `docs/engineer/account/profile/preferences/IMPLEMENTATION_PLAN.md` 时必须标记 blocked，并把 next owner 指向 `engineer-agent:feature-implementor` 补齐实施计划。"
-        },
-        {
-          "id": "no_e2e_mutation_or_execution",
-          "description": "不更新或执行验收 TC",
-          "text": "在缺已确认实施计划时，不得创建、更新或执行 E2E acceptance TC，也不得把 QA 功能树空目录当作可执行覆盖。"
+          "id": "specialist_gate_pointer",
+          "description": "Specialist 权威门禁指针",
+          "text": "路由输出必须声明选中的 specialist，并指出该 specialist 的权威 E2E memory、platform version、credential、execution entry、PRD/TRD/implementation plan 与 blocked-condition 门禁适用；不得在 qa-agent 路由输出中展开或复述缺计划后的阻塞、交接或执行协议，展开复述应判 FAIL。"
         },
         {
           "id": "keeps_single_route",
           "description": "单一路由",
-          "text": "必须选择一个最窄 QA route，并把缺 plan 作为 blocker，而不是并行调用多个 QA skill 或进入实现修复。"
+          "text": "必须选择一个最窄 QA route，而不是并行调用多个 QA skill、执行 specialist 协议或进入实现修复。"
         }
       ]
     }

--- a/agents/qa/test/qa-agent/evals/workspace/eval-1-route-mixed-qa-request/comparison.md
+++ b/agents/qa/test/qa-agent/evals/workspace/eval-1-route-mixed-qa-request/comparison.md
@@ -9,49 +9,45 @@
 ## Test Set / Fixture Version
 
 - Eval schema: `evals.json` v1.0
-- Fixture version: repository commit `778b042`
-- Fresh run: `2026-07-30 19:26:38 +0800`
-- Runtime directory: `tmp/eval-runs/issue-196-pr-b-20260730-192638/qa/agents/qa/test/qa-agent/evals/workspace/eval-1-route-mixed-qa-request/`
+- Fixture version: repository commit `cdfc879` plus current working-tree assertion alignment
+- Fresh run: `2026-07-30 19:56:24 +0800`
+- Runtime directory: `tmp/eval-runs/issue-196-pr-b-qa-agent-20260730-195624/eval-001-route-mixed-qa-request/`
 - `eval_metadata.json` 未声明 `execution_cleanup`。
 
 ## Latest Result
 
-- Behavior result: **FAIL**
+- Behavior result: **PASS**
 - Coverage result: **FULL**
 - 所有 assertion 场景均已触发；无 `NOT EXERCISED` assertion。
-- 变更点检查：with-skill 输出只声明 specialist 的权威门禁指针，未复述完整门禁细节，符合当前 `qa-agent` router 的收敛目标；但这与本 eval 仍要求 router 展开 E2E、凭据/报告和对齐门禁细节的 assertions 发生直接冲突。
+- 变更点检查：with-skill 输出声明所选 specialist 及权威门禁适用，只保留指针，未展开 specialist 协议。
 
-Overall result: FAIL
+Overall result: PASS
 
 ## Assertion Results
 
-- PASS `assertion_1`: 选择单一主 route `spec-based-tester`，并说明其最符合文档化验收 outcome。
-- FAIL `assertion_2`: 列出了 PRD、TRD、实现变更和 CI 日志，但没有显式列出环境说明与测试命令。
-- FAIL `qa`: 仅列出 `TEST_SUITE.md`、`FLOW_INDEX.md`，完整 `cases/`、`scripts/`、历史 `results/`、`_reports/` 只由 specialist 指针承接，未满足 assertion 的字面展开要求。
-- FAIL `e2e_execution_protocol`: 当前 router 正确保留指针，但未按旧 assertion 逐项复述场景、平台版本、`unknown` 禁止、执行入口与 subagent 规则。
-- FAIL `credential_and_report_refs`: 当前 router 正确保留 credential/report 指针，但未按旧 assertion 展开两个 reference 与本地凭据路径。
-- FAIL `alignment_and_plan_gate`: 当前 router 正确保留 PRD/TRD/plan 指针，但未按旧 assertion 展开各 gap 的 next owner。
-- PASS `assertion_4`: 预期 artifact 包含 requirement matrix、evidence references、risk notes 与 defect handoff notes。
+- PASS `assertion_1`: 选择单一主 route `spec-based-tester`，并说明文档化验收是当前最窄 evidence outcome。
+- PASS `assertion_2`: 显式列出 PRD、TRD、实现变更、CI 日志、环境约束与 `npm test -- login`，未假设端口。
+- PASS `specialist_gate_pointer`: 声明 `spec-based-tester` 的 E2E memory、platform version、credential、execution entry、PRD/TRD/implementation plan 与 blocked-condition 权威门禁适用；没有展开协议。
+- PASS `assertion_4`: 预期 artifact 包含 requirement matrix、execution path、evidence references、结果/覆盖、risk notes 与 follow-up。
 - PASS `assertion_5`: 未并行调用多个 specialist，intermittent 失败保持 risk/follow-up，不冒充 confirmed bug。
 
 ## With-Skill Behavior
 
-with-skill 候选选择 `spec-based-tester`，保留 CI 风险边界并停止在路由阶段。它体现了 PR-B 的 router 指针收敛，但无法同时满足仍要求复制 specialist 协议的旧 assertions，因此 Behavior 判 FAIL。
+with-skill 候选选择 `spec-based-tester`，完整传递 fixture 上下文，保留 CI 风险边界并停止在路由阶段。门禁只以权威 specialist 指针声明，没有复制具体执行、凭据或阻塞协议。
 
 ## Fresh Without-Skill Baseline
 
-本轮 baseline 使用同一 prompt 与 fixture 于隔离 scratch 重新生成；未读取 `qa-agent` SKILL、QA README 或历史 baseline。它选择 `bug-analyzer`，候选与 verdict 均生成成功，但同样缺少 repo-specific specialist 门禁，semantic verdict 为 FAIL。
+本轮 baseline 使用同一 prompt 与 fixture 于隔离 scratch 重新生成；未读取或应用 `qa-agent` SKILL、QA README，也未复用历史 baseline。它选择 `bug-analyzer`，偏离文档化验收主 outcome，且没有声明 repo-specific specialist 权威门禁指针。
 
 ## Failures
 
-- Router 新契约与当前 eval 的细节展开 assertions 不一致。
-- 上下文传递未显式包含环境说明与测试命令。
+- 无 with-skill assertion 失败。
 
 ## Next Steps
 
-- 后续由维护者决定是把 assertions 收敛为“权威指针存在且不复述”，还是恢复 router 细节；本次 eval 不修改 fixture。
+- 保持 router 指针契约；后续 specialist 负责执行其权威门禁与测试协议。
 
 ## Runtime Artifact Policy
 
-- 两条 candidate、两条 verdict、diagnostics 与 `comparison.auto.md` 均在上述 `tmp/eval-runs/` 目录，返回码均为 0、无 timeout。
+- 新生成的 with-skill / without-skill candidate 与 verdict 均在上述 `tmp/eval-runs/` 目录。
 - Runtime 产物不提交；durable 结果仅为本文件。

--- a/agents/qa/test/qa-agent/evals/workspace/eval-1-route-mixed-qa-request/comparison.md
+++ b/agents/qa/test/qa-agent/evals/workspace/eval-1-route-mixed-qa-request/comparison.md
@@ -2,49 +2,56 @@
 
 ## Evaluation Target
 
-- Agent: `qa`
 - Skill: `qa-agent`
 - Eval: `eval-001-route-mixed-qa-request`
-- Test case: route-mixed-qa-request
-- Workspace: `workspace/eval-1-route-mixed-qa-request`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-08 for PR #98 trigger description routing review.
+- Prompt target: 对登录重构验收请求与 intermittent CI 失败先做单一路由，不执行测试。
 
 ## Test Set / Fixture Version
 
-- Schema: `evals.json` v1.0
-- Fixture: login refresh implementation with PM acceptance question and intermittent CI failure evidence.
-- Context read before applying the skill: `AGENTS.md`, `agents/qa/README.md`, `agents/qa/skills/qa-agent/SKILL.md`, `evals.json`, workspace `eval_metadata.json`, `docs/pm/login-refresh/PRD.md`, `docs/engineer/login-refresh/TRD.md`, `docs/qa/e2e/auth/login/login-refresh/TEST_SUITE.md`, `FLOW_INDEX.md`, `implementation/changes.md`, and `ci/login-intermittent-failure.log`.
-- Runtime evidence: fresh subagent artifacts were generated under `tmp/eval-runs/2026-07-08-router-trigger-batch3/eval-001-route-mixed-qa-request/`.
+- Eval schema: `evals.json` v1.0
+- Fixture version: repository commit `778b042`
+- Fresh run: `2026-07-30 19:26:38 +0800`
+- Runtime directory: `tmp/eval-runs/issue-196-pr-b-20260730-192638/qa/agents/qa/test/qa-agent/evals/workspace/eval-1-route-mixed-qa-request/`
+- `eval_metadata.json` 未声明 `execution_cleanup`。
 
-## Assertions
+## Latest Result
 
-- PASS `assertion_1`: the primary QA route is `spec-based-tester` because PM asks whether an implementation can enter documented acceptance; the intermittent CI failure remains a risk note or possible `bug-analyzer` follow-up.
-- PASS `assertion_2`: downstream context includes PM/spec, TRD, implementation changes, CI failure log, QA E2E memory, environment constraints, and test command constraints.
-- PASS `qa`: E2E work reads the function-tree memory set under `docs/qa/e2e/{feature_path}/`, including suite, flow index, cases, scripts, prior results, and reports.
-- PASS `e2e_execution_protocol`: E2E routing requires scenario and platform version, blocks missing versions instead of writing `unknown`, selects repo harness > Chrome plugin / browser connector > Playwright fallback, and delegates TC execution to subagents.
-- PASS `credential_and_report_refs`: credential storage uses `references/e2e-credential-store.md` and `.qa/e2e/accounts.local.json`; summary reporting uses `references/e2e-test-report.md`.
-- PASS `alignment_and_plan_gate`: existing-feature and code-complete E2E updates require same-path PRD, TRD, product decisions when present, and confirmed `IMPLEMENTATION_PLAN.md`; gaps return to PM, `trd-gen`, or `feature-implementor`.
-- PASS `assertion_4`: expected artifacts include route decision, requirement matrix, execution path, evidence references, risk notes, blockers, and defect handoff notes.
-- PASS `assertion_5`: only one primary QA route is selected; the intermittent failure is not promoted to a confirmed bug without stronger evidence.
+- Behavior result: **FAIL**
+- Coverage result: **FULL**
+- 所有 assertion 场景均已触发；无 `NOT EXERCISED` assertion。
+- 变更点检查：with-skill 输出只声明 specialist 的权威门禁指针，未复述完整门禁细节，符合当前 `qa-agent` router 的收敛目标；但这与本 eval 仍要求 router 展开 E2E、凭据/报告和对齐门禁细节的 assertions 发生直接冲突。
 
-## With Skill Behavior
+Overall result: FAIL
 
-`qa-agent` satisfies the mixed QA routing contract after the PR #98 trigger description edits. The with-skill run selected the single primary route `qa-agent:spec-based-tester` because the current evidence outcome is documented acceptance readiness. It preserved the intermittent CI failure as a risk note or possible `bug-analyzer` follow-up, not a confirmed bug, and carried the required PM/spec, TRD, implementation changes, CI evidence, QA E2E memory, platform-version gate, execution-entry priority, credential/report references, and PRD/TRD/implementation-plan gate into the selected specialist. It did not execute tests or invoke multiple QA skills.
+## Assertion Results
 
-## Without Skill Baseline
+- PASS `assertion_1`: 选择单一主 route `spec-based-tester`，并说明其最符合文档化验收 outcome。
+- FAIL `assertion_2`: 列出了 PRD、TRD、实现变更和 CI 日志，但没有显式列出环境说明与测试命令。
+- FAIL `qa`: 仅列出 `TEST_SUITE.md`、`FLOW_INDEX.md`，完整 `cases/`、`scripts/`、历史 `results/`、`_reports/` 只由 specialist 指针承接，未满足 assertion 的字面展开要求。
+- FAIL `e2e_execution_protocol`: 当前 router 正确保留指针，但未按旧 assertion 逐项复述场景、平台版本、`unknown` 禁止、执行入口与 subagent 规则。
+- FAIL `credential_and_report_refs`: 当前 router 正确保留 credential/report 指针，但未按旧 assertion 展开两个 reference 与本地凭据路径。
+- FAIL `alignment_and_plan_gate`: 当前 router 正确保留 PRD/TRD/plan 指针，但未按旧 assertion 展开各 gap 的 next owner。
+- PASS `assertion_4`: 预期 artifact 包含 requirement matrix、evidence references、risk notes 与 defect handoff notes。
+- PASS `assertion_5`: 未并行调用多个 specialist，intermittent 失败保持 risk/follow-up，不冒充 confirmed bug。
 
-Fresh baseline generated on 2026-07-08 from the eval prompt and fixture files only, without applying `qa-agent`, the QA Agent README, historical `comparison.md`, or any previous baseline. The baseline gave a plausible generic acceptance-validation recommendation, but omitted several repo-specific protocol details: the complete E2E memory read set, platform-version blocking rule, credential/report references, and missing implementation-plan owner.
+## With-Skill Behavior
+
+with-skill 候选选择 `spec-based-tester`，保留 CI 风险边界并停止在路由阶段。它体现了 PR-B 的 router 指针收敛，但无法同时满足仍要求复制 specialist 协议的旧 assertions，因此 Behavior 判 FAIL。
+
+## Fresh Without-Skill Baseline
+
+本轮 baseline 使用同一 prompt 与 fixture 于隔离 scratch 重新生成；未读取 `qa-agent` SKILL、QA README 或历史 baseline。它选择 `bug-analyzer`，候选与 verdict 均生成成功，但同样缺少 repo-specific specialist 门禁，semantic verdict 为 FAIL。
 
 ## Failures
 
-- None found. PR #98 did not regress mixed QA single-route selection, E2E gate preservation, risk handling for intermittent CI evidence, or the no-direct-execution boundary.
+- Router 新契约与当前 eval 的细节展开 assertions 不一致。
+- 上下文传递未显式包含环境说明与测试命令。
 
 ## Next Steps
 
-- Keep this eval as regression coverage for mixed QA requests, single-route selection, and E2E gate preservation.
+- 后续由维护者决定是把 assertions 收敛为“权威指针存在且不复述”，还是恢复 router 细节；本次 eval 不修改 fixture。
 
-## Runtime Artifacts Policy
+## Runtime Artifact Policy
 
-- Runtime artifacts were created only under `tmp/eval-runs/2026-07-08-router-trigger-batch3/eval-001-route-mixed-qa-request/`.
-- Generated `with_skill.md`, `without_skill.md`, and `verdict.md` are scratch evidence only and must not be committed.
-- Durable committed evidence for this run is this `comparison.md`.
+- 两条 candidate、两条 verdict、diagnostics 与 `comparison.auto.md` 均在上述 `tmp/eval-runs/` 目录，返回码均为 0、无 timeout。
+- Runtime 产物不提交；durable 结果仅为本文件。

--- a/agents/qa/test/qa-agent/evals/workspace/eval-2-empty-qa-directory-expands-cases/comparison.md
+++ b/agents/qa/test/qa-agent/evals/workspace/eval-2-empty-qa-directory-expands-cases/comparison.md
@@ -9,47 +9,44 @@
 ## Test Set / Fixture Version
 
 - Eval schema: `evals.json` v1.0
-- Fixture version: repository commit `778b042`
-- Fresh run: `2026-07-30 19:26:38 +0800`
-- Runtime directory: `tmp/eval-runs/issue-196-pr-b-20260730-192638/qa/agents/qa/test/qa-agent/evals/workspace/eval-2-empty-qa-directory-expands-cases/`
+- Fixture version: repository commit `cdfc879` plus current working-tree assertion alignment
+- Fresh run: `2026-07-30 19:56:24 +0800`
+- Runtime directory: `tmp/eval-runs/issue-196-pr-b-qa-agent-20260730-195624/eval-002-empty-qa-directory-expands-cases/`
 - `eval_metadata.json` 未声明 `execution_cleanup`。
 
 ## Latest Result
 
-- Behavior result: **FAIL**
+- Behavior result: **PASS**
 - Coverage result: **FULL**
 - 所有 assertion 场景均已触发；无 `NOT EXERCISED` assertion。
-- 变更点检查：候选逐项复述了 specialist 的完整 E2E memory、平台版本、执行入口、subagent、凭据和报告规则，没有保持“router 只保留权威指针”的 PR-B 目标。
+- 变更点检查：with-skill 输出识别空功能树并传递探索上下文，同时只声明 specialist 权威门禁指针，未展开协议。
 
-Overall result: FAIL
+Overall result: PASS
 
 ## Assertion Results
 
 - PASS `assertion_1`: 正确识别空功能树不是现有覆盖。
-- PASS `assertion_2`: 用户已授权探索，要求读取目标源文件与环境说明。
-- PASS `assertion_3`: 要求更新 `TEST_SUITE.md`、`FLOW_INDEX.md` 并记录探索证据。
-- PASS `e2e`: 给出独立 TC/script 路径并禁止明文凭据。
-- PASS `assertion_5`: 要求基于新增 TC 执行并保留 repo harness > Chrome/browser > Playwright 顺序。
-- PASS `version_and_subagent_gate`: 平台版本缺失时 blocked，不写 `unknown`，TC 交给 subagent，报告路径正确。
+- PASS `assertion_2`: 用户已授权探索，要求读取目标源文件、环境说明与仓库现有测试配置/命令，没有重复询问或直接 blocked。
+- PASS `specialist_gate_pointer`: 声明 `exploratory-tester` 的 E2E memory、platform version、credential、execution entry、PRD/TRD/implementation plan 与 blocked-condition 权威门禁适用；没有展开协议。
 - PASS `assertion_6`: 选择单一 `exploratory-tester` route，未进入实现修复。
 
 ## With-Skill Behavior
 
-候选满足现有七条 assertions，但输出把 specialist 协议完整复制进 router；这违反当前 `qa-agent` 的 `Output Behavior` 指针契约，属于本次行为变更的直接回归，因此 Behavior 判 FAIL。
+候选选择单一 `exploratory-tester` route，识别空目录不是覆盖，并在用户已授权的前提下传递目标代码、环境和测试命令发现任务。输出没有复制平台版本、凭据、执行入口或 blocked-condition 的具体协议。
 
 ## Fresh Without-Skill Baseline
 
-本轮 baseline 使用同一 prompt 与 fixture 新生成，未读取 skill、QA README 或历史 baseline。candidate/verdict 均成功；baseline 也复制了大部分 specialist 细节，但遗漏测试命令与完整探索沉淀字段，semantic verdict 为 FAIL。
+本轮 baseline 使用同一 prompt 与 fixture 新生成，未读取或应用 skill、QA README，也未复用历史 baseline。它能识别空目录并选择单一路由，但直接展开 platform version、credential、execution entry、subagent 与报告协议，违反当前指针断言。
 
 ## Failures
 
-- PR-B router 指针收敛未在该候选中生效，输出仍复述 specialist 门禁细节。
+- 无 with-skill assertion 失败。
 
 ## Next Steps
 
-- 保留 assertions 结果与 router 契约失败的双重事实；后续应让 eval prompt/judge 明确验证“只输出指针”。
+- 保持 router 只传递探索上下文和权威门禁指针；由 specialist 执行实际用例扩充与验证协议。
 
 ## Runtime Artifact Policy
 
-- 两条 candidate、两条 verdict、diagnostics 与 `comparison.auto.md` 均在上述 `tmp/eval-runs/` 目录，返回码均为 0、无 timeout。
+- 新生成的 with-skill / without-skill candidate 与 verdict 均在上述 `tmp/eval-runs/` 目录。
 - Runtime 产物不提交；durable 结果仅为本文件。

--- a/agents/qa/test/qa-agent/evals/workspace/eval-2-empty-qa-directory-expands-cases/comparison.md
+++ b/agents/qa/test/qa-agent/evals/workspace/eval-2-empty-qa-directory-expands-cases/comparison.md
@@ -2,49 +2,54 @@
 
 ## Evaluation Target
 
-- Agent: `qa`
 - Skill: `qa-agent`
 - Eval: `eval-002-empty-qa-directory-expands-cases`
-- Test case: empty-qa-directory-expands-cases
-- Workspace: `workspace/eval-2-empty-qa-directory-expands-cases`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-08 for PR #98 trigger description routing review.
+- Prompt target: 对已有但无 TC 的 E2E 功能树做路由与执行协议说明。
 
 ## Test Set / Fixture Version
 
-- Schema: `evals.json` v1.0
-- Fixture: existing empty E2E function tree for profile settings plus source files and QA environment notes.
-- Context read before applying the skill: `AGENTS.md`, `agents/qa/README.md`, `agents/qa/skills/qa-agent/SKILL.md`, `evals.json`, workspace `eval_metadata.json`, `docs/qa/e2e/account/profile-settings/profile-form/TEST_SUITE.md`, `FLOW_INDEX.md`, `environment/qa-env.md`, `src/routes/profile-settings.md`, `src/pages/ProfileSettingsPage.tsx`, and `src/components/ProfileSettingsForm.tsx`.
-- Runtime evidence: fresh subagent artifacts were generated under `tmp/eval-runs/2026-07-08-router-trigger-batch3/eval-002-empty-qa-directory-expands-cases/`.
+- Eval schema: `evals.json` v1.0
+- Fixture version: repository commit `778b042`
+- Fresh run: `2026-07-30 19:26:38 +0800`
+- Runtime directory: `tmp/eval-runs/issue-196-pr-b-20260730-192638/qa/agents/qa/test/qa-agent/evals/workspace/eval-2-empty-qa-directory-expands-cases/`
+- `eval_metadata.json` 未声明 `execution_cleanup`。
 
-## Assertions
+## Latest Result
 
-- PASS `assertion_1`: the route recognizes that the QA function tree exists but has no executable TC and must not be treated as existing coverage.
-- PASS `assertion_2`: because the user confirmed a feature-update and authorized exploration, the downstream route should inspect target files and environment notes instead of asking whether exploration is allowed.
-- PASS `assertion_3`: exploration must update `TEST_SUITE.md` and `FLOW_INDEX.md` with files explored, discovered route/form/commands, coverage meaning, and assumptions.
-- PASS `e2e`: each new E2E case must be stored as `cases/TC-NNN-<short-slug>.md` with a matching `scripts/TC-NNN-<short-slug>.spec.md`, without plaintext secrets.
-- PASS `assertion_5`: validation is TC-driven, feature-update scope stays on the changed feature and direct impacts, and execution entry follows repo harness > Chrome plugin / browser connector > Playwright fallback.
-- PASS `version_and_subagent_gate`: platform version is required before execution; missing version blocks execution and reports go to `_reports/{platform-version}/test-reports-{test-time}.md` only after a real version is known.
-- PASS `assertion_6`: the router selects one narrow QA route and does not expand QA routing into implementation repair or multiple QA specialists.
+- Behavior result: **FAIL**
+- Coverage result: **FULL**
+- 所有 assertion 场景均已触发；无 `NOT EXERCISED` assertion。
+- 变更点检查：候选逐项复述了 specialist 的完整 E2E memory、平台版本、执行入口、subagent、凭据和报告规则，没有保持“router 只保留权威指针”的 PR-B 目标。
 
-## With Skill Behavior
+Overall result: FAIL
 
-`qa-agent` satisfies the empty-directory E2E route after the PR #98 trigger description edits. The with-skill run selected a single primary route, `qa-agent:spec-based-tester`, recognized that `docs/qa/e2e/account/profile-settings/profile-form/` exists but has no executable TC, required targeted exploration of route, page, form, environment, harness, and test-command context, and required updates to `TEST_SUITE.md`, `FLOW_INDEX.md`, independent `cases/TC-NNN-<short-slug>.md`, and matching `scripts/TC-NNN-<short-slug>.spec.md` before TC-driven execution. It preserved the feature-update scope, execution-entry priority, subagent execution rule, and platform-version blocker; missing platform version blocks execution and forbids `unknown` result paths.
+## Assertion Results
 
-## Without Skill Baseline
+- PASS `assertion_1`: 正确识别空功能树不是现有覆盖。
+- PASS `assertion_2`: 用户已授权探索，要求读取目标源文件与环境说明。
+- PASS `assertion_3`: 要求更新 `TEST_SUITE.md`、`FLOW_INDEX.md` 并记录探索证据。
+- PASS `e2e`: 给出独立 TC/script 路径并禁止明文凭据。
+- PASS `assertion_5`: 要求基于新增 TC 执行并保留 repo harness > Chrome/browser > Playwright 顺序。
+- PASS `version_and_subagent_gate`: 平台版本缺失时 blocked，不写 `unknown`，TC 交给 subagent，报告路径正确。
+- PASS `assertion_6`: 选择单一 `exploratory-tester` route，未进入实现修复。
 
-Fresh baseline generated on 2026-07-08 from the eval prompt and fixture files only, without applying `qa-agent`, the QA Agent README, historical `comparison.md`, or any previous baseline. The baseline recognized a need to inspect code and add tests, but lacked the complete function-tree persistence contract, repo harness > Chrome / browser connector > Playwright execution priority, default subagent execution, report path rules, and `unknown` prohibition.
+## With-Skill Behavior
+
+候选满足现有七条 assertions，但输出把 specialist 协议完整复制进 router；这违反当前 `qa-agent` 的 `Output Behavior` 指针契约，属于本次行为变更的直接回归，因此 Behavior 判 FAIL。
+
+## Fresh Without-Skill Baseline
+
+本轮 baseline 使用同一 prompt 与 fixture 新生成，未读取 skill、QA README 或历史 baseline。candidate/verdict 均成功；baseline 也复制了大部分 specialist 细节，但遗漏测试命令与完整探索沉淀字段，semantic verdict 为 FAIL。
 
 ## Failures
 
-- None found. Missing platform version is the expected execution blocker for this fixture, not a router failure.
-- PR #98 did not regress empty-directory expansion, E2E persistence, version-gated execution, or QA route boundaries.
+- PR-B router 指针收敛未在该候选中生效，输出仍复述 specialist 门禁细节。
 
 ## Next Steps
 
-- Keep this eval as regression coverage for empty E2E function-tree expansion and version-gated execution.
+- 保留 assertions 结果与 router 契约失败的双重事实；后续应让 eval prompt/judge 明确验证“只输出指针”。
 
-## Runtime Artifacts Policy
+## Runtime Artifact Policy
 
-- Runtime artifacts were created only under `tmp/eval-runs/2026-07-08-router-trigger-batch3/eval-002-empty-qa-directory-expands-cases/`.
-- Generated `with_skill.md`, `without_skill.md`, and `verdict.md` are scratch evidence only and must not be committed.
-- Durable committed evidence for this run is this `comparison.md`.
+- 两条 candidate、两条 verdict、diagnostics 与 `comparison.auto.md` 均在上述 `tmp/eval-runs/` 目录，返回码均为 0、无 timeout。
+- Runtime 产物不提交；durable 结果仅为本文件。

--- a/agents/qa/test/qa-agent/evals/workspace/eval-3-feature-path-missing-plan-blocked/comparison.md
+++ b/agents/qa/test/qa-agent/evals/workspace/eval-3-feature-path-missing-plan-blocked/comparison.md
@@ -9,44 +9,43 @@
 ## Test Set / Fixture Version
 
 - Eval schema: `evals.json` v1.0
-- Fixture version: repository commit `778b042`
-- Fresh run: `2026-07-30 19:26:38 +0800`
-- Runtime directory: `tmp/eval-runs/issue-196-pr-b-20260730-192638/qa/agents/qa/test/qa-agent/evals/workspace/eval-3-feature-path-missing-plan-blocked/`
+- Fixture version: repository commit `cdfc879` plus current working-tree assertion alignment
+- Fresh run: `2026-07-30 19:56:24 +0800`
+- Runtime directory: `tmp/eval-runs/issue-196-pr-b-qa-agent-20260730-195624/eval-003-feature-path-missing-plan-blocked/`
 - `eval_metadata.json` 未声明 `execution_cleanup`。
 
 ## Latest Result
 
-- Behavior result: **FAIL**
+- Behavior result: **PASS**
 - Coverage result: **FULL**
 - 所有 assertion 场景均已触发；无 `NOT EXERCISED` assertion。
-- 变更点检查：候选直接执行了 specialist 的 implementation-plan gate 并复述详细 E2E 状态，没有仅保留 specialist 门禁指针。
+- 变更点检查：with-skill 输出保留同路径上下文，只声明 specialist 权威门禁适用，没有展开缺计划后的阻塞、交接或执行协议。
 
-Overall result: FAIL
+Overall result: PASS
 
 ## Assertion Results
 
 - PASS `reads_same_feature_path`: 正确保留 `account/profile/preferences` 及同路径 PRD/TRD/QA 功能树。
-- PASS `blocks_missing_plan`: 缺 `IMPLEMENTATION_PLAN.md` 时 blocked，next owner 为 `engineer-agent:feature-implementor`。
-- PASS `no_e2e_mutation_or_execution`: 没有创建、更新或执行验收 TC。
+- PASS `specialist_gate_pointer`: 声明 `spec-based-tester` 的 E2E memory、platform version、credential、execution entry、PRD/TRD/implementation plan 与 blocked-condition 权威门禁适用；没有复述缺计划后的协议。
 - PASS `keeps_single_route`: 选择单一 `spec-based-tester` route，未进入实现修复。
 
 ## With-Skill Behavior
 
-blocked 是正确产品行为，四条 assertions 也全部满足；但 router 自己展开并裁决了 specialist 的详细 plan/E2E 门禁，与当前 `qa-agent` 只保留 gate pointer 的职责边界冲突，因此 Behavior 判 FAIL。
+候选把 `account/profile/preferences` 及同路径文档完整传给单一 `spec-based-tester`，并停止在 router 边界。它没有代替 specialist 裁决 implementation-plan gate，也没有复述缺计划后的交接或执行协议。
 
 ## Fresh Without-Skill Baseline
 
-本轮 baseline 使用同一 prompt 与 fixture 新生成，未读取 skill、QA README 或历史 baseline。candidate/verdict 均成功；baseline 同样识别缺 plan 并 blocked，semantic verdict 为 PASS。
+本轮 baseline 使用同一 prompt 与 fixture 新生成，未读取或应用 skill、QA README，也未复用历史 baseline。它识别 feature path 和缺失 plan，但直接裁决 blocked，并复述 Engineer 交接、平台版本、凭据、执行环境与 subagent 协议，违反当前指针断言。
 
 ## Failures
 
-- PR-B router 指针收敛未在该候选中生效；输出仍复述 specialist 门禁细节。
+- 无 with-skill assertion 失败。
 
 ## Next Steps
 
-- 后续 eval 应把“router 只选择 route、声明权威指针；specialist 再做详细门禁”设为显式 assertion。
+- 保持 router 只选择 route、传递同路径上下文并声明权威指针；具体门禁判断由 specialist 执行。
 
 ## Runtime Artifact Policy
 
-- 两条 candidate、两条 verdict、diagnostics 与 `comparison.auto.md` 均在上述 `tmp/eval-runs/` 目录，返回码均为 0、无 timeout。
+- 新生成的 with-skill / without-skill candidate 与 verdict 均在上述 `tmp/eval-runs/` 目录。
 - Runtime 产物不提交；durable 结果仅为本文件。

--- a/agents/qa/test/qa-agent/evals/workspace/eval-3-feature-path-missing-plan-blocked/comparison.md
+++ b/agents/qa/test/qa-agent/evals/workspace/eval-3-feature-path-missing-plan-blocked/comparison.md
@@ -2,47 +2,51 @@
 
 ## Evaluation Target
 
-- Agent: `qa`
 - Skill: `qa-agent`
 - Eval: `eval-003-feature-path-missing-plan-blocked`
-- Test case: feature-path-missing-plan-blocked
-- Workspace: `workspace/eval-3-feature-path-missing-plan-blocked`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-08 for PR #98 trigger description routing review.
+- Prompt target: 识别同路径上下文与缺 implementation plan blocker。
 
 ## Test Set / Fixture Version
 
-- Schema: `evals.json` v1.0
-- Fixture: same-path PRD/TRD and QA E2E function tree for `account/profile/preferences`, with no confirmed implementation plan.
-- Context read before applying the skill: `AGENTS.md`, `agents/qa/README.md`, `agents/qa/skills/qa-agent/SKILL.md`, `evals.json`, workspace `eval_metadata.json`, `docs/pm/account/profile/preferences/PRD.md`, `docs/engineer/account/profile/preferences/TRD.md`, `docs/qa/e2e/account/profile/preferences/TEST_SUITE.md`, and `FLOW_INDEX.md`.
-- Runtime evidence: fresh subagent artifacts were generated under `tmp/eval-runs/2026-07-08-router-trigger-batch3/eval-003-feature-path-missing-plan-blocked/`.
+- Eval schema: `evals.json` v1.0
+- Fixture version: repository commit `778b042`
+- Fresh run: `2026-07-30 19:26:38 +0800`
+- Runtime directory: `tmp/eval-runs/issue-196-pr-b-20260730-192638/qa/agents/qa/test/qa-agent/evals/workspace/eval-3-feature-path-missing-plan-blocked/`
+- `eval_metadata.json` 未声明 `execution_cleanup`。
 
-## Assertions
+## Latest Result
 
-- PASS `reads_same_feature_path`: the route preserves `account/profile/preferences`, reads same-path PRD/TRD, and keeps the QA E2E function tree under the same path.
-- PASS `blocks_missing_plan`: missing `docs/engineer/account/profile/preferences/IMPLEMENTATION_PLAN.md` is a blocker, with next owner `engineer-agent:feature-implementor`.
-- PASS `no_e2e_mutation_or_execution`: no E2E acceptance TC is created, updated, or executed without the confirmed implementation plan.
-- PASS `keeps_single_route`: the router keeps one narrow QA route and treats the missing plan as the blocker instead of invoking multiple QA skills or entering implementation repair.
+- Behavior result: **FAIL**
+- Coverage result: **FULL**
+- 所有 assertion 场景均已触发；无 `NOT EXERCISED` assertion。
+- 变更点检查：候选直接执行了 specialist 的 implementation-plan gate 并复述详细 E2E 状态，没有仅保留 specialist 门禁指针。
 
-## With Skill Behavior
+Overall result: FAIL
 
-`qa-agent` satisfies the expected blocked behavior after the PR #98 trigger description edits. The with-skill run selected the single route `qa-agent:spec-based-tester`, resolved `feature_path` as `account/profile/preferences`, read same-path PRD/TRD and the QA E2E function tree, and marked the QA work blocked because `docs/engineer/account/profile/preferences/IMPLEMENTATION_PLAN.md` is missing. It pointed the next owner to `engineer-agent:feature-implementor` and did not create, update, or execute E2E acceptance TC.
+## Assertion Results
 
-## Without Skill Baseline
+- PASS `reads_same_feature_path`: 正确保留 `account/profile/preferences` 及同路径 PRD/TRD/QA 功能树。
+- PASS `blocks_missing_plan`: 缺 `IMPLEMENTATION_PLAN.md` 时 blocked，next owner 为 `engineer-agent:feature-implementor`。
+- PASS `no_e2e_mutation_or_execution`: 没有创建、更新或执行验收 TC。
+- PASS `keeps_single_route`: 选择单一 `spec-based-tester` route，未进入实现修复。
 
-Fresh baseline generated on 2026-07-08 from the eval prompt and fixture files only, without applying `qa-agent`, the QA Agent README, historical `comparison.md`, or any previous baseline. The baseline also paused TC creation or execution because the fixture clearly signals a missing implementation plan, but it did not fully preserve the repo-specific single QA route, next owner, and E2E gate details.
+## With-Skill Behavior
+
+blocked 是正确产品行为，四条 assertions 也全部满足；但 router 自己展开并裁决了 specialist 的详细 plan/E2E 门禁，与当前 `qa-agent` 只保留 gate pointer 的职责边界冲突，因此 Behavior 判 FAIL。
+
+## Fresh Without-Skill Baseline
+
+本轮 baseline 使用同一 prompt 与 fixture 新生成，未读取 skill、QA README 或历史 baseline。candidate/verdict 均成功；baseline 同样识别缺 plan 并 blocked，semantic verdict 为 PASS。
 
 ## Failures
 
-- None found. The blocked route is the expected pass condition for this eval.
-- PR #98 did not regress same-path feature handling, missing-plan blocking, or the no-E2E-mutation boundary.
+- PR-B router 指针收敛未在该候选中生效；输出仍复述 specialist 门禁细节。
 
 ## Next Steps
 
-- Keep this eval as regression coverage for missing implementation-plan blocking before E2E acceptance mutation or execution.
-- Product workflow represented by the fixture should continue only after `engineer-agent:feature-implementor` supplies the confirmed same-path implementation plan.
+- 后续 eval 应把“router 只选择 route、声明权威指针；specialist 再做详细门禁”设为显式 assertion。
 
-## Runtime Artifacts Policy
+## Runtime Artifact Policy
 
-- Runtime artifacts were created only under `tmp/eval-runs/2026-07-08-router-trigger-batch3/eval-003-feature-path-missing-plan-blocked/`.
-- Generated `with_skill.md`, `without_skill.md`, and `verdict.md` are scratch evidence only and must not be committed.
-- Durable committed evidence for this run is this `comparison.md`.
+- 两条 candidate、两条 verdict、diagnostics 与 `comparison.auto.md` 均在上述 `tmp/eval-runs/` 目录，返回码均为 0、无 timeout。
+- Runtime 产物不提交；durable 结果仅为本文件。

--- a/agents/qa/test/regression-suite/evals/workspace/eval-1-verify-bug-fix/comparison.md
+++ b/agents/qa/test/regression-suite/evals/workspace/eval-1-verify-bug-fix/comparison.md
@@ -1,49 +1,54 @@
-# Eval Result: regression-suite-verify-bug-fix
+# Eval Result: eval-001-verify-bug-fix
 
 ## Evaluation Target
 
-- Agent: `qa`
 - Skill: `regression-suite`
 - Eval: `eval-001-verify-bug-fix`
-- Test case: verify-bug-fix
-- Workspace: `workspace/eval-1-verify-bug-fix`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
-- Validation method: fresh Codex subagent review; baseline was derived before reading `regression-suite` or QA README, then with-skill behavior was checked against `SKILL.md`, `agents/qa/README.md`, direct shared references, eval assertions, and fixture evidence.
+- Prompt target: 复用 BUG-001 与修复上下文做定向回归判断。
 
 ## Test Set / Fixture Version
 
-- Schema: `evals.json` v1.0
-- Prompt: 验证 Bug #001 的修复，执行回归测试
-- Fixture context: `BUG-001.md`, `PR-001.md`, QA environment note, `TEST_SUITE.md`, `FLOW_INDEX.md`, `cases/TC-001-login-session.md`, and `scripts/TC-001-login-session.spec.md`.
-- Scenario and version: `feature-update`, platform version `v1.2.0-fix.1`.
+- Eval schema: `evals.json` v1.0
+- Fixture version: repository commit `778b042`
+- Fresh run: `2026-07-30 19:26:38 +0800`
+- Runtime directory: `tmp/eval-runs/issue-196-pr-b-20260730-192638/qa/agents/qa/test/regression-suite/evals/workspace/eval-1-verify-bug-fix/`
+- `eval_metadata.json` 未声明 `execution_cleanup`。
 
-## Without Skill Baseline
+## Latest Result
 
-- A generic regression answer would likely run or recommend `npm test -- login-regression` and stop at the original happy path.
-- It might not preserve the original failure, expected behavior, fix context, adjacent invalid-credential and locked-account risks, and evidence confidence as separate report fields.
-- It could over-expand a local `feature-update` into release-wide coverage or skip the existing function-tree E2E memory.
-- It would be less likely to block acceptance TC execution when same-path PRD/TRD or confirmed implementation-plan evidence is missing.
+- Behavior result: **PASS**
+- Coverage result: **FULL**
+- 缺同路径 PRD/TRD/plan 已触发预期 blocker；无 `NOT EXERCISED` assertion。
+- 非 E2E 路径变更检查：fixture 是 E2E `feature-update` 回归，未触发 `docs/qa/{feature_path}/regression-verification.md`。
 
-## With Skill Behavior
+Overall result: PASS
 
-- PASS: `regression-suite` requires the original bug report, failing evidence, fix context, expected behavior, and scoped regression target before execution. The fixture provides original login 500 behavior, expected session creation, fix summary, adjacent serialization risks, and QA environment notes.
-- PASS: The skill reuses existing QA memory under `docs/qa/e2e/auth/login/session-start/`, including suite, flow index, case file, script, prior results, and reports when available.
-- PASS: The verification scope covers original failure recheck, expected fixed behavior, and adjacent invalid-credential and locked-account branches because they share response serialization.
-- PASS: `feature-update` scope stays limited to the fixed flow, direct impact paths, shared components, adjacent flows, and related state branches; full active E2E coverage is reserved for `release`.
-- PASS: Platform version `v1.2.0-fix.1` is available, so any actual result archive would append under `results/TC-001-login-session/v1.2.0-fix.1/` and would not overwrite history.
-- PASS: Because this is a bug-fix regression, the skill requires a visible same-path PRD/TRD/confirmed `IMPLEMENTATION_PLAN.md` gate before executing or updating acceptance TC. The fixture does not include those documents, so the correct with-skill execution result is blocked at that gate rather than release-ready.
-- PASS: The report contract keeps run status (`pass`, `fail`, `blocked`) separate from evidence confidence and includes release recommendation. With the missing alignment/plan evidence in this fixture, recommendation should be `blocked` or `needs more verification`, not `safe to release`.
+## Assertion Results
+
+- PASS `assertion_1`: 读取 BUG-001、PR-001，复用原始步骤、预期与共享序列化风险。
+- PASS `qa`: 使用 suite、flow、case、script；无历史 results/reports 可用时没有伪造其内容。
+- PASS `assertion_3`: original failure、fixed behavior 与总状态均为 blocked/not executed。
+- PASS `assertion_4`: `feature-update` 只覆盖成功登录、无效凭据、锁定账号与 session/redirect 直接面。
+- PASS `alignment_version_archive`: 同路径 PRD/TRD/plan 缺失导致 blocked；平台版本与追加目录明确，不覆盖历史。
+- PASS `assertion_5`: release recommendation 为 blocked，run status 与 confidence 分离。
+
+## With-Skill Behavior
+
+候选没有因为 fixture 提供了 bug、fix 和平台版本就越过对齐门禁；blocked 是正确的 assertion 满足方式。
+
+## Fresh Without-Skill Baseline
+
+同一 prompt/fixture 的全新 baseline 已生成，未读取 skill、QA README 或历史 baseline。candidate/verdict 均成功；baseline 缺 PRD/TRD/plan gate，semantic verdict 为 FAIL。
 
 ## Failures
 
-- None identified. The current skill contract satisfies all eval assertions for original-context reuse, QA case reuse, fix verification, adjacent-risk scope, alignment and version archive gates, release recommendation, and status/confidence separation.
+- 无。
 
 ## Next Steps
 
-- No fixture or skill change is required from this eval.
-- A real run should provide or confirm same-path PRD, TRD, and implementation-plan evidence before executing or archiving the E2E regression result.
+- 补齐同路径 PRD/TRD/confirmed plan 后才可执行与归档真实回归证据。
 
 ## Runtime Artifact Policy
 
-- No runtime artifacts were created for this validation.
-- Do not commit transcripts, verdicts, timing files, diagnostics, `with_skill/`, `without_skill/`, `outputs/`, or `comparison.auto.md`.
+- 两条 candidate、两条 verdict、diagnostics 与 `comparison.auto.md` 均在上述 `tmp/eval-runs/`，返回码均为 0、无 timeout。
+- Runtime 不提交；durable 结果仅为本文件。

--- a/agents/qa/test/regression-suite/evals/workspace/eval-2-blocked-without-original-bug-context/comparison.md
+++ b/agents/qa/test/regression-suite/evals/workspace/eval-2-blocked-without-original-bug-context/comparison.md
@@ -1,46 +1,53 @@
-# Eval Result: regression-suite-blocked-without-original-bug-context
+# Eval Result: eval-002-blocked-without-original-bug-context
 
 ## Evaluation Target
 
-- Agent: `qa`
 - Skill: `regression-suite`
 - Eval: `eval-002-blocked-without-original-bug-context`
-- Test case: blocked-without-original-bug-context
-- Workspace: `workspace/eval-2-blocked-without-original-bug-context`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
-- Validation method: fresh Codex subagent review; baseline was derived before reading `regression-suite` or QA README, then with-skill behavior was checked against `SKILL.md`, `agents/qa/README.md`, direct shared references, eval assertions, and fixture evidence.
+- Prompt target: 原始 bug、修复与环境均缺失时给出 blocked 回归结论。
 
 ## Test Set / Fixture Version
 
-- Schema: `evals.json` v1.0
-- Prompt: 复测上周修过的支付按钮问题，但仓库里找不到原始 bug 报告、失败证据、修复 PR 或可用测试环境。请给出回归验证结论。
-- Fixture context: `notes/missing-context.md`
-- Evidence present: explicit note that original bug report, failing evidence, fix PR, test command, and QA environment are unavailable.
+- Eval schema: `evals.json` v1.0
+- Fixture version: repository commit `778b042`
+- Fresh run: `2026-07-30 19:26:38 +0800`
+- Runtime directory: `tmp/eval-runs/issue-196-pr-b-20260730-192638/qa/agents/qa/test/regression-suite/evals/workspace/eval-2-blocked-without-original-bug-context/`
+- `eval_metadata.json` 未声明 `execution_cleanup`。
 
-## Without Skill Baseline
+## Latest Result
 
-- A generic regression response might provide speculative retest steps and a soft recommendation instead of an explicit blocked conclusion.
-- It could treat "no evidence of failure" as enough for progress, omitting original failure recheck and fixed-behavior status.
-- It would be less likely to block platform-version archive paths and might not distinguish local feature-update checks from release-wide E2E conclusions.
+- Behavior result: **PASS**
+- Coverage result: **FULL**
+- 所有 blocked assertions 均由 fixture 明确触发；无 `NOT EXERCISED`。
+- 非 E2E 路径变更检查：没有足够 `feature_path` 或 fix evidence 生成正式报告，`docs/qa/{feature_path}/regression-verification.md` 分支未触发。
 
-## With Skill Behavior
+Overall result: PASS
 
-- PASS: `regression-suite` requires original failure evidence, fix context, expected behavior, and a scoped regression target. The fixture lacks all of these, so the correct result is blocked.
-- PASS: Original failure recheck, fixed behavior, adjacent regression checks, platform version confirmation, and PRD/TRD/implementation-plan alignment must be `blocked` or `not executed`, never `pass`.
-- PASS: The blocked report still includes original failure recheck, fixed behavior, adjacent regression checks, release recommendation, and evidence confidence.
-- PASS: Release recommendation must be `blocked` or `needs more verification`; absent failures do not imply release readiness.
-- PASS: The skill requires platform version and environment before archiving results, avoids `unknown`, and does not treat an unscoped local retest as a release-wide E2E result.
+## Assertion Results
+
+- PASS `assertion_1`: 先指出原始 bug、失败证据、修复 PR 与环境缺失，不做泛化回归。
+- PASS `blocked`: original failure、fixed behavior、adjacent checks、平台版本与对齐均 blocked/not executed。
+- PASS `assertion_3`: 所需结构与 confidence 完整。
+- PASS `assertion_4`: recommendation 为 blocked，不建议 release ready。
+- PASS `no_unknown_or_unscoped_release`: 不使用 `unknown`，不冒充 release 全量，并列出恢复证据。
+
+## With-Skill Behavior
+
+候选把“资料缺失”与“新回归”分开，明确恢复验证所需输入；合法 blocked 满足全部 assertions。
+
+## Fresh Without-Skill Baseline
+
+同一 prompt/fixture 的全新 baseline 已生成，未读取 skill、QA README 或历史 baseline。candidate/verdict 均成功，baseline 也满足全部 assertions，semantic verdict 为 PASS。
 
 ## Failures
 
-- None identified. The current skill contract satisfies all eval assertions for missing original evidence, blocked status, structured blocked output, release boundary, and avoiding `unknown` or unscoped release conclusions.
+- 无。
 
 ## Next Steps
 
-- No fixture or skill change is required from this eval.
-- To unblock a real run, provide the original bug report, failing evidence, fix PR or implementation notes, expected behavior, QA environment, scenario, and platform version.
+- 只有补齐原始 bug、修复证据、环境、版本和预期后才重启回归。
 
 ## Runtime Artifact Policy
 
-- No runtime artifacts were created for this validation.
-- Do not commit transcripts, verdicts, timing files, diagnostics, `with_skill/`, `without_skill/`, `outputs/`, or `comparison.auto.md`.
+- 两条 candidate、两条 verdict、diagnostics 与 `comparison.auto.md` 均在上述 `tmp/eval-runs/`，返回码均为 0、无 timeout。
+- Runtime 不提交；durable 结果仅为本文件。

--- a/agents/qa/test/regression-suite/evals/workspace/eval-3-mapped-doc-regression/comparison.md
+++ b/agents/qa/test/regression-suite/evals/workspace/eval-3-mapped-doc-regression/comparison.md
@@ -1,37 +1,51 @@
-# Consumption Regression Comparison
+# Eval Result: eval-003-mapped-doc-regression
 
 ## Evaluation Target
 
 - Skill: `regression-suite`
 - Eval: `eval-003-mapped-doc-regression`
+- Prompt target: 由 change-map 收敛搜索阈值回归范围并以代码确定实际值。
 
 ## Test Set / Fixture Version
 
-- Fixture: `ws1-consumption-v1`
-- Commit: `0b000b9`
+- Eval schema: `evals.json` v1.0
+- Fixture version: repository commit `778b042`
+- Fresh run: `2026-07-30 19:26:38 +0800`
+- Runtime directory: `tmp/eval-runs/issue-196-pr-b-20260730-192638/qa/agents/qa/test/regression-suite/evals/workspace/eval-3-mapped-doc-regression/`
+- `eval_metadata.json` 未声明 `execution_cleanup`。
 
 ## Latest Result
 
-**PASS** — with-skill 以代码阈值 3 核证出文档声明 2 的分歧，回归判定诚实标记 blocked（缺证据链），并制定锚定代码事实的定向边界范围。
+- Behavior result: **PASS**
+- Coverage result: **FULL**
+- 无 `NOT EXERCISED` assertion。
+- 非 E2E 路径变更检查：prompt 只要求回归范围与阈值判断，没有要求持久化报告；`docs/qa/{feature_path}/regression-verification.md` 未覆盖。
+
+Overall result: PASS
+
+## Assertion Results
+
+- PASS `reads_mapped_docs_first`: change-map 将范围收窄到 `search-query.md`，未遍历其他文档。
+- PASS `verifies_against_code`: 代码阈值 3、文档阈值 2 分开记录，并围绕 2/3 边界设计直接路径。
+- PASS `treats_unverified_as_low_trust`: `unverified` 文档不作为 pass/release-ready 的独立依据。
 
 ## With-Skill Behavior
 
-- 命中映射文档后回规则文件核证阈值，分歧结构化记录且不采信 unverified 文档值。
-- 回归门禁行为正确：缺 feature_path/PRD/TRD/实施计划与原始失败证据时不宣称验证通过，产出结构化回归报告。
+候选以代码值 3 为事实，同时保留目标预期仍需确认的边界，没有把过时文档直接当回归 oracle。
 
-## Without-Skill Baseline
+## Fresh Without-Skill Baseline
 
-- 来源：本次 fresh `codex exec` 独立子进程，同一原始 prompt 与 fixture，未接触 skill 或消费契约提示。
-- baseline 同样静态确认阈值并区分 hotfix/预期变更路径，判断合格，但报告组织与证据结构较松散。
+同一 prompt/fixture 的全新 baseline 已生成，未读取 skill、QA README 或历史 baseline。candidate/verdict 均成功；baseline 也满足三条 assertions，semantic verdict 为 PASS。
 
 ## Failures
 
-- 无。
+- 无 assertion failure。
 
 ## Next Steps
 
-- 保留本结果；后续 fixture 可增加干扰文档以放大行为差距。
+- PR-B 非 E2E 路径需独立持久化报告 fixture；本次不改现有 eval。
 
 ## Runtime Artifact Policy
 
-- 运行期产物只存放于 `tmp/eval-runs/`，不提交到 git。
+- 两条 candidate、两条 verdict、diagnostics 与 `comparison.auto.md` 均在上述 `tmp/eval-runs/`，返回码均为 0、无 timeout。
+- Runtime 不提交；durable 结果仅为本文件。

--- a/agents/qa/test/spec-based-tester/evals/workspace/eval-1-test-from-spec/comparison.md
+++ b/agents/qa/test/spec-based-tester/evals/workspace/eval-1-test-from-spec/comparison.md
@@ -9,9 +9,9 @@
 ## Test Set / Fixture Version
 
 - Eval schema: `evals.json` v1.0
-- Fixture version: repository commit `778b042`
-- Fresh run: `2026-07-30 19:26:38 +0800`
-- Runtime directory: `tmp/eval-runs/issue-196-pr-b-20260730-192638/qa/agents/qa/test/spec-based-tester/evals/workspace/eval-1-test-from-spec/`
+- Fixture version: repository commit `cdfc879`
+- Fresh run: `2026-07-30 19:56:59 +0800`
+- Runtime directory: `tmp/eval-runs/issue-196-pr-b-spec-20260730-195659-eval001/qa/agents/qa/test/spec-based-tester/evals/workspace/eval-1-test-from-spec/`
 - `eval_metadata.json` 未声明 `execution_cleanup`。
 
 ## Latest Result
@@ -20,38 +20,38 @@
 - Coverage result: **PARTIAL**
 - `e2e` 的“新增/补充 TC”分支为 **NOT EXERCISED**：fixture 已有 TC，本轮未扩充。
 - `versioned_report_archive` 的真实 result/snapshot/report 写入分支为 **NOT EXERCISED**：本轮没有产品测试结果；场景与版本确认子项已覆盖。
-- 非 E2E 路径变更检查：该 fixture 是 E2E `feature-update`，未触发 `docs/qa/{feature_path}/spec-validation.md`。
 
 Overall result: FAIL
 
 ## Assertion Results
 
-- FAIL `assertion_1`: 候选未显式证明已读 PRD/TRD/package、变更说明状态，也未完整记录环境假设、未知项和 blocker。
-- FAIL `assertion_2`: 引用了既有 TC，但未记录 `FLOW_INDEX.md`、缺失 scripts、历史 results/reports 的读取/缺失状态。
-- PASS `assertion_3`: 选择 repo harness `npm test -- checkout-discount`，不臆造浏览器入口。
-- PASS `assertion_4`: requirement matrix 使用 blocked，未把未执行项当缺陷。
-- FAIL `assertion_5`: 有 matrix、execution path、risk notes，但缺显式 evidence references 段落与逐项可追踪来源。
-- NOT EXERCISED `e2e`: 未新增或补充 TC；没有证据表明单文件约束回归。
+- FAIL `assertion_1`: 候选引用了 test spec、PRD、TRD 和 `package.json`，但未把缺失变更说明、环境假设、未知项和 blocked 检查整理成执行前基线。
+- FAIL `assertion_2`: 候选引用了 suite、flow 和既有 TC，但未明确声明复用该 TC，也未记录缺失的 `scripts/*.spec.md`、历史 `results/` 与 `_reports/`。
+- PASS `assertion_3`: 选择 repo harness `npm test -- checkout-discount`，没有臆造浏览器或 Playwright 入口。
+- PASS `assertion_4`: requirement matrix 使用 `blocked`，未把未执行项写成失败或缺陷。
+- PASS `assertion_5`: 包含 requirement matrix、execution path、evidence references 和 risk notes，并保留逐项状态与说明。
+- NOT EXERCISED `e2e`: 未新增或补充 TC；现有单文件 TC 被正确引用，没有发现约束回归。
 - PASS `versioned_report_archive`: 已确认 `feature-update` 与 `v0.3.0-dev`；没有执行结果时未伪造 archive。实际归档分支未覆盖。
-- PASS `assertion_7`: 没有把 blocked/unknown 交给 bug-analyzer。
+- PASS `assertion_7`: 没有把 blocked/unknown 项交给 `bug-analyzer`。
 
 ## With-Skill Behavior
 
-不执行产品测试时保持 blocked 是正确的；FAIL 来自 preflight 与 evidence traceability 不完整，而非缺少实跑本身。
+候选正确收敛范围、选择 repo harness、输出结构化证据并诚实保持 blocked。Behavior 仍为 FAIL，因为 preflight 没有完整记录上下文缺口和 QA memory 缺失项，无法证明按 specialist 协议完成执行前检查。
 
 ## Fresh Without-Skill Baseline
 
-同一 prompt/fixture 的全新 baseline 已生成，未读取 skill、QA README 或历史 baseline。candidate/verdict 均成功；baseline 也缺完整 E2E memory，semantic verdict 为 FAIL。
+同一 prompt/fixture 的全新 baseline 已生成，未读取或应用 skill 与 QA README。candidate 和 fresh judge 均成功；baseline 同样遗漏变更说明状态、执行前未知项以及 `scripts`、历史 `results/`、`_reports/` 的缺失记录，semantic verdict 为 FAIL。
 
 ## Failures
 
-- Preflight read set、未知项与 evidence references 不完整。
+- 执行前基线未显式记录变更说明缺失、环境假设、未知项与 blocked 检查。
+- 未完整记录 QA memory 的读取/缺失状态，也未明确声明复用既有 TC。
 
 ## Next Steps
 
-- 后续候选应显式记录缺失 scripts/results/reports；非 E2E 路径另需专门 fixture。
+- 后续候选应在执行前逐项记录 fixture 已读来源与缺失项，再进入执行路径和 requirement matrix。
 
 ## Runtime Artifact Policy
 
-- 两条 candidate、两条 verdict、diagnostics 与 `comparison.auto.md` 均在上述 `tmp/eval-runs/`，返回码均为 0、无 timeout。
+- 两条 candidate、两条 fresh judge verdict、diagnostics 与 `comparison.auto.md` 均在上述 `tmp/eval-runs/`；所有 Codex 调用返回码为 0，且无 timeout。
 - Runtime 不提交；durable 结果仅为本文件。

--- a/agents/qa/test/spec-based-tester/evals/workspace/eval-1-test-from-spec/comparison.md
+++ b/agents/qa/test/spec-based-tester/evals/workspace/eval-1-test-from-spec/comparison.md
@@ -2,48 +2,56 @@
 
 ## Evaluation Target
 
-- Agent: `qa`
 - Skill: `spec-based-tester`
 - Eval: `eval-001-test-from-spec`
-- Test case: test-from-spec
-- Workspace: `workspace/eval-1-test-from-spec`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
-- Validation method: fresh Codex subagent review; baseline was derived before reading `spec-based-tester` or QA README, then with-skill behavior was checked against `SKILL.md`, `agents/qa/README.md`, direct shared references, eval assertions, and fixture evidence.
+- Prompt target: 从 checkout discount test spec 选择并报告规范验证。
 
 ## Test Set / Fixture Version
 
-- Schema: `evals.json` v1.0
-- Expected output: 测试报告，包含通过/失败统计和失败用例详情
-- Fixture context: `docs/test-spec.md`, `docs/prd.md`, `docs/trd.md`, `docs/qa/e2e/commerce/checkout/discount-code/TEST_SUITE.md`, `FLOW_INDEX.md`, `cases/TC-001-discount-code.md`, and `package.json`.
-- Scenario and version: `feature-update`, platform version `v0.3.0-dev`.
+- Eval schema: `evals.json` v1.0
+- Fixture version: repository commit `778b042`
+- Fresh run: `2026-07-30 19:26:38 +0800`
+- Runtime directory: `tmp/eval-runs/issue-196-pr-b-20260730-192638/qa/agents/qa/test/spec-based-tester/evals/workspace/eval-1-test-from-spec/`
+- `eval_metadata.json` 未声明 `execution_cleanup`。
 
-## Without Skill Baseline
+## Latest Result
 
-- A generic spec-test answer would likely run the obvious `npm test` command or summarize expected checks without first recording scope, environment assumptions, unknowns, and blocked checks.
-- It might not reuse the existing `docs/qa/e2e/commerce/checkout/discount-code/` function-tree memory before considering new cases.
-- It could treat missing scripts, previous results, or reports as irrelevant instead of recording them as absent.
-- It would be more likely to turn blocked or assumed observations into bugs without confirmed reproducible evidence.
+- Behavior result: **FAIL**
+- Coverage result: **PARTIAL**
+- `e2e` 的“新增/补充 TC”分支为 **NOT EXERCISED**：fixture 已有 TC，本轮未扩充。
+- `versioned_report_archive` 的真实 result/snapshot/report 写入分支为 **NOT EXERCISED**：本轮没有产品测试结果；场景与版本确认子项已覆盖。
+- 非 E2E 路径变更检查：该 fixture 是 E2E `feature-update`，未触发 `docs/qa/{feature_path}/spec-validation.md`。
 
-## With Skill Behavior
+Overall result: FAIL
 
-- PASS: `spec-based-tester` requires reading the test spec, PRD, TRD, repository instructions, implementation context when available, and existing QA memory before execution.
-- PASS: The fixture has an existing `TC-001-discount-code` in the function-tree QA directory, so the skill reuses that TC as the primary scope and does not fall back to a legacy single-level QA directory.
-- PASS: Missing `scripts/*.spec.md`, prior `results/`, and `_reports/` must be recorded as absent or blocked rather than skipped; any future E2E script must use `scripts/TC-NNN-<short-slug>.spec.md`.
-- PASS: The narrowest execution path is the repo harness `npm test -- checkout-discount`, referenced by both TRD and `TEST_SUITE.md`; Chrome plugin / browser connector and standalone Playwright are lower-priority fallbacks.
-- PASS: Requirement matrix statuses are limited to `pass`, `fail`, `blocked`, or `assumed`, with evidence references and notes for each requirement.
-- PASS: E2E execution requires scenario and platform version. This fixture has `feature-update` and `v0.3.0-dev`, so archive/report paths are versioned and never use `unknown`.
-- PASS: Handoff to `bug-analyzer` is allowed only for confirmed reproducible failures with evidence; blocked, assumed, flaky, or thin-evidence items remain in the QA report.
+## Assertion Results
+
+- FAIL `assertion_1`: 候选未显式证明已读 PRD/TRD/package、变更说明状态，也未完整记录环境假设、未知项和 blocker。
+- FAIL `assertion_2`: 引用了既有 TC，但未记录 `FLOW_INDEX.md`、缺失 scripts、历史 results/reports 的读取/缺失状态。
+- PASS `assertion_3`: 选择 repo harness `npm test -- checkout-discount`，不臆造浏览器入口。
+- PASS `assertion_4`: requirement matrix 使用 blocked，未把未执行项当缺陷。
+- FAIL `assertion_5`: 有 matrix、execution path、risk notes，但缺显式 evidence references 段落与逐项可追踪来源。
+- NOT EXERCISED `e2e`: 未新增或补充 TC；没有证据表明单文件约束回归。
+- PASS `versioned_report_archive`: 已确认 `feature-update` 与 `v0.3.0-dev`；没有执行结果时未伪造 archive。实际归档分支未覆盖。
+- PASS `assertion_7`: 没有把 blocked/unknown 交给 bug-analyzer。
+
+## With-Skill Behavior
+
+不执行产品测试时保持 blocked 是正确的；FAIL 来自 preflight 与 evidence traceability 不完整，而非缺少实跑本身。
+
+## Fresh Without-Skill Baseline
+
+同一 prompt/fixture 的全新 baseline 已生成，未读取 skill、QA README 或历史 baseline。candidate/verdict 均成功；baseline 也缺完整 E2E memory，semantic verdict 为 FAIL。
 
 ## Failures
 
-- None identified. The current skill contract satisfies all eval assertions for context baseline, E2E memory reuse, execution-path choice, result grading, structured evidence, single-file E2E constraints, versioned report archive, and bug handoff boundary.
+- Preflight read set、未知项与 evidence references 不完整。
 
 ## Next Steps
 
-- No fixture or skill change is required from this eval.
-- If this eval is later executed as real E2E, add or confirm a matching script file before script-based replay, and keep absent historical results/reports visible in the preflight.
+- 后续候选应显式记录缺失 scripts/results/reports；非 E2E 路径另需专门 fixture。
 
 ## Runtime Artifact Policy
 
-- No runtime artifacts were created for this validation.
-- Do not commit transcripts, verdicts, timing files, diagnostics, `with_skill/`, `without_skill/`, `outputs/`, or `comparison.auto.md`.
+- 两条 candidate、两条 verdict、diagnostics 与 `comparison.auto.md` 均在上述 `tmp/eval-runs/`，返回码均为 0、无 timeout。
+- Runtime 不提交；durable 结果仅为本文件。

--- a/agents/qa/test/spec-based-tester/evals/workspace/eval-2-boundary-test-generation/comparison.md
+++ b/agents/qa/test/spec-based-tester/evals/workspace/eval-2-boundary-test-generation/comparison.md
@@ -2,49 +2,54 @@
 
 ## Evaluation Target
 
-- Agent: `qa`
 - Skill: `spec-based-tester`
 - Eval: `eval-002-boundary-test-generation`
-- Test case: boundary-test-generation
-- Workspace: `workspace/eval-2-boundary-test-generation`
-- Latest result: PASS - fresh Codex subagent validation completed on 2026-07-05
-- Validation method: fresh Codex subagent review; baseline was derived before reading `spec-based-tester` or QA README, then with-skill behavior was checked against `SKILL.md`, `agents/qa/README.md`, direct shared references, eval assertions, and fixture evidence.
+- Prompt target: 对登录表单边界做同路径门禁后的结构化验证。
 
 ## Test Set / Fixture Version
 
-- Schema: `evals.json` v1.0
-- Expected output: 结构化边界验证报告，包含 requirement matrix、execution path、evidence references、risk notes 和 handoff decision
-- Fixture context: `docs/pm/login-refresh/PRD.md`, `docs/engineer/login-refresh/TRD.md`, `implementation/changes.md`, `docs/qa/e2e/auth/login/login-form/TEST_SUITE.md`, `FLOW_INDEX.md`, `cases/TC-001-login-boundaries.md`, `scripts/TC-001-login-boundaries.spec.md`, and `package.json`.
-- Scenario and version: `feature-update`, platform version `v1.2.0-rc.1`.
+- Eval schema: `evals.json` v1.0
+- Fixture version: repository commit `778b042`
+- Fresh run: `2026-07-30 19:26:38 +0800`
+- Runtime directory: `tmp/eval-runs/issue-196-pr-b-20260730-192638/qa/agents/qa/test/spec-based-tester/evals/workspace/eval-2-boundary-test-generation/`
+- `eval_metadata.json` 未声明 `execution_cleanup`。
 
-## Without Skill Baseline
+## Latest Result
 
-- A generic boundary-test answer would likely enumerate empty values, long strings, special characters, invalid email, and locked-account checks, then run `npm test` without a formal preflight.
-- It might skip existing QA memory and recreate cases from the prompt.
-- It could treat missing browser URL or missing confirmed implementation plan as a minor caveat instead of a blocked gate.
-- It would be more likely to hand off assumed failures to bug analysis without confirmed reproducible evidence.
+- Behavior result: **FAIL**
+- Coverage result: **PARTIAL**
+- `assertion_3` 为 **NOT EXERCISED**：缺 confirmed `IMPLEMENTATION_PLAN.md` 已合法阻塞实际边界执行，不能要求候选越过门禁实跑。
+- 非 E2E 路径变更检查：该 fixture 是 E2E `feature-update`，未触发 `docs/qa/{feature_path}/spec-validation.md`。
 
-## With Skill Behavior
+Overall result: FAIL
 
-- PASS: `spec-based-tester` requires PRD, TRD, implementation context, repository test commands, and QA function-tree files before execution.
-- PASS: Existing QA memory at `docs/qa/e2e/auth/login/login-form/` is primary. The provided `TC-001-login-boundaries` and matching script cover empty values, overlong input, special characters, invalid email format, and locked-account state.
-- PASS: The narrowest execution path is the repo harness `npm test -- login-boundaries`, referenced by TRD, `TEST_SUITE.md`, and the script. Chrome plugin / browser connector is only for visible assertions the harness cannot cover; standalone Playwright remains fallback.
-- PASS: The validation report must include requirement matrix, execution path, evidence references, risk notes, blocked items, and handoff decision, with each boundary marked `pass`, `fail`, `blocked`, or `assumed`.
-- PASS: Platform version `v1.2.0-rc.1` is present, so versioned result/archive paths are available and must not use `unknown`.
-- PASS: The direct hotfix or feature-update boundary is tight: validate changed login form behavior and direct impact paths, not release-wide E2E coverage.
-- PASS: The alignment-plan gate is enforced. Because the fixture does not include `docs/engineer/login-refresh/IMPLEMENTATION_PLAN.md`, real execution or E2E documentation update should be blocked and routed to `engineer-agent:feature-implementor` rather than fabricating boundary validation results.
-- PASS: Handoff to `bug-analyzer` is allowed only for confirmed reproducible failures with evidence; missing environment, blocked checks, assumptions, and unstable observations stay in the QA report.
+## Assertion Results
+
+- PASS `assertion_1`: preflight 记录范围、输入约束、环境假设、缺 plan、缺 URL、缺历史结果等 blocker。
+- PASS `assertion_2`: 先读 suite、flow、case、script，并显式记录 results/reports 缺失。
+- NOT EXERCISED `assertion_3`: 计划门禁阻止实际边界执行；候选正确把五类边界保留为 assumed。
+- PASS `assertion_4`: 每项使用 pass/assumed/blocked 且有 evidence reference。
+- PASS `assertion_5`: 包含 requirement matrix、execution path、evidence、risk、handoff。
+- PASS `assertion_6`: 不把 assumed/blocked 当 bug，列出未覆盖风险。
+- FAIL `alignment_plan_gate`: 正确发现缺 `IMPLEMENTATION_PLAN.md`，但没有把 next owner 指向 `engineer-agent:feature-implementor`；下一步反而建议补 URL 后直接执行，遗漏 plan 必须先补齐的顺序。
+
+## With-Skill Behavior
+
+候选正确停止执行并诚实标记 assumed/blocked；核心失败是缺 plan 后的 next-owner 与恢复顺序错误。
+
+## Fresh Without-Skill Baseline
+
+同一 prompt/fixture 的全新 baseline 已生成，未读取 skill、QA README 或历史 baseline。candidate/verdict 均成功；baseline 完全遗漏 plan gate，semantic verdict 为 FAIL。
 
 ## Failures
 
-- None identified. The current skill contract satisfies all eval assertions for scope and assumptions, function-tree priority, boundary execution, evidence/status layering, required report structure, risk handoff, alignment-plan gate, and direct feature-update scope.
+- 缺 plan 没有交还 `engineer-agent:feature-implementor`，恢复步骤错误。
 
 ## Next Steps
 
-- No fixture or skill change is required from this eval.
-- A real run should provide the confirmed implementation plan before executing or archiving E2E boundary evidence; browser-only checks also require a deployed app URL such as `QA_BASE_URL`.
+- 先确认同路径 implementation plan，再谈 harness 或 URL 执行。
 
 ## Runtime Artifact Policy
 
-- No runtime artifacts were created for this validation.
-- Do not commit transcripts, verdicts, timing files, diagnostics, `with_skill/`, `without_skill/`, `outputs/`, or `comparison.auto.md`.
+- 两条 candidate、两条 verdict、diagnostics 与 `comparison.auto.md` 均在上述 `tmp/eval-runs/`，返回码均为 0、无 timeout。
+- Runtime 不提交；durable 结果仅为本文件。

--- a/agents/qa/test/spec-based-tester/evals/workspace/eval-2-boundary-test-generation/comparison.md
+++ b/agents/qa/test/spec-based-tester/evals/workspace/eval-2-boundary-test-generation/comparison.md
@@ -9,9 +9,9 @@
 ## Test Set / Fixture Version
 
 - Eval schema: `evals.json` v1.0
-- Fixture version: repository commit `778b042`
-- Fresh run: `2026-07-30 19:26:38 +0800`
-- Runtime directory: `tmp/eval-runs/issue-196-pr-b-20260730-192638/qa/agents/qa/test/spec-based-tester/evals/workspace/eval-2-boundary-test-generation/`
+- Fixture version: repository commit `cdfc879`
+- Fresh run: `2026-07-30 20:02:13 +0800`
+- Runtime directory: `tmp/eval-runs/issue-196-pr-b-spec-20260730-200213-eval002/qa/agents/qa/test/spec-based-tester/evals/workspace/eval-2-boundary-test-generation/`
 - `eval_metadata.json` 未声明 `execution_cleanup`。
 
 ## Latest Result
@@ -19,37 +19,36 @@
 - Behavior result: **FAIL**
 - Coverage result: **PARTIAL**
 - `assertion_3` 为 **NOT EXERCISED**：缺 confirmed `IMPLEMENTATION_PLAN.md` 已合法阻塞实际边界执行，不能要求候选越过门禁实跑。
-- 非 E2E 路径变更检查：该 fixture 是 E2E `feature-update`，未触发 `docs/qa/{feature_path}/spec-validation.md`。
 
 Overall result: FAIL
 
 ## Assertion Results
 
-- PASS `assertion_1`: preflight 记录范围、输入约束、环境假设、缺 plan、缺 URL、缺历史结果等 blocker。
-- PASS `assertion_2`: 先读 suite、flow、case、script，并显式记录 results/reports 缺失。
-- NOT EXERCISED `assertion_3`: 计划门禁阻止实际边界执行；候选正确把五类边界保留为 assumed。
-- PASS `assertion_4`: 每项使用 pass/assumed/blocked 且有 evidence reference。
-- PASS `assertion_5`: 包含 requirement matrix、execution path、evidence、risk、handoff。
-- PASS `assertion_6`: 不把 assumed/blocked 当 bug，列出未覆盖风险。
-- FAIL `alignment_plan_gate`: 正确发现缺 `IMPLEMENTATION_PLAN.md`，但没有把 next owner 指向 `engineer-agent:feature-implementor`；下一步反而建议补 URL 后直接执行，遗漏 plan 必须先补齐的顺序。
+- PASS `assertion_1`: preflight 记录范围、五类输入约束、环境假设、缺 plan、缺 URL 和未执行状态。
+- PASS `assertion_2`: 明确先读 suite、flow、case、script，并记录没有历史 `results/` 或 `_reports/` 证据。
+- NOT EXERCISED `assertion_3`: 实施计划门禁阻止实际边界执行；候选正确把五类边界保留为 `assumed`。
+- PASS `assertion_4`: 每项使用 `assumed` 或 `blocked`，并提供可追踪 evidence references。
+- PASS `assertion_5`: 包含 requirement matrix、execution path、evidence references、risk notes 和 handoff decision。
+- PASS `assertion_6`: 没有把 assumed/blocked 项当成缺陷，且列出未覆盖风险。
+- FAIL `alignment_plan_gate`: 正确发现缺 `IMPLEMENTATION_PLAN.md` 并标记 blocked，但没有把 next owner 指向 `engineer-agent:feature-implementor`；后续建议反而先补 `QA_BASE_URL` 并执行 harness，遗漏必须先补齐 plan 的恢复顺序。
 
 ## With-Skill Behavior
 
-候选正确停止执行并诚实标记 assumed/blocked；核心失败是缺 plan 后的 next-owner 与恢复顺序错误。
+候选正确执行了文档与 QA memory preflight，也没有伪造边界结果。核心回归仍是实施计划门禁的 handoff 不完整：识别 blocker 后没有交还权威 owner，且恢复步骤顺序错误。
 
 ## Fresh Without-Skill Baseline
 
-同一 prompt/fixture 的全新 baseline 已生成，未读取 skill、QA README 或历史 baseline。candidate/verdict 均成功；baseline 完全遗漏 plan gate，semantic verdict 为 FAIL。
+同一 prompt/fixture 的全新 baseline 已生成，未读取或应用 skill 与 QA README。candidate 和 fresh judge 均成功；baseline 完全没有识别缺失的 `IMPLEMENTATION_PLAN.md`，只以测试环境和 `QA_BASE_URL` 为 blocker，因而同样不满足 `alignment_plan_gate`，semantic verdict 为 FAIL。
 
 ## Failures
 
-- 缺 plan 没有交还 `engineer-agent:feature-implementor`，恢复步骤错误。
+- 缺 plan 后没有交还 `engineer-agent:feature-implementor`，恢复步骤错误。
 
 ## Next Steps
 
-- 先确认同路径 implementation plan，再谈 harness 或 URL 执行。
+- 先补齐并确认同路径 `IMPLEMENTATION_PLAN.md`，再恢复 repo harness 或浏览器验证。
 
 ## Runtime Artifact Policy
 
-- 两条 candidate、两条 verdict、diagnostics 与 `comparison.auto.md` 均在上述 `tmp/eval-runs/`，返回码均为 0、无 timeout。
+- 两条 candidate、两条 fresh judge verdict、diagnostics 与 `comparison.auto.md` 均在上述 `tmp/eval-runs/`；所有 Codex 调用返回码为 0，且无 timeout。
 - Runtime 不提交；durable 结果仅为本文件。

--- a/agents/qa/test/spec-based-tester/evals/workspace/eval-3-mapped-doc-acceptance/comparison.md
+++ b/agents/qa/test/spec-based-tester/evals/workspace/eval-3-mapped-doc-acceptance/comparison.md
@@ -1,37 +1,51 @@
-# Consumption Regression Comparison
+# Eval Result: eval-003-mapped-doc-acceptance
 
 ## Evaluation Target
 
 - Skill: `spec-based-tester`
 - Eval: `eval-003-mapped-doc-acceptance`
+- Prompt target: 由 change-map 定位昵称长度文档并以代码形成验收矩阵。
 
 ## Test Set / Fixture Version
 
-- Fixture: `ws1-consumption-v1`
-- Commit: `0b000b9`
+- Eval schema: `evals.json` v1.0
+- Fixture version: repository commit `778b042`
+- Fresh run: `2026-07-30 19:26:38 +0800`
+- Runtime directory: `tmp/eval-runs/issue-196-pr-b-20260730-192638/qa/agents/qa/test/spec-based-tester/evals/workspace/eval-3-mapped-doc-acceptance/`
+- `eval_metadata.json` 未声明 `execution_cleanup`。
 
 ## Latest Result
 
-**PASS** — with-skill 对规范 80 vs 实现 64 给出 FAIL 判定并附静态断言证据，运行时边界诚实标记 BLOCKED，验收矩阵结构化落档。
+- Behavior result: **PASS**
+- Coverage result: **FULL**
+- 无 `NOT EXERCISED` assertion。
+- 非 E2E 路径变更检查：prompt 要求矩阵和证据结论但未要求持久化报告；`docs/qa/{feature_path}/spec-validation.md` 未覆盖。
+
+Overall result: PASS
+
+## Assertion Results
+
+- PASS `reads_mapped_docs_first`: 先由 change-map 命中 `profile-validation.md`，未遍历无关文档。
+- PASS `verifies_against_code`: 文档 80、代码 64 的路径、声明、事实与验收影响均完整记录。
+- PASS `treats_unverified_as_low_trust`: 将 `unverified` 文档作为低信任定位线索，关键判断由代码支撑。
 
 ## With-Skill Behavior
 
-- 按契约读取映射规范后以实现配置核证，FAIL/BLOCKED 判定均有证据支撑，不虚构运行时行为。
-- 产出结构化验收报告与需求矩阵，分歧可直接供后续 QA/工程消费。
+候选提供结构化 requirement matrix，并清楚区分映射定位成功、代码核证成功与规范一致性失败。
 
-## Without-Skill Baseline
+## Fresh Without-Skill Baseline
 
-- 来源：本次 fresh `codex exec` 独立子进程，同一原始 prompt 与 fixture，未接触 skill 或消费契约提示。
-- baseline 同样确认不一致且不越权宣称运行时验证，但验收产物组织较松散，未形成结构化判定矩阵。
+同一 prompt/fixture 的全新 baseline 已生成，未读取 skill、QA README 或历史 baseline。candidate/verdict 均成功；baseline 同样满足三条 assertions，semantic verdict 为 PASS。
 
 ## Failures
 
-- 无。
+- 无 assertion failure。
 
 ## Next Steps
 
-- 保留本结果；后续 fixture 可增加干扰文档以放大行为差距。
+- PR-B 非 E2E 路径需独立要求持久化报告的 fixture；本次不改现有 eval。
 
 ## Runtime Artifact Policy
 
-- 运行期产物只存放于 `tmp/eval-runs/`，不提交到 git。
+- 两条 candidate、两条 verdict、diagnostics 与 `comparison.auto.md` 均在上述 `tmp/eval-runs/`，返回码均为 0、无 timeout。
+- Runtime 不提交；durable 结果仅为本文件。

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -89,27 +89,27 @@
     "qa-agent": {
       "source": "agents/qa/skills/qa-agent",
       "sourceType": "local",
-      "computedHash": "da8e090f4d177603e98e401cbe2ab16ea22561ec87bd9c557b760668cc555b67"
+      "computedHash": "b5c98fe91caca56f7f8d0601038501538f153f3459f7a03c992b940916b17ff5"
     },
     "exploratory-tester": {
       "source": "agents/qa/skills/exploratory-tester",
       "sourceType": "local",
-      "computedHash": "17acd406eba037ce820b7d06abf39c87a3c4d4784b05c84f36153b293fcdb0ba"
+      "computedHash": "19249a06f099107a6ceeac31b2cf0ba58c8f6bc6bf1c9febfbfc4cfe39c8a851"
     },
     "spec-based-tester": {
       "source": "agents/qa/skills/spec-based-tester",
       "sourceType": "local",
-      "computedHash": "c86f7a079707efcad34d086aeeceb138d61b692a37e1c65d8e78d12987e326f0"
+      "computedHash": "6601376729dc484464e57239ff0098c8ac8af352c84acb93eb0a55b689509ffe"
     },
     "bug-analyzer": {
       "source": "agents/qa/skills/bug-analyzer",
       "sourceType": "local",
-      "computedHash": "00f47147836c31573d885b266081f2d63557d97208f6abf1f204284dff36afad"
+      "computedHash": "f80e7bd39447ad47c5e3e03231591d8675bedf0df19a020d7dc82950cfa6609f"
     },
     "regression-suite": {
       "source": "agents/qa/skills/regression-suite",
       "sourceType": "local",
-      "computedHash": "8ab2e598880eb3199552bf10cedc88bf68c559e8d4bd6cfbca5073a234db3e57"
+      "computedHash": "5aafc0a0907e9c013a7b840ac21d8eb4da4a256346b1fab8c5d72c750c474563"
     },
     "devops-agent": {
       "source": "agents/devops/skills/devops-agent",


### PR DESCRIPTION
## 变更摘要

关联 #196。

### L1-4：QA 非 E2E 输出路径

- `bug-analyzer`、`exploratory-tester`、`regression-suite`、`spec-based-tester` 的非 E2E fallback 报告统一落到 `docs/qa/{feature_path}/<report>.md`。
- 移除旧的 `docs/qa-reports/YYYY-MM-DD-*` 约定，文件名不再携带日期。
- 全深度检查 4 个 specialist 的 eval-1 fixture 后，仅 `bug-analyzer eval-001` 确实触发非 E2E fallback，因此只为该场景新增 `non_e2e_report_path` 断言。
- `exploratory-tester eval-001`、`regression-suite eval-001`、`spec-based-tester eval-001` 均包含 `docs/qa/e2e/{feature_path}/` 用例树，属于纯 E2E 场景，不添加非 E2E 路径断言。

### L1-7：qa-agent router 收敛

- `qa-agent` 保持指针式 router：选择单一 specialist、传递上下文，并声明 specialist 的权威门禁适用。
- router 不再复述 E2E memory、platform version、credential、execution entry、PRD/TRD/implementation plan、blocked condition 的具体协议。
- 3 条 `qa-agent` eval 将旧的 specialist 门禁展开断言改为 `specialist_gate_pointer`；若 router 展开复述具体门禁，应判 FAIL。
- 其余路由选择、上下文传递、单一主路由与角色边界要求保留。

## Fresh Sub-Agent 重跑结果

每条均重新生成 `with_skill` 与全新 `without_skill` baseline，未复用上一轮 baseline。运行期 candidate、verdict 与 diagnostics 仅保存在 `tmp/eval-runs/`，未提交。

| Skill | Eval | Behavior | Coverage | Overall | 说明 |
| --- | --- | --- | --- | --- | --- |
| qa-agent | eval-001 | PASS | FULL | PASS | 单一路由到 `spec-based-tester`，只声明权威门禁指针 |
| qa-agent | eval-002 | PASS | FULL | PASS | 识别空 E2E 功能树并路由到 `exploratory-tester`，未展开 specialist 协议 |
| qa-agent | eval-003 | PASS | FULL | PASS | 保留同路径上下文，未代替 specialist 裁决缺 plan 门禁 |
| bug-analyzer | eval-001 | PASS | FULL | PASS | 新增非 E2E 路径断言通过：`docs/qa/{feature_path}/bug-<short-slug>.md`，无日期且不使用 `docs/qa-reports/` |
| exploratory-tester | eval-001 | PASS | FULL | PASS | blocked preflight 的 timebox 来源闭环；fixture 为纯 E2E |
| spec-based-tester | eval-001 | FAIL | PARTIAL | FAIL | 执行前基线未完整记录变更说明/环境假设/未知与 blocker；未明确复用 TC，也未记录 scripts/results/_reports 缺失 |
| spec-based-tester | eval-002 | FAIL | PARTIAL | FAIL | 发现缺 implementation plan 但未交还 `engineer-agent:feature-implementor`，恢复步骤顺序错误；实际边界执行因门禁合法 NOT EXERCISED |

本轮没有把仍失败的 specialist eval 强行改判为 PASS；两条 spec-based 结果作为真实回归证据保留，另行处理。

## 验证

- `uv run scripts/check_repository_contract.py`
- `uv run scripts/check_eval_contract.py`
- `uv run scripts/check_eval_artifacts.py`
- `uv run scripts/check_doc_contract.py`
- `uv run scripts/summarize_eval_results.py`
- CI 同款确定性 Python 测试：205 passed

汇总脚本可解析全部 186 份 `comparison.md`；当前 QA 汇总为：

- `bug-analyzer`：3 PASS
- `exploratory-tester`：3 PASS
- `qa-agent`：3 PASS
- `regression-suite`：3 PASS
- `spec-based-tester`：1 PASS、2 FAIL
