### PR TITLE
docs: CONTRIBUTING pytest 清单与 CI 对齐 (#209)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,9 @@ uv run --with pytest pytest \
   agents/docs/test/test_docs_run_eval.py \
   agents/test_doc_contract.py \
   agents/test_eval_contract.py \
-  scripts/test_install_codex_skills.py
+  scripts/test_install_codex_skills.py \
+  scripts/test_summarize_eval_results.py \
+  scripts/test_check_repository_contract.py
 ```
 
 Optional JSON static format check:

--- a/CONTRIBUTING_zh.md
+++ b/CONTRIBUTING_zh.md
@@ -31,7 +31,9 @@ uv run --with pytest pytest \
   agents/docs/test/test_docs_run_eval.py \
   agents/test_doc_contract.py \
   agents/test_eval_contract.py \
-  scripts/test_install_codex_skills.py
+  scripts/test_install_codex_skills.py \
+  scripts/test_summarize_eval_results.py \
+  scripts/test_check_repository_contract.py
 ```
 
 可选 JSON 静态格式检查：


### PR DESCRIPTION
## 背景

Fixes #209

CI 的 `python-tests` job 除 CONTRIBUTING 列出的清单外，还执行：

- `scripts/test_summarize_eval_results.py`
- `scripts/test_check_repository_contract.py`

`CONTRIBUTING.md` 与 `CONTRIBUTING_zh.md` 的本地 pytest 清单均未包含这两项，贡献者严格按文档执行本地检查时比 required CI 少跑两个测试文件。

## 改动

- `CONTRIBUTING.md`、`CONTRIBUTING_zh.md`：pytest 清单补上上述两个测试文件，与 `.github/workflows/ci.yml` 的 `python-tests` 完全一致。

## 验证

- 本地按补齐后的清单完整执行 `uv run --with pytest pytest ...`：205 passed。
- 与 `.github/workflows/ci.yml:63-74` 逐行比对，清单一致。

无行为变更，纯文档对齐（hotfix）。
