### PR TITLE
fix: debugger 接入 change_tier 并合并修复确认 (#196)

### DIFF
--- a/agents/engineer/skills/debugger/SKILL.md
+++ b/agents/engineer/skills/debugger/SKILL.md
@@ -29,7 +29,7 @@ Align Expected Behavior → Reproduce → Analyze → Report + Repair Plan → C
 
 Do NOT jump to fixing. Do NOT propose or apply a fix before understanding the
 expected behavior, root cause, reporting the analysis, and getting confirmation
-on the repair plan. Do NOT update E2E test cases before the plan is confirmed.
+on the repair plan. Do NOT create or update E2E test cases before the plan is confirmed.
 
 ## PM Handoff Entry Gate
 

--- a/agents/engineer/skills/debugger/SKILL.md
+++ b/agents/engineer/skills/debugger/SKILL.md
@@ -6,10 +6,9 @@ visibility: internal
 
 # Debugger
 
-Systematically reproduce, diagnose, and fix bugs. Follows a strict process:
-align expected behavior first, reproduce the failure, analyze the root cause,
-report the bug analysis, plan the repair with user confirmation, then fix
-minimally and verify.
+Systematically reproduce, diagnose, and fix bugs: align expected behavior,
+reproduce the failure, analyze the root cause, present the analysis and repair
+plan together, get user confirmation, then fix minimally and verify.
 
 ## When to Use
 
@@ -25,13 +24,12 @@ minimally and verify.
 **Never guess.** Follow this order strictly:
 
 ```
-Align Expected Behavior → Reproduce → Analyze → Report → Repair Plan → Confirm → Fix → Verify
+Align Expected Behavior → Reproduce → Analyze → Report + Repair Plan → Confirm → Fix → Verify
 ```
 
 Do NOT jump to fixing. Do NOT propose or apply a fix before understanding the
 expected behavior, root cause, reporting the analysis, and getting confirmation
-on the repair plan. Do NOT create or update E2E test cases before the repair
-plan is confirmed.
+on the repair plan. Do NOT update E2E test cases before the plan is confirmed.
 
 ## PM Handoff Entry Gate
 
@@ -65,10 +63,14 @@ asks not to use sub-agents.
 
 ## Repair Plan Gate
 
-After the root cause is confirmed, output the bug analysis report first and ask
-whether the user wants a repair implementation plan. Do not write code yet.
+After confirming the root cause, output the bug analysis and repair plan
+together without asking whether to produce the plan. Do not write code yet.
 
-If the user confirms, produce a repair plan that includes:
+Consume `change_tier` from the PM handoff packet. When an equivalent confirmed
+document chain satisfies the entry gate without a handoff packet, default to
+`standard` per the contract in `AGENTS.md` (变更分级契约). For `hotfix`, the
+plan may be one sentence covering root cause and repair approach plus the
+verification command. For `standard` and `major`, include:
 
 - problem, root cause, location, and impact
 - PRD/TRD alignment conclusion and source document paths
@@ -81,9 +83,9 @@ If the user confirms, produce a repair plan that includes:
 - whether implementation/validation sub-agent split is needed
 - risks, blockers, and forbidden areas
 
-Present the repair plan and wait for user confirmation. Do not apply the fix,
-update tests, update E2E TC, update E2E scripts or results, or delegate
-implementation until the user confirms the exact repair plan.
+Present the combined analysis and tier-appropriate plan, then wait for one user
+confirmation. Until then, do not apply the fix, update tests or E2E artifacts,
+or delegate implementation.
 
 ## Step 0 — Align expected behavior with PRD / TRD
 
@@ -233,12 +235,12 @@ Before fixing, state the root cause clearly:
 **影响**: <what else might be affected>
 ```
 
-## Step 5 — Report and ask for repair planning
+## Step 5 — Report analysis and repair plan
 
-After confirming the root cause, report the analysis before planning or fixing:
+Report the analysis and tier-appropriate repair plan together before fixing:
 
 ```text
-## Bug 分析汇报
+## Bug 分析与修复计划
 
 - **问题**: <what's happening>
 - **预期依据**: <PRD / TRD paths and sections, optional decisions, or blocked alignment gap>
@@ -246,19 +248,6 @@ After confirming the root cause, report the analysis before planning or fixing:
 - **位置**: <file:line>
 - **影响**: <what else might be affected>
 - **复现证据**: <command/action and observed failure>
-
-是否需要我基于这个根因产出修复实施计划？
-```
-
-Wait for the user's answer before producing a repair plan. If the user does not
-confirm, stop after the analysis report.
-
-## Step 6 — Produce repair implementation plan
-
-Only after the user confirms repair planning, produce the plan:
-
-```text
-## 修复实施计划
 
 ### 文件变更清单
 - 修改 `<path>` — <minimal fix and why>
@@ -275,9 +264,10 @@ Only after the user confirms repair planning, produce the plan:
 确认后开始修复？
 ```
 
-Wait for user confirmation before fixing.
+For `hotfix`, compress the template as described in the gate above. For
+`standard` and `major`, keep it in full. Wait for one confirmation before fixing.
 
-## Step 7 — Implement minimal fix
+## Step 6 — Implement minimal fix
 
 Fix the root cause with the smallest possible change:
 
@@ -291,7 +281,7 @@ the root cause and repair plan are confirmed. The task must include the failing
 command, confirmed root cause, confirmed repair plan, owned files or modules,
 forbidden areas, and the requirement not to revert unrelated changes.
 
-## Step 8 — Verify fix
+## Step 7 — Verify fix
 
 Run the previously failing command:
 
@@ -316,7 +306,7 @@ It should check the failure evidence, root-cause fit, regression coverage,
 repository rules, unrelated changes, and residual risk. It must not broaden the
 fix scope.
 
-## Step 9 — Report
+## Step 8 — Report
 
 ```text
 ## 修复报告

--- a/agents/engineer/test/debugger/evals/evals.json
+++ b/agents/engineer/test/debugger/evals/evals.json
@@ -6,10 +6,10 @@
     {
       "id": "eval-001-fix-failing-test",
       "name": "fix-failing-test",
-      "description": "Verifies that debugger aligns expected behavior with PRD/TRD, reproduces and analyzes a failing test, then asks whether to produce a repair implementation plan before fixing.",
+      "description": "Verifies that debugger aligns expected behavior with PRD/TRD, reproduces the failure, then presents root-cause analysis and the repair plan together before one implementation confirmation.",
       "prompt": "测试 test/api/notifications.test.ts 失败了，帮我修复",
       "workspace": "workspace/eval-001-fix-failing-test",
-      "expected_output": "读取 PRD/TRD 确认 active notification 应排除 archived → 复现 → 根因分析 → Bug 分析汇报 → 询问是否产出修复实施计划，不直接修复",
+      "expected_output": "读取 PRD/TRD 确认 active notification 应排除 archived → 复现 → 根因分析与修复计划一次呈现 → 等待一次用户确认，不直接修复",
       "assertions": [
         {
           "id": "aligns_expected_behavior",
@@ -32,9 +32,9 @@
           "text": "输出明确的根因分析，不是猜测"
         },
         {
-          "id": "asks_for_repair_plan",
-          "description": "询问修复实施计划",
-          "text": "输出必须先给出 Bug 分析汇报，并询问用户是否需要基于根因产出修复实施计划。"
+          "id": "presents_combined_analysis_and_plan",
+          "description": "合并呈现分析与修复计划",
+          "text": "输出必须把根因分析与修复计划一次呈现，不得询问是否需要产出计划；动代码前只等待一次用户确认。"
         },
         {
           "id": "blocks_e2e_before_repair_plan",

--- a/agents/engineer/test/debugger/evals/workspace/eval-001-fix-failing-test/README.md
+++ b/agents/engineer/test/debugger/evals/workspace/eval-001-fix-failing-test/README.md
@@ -5,6 +5,5 @@ The notification API should omit archived notifications from the active list,
 but the fixture implementation currently returns them.
 
 Expected behavior: `debugger` should reproduce the failing test, identify the
-root cause from the implementation and PRD/TRD expectation, output a bug
-analysis report, and ask whether to produce a repair implementation plan before
-changing code.
+root cause from the implementation and PRD/TRD expectation, present the bug analysis and repair plan together, and wait for one user
+confirmation before changing code.

--- a/agents/engineer/test/debugger/evals/workspace/eval-001-fix-failing-test/comparison.md
+++ b/agents/engineer/test/debugger/evals/workspace/eval-001-fix-failing-test/comparison.md
@@ -1,68 +1,53 @@
-# Eval Result: debugger-fix-failing-test
+# Eval Result: eval-001-fix-failing-test
 
 ## Evaluation Target
 
 - Agent: `engineer`
 - Skill: `debugger`
 - Eval: `eval-001-fix-failing-test`
-- Test case: fix-failing-test
 - Workspace: `workspace/eval-001-fix-failing-test`
-- Latest result: PASS - fresh Codex subagent validation on 2026-06-23
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: Notification API returns archived notifications in the active list,
-  causing `test/api/notifications.test.ts` to fail.
-- Expected-behavior docs: PRD and confirmed TRD only; no separate
-  `DECISIONS.md` is present in this fixture.
+- 日期：2026-07-30
+- Fixture：active notification 实现错误地排除 `read` 并保留 `archived`。
+- Fresh run：`tmp/eval-runs/issue-196-l2-2-debugger-20260730-220643/`
+- 本轮重新生成 with-skill 与 without-skill 候选，未复用历史 baseline。
 
-## With Skill
+## Assertion Results
 
-Current `SKILL.md` satisfies all assertions:
+- PASS `aligns_expected_behavior`：引用 PRD/TRD，明确 active 包含 unread/read、排除 archived。
+- PASS `classifies_requirement_alignment`：根因分析前分类为 `implementation_deviation`。
+- PASS `reproduces_failure`：记录测试命令、退出码、实际/预期数组及 AssertionError。
+- PASS `reports_root_cause`：定位错误过滤条件及其双向影响。
+- PASS `presents_combined_analysis_and_plan`：根因与 standard 修复计划一次呈现，只等待一次实施确认。
+- PASS `blocks_e2e_before_repair_plan`：计划确认前禁止更新 E2E，后续交接要求引用已确认 IMPLEMENTATION_PLAN。
+- PASS `does_not_fix_directly`：未修改代码、测试或 E2E，也未声称验证修复通过。
 
-- Fresh Codex subagent validation on 2026-06-23 read the current skill docs, Engineer README, eval definition, fixture metadata/context, and this comparison; all listed assertions are satisfied.
-  `debugger` aligns PRD/TRD expected behavior first, classifies requirement
-  alignment, reproduces and analyzes before planning, blocks E2E updates before
-  confirmed repair planning, and does not fix directly.
-- `aligns_expected_behavior`: Step 0 requires reading
-  `docs/pm/{feature_path}/PRD.md` and `docs/engineer/{feature_path}/TRD.md` before
-  deciding code should change. The fixture PRD/TRD define active notifications
-  as `unread` and `read` only, excluding `archived`.
-- `classifies_requirement_alignment`: Step 0 requires recording the alignment
-  classification explicitly, including `implementation_deviation`,
-  `requirement_change`, `missing_docs`, and `trd_gap`; an implementation
-  deviation is the only normal path that continues toward reproduction and
-  repair.
-- `reproduces_failure`: Steps 1 and 2 require collecting error context and
-  running the exact failing command.
-- `reports_root_cause`: Steps 3 through 5 require source-code analysis,
-  explicit root-cause reporting, location, impact, and reproduction evidence.
-- `asks_for_repair_plan`: Step 5 requires a Bug analysis report and asks
-  whether to produce a repair implementation plan before planning or fixing.
-- `blocks_e2e_before_repair_plan`: The Core Principle and Repair Plan Gate block
-  E2E TC updates before the repair plan is confirmed. Step 0 also requires any
-  post-fix QA E2E handoff to cite the confirmed
-  `docs/engineer/{feature_path}/IMPLEMENTATION_PLAN.md`.
-- `does_not_fix_directly`: The Core Principle and Repair Plan Gate prohibit
-  jumping directly to fixing, modifying code, updating tests, updating E2E
-  assets, or claiming verification before the exact repair plan is confirmed.
+## With-Skill Behavior
 
-## Without Skill / Baseline
+候选按无显式 `change_tier` 的 `standard` 路径，一次完成预期对齐、真实复现、根因分析和最小修复计划，并停在唯一一次实施确认门禁。
 
-- May jump directly to code changes after seeing the failing assertion.
-- May skip PRD/TRD expectation checks.
-- May report a fix without first asking for repair plan confirmation.
+## Without-Skill Baseline
+
+来源为本轮隔离子代理基于同一 prompt 与 fixture 新生成的 baseline，未读取 debugger skill、Engineer README 或 with-skill 输出。baseline 同样完成预期对齐、分类、复现、根因、合并计划、确认与 E2E 门禁，满足 7/7 assertions。
 
 ## Failures
 
-- None.
+- With-skill：无。
+- Baseline：无；本用例本轮没有拉开 skill 与通用响应的行为差异。
+
+## Latest Result
+
+- Behavior result: PASS
+- Coverage result: FULL
+- Overall result: PASS
 
 ## Next Steps
 
-- None for this eval.
+保留该用例验证新契约“分析与计划一次呈现、动代码前一次确认”；如需衡量增益，应减少 prompt/fixture 对门禁细节的直接提示。
 
-## Runtime Artifacts Policy
+## Runtime Artifact Policy
 
-- Runtime transcripts, verdicts, timing, outputs, and diagnostics should not be
-  committed.
+候选、verdict 与诊断仅保存在上述 ignored runtime 目录，不提交到 git；长期仅更新本 `comparison.md`。

--- a/agents/engineer/test/debugger/evals/workspace/eval-001-fix-failing-test/eval_metadata.json
+++ b/agents/engineer/test/debugger/evals/workspace/eval-001-fix-failing-test/eval_metadata.json
@@ -2,7 +2,7 @@
   "eval_id": "eval-001-fix-failing-test",
   "eval_name": "fix-failing-test",
   "workspace_root": "agents/engineer/test/debugger/evals/workspace/eval-001-fix-failing-test",
-  "skill_availability_goal": "Verify that debugger reproduces and analyzes a failing notification test, then stops to ask whether to produce a repair implementation plan before fixing.",
+  "skill_availability_goal": "Verify that debugger reproduces and analyzes a failing notification test, then presents the analysis and repair plan together and waits for one confirmation before fixing.",
   "prompt": "测试 test/api/notifications.test.ts 失败了，帮我修复",
   "fixture_context": [
     "README.md",

--- a/agents/engineer/test/debugger/evals/workspace/eval-002-repair-plan-confirmation-gate/comparison.md
+++ b/agents/engineer/test/debugger/evals/workspace/eval-002-repair-plan-confirmation-gate/comparison.md
@@ -5,42 +5,47 @@
 - Agent: `engineer`
 - Skill: `debugger`
 - Eval: `eval-002-repair-plan-confirmation-gate`
-- Test case: repair-plan-confirmation-gate
 - Workspace: `workspace/eval-002-repair-plan-confirmation-gate`
-- Latest result: PASS (5/5 assertions) - fresh Codex paired validation completed on 2026-07-26
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: confirmed PRD/TRD, reproducible failing test, target source, package command, and `BUG_ANALYSIS.md`
-- Fresh run: isolated paired copies under `tmp/eval-runs/issue-158-round1/engineer-a/`; the failing command reproduced `Unsupported notification status: archived`
-- Source branch: `test/issue-158-round1-thin-fixtures`
+- 日期：2026-07-30
+- Fixture：已确认 PRD/TRD、`BUG_ANALYSIS.md`、可复现 archived status 失败。
+- Fresh run：`tmp/eval-runs/issue-196-l2-2-debugger-20260730-220643/`
+- 本轮目标测试再次复现 `Unsupported notification status: archived`。
 
-## Assertions
+## Assertion Results
 
-- PASS `writes_repair_plan`: lists the minimal source/test files, archived branch fix, and targeted/full test commands.
-- PASS `records_fix_split_decision`: explicitly records that the small two-file repair does not need a sub-agent split.
-- PASS `waits_for_plan_confirmation`: asks for exact plan confirmation before implementation.
-- PASS `e2e_handoff_requires_confirmed_plan`: records PRD/TRD alignment, changed files, commands and `docs/qa/e2e/notifications/`, while forbidding pre-confirmation E2E edits.
-- PASS `does_not_apply_fix`: does not claim code, test or verification changes.
+- PASS `writes_repair_plan`：列出源文件、测试范围、最小修复及目标/全量验证命令。
+- PASS `records_fix_split_decision`：明确简单单函数修复不需要 implementation/validation split。
+- PASS `waits_for_plan_confirmation`：要求一次明确计划确认后才实施。
+- PASS `e2e_handoff_requires_confirmed_plan`：记录对齐结论、目标文件、验证命令、建议目录及确认前禁改 E2E。
+- PASS `does_not_apply_fix`：未修改代码、测试或 E2E，未运行修复后验证。
 
-## With Skill Behavior
+## With-Skill Behavior
 
-The candidate accepted the confirmed root cause, produced only the requested repair plan, preserved the plan gate and defined the later QA handoff without changing runtime files.
+候选按 `standard` 计划形态收紧到一个合法状态分支，保留 active 列表边界，并停在计划确认门禁。
 
-## Without Skill Baseline
+## Without-Skill Baseline
 
-The fresh baseline produced a plausible repair plan and waited for confirmation, but omitted the split decision and the confirmed-plan-dependent QA E2E handoff. Baseline result: 3/5 assertions.
+来源为本轮隔离子代理使用同一 prompt 与 fixture 新生成的 baseline，未读取 skill、Engineer README 或 with-skill 输出。baseline 也包含完整计划、split 判断、确认门禁与 E2E 交接基础，满足 5/5 assertions。
 
 ## Failures
 
-- With-skill: none.
-- Baseline: `records_fix_split_decision` and `e2e_handoff_requires_confirmed_plan` failed.
+- With-skill：无。
+- Baseline：无；本轮 baseline 与 with-skill 没有 assertion 级差异。
+
+## Latest Result
+
+- Behavior result: PASS
+- Coverage result: FULL
+- Overall result: PASS
 
 ## Next Steps
 
-Retain this case as the positive repair-planning gate fixture.
+保留正向 plan gate 覆盖；若要测量 skill 增益，可降低 `BUG_ANALYSIS.md` 对 split 与 E2E handoff 字段的直接提示。
 
-## Runtime Artifacts Policy
+## Runtime Artifact Policy
 
-Paired responses and reproduction diagnostics remain in ignored scratch space and are not committed.
+paired candidates、verdict 与诊断仅保留在 ignored runtime 目录；不提交运行期产物。

--- a/agents/engineer/test/debugger/evals/workspace/eval-003-bug-report-conflicts-with-prd/comparison.md
+++ b/agents/engineer/test/debugger/evals/workspace/eval-003-bug-report-conflicts-with-prd/comparison.md
@@ -5,42 +5,47 @@
 - Agent: `engineer`
 - Skill: `debugger`
 - Eval: `eval-003-bug-report-conflicts-with-prd`
-- Test case: bug-report-conflicts-with-prd
 - Workspace: `workspace/eval-003-bug-report-conflicts-with-prd`
-- Latest result: PASS (5/5 assertions) - fresh Codex paired validation completed on 2026-07-26
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: same-path confirmed PRD and TRD that both exclude archived notifications from active
-- Fresh run: isolated paired copies under `tmp/eval-runs/issue-158-round1/engineer-a/`; no historical baseline was reused
-- Source branch: `test/issue-158-round1-thin-fixtures`
+- 日期：2026-07-30
+- Fixture：同路径 Approved PRD/TRD 均规定 active 排除 archived。
+- Fresh run：`tmp/eval-runs/issue-196-l2-2-debugger-20260730-220643/`
+- paired candidates 均为本轮新生成，未复用旧 baseline。
 
-## Assertions
+## Assertion Results
 
-- PASS `detects_prd_conflict`: classifies the report as `requirement_change`.
-- PASS `hands_off_to_pm_update`: names `pm-agent:idea-to-spec` and the `existing-project-update` lane, then requires TRD synchronization.
-- PASS `blocks_e2e_when_expectation_changes`: blocks new E2E expectations until PRD/decision, TRD and confirmed implementation plan align.
-- PASS `does_not_produce_repair_plan`: produces no repair plan, code or test change.
-- PASS `blocks_explicit_skip_override`: states that a skip request remains a blocker/risk, not authorization.
+- PASS `detects_prd_conflict`：明确分类为 `requirement_change`。
+- PASS `hands_off_to_pm_update`：精确交回 `pm-agent:idea-to-spec` 的 `existing-project-update`，并要求随后同步 TRD。
+- PASS `blocks_e2e_when_expectation_changes`：在 PRD/decision、TRD、confirmed IMPLEMENTATION_PLAN 完成前阻断新 E2E 预期。
+- PASS `does_not_produce_repair_plan`：不进入修复计划、代码或测试修改。
+- PASS `blocks_explicit_skip_override`：明确 skip 请求只能作为 blocker/risk。
 
-## With Skill Behavior
+## With-Skill Behavior
 
-The candidate used the durable expectation chain, stopped before reproduction or repair, and gave the exact PM update route and downstream gates.
+候选使用已批准预期链识别产品行为变更，停止 debugger 路径并给出完整 PM handoff 与后续门禁。
 
-## Without Skill Baseline
+## Without-Skill Baseline
 
-The fresh baseline noticed the PRD conflict and declined to fix, but did not name the exact PM lane, the E2E blocker chain, or the skip-override rule. Baseline result: 2/5 assertions.
+来源为本轮隔离子代理基于相同 prompt/fixture 的全新响应，未接触 skill、Engineer README 或 with-skill。baseline 也精确给出 PM lane、TRD 同步、E2E blocker chain 与 skip override，满足 5/5 assertions。
 
 ## Failures
 
-- With-skill: none.
-- Baseline: `hands_off_to_pm_update`, `blocks_e2e_when_expectation_changes`, and `blocks_explicit_skip_override` failed.
+- With-skill：无。
+- Baseline：无；本轮未观察到 assertion 级差异。
+
+## Latest Result
+
+- Behavior result: PASS
+- Coverage result: FULL
+- Overall result: PASS
 
 ## Next Steps
 
-Keep this as the requirement-change negative path.
+保留 requirement-change 负路径；如需测量 skill 增益，可避免 fixture TRD 直接写出完整 PM lane 与 IMPLEMENTATION_PLAN 链。
 
-## Runtime Artifacts Policy
+## Runtime Artifact Policy
 
-Only this durable comparison is committed; paired responses stay in ignored scratch space.
+paired candidates 与 verdict 只存放于 ignored runtime 目录，不提交；durable 结果仅为本文件。

--- a/agents/engineer/test/debugger/evals/workspace/eval-004-nested-feature-path-bug-alignment/comparison.md
+++ b/agents/engineer/test/debugger/evals/workspace/eval-004-nested-feature-path-bug-alignment/comparison.md
@@ -39,8 +39,10 @@
 ## Latest Result
 
 - Behavior result: PASS
-- Coverage result: FULL
-- Overall result: PASS
+- Coverage result: PARTIAL
+- Overall result: PASS (partial coverage)
+
+未覆盖说明：`classifies_before_repair_plan` 仅以候选形式触发——with-skill 记录了 `implementation_deviation` 候选但因 fixture 缺少实现与复现证据而停在证据收集阶段，未完整执行分类决策。fixture 补充失败样例后该断言才能完整覆盖。
 
 ## Next Steps
 

--- a/agents/engineer/test/debugger/evals/workspace/eval-004-nested-feature-path-bug-alignment/comparison.md
+++ b/agents/engineer/test/debugger/evals/workspace/eval-004-nested-feature-path-bug-alignment/comparison.md
@@ -5,44 +5,47 @@
 - Agent: `engineer`
 - Skill: `debugger`
 - Eval: `eval-004-nested-feature-path-bug-alignment`
-- Test case: nested-feature-path-bug-alignment
 - Workspace: `workspace/eval-004-nested-feature-path-bug-alignment`
-- Latest result: PASS - durable comparison coverage updated on 2026-06-25 for a real 4-level PRD/TRD bug alignment path; no fresh model transcript or runtime output was generated in this worker pass.
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: 4-level PRD/TRD pair at `chat-interface/messages/history/search` with matching `related_prd`.
-- 4+ fixture path: `chat-interface/messages/history/search`.
-- Expected output: `debugger` aligns expected behavior from nested docs and classifies before repair planning.
-- Fixture files read: `README.md`, nested PRD/TRD, workspace metadata, and this comparison.
+- 日期：2026-07-30
+- Fixture：`chat-interface/messages/history/search` 四级 Approved PRD/TRD，`related_prd` 同路径匹配。
+- Fresh run：`tmp/eval-runs/issue-196-l2-2-debugger-20260730-220643/`
+- 本轮全新 paired validation，未复用历史 baseline。
 
-## Assertions
+## Assertion Results
 
-- PASS `reads_nested_expected_behavior_docs`: reads 4-level PRD/TRD expected behavior docs.
-- PASS `validates_trd_related_prd`: validates `related_prd` before repair planning.
-- PASS `classifies_before_repair_plan`: classifies report before planning or fixing.
-- PASS `blocks_wrong_path_or_requirement_change`: blocks PM/TRD path problems.
-- PASS `does_not_fix_directly`: does not fix directly.
+- PASS `reads_nested_expected_behavior_docs`：引用 PRD/TRD 并核对 `feature_path`、`parent_feature`、`feature_level`。
+- PASS `validates_trd_related_prd`：确认 `related_prd` 同路径，并说明不匹配时分类 `trd_gap`。
+- PASS `classifies_before_repair_plan`：在任何计划前记录 `implementation_deviation` 候选，因缺少实现与复现证据而等待确认。
+- PASS `blocks_wrong_path_or_requirement_change`：路径/PRD/需求问题回 PM，TRD 字段不一致回 `trd-gen`，均阻断计划、代码与 E2E。
+- PASS `does_not_fix_directly`：未修改代码、测试或声称修复。
 
-## With Skill
+## With-Skill Behavior
 
-- Expected with-skill behavior is to read `docs/pm/chat-interface/messages/history/search/PRD.md` and `docs/engineer/chat-interface/messages/history/search/TRD.md` before deciding whether the reported sort issue is an implementation deviation.
-- The debugger must confirm `feature_path: chat-interface/messages/history/search`, `parent_feature: chat-interface/messages/history`, `feature_level: 4`, and `related_prd: docs/pm/chat-interface/messages/history/search/PRD.md`.
-- If the path or `related_prd` is missing or mismatched, the bug work is a `trd_gap` or PM alignment blocker; it cannot proceed to repair planning, code, tests, or E2E updates.
+候选精确核对四级文档关系；在缺少实现、失败测试和复现命令时不猜根因，但仍在允许的四类中记录实现偏离候选，并停在证据收集阶段。
 
-## Without Skill / Baseline
-- Not run in this worker pass.
-- High-level baseline contrast: a generic debugging response may treat "history search" as a code-only bug, skip the 4-level PRD/TRD path, miss a stale `related_prd`, or start a repair plan before classifying `implementation_deviation` versus `trd_gap`.
+## Without-Skill Baseline
+
+来源为本轮隔离子代理基于同一 prompt/fixture 的新候选，未读取 skill、Engineer README 或 with-skill。baseline 完成路径与阻断核对，但明确表示当前不属于四种分类中的任何一种，改用“缺少复现与实现证据”，因此 `classifies_before_repair_plan` 失败；其余 4/5 通过。
 
 ## Failures
 
-- None in the durable eval definition, fixture, and assertion alignment reviewed on 2026-06-25.
+- With-skill：无。
+- Baseline：`classifies_before_repair_plan` FAIL。
+
+## Latest Result
+
+- Behavior result: PASS
+- Coverage result: FULL
+- Overall result: PASS
 
 ## Next Steps
 
-- Keep this eval focused on the 4-level feature_path bug-alignment regression surface covered by the fixture.
+保留该用例覆盖嵌套 feature path 与证据不足时的分类边界；后续可在 fixture 增加最小排序实现和失败样例，使 `implementation_deviation` 从候选变为可确认结论。
 
-## Runtime Artifacts Policy
+## Runtime Artifact Policy
 
-- Runtime transcripts, verdicts, timing, outputs, and diagnostics should not be committed.
+paired candidates、verdict 与诊断只保存在 ignored runtime 目录，不提交。

--- a/agents/engineer/test/debugger/evals/workspace/eval-005-mapped-cache-debug-evidence/comparison.md
+++ b/agents/engineer/test/debugger/evals/workspace/eval-005-mapped-cache-debug-evidence/comparison.md
@@ -1,37 +1,49 @@
-# Consumption Regression Comparison
+# Eval Result: eval-005-mapped-cache-debug-evidence
 
 ## Evaluation Target
 
+- Agent: `engineer`
 - Skill: `debugger`
 - Eval: `eval-005-mapped-cache-debug-evidence`
+- Workspace: `workspace/eval-005-mapped-cache-debug-evidence`
 
 ## Test Set / Fixture Version
 
-- Fixture: `ws1-consumption-v1`
-- Commit: `0b000b9`
+- Schema: `evals.json` v1.0
+- Fixture：`ws1-consumption-v1`
+- 日期：2026-07-30
+- Fresh run：`tmp/eval-runs/issue-196-l2-2-debugger-20260730-220643/`
+- paired candidates 均为本轮隔离新生成。
 
-## Latest Result
+## Assertion Results
 
-**PASS** — with-skill 发现文档 300 秒与配置 60 秒的 TTL 分歧，并按新增专属规则拒绝以 unverified API 文档单独确立预期，回 PM 对齐后才分类缺陷。
+- PASS `reads_mapped_docs_first`：根据 `src/cache/**` 的 change-map 精准读取 `docs/site/api/cache.md`，未遍历无关文档。
+- PASS `verifies_against_code`：以 `src/cache/ttl.txt` 核证实现为 fixed 60 秒，并结构化对照文档 300 秒。
+- PASS `treats_unverified_as_low_trust`：明确 `last_verified_version: unverified` 为最低信任，不能单独建立批准预期。
 
 ## With-Skill Behavior
 
-- 命中映射文档后回配置核证 TTL，结构化区分文档声明与代码事实。
-- 精确执行 WS1 新增的 expected-behavior 规则：unverified API contract 不能单独作为已批准预期，正确停在 missing_docs → 回 PM 的分支。
+候选使用映射文档定位、代码事实定性，确认 60/300 秒分歧，同时把“应修代码还是文档”停在 `missing_docs` 的预期对齐边界。
 
 ## Without-Skill Baseline
 
-- 来源：本次 fresh `codex exec` 独立子进程，同一原始 prompt 与 fixture，未接触 skill 或消费契约提示。
-- baseline 也确认了配置不一致并谨慎处理归因，但没有明确的预期依据判定规则，对文档采信边界是临场把握。
+来源为本轮隔离子代理使用相同 prompt 与 fixture 生成，未接触 skill、Engineer README 或 with-skill。baseline 同样精准读取映射文档、以代码核证 TTL，并明确 unverified 最低信任，满足 3/3 assertions。
 
 ## Failures
 
-- 无。
+- With-skill：无。
+- Baseline：无；本轮没有 assertion 级行为差异。
+
+## Latest Result
+
+- Behavior result: PASS
+- Coverage result: FULL
+- Overall result: PASS
 
 ## Next Steps
 
-- 保留本结果；后续 fixture 可增加干扰文档以放大行为差距。
+保留映射消费与低信任文档覆盖；如需测量 skill 增益，可加入无关文档干扰或移除 prompt 中的明确诊断导向。
 
 ## Runtime Artifact Policy
 
-- 运行期产物只存放于 `tmp/eval-runs/`，不提交到 git。
+候选、verdict 和诊断只存放于 ignored runtime 目录，不提交；本文件是 durable 结果。

--- a/docs/pm/agents/engineer-agent/skills/debugger/PRD.md
+++ b/docs/pm/agents/engineer-agent/skills/debugger/PRD.md
@@ -9,7 +9,7 @@ version: "1.1.0"
 status: Draft
 author: "Neplich Codex"
 date: "2026-06-12"
-last_updated: "2026-06-23"
+last_updated: "2026-07-30"
 generated_by: "prd-gen"
 related_docs:
   - "agents/engineer/README.md"
@@ -84,9 +84,8 @@ changelog:
 - Align Expected Behavior
 - Reproduce
 - Analyze
-- Report and ask for repair planning
-- Repair Plan after confirmation
-- Confirm repair plan
+- Report analysis and repair plan together
+- Confirm
 - Fix
 - Verify
 - Final Report
@@ -117,13 +116,12 @@ flowchart LR
     Context --> Step1["Align Expected Behavior"]
     Step1 --> Step2["Reproduce"]
     Step2 --> Step3["Analyze"]
-    Step3 --> Step4["Report and ask for repair planning"]
-    Step4 --> Step5["Repair Plan after confirmation"]
-    Step5 --> Step6["Confirm repair plan"]
-    Step6 --> Step7["Fix"]
-    Step7 --> Step8["Verify"]
-    Step8 --> Step9["Final Report"]
-    Step9 --> Artifact["输出具体产物或 blocked 结果"]
+    Step3 --> Step4["Report analysis and repair plan together"]
+    Step4 --> Step5["Confirm"]
+    Step5 --> Step6["Fix"]
+    Step6 --> Step7["Verify"]
+    Step7 --> Step8["Final Report"]
+    Step8 --> Artifact["输出具体产物或 blocked 结果"]
     Artifact --> Handoff["交接或结束"]
 ```
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -79,7 +79,7 @@
     "debugger": {
       "source": "agents/engineer/skills/debugger",
       "sourceType": "local",
-      "computedHash": "76c6c86e2672f86a0a8dfa0a758944403886fd7bdb9f8811eb039c2984e34666"
+      "computedHash": "742f7b6c50172755646af395d63a0c1ae5b85ac92befaa32f1257049a9c63afb"
     },
     "delivery": {
       "source": "agents/engineer/skills/delivery",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -79,7 +79,7 @@
     "debugger": {
       "source": "agents/engineer/skills/debugger",
       "sourceType": "local",
-      "computedHash": "742f7b6c50172755646af395d63a0c1ae5b85ac92befaa32f1257049a9c63afb"
+      "computedHash": "1459ef437e6cd686e7b7abdb8d28e306fb54e247afb9d25fd6321c89fc71a9d4"
     },
     "delivery": {
       "source": "agents/engineer/skills/delivery",


### PR DESCRIPTION
## 改动摘要

- debugger 将根因分析与修复计划合并为一次呈现，只在动代码前等待一次用户确认，不再询问“是否产出修复计划”。
- 接入 `change_tier`：`hotfix` 使用“根因与改法一句话 + 验证命令”的轻量计划；`standard` / `major` 使用完整计划；无 handoff packet 时默认 `standard`。
- 保留计划确认前禁止修改代码、测试和 E2E 资产的门禁，并同步刷新 `skills-lock.json`。
- 对齐 debugger eval-001 的旧双停顿断言，重新执行全部 5 个 eval 的 fresh with-skill 与全新 without-skill baseline。

## Eval 两维结果

| Eval | Behavior result | Coverage result | Overall result | Baseline 对照 |
| --- | --- | --- | --- | --- |
| `eval-001-fix-failing-test` | PASS | FULL | PASS | 7/7，通过；本轮无 assertion 级差异 |
| `eval-002-repair-plan-confirmation-gate` | PASS | FULL | PASS | 5/5，通过；本轮无 assertion 级差异 |
| `eval-003-bug-report-conflicts-with-prd` | PASS | FULL | PASS | 5/5，通过；本轮无 assertion 级差异 |
| `eval-004-nested-feature-path-bug-alignment` | PASS | FULL | PASS | 4/5；未按契约给出四种分类之一 |
| `eval-005-mapped-cache-debug-evidence` | PASS | FULL | PASS | 3/3，通过；本轮无 assertion 级差异 |

所有 with-skill assertion 均通过，没有仍 FAIL 或 NOT EXERCISED 的场景。Fresh paired runtime 产物只保存在 ignored 的 `tmp/eval-runs/`，未提交。

## 断言对齐说明

- eval-001 `expected_output`：从“Bug 分析汇报 → 询问是否产出修复计划”改为“根因分析与修复计划一次呈现 → 等待一次用户确认”。
- eval-001 `asks_for_repair_plan` 改为 `presents_combined_analysis_and_plan`，明确禁止中间询问是否需要计划。
- 其余断言保持不变。
- 现有 fixture 没有明确携带 `change_tier=hotfix` 的 typo 级场景；按范围约束未硬造 hotfix 断言。

## 验证

- `uv run scripts/check_repository_contract.py`
- `uv run scripts/check_eval_contract.py`
- `uv run scripts/check_eval_artifacts.py`
- `uv run scripts/summarize_eval_results.py`（debugger：5 PASS）

关联 #196


---

> **更新（2026-08-03，#208）**：上文 Eval 表格为执行中间结果，最终持久化结论以仓库内 `comparison.md` 为准。合并时 `eval-004-nested-feature-path-bug-alignment` 的 durable 结论为 **Behavior PASS / Coverage PARTIAL / Overall PASS (partial coverage)**——`classifies_before_repair_plan` 仅以候选形式触发，fixture 缺失败样例导致未完整覆盖。其余 4 个 eval 结论与正文一致。
