### PR TITLE
fix: deployment-planner 目标矩阵驱动按需生成 (#196)

### DIFF
--- a/agents/devops/skills/deployment-planner/SKILL.md
+++ b/agents/devops/skills/deployment-planner/SKILL.md
@@ -6,7 +6,9 @@ visibility: internal
 
 # Deployment Planner
 
-Generate three deployment configurations based on project requirements: local development, Docker containerization, and Kubernetes (Helm) orchestration.
+Generate deployment configurations for the confirmed target matrix. Local
+development, Docker containerization, and Kubernetes (Helm) orchestration are
+available targets, not defaults.
 
 ## When to Use
 
@@ -36,11 +38,19 @@ Before generating anything, inspect:
 
 - the current codebase shape and runtime stack
 - relevant engineering docs and PM deployment requirements when they exist
+- the deployment target matrix
 - whether `deploy/` already exists
 - whether the work is repo-wide or feature-scoped
 - for feature-scoped work, the confirmed `feature_path` and the matching
   `docs/engineer/{feature_path}/TRD.md` and
   `docs/engineer/{feature_path}/IMPLEMENTATION_PLAN.md`
+
+Determine the target matrix before generating any files. When the TRD or PM
+handoff packet explicitly names deployment targets, generate only those
+targets. Otherwise, infer targets only when existing deployment assets such as
+`deploy/` or CI configuration provide sufficient evidence. If neither source
+defines the targets clearly, ask the user which targets are required. Never
+default to generating local, Docker, and Helm together.
 
 If `deploy/` already exists, prefer extension or targeted iteration over blind regeneration.
 
@@ -61,6 +71,7 @@ Read from engineering docs, PM docs, or ask the user:
 - **Tech stack**: Language, framework, database
 - **Scale**: Expected users, traffic volume
 - **Environment needs**: staging/production split
+- **Deployment targets**: Local, Docker, Kubernetes/Helm, or another confirmed target
 - **Dependencies**: External services, databases
 
 ## Step 1 — Analyze Project Requirements
@@ -81,89 +92,86 @@ If no durable deployment requirements exist, ask the user:
 2. What runtime/language does it use?
 3. Does it need a database? Which one?
 4. Any external services required?
+5. Which deployment targets are required?
 
-## Step 2 — Create Local Development Setup (`deploy/local/`)
+## Step 2 — Local Development Target Reference (`deploy/local/`)
 
-Generate files for local development:
+When the target matrix includes local development, generated assets must
+document prerequisites and dependencies, quick start and startup behavior,
+required environment variables, and database setup or migrations when needed.
 
-### 2.1 Create `deploy/local/README.md`
+Reference structure:
+```
+deploy/local/
+├── README.md
+├── .env.example
+└── start.sh
+```
 
-Document:
-- Prerequisites (Node.js version, Python version, etc.)
-- Quick start commands
-- Environment variables needed
-- Database setup instructions
-
-### 2.2 Create `deploy/local/.env.example`
-
-Template with all required environment variables:
+An environment example may include:
 ```
 DATABASE_URL=postgresql://localhost:5432/myapp_dev
 REDIS_URL=redis://localhost:6379
 API_KEY=your_api_key_here
 ```
 
-### 2.3 Create `deploy/local/start.sh`
-
-Startup script that:
+The startup entry should:
 - Checks prerequisites
 - Starts database (if needed)
 - Runs migrations
 - Starts the application
 
-## Step 3 — Create Docker Setup (`deploy/docker/`)
+## Step 3 — Docker Target Reference (`deploy/docker/`)
 
-Generate Docker containerization files:
+When the target matrix includes Docker, generated assets must document Docker
+and Compose prerequisites, build and run commands, port mappings, volume
+mounts, environment variables, and service dependencies.
 
-### 3.1 Create `deploy/docker/README.md`
+Reference structure:
+```
+deploy/docker/
+├── README.md
+├── Dockerfile
+├── docker-compose.yml
+└── .env.example
+```
 
-Document:
-- Docker and docker-compose installation
-- Build and run commands
-- Port mappings
-- Volume mounts
-
-### 3.2 Create `deploy/docker/Dockerfile`
-
-Multi-stage build optimized for production:
+The Dockerfile should:
 - Use official base images
 - Install dependencies
 - Copy application code
 - Set up non-root user
 - Expose ports
 
-### 3.3 Create `deploy/docker/docker-compose.yml`
-
-Define services:
+The Compose setup should define:
 - Application container
 - Database container (if needed)
 - Redis/cache (if needed)
 - Network configuration
 - Volume persistence
 
-### 3.4 Create `deploy/docker/.env.example`
+## Step 4 — Kubernetes/Helm Target Reference (`deploy/helm/`)
 
-Docker-specific environment variables
+When the target matrix includes Kubernetes/Helm, generated assets must document
+Helm prerequisites, chart installation, configuration options, scaling, and
+runtime dependencies.
 
-## Step 4 — Create Kubernetes/Helm Setup (`deploy/helm/`)
+Reference structure:
+```
+deploy/helm/
+├── README.md
+├── Chart.yaml
+├── values.yaml
+└── templates/
+    ├── deployment.yaml
+    ├── service.yaml
+    ├── ingress.yaml
+    ├── configmap.yaml
+    ├── secret.yaml
+    └── hpa.yaml
+```
 
-Generate Helm charts for K8s deployment:
-
-### 4.1 Create `deploy/helm/README.md`
-
-Document:
-- Helm installation
-- Chart installation commands
-- Configuration options
-- Scaling instructions
-
-### 4.2 Create `deploy/helm/Chart.yaml`
-
-Helm chart metadata
-
-### 4.3 Create `deploy/helm/values.yaml`
-
-Default configuration:
+Default values should cover:
 - Replica count
 - Image repository and tag
 - Resource limits (CPU, memory)
@@ -171,9 +179,7 @@ Default configuration:
 - Ingress configuration
 - Environment variables
 
-### 4.4 Create `deploy/helm/templates/`
-
-K8s resource templates:
+Kubernetes resource templates should cover:
 - `deployment.yaml` - Application deployment
 - `service.yaml` - Service definition
 - `ingress.yaml` - Ingress rules (if needed)
@@ -183,36 +189,15 @@ K8s resource templates:
 
 ## Step 5 — Verify Directory Structure
 
-Ensure all files are created:
+Verify only the targets selected in the target matrix:
 
 ```bash
 tree deploy/
 ```
 
-Expected structure:
-```
-deploy/
-├── local/
-│   ├── README.md
-│   ├── .env.example
-│   └── start.sh
-├── docker/
-│   ├── README.md
-│   ├── Dockerfile
-│   ├── docker-compose.yml
-│   └── .env.example
-└── helm/
-    ├── README.md
-    ├── Chart.yaml
-    ├── values.yaml
-    └── templates/
-        ├── deployment.yaml
-        ├── service.yaml
-        ├── ingress.yaml
-        ├── configmap.yaml
-        ├── secret.yaml
-        └── hpa.yaml
-```
+Compare the result with the selected target reference structures and confirm
+that each target includes its required usage, environment, startup, and
+dependency information.
 
 ## Step 6 — Summary
 
@@ -220,22 +205,11 @@ Output:
 ```
 ## 部署配置生成完成
 
-已创建三种部署方案：
+目标矩阵：
+- <target>: <created path and startup/install command>
 
-### Local 开发环境
-- 位置: `deploy/local/`
-- 启动: `cd deploy/local && ./start.sh`
-- 用途: 本地开发调试
-
-### Docker 容器化
-- 位置: `deploy/docker/`
-- 启动: `cd deploy/docker && docker-compose up`
-- 用途: 一键部署，环境一致性
-
-### Kubernetes (Helm)
-- 位置: `deploy/helm/`
-- 安装: `helm install myapp ./deploy/helm`
-- 用途: 生产环境，高可用，自动扩展
+未选择的目标：
+- <target>: <reason omitted>
 
 ### 下一步建议
 - 使用 `cicd-bootstrap` skill 搭建自动化部署流程
@@ -247,6 +221,8 @@ Output:
 - **No database**: Skip database-related configurations
 - **Monorepo**: Generate separate configs for each service
 - **Existing deploy/ directory**: Ask user before overwriting
+- **Target not selected**: Do not generate Helm when Kubernetes is absent from
+  the target matrix, or Docker assets when containerization is absent
 - **Unsupported tech stack**: Search for official deployment guides
 
 ## Output Rules

--- a/agents/devops/test/deployment-planner/evals/evals.json
+++ b/agents/devops/test/deployment-planner/evals/evals.json
@@ -100,6 +100,11 @@
           "id": "treats_unverified_as_low_trust",
           "description": "未核证运行时文档最低信任",
           "text": "对 last_verified_version: unverified 按最低信任处理，关键部署参数必须由代码或测试证据确认。"
+        },
+        {
+          "id": "omits_unselected_targets",
+          "description": "不生成未选择的部署目标",
+          "text": "目标矩阵仅包含容器化部署建议；不得生成 deploy/local 或 deploy/helm 资产。"
         }
       ]
     },

--- a/agents/devops/test/deployment-planner/evals/workspace/eval-001-nextjs-web-app/comparison.md
+++ b/agents/devops/test/deployment-planner/evals/workspace/eval-001-nextjs-web-app/comparison.md
@@ -5,46 +5,56 @@
 - Agent: `devops`
 - Skill: `deployment-planner`
 - Eval: `eval-001-nextjs-web-app`
-- Test case: nextjs-web-app
 - Workspace: `workspace/eval-001-nextjs-web-app`
-- Latest result: PASS - 2026-07-26 fresh paired validation completed; with_skill and fresh without_skill both satisfied 8/8 assertions.
+- Validation: 2026-07-31 fresh paired Codex subagent validation
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: confirmed repo-wide deployment handoff, Next.js manifest, and health endpoint
-- Expected output: 在 deploy/ 目录下生成三个子目录，每个包含 README.md 和相应的配置文件
+- Fixture: confirmed repo-wide handoff, Next.js manifest, and health endpoint
+- With-skill source: `tmp/eval-runs/issue-196-l2-1-20260731-0008/with_skill/eval-001-nextjs-web-app/`
+- Fresh baseline source: `tmp/eval-runs/issue-196-l2-1-20260731-0008/without_skill_fresh2/eval-001-nextjs-web-app/`
 
-## Assertions
+## Latest Result
 
-- PASS `deploy_local_readme_md`: 生成 local README。
-- PASS `deploy_local_env_example_database_url_redis_url`: local env 包含 `DATABASE_URL` 与 `REDIS_URL`。
-- PASS `deploy_local_start_sh`: local start script 可执行。
-- PASS `deploy_docker_dockerfile`: 生成 Dockerfile。
-- PASS `deploy_docker_docker_compose_yml_app_postgres_redis`: Compose 包含 app、postgres、redis。
-- PASS `deploy_helm_chart_yaml`: 生成 Helm Chart。
-- PASS `deploy_helm_values_yaml_replicacount`: values 包含 `replicaCount`。
-- PASS `deploy_helm_templates_deployment_yaml`: 生成 deployment template。
+- Behavior result: PASS
+- Coverage result: FULL
+- All 8 with-skill assertions were exercised and passed.
 
-## With Skill
+Overall result: PASS
 
-- 除满足 8 项断言外，还提供 multi-stage/non-root 镜像、依赖健康门禁、持久卷、外部服务 values、probes 与 resources。
-- with_skill 与 baseline 的 Compose 均通过 `config --quiet`。
+## Assertion Results
 
-## Without Skill / Baseline
+- PASS `deploy_local_readme_md`: `generated/deploy/local/README.md` exists.
+- PASS `deploy_local_env_example_database_url_redis_url`: local `.env.example` contains both `DATABASE_URL` and `REDIS_URL`.
+- PASS `deploy_local_start_sh`: `generated/deploy/local/start.sh` exists and has executable mode `-rwxr-xr-x`.
+- PASS `deploy_docker_dockerfile`: `generated/deploy/docker/Dockerfile` exists.
+- PASS `deploy_docker_docker_compose_yml_app_postgres_redis`: `docker-compose.yml` defines exactly the required `app`, `postgres`, and `redis` services.
+- PASS `deploy_helm_chart_yaml`: `generated/deploy/helm/Chart.yaml` exists.
+- PASS `deploy_helm_values_yaml_replicacount`: Helm values define `replicaCount`.
+- PASS `deploy_helm_templates_deployment_yaml`: the Helm deployment template exists.
 
-- 2026-07-26 使用同一 prompt 和 fixture 重新生成 fresh baseline，未读取或应用 deployment-planner skill、Agent README、历史 comparison 或旧 baseline。
-- baseline 同样满足 8/8 assertions，但镜像加固、健康门禁和 Helm 运行约束较简略。
+## With-Skill Behavior
+
+- The output derived the explicit local, Docker, and Helm target matrix from the handoff and generated all required artifacts.
+- It preserved the handoff boundary: Compose includes PostgreSQL and Redis, while Helm deploys only the application and injects external dependency addresses.
+
+## Fresh Without-Skill Baseline
+
+- The valid fresh baseline used the same prompt and pristine fixture without reading or applying the target skill or DevOps Agent README.
+- It satisfied 6/8 exact artifact assertions. It omitted `deploy/local/start.sh` and named the Compose file `compose.yaml` instead of the asserted `docker-compose.yml`, although the alternate Compose file did contain the three required services.
+- The earlier `tmp/eval-runs/issue-196-l2-1-20260731-0008/without_skill/` run is excluded because its isolation was invalid; none of its output informed this result.
 
 ## Failures
 
-- 无 assertion failure。
-- 环境中没有 Helm，未运行 `helm lint`；当前 assertions 对 skill 增益的区分度有限。
+- No with-skill assertion failure or validation blocker.
+- The valid baseline missed two exact artifact-contract assertions.
 
 ## Next Steps
 
-- 保留 local、Docker、Helm 三目标覆盖。
+- Keep this target-matrix and exact-artifact regression case.
 
-## Runtime Artifacts Policy
+## Runtime Artifact Policy
 
-- Runtime transcripts, verdicts, timing, outputs, and diagnostics were generated only in an ignored scratch workspace and are not committed.
+- Runtime candidates, generated files, transcripts, results, and diagnostics remain under ignored `tmp/eval-runs/` paths and are not copied into the durable fixture.
+- Only this durable `comparison.md` is updated.

--- a/agents/devops/test/deployment-planner/evals/workspace/eval-002-python-api-only/comparison.md
+++ b/agents/devops/test/deployment-planner/evals/workspace/eval-002-python-api-only/comparison.md
@@ -5,41 +5,51 @@
 - Agent: `devops`
 - Skill: `deployment-planner`
 - Eval: `eval-002-python-api-only`
-- Test case: python-api-only
 - Workspace: `workspace/eval-002-python-api-only`
-- Latest result: PASS - 2026-07-26 fresh paired validation completed; with_skill and fresh without_skill both satisfied 3/3 assertions.
+- Validation: 2026-07-31 fresh paired Codex subagent validation
 
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture: confirmed API-only deployment handoff, FastAPI manifest, and health endpoint with an explicit no-database boundary
-- Expected output: 生成简化的部署配置，不包含数据库相关内容
+- Fixture: confirmed API-only handoff, FastAPI manifest, health endpoint, and explicit no-database boundary
+- With-skill source: `tmp/eval-runs/issue-196-l2-1-20260731-0008/with_skill/eval-002-python-api-only/`
+- Fresh baseline source: `tmp/eval-runs/issue-196-l2-1-20260731-0008/without_skill_fresh2/eval-002-python-api-only/`
 
-## Assertions
+## Latest Result
 
-- PASS `deploy_local_env_example_database_url`: local env 不包含 `DATABASE_URL`。
-- PASS `deploy_docker_docker_compose_yml_app`: Compose 仅包含 app 服务。
-- PASS `deploy_local_start_sh`: start script 不包含数据库初始化。
+- Behavior result: PASS
+- Coverage result: FULL
+- All 3 with-skill assertions were exercised and passed.
 
-## With Skill
+Overall result: PASS
 
-- 满足 3 项负向边界断言，并额外提供 non-root 镜像、healthcheck 和 Helm probes/resources。
-- Compose 解析通过。
+## Assertion Results
 
-## Without Skill / Baseline
+- PASS `deploy_local_env_example_database_url`: generated local `.env.example` contains only `PORT` and no `DATABASE_URL`.
+- PASS `deploy_docker_docker_compose_yml_app`: generated `docker-compose.yml` defines only the `app` service.
+- PASS `deploy_local_start_sh`: generated executable `start.sh` contains no database, Redis, migration, or initialization step.
 
-- 2026-07-26 使用同一 prompt 和 fixture 重新生成 fresh baseline，未读取或应用 deployment-planner skill、Agent README、历史 comparison 或旧 baseline。
-- baseline 同样满足 3/3 assertions，没有引入数据库变量、服务或初始化步骤。
+## With-Skill Behavior
+
+- The output generated the confirmed local, Docker, and Helm targets while preserving the API-only boundary across all assets.
+- It did not invent a persistence dependency, related environment variable, or initialization step.
+
+## Fresh Without-Skill Baseline
+
+- The valid fresh baseline used the same prompt and pristine fixture without reading or applying the target skill or DevOps Agent README.
+- Its prose preserved the no-database semantic boundary, but it satisfied 0/3 exact artifact assertions: local `.env.example` and `start.sh` were absent, and the Compose artifact was named `compose.yaml` with service key `api`, not the asserted `docker-compose.yml` containing only `app`.
+- The earlier `tmp/eval-runs/issue-196-l2-1-20260731-0008/without_skill/` run is excluded because its isolation was invalid; none of its output informed this result.
 
 ## Failures
 
-- 无 assertion failure。
-- 环境中没有 Helm，未运行 `helm lint`；当前 assertions 对 skill 增益的区分度有限。
+- No with-skill assertion failure or validation blocker.
+- The valid baseline preserved the broad no-database behavior but missed all three exact generated-artifact contracts.
 
 ## Next Steps
 
-- 保留 API-only 的 no-database 负向覆盖。
+- Keep this negative-boundary regression case and its exact artifact checks.
 
-## Runtime Artifacts Policy
+## Runtime Artifact Policy
 
-- Runtime transcripts, verdicts, timing, outputs, and diagnostics were generated only in an ignored scratch workspace and are not committed.
+- Runtime candidates, generated files, transcripts, results, and diagnostics remain under ignored `tmp/eval-runs/` paths and are not copied into the durable fixture.
+- Only this durable `comparison.md` is updated.

--- a/agents/devops/test/deployment-planner/evals/workspace/eval-003-mapped-doc-deployment/comparison.md
+++ b/agents/devops/test/deployment-planner/evals/workspace/eval-003-mapped-doc-deployment/comparison.md
@@ -1,37 +1,57 @@
-# Consumption Regression Comparison
+# Eval Result: eval-003-mapped-doc-deployment
 
 ## Evaluation Target
 
+- Agent: `devops`
 - Skill: `deployment-planner`
 - Eval: `eval-003-mapped-doc-deployment`
+- Workspace: `workspace/eval-003-mapped-doc-deployment`
+- Validation: 2026-07-31 fresh paired Codex subagent validation
 
 ## Test Set / Fixture Version
 
-- Fixture: `ws1-consumption-v1`
-- Commit: `0b000b9`
+- Schema: `evals.json` v1.0
+- Fixture: `change-map.yaml`, mapped unverified runtime document, and conflicting code configuration
+- With-skill source: `tmp/eval-runs/issue-196-l2-1-20260731-0008/with_skill/eval-003-mapped-doc-deployment/`
+- Fresh baseline source: `tmp/eval-runs/issue-196-l2-1-20260731-0008/without_skill_fresh2/eval-003-mapped-doc-deployment/`
 
 ## Latest Result
 
-**PASS** — with-skill 以配置文件 8081 为部署事实、识别文档 8080 声明为分歧并给出健康检查/流量转发失败的具体影响，部署方案锚定代码证据。
+- Behavior result: PASS
+- Coverage result: FULL
+- All 4 with-skill assertions were exercised and passed.
+
+Overall result: PASS
+
+## Assertion Results
+
+- PASS `reads_mapped_docs_first`: the recorded read order is change-map, mapped runtime document, then code verification; the output reports no unrelated site-doc traversal.
+- PASS `verifies_against_code`: the output identifies documentation port 8080 versus code port 8081 and explains health-check and traffic-routing impact.
+- PASS `treats_unverified_as_low_trust`: it explicitly treats `last_verified_version: unverified` as lowest trust and uses code to confirm the critical port.
+- PASS `omits_unselected_targets`: the matrix contains only containerization advice, creates no deploy assets, and explicitly omits local and Helm targets.
 
 ## With-Skill Behavior
 
-- 命中映射文档后以 server.conf 核证端口，分歧以文档/代码/影响/建议表结构化输出。
-- 部署拓扑图与配置基于代码事实 8081，不采信 unverified 文档端口。
+- The output followed the change-map consumption path, separated documentation claims from verified code facts, and based the deployment advice on port 8081.
+- It kept the output to the requested minimal container recommendation instead of generating unselected deployment targets.
 
-## Without-Skill Baseline
+## Fresh Without-Skill Baseline
 
-- 来源：本次 fresh `codex exec` 独立子进程，同一原始 prompt 与 fixture，未接触 skill 或消费契约提示。
-- baseline 同样识别端口冲突并锚定实际配置，工程判断合格，但分歧记录为叙述式，未按契约形成结构化证据。
+- The valid fresh baseline used the same prompt and pristine fixture without reading or applying the target skill, DevOps Agent README, or consumption contract.
+- It satisfied 2/4 assertions: it correctly selected code port 8081 and generated no unselected assets.
+- It did not satisfy the mapped-doc-first assertion because its recorded read order began with the mapped document before the change-map. It also called the document stale but did not explicitly connect the `unverified` marker to the lowest-trust rule for critical parameters.
+- The earlier `tmp/eval-runs/issue-196-l2-1-20260731-0008/without_skill/` run is excluded because its isolation was invalid; none of its output informed this result.
 
 ## Failures
 
-- 无。
+- No with-skill assertion failure or validation blocker.
+- The valid baseline missed the contract-specific read-order and unverified-trust assertions.
 
 ## Next Steps
 
-- 保留本结果；后续 fixture 可增加干扰文档以放大行为差距。
+- Keep this case to preserve the change-map-first and low-trust verification behavior.
 
 ## Runtime Artifact Policy
 
-- 运行期产物只存放于 `tmp/eval-runs/`，不提交到 git。
+- Runtime candidates, results, transcripts, and diagnostics remain under ignored `tmp/eval-runs/` paths and are not copied into the durable fixture.
+- Only this durable `comparison.md` is updated.

--- a/agents/devops/test/deployment-planner/evals/workspace/eval-004-docs-build-variant-matrix/comparison.md
+++ b/agents/devops/test/deployment-planner/evals/workspace/eval-004-docs-build-variant-matrix/comparison.md
@@ -1,41 +1,57 @@
-# Skill Eval Comparison
+# Eval Result: eval-004-docs-build-variant-matrix
 
 ## Evaluation Target
 
+- Agent: `devops`
 - Skill: `deployment-planner`
 - Eval: `eval-004-docs-build-variant-matrix`
-- Review context: issue #162 fresh paired validation
+- Workspace: `workspace/eval-004-docs-build-variant-matrix`
+- Validation: 2026-07-31 fresh paired Codex subagent validation
 
 ## Test Set / Fixture Version
 
-- Fixture: issue #162 scenario evidence in this workspace
-- Validation date: 2026-07-22
-- Execution cleanup: all declared runtime paths were absent from pristine scratch fixtures
+- Schema: `evals.json` v1.0
+- Fixture: documentation host evidence for Public, Internal, and Preview build variants
+- With-skill source: `tmp/eval-runs/issue-196-l2-1-20260731-0008/with_skill/eval-004-docs-build-variant-matrix/`
+- Fresh baseline source: `tmp/eval-runs/issue-196-l2-1-20260731-0008/without_skill_fresh2/eval-004-docs-build-variant-matrix/`
 
 ## Latest Result
 
-**PASS (3/3 assertions)** — fresh Codex subagent semantic review.
+- Behavior result: PASS
+- Coverage result: FULL
+- All 3 with-skill assertions were exercised and passed.
+
+Overall result: PASS
+
+## Assertion Results
+
+- PASS `enumerates_all_docs_variants`: the matrix includes Public, Internal, and host Preview and does not claim completeness.
+- PASS `covers_deployment_unit_chain`: each row covers build target, context, static entry, image unit, Compose, Kubernetes/Helm resources and values, health check, runtime entry, and disposition.
+- PASS `hands_units_to_cicd`: every variant receives an explicit integrated or blocked disposition, confirmed image coverage is handed to `cicd-bootstrap`, and no workflow is created.
 
 ## With-Skill Behavior
 
-- 矩阵覆盖 Public/Internal/Preview 及完整 deployment-unit 字段，逐变体处置并交 CI/CD。
-- Candidate source: fresh `tmp/eval-runs/issue-162/with_skill/eval-004-docs-build-variant-matrix/candidate-output.md`.
+- The output makes missing evidence explicit instead of inventing deployment details and correctly concludes that overall completeness is blocked.
+- Public, Internal, and Preview remain visible through the full deployment-unit chain, including the non-production Preview variant.
+- The blockers recorded in the runtime result are fixture evidence gaps and expected matrix dispositions, not eval execution blockers or assertion failures.
 
 ## Fresh Without-Skill Baseline
 
-- PARTIAL (1/3)；列出三个变体，但缺 context/static entry、K8s resources、values、health、runtime 与稳定处置。
-- The same prompt and pristine fixture were used; no historical baseline, target skill, Agent README, shared skill-map, old comparison, or with-skill output was used to compose it.
+- The valid fresh baseline used the same prompt and pristine fixture without reading or applying the target skill or DevOps Agent README.
+- It satisfied 1/3 assertions by enumerating all three variants.
+- It omitted build context, static entry, named image units, Kubernetes resource chain, values, health checks, and runtime entry, and it did not hand confirmed image units to `cicd-bootstrap` with canonical per-variant dispositions.
+- The earlier `tmp/eval-runs/issue-196-l2-1-20260731-0008/without_skill/` run is excluded because its isolation was invalid; none of its output informed this result.
 
 ## Failures
 
-- baseline 部署单元矩阵不完整。
-- No with-skill assertion failure or runner/credential blocker.
+- No with-skill assertion failure or eval execution blocker.
+- The valid baseline missed deployment-unit-chain completeness and CI/CD handoff assertions.
 
 ## Next Steps
 
-- Keep this regression case; strengthen fixture ambiguity later where the baseline already passes.
+- Keep this completeness-gate regression case; fixture evidence gaps should continue to produce explicit blocked dispositions without reducing assertion coverage.
 
 ## Runtime Artifact Policy
 
-- Runtime candidates, copied fixtures, verdict, status, and diagnostics remain under `tmp/eval-runs/issue-162/` and are not committed.
-- Only this durable comparison, eval definition, metadata, and fixture evidence are submitted.
+- Runtime candidates, results, transcripts, and diagnostics remain under ignored `tmp/eval-runs/` paths and are not copied into the durable fixture.
+- Only this durable `comparison.md` is updated.

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -119,7 +119,7 @@
     "deployment-planner": {
       "source": "agents/devops/skills/deployment-planner",
       "sourceType": "local",
-      "computedHash": "1bee4e3ae951695abb4da941764855e30b2fb0fec9352c810d026ce8035c8c09"
+      "computedHash": "e4a2c8896011d8c1c4aff8a45978bf10f51a19b7dc6f1fa7f49bdba4041c79a3"
     },
     "cicd-bootstrap": {
       "source": "agents/devops/skills/cicd-bootstrap",


### PR DESCRIPTION
## 改动摘要

- deployment-planner 在生成文件前先确定目标矩阵：优先使用 TRD / PM handoff 明确目标，其次从现有部署资产推断；证据不足时询问用户。
- local、Docker、Helm 调整为按选中 target 使用的参考结构，不再默认三套全生成。
- 未选择 Kubernetes/Helm 时不生成 Helm 资产，未选择容器化时不生成 Docker 资产。
- 对齐 deployment-planner 全部 eval，并完成本轮 fresh with-skill / without-skill paired validation。

## Eval 两维结果

| Eval | Behavior result | Coverage result | Overall result | With-skill |
| --- | --- | --- | --- | --- |
| `eval-001-nextjs-web-app` | PASS | FULL | PASS | 8/8 |
| `eval-002-python-api-only` | PASS | FULL | PASS | 3/3 |
| `eval-003-mapped-doc-deployment` | PASS | FULL | PASS | 4/4 |
| `eval-004-docs-build-variant-matrix` | PASS | FULL | PASS | 3/3 |

有效 fresh without-skill baseline 的精确断言对照分别为 6/8、0/3、2/4、1/3。首次 baseline 因读取到 assertions 造成隔离违规，已明确作废并排除；comparison 仅使用重新生成的有效 baseline。

## 断言对齐说明

- `eval-001`：PM handoff 明确选择 local、Docker、Helm，原断言保持不动。
- `eval-002`：PM handoff 明确选择 local、Docker、Helm，原断言保持不动。
- `eval-003`：场景只要求最小容器部署建议，新增 `omits_unselected_targets`，要求不得生成 `deploy/local` 或 `deploy/helm`。
- `eval-004`：文档构建变体矩阵场景不涉及默认三套生成，原断言保持不动。

## 验证

- `uv run scripts/check_eval_contract.py`
- `uv run scripts/check_eval_artifacts.py`
- `uv run scripts/check_repository_contract.py`
- `uv run scripts/summarize_eval_results.py`

以上均通过，汇总脚本可解析 deployment-planner 为 4/4 PASS。
