### PR TITLE
docs: DevOps PRD 与 README 同步按需产物行为 (#206)

### DIFF
--- a/agents/devops/README.md
+++ b/agents/devops/README.md
@@ -23,10 +23,10 @@
 | Skill | When to use | Main output |
 | --- | --- | --- |
 | `devops-agent` | DevOps request routing | Specialist selection and execution path |
-| `deployment-planner` | New or updated deployment config, containers, Kubernetes/Helm | `deploy/local/`, `deploy/docker/`, `deploy/helm/` |
+| `deployment-planner` | New or updated deployment config, containers, Kubernetes/Helm | `deploy/` assets for the confirmed target matrix (local / docker / helm are options, not defaults) |
 | `cicd-bootstrap` | GitHub Actions / release workflow | CI/CD configuration files |
 | `env-config-auditor` | Environment variables, secrets, runtime config coverage | Config audit report and gap list |
-| `incident-playbook-writer` | Rollback, troubleshooting, on-call preparation | Runbook and incident playbook |
+| `incident-playbook-writer` | Rollback, troubleshooting, on-call preparation | Only the user-selected, evidence-backed runbooks and incident playbooks |
 
 ## Routing Rules
 
@@ -38,6 +38,10 @@
 Default rule: if the core question is "how do we deploy it?", start with `deployment-planner`. If deployment already exists but automation is missing, start with `cicd-bootstrap`.
 
 ## Deployment Artifact Model
+
+Local, Docker, and Helm are available targets, not a default bundle. Generate
+only the targets confirmed by the TRD, the PM handoff packet, existing
+deployment assets, or the user. The full layout looks like:
 
 ```text
 deploy/

--- a/agents/devops/README_zh.md
+++ b/agents/devops/README_zh.md
@@ -23,10 +23,10 @@
 | Skill | 适用场景 | 主要产物 |
 | --- | --- | --- |
 | `devops-agent` | DevOps 请求入口与路由 | 下游 skill 选择与执行路径 |
-| `deployment-planner` | 新建或扩展部署配置、容器化、K8s/Helm | `deploy/local/`、`deploy/docker/`、`deploy/helm/` |
+| `deployment-planner` | 新建或扩展部署配置、容器化、K8s/Helm | 按已确认目标矩阵生成的 `deploy/` 产物（local / docker / helm 为可选目标，非默认组合） |
 | `cicd-bootstrap` | GitHub Actions / release workflow | CI/CD 配置文件 |
 | `env-config-auditor` | 环境变量、secrets、运行时配置覆盖率 | 配置审计报告、缺口清单 |
-| `incident-playbook-writer` | 回滚、故障排查、on-call 准备 | runbook、incident playbook |
+| `incident-playbook-writer` | 回滚、故障排查、on-call 准备 | 仅用户明确选择且证据充分的 runbook 与 incident playbook |
 
 ## 路由规则
 
@@ -38,6 +38,9 @@
 默认规则：如果核心问题是“让系统可部署”，从 `deployment-planner` 开始；如果已有部署但缺自动化，从 `cicd-bootstrap` 开始。
 
 ## 部署产物模型
+
+local、Docker、Helm 是可选部署目标，不是默认组合。只生成 TRD、PM handoff packet、
+现有部署资产或用户确认的目标。完整布局如下：
 
 ```text
 deploy/

--- a/docs/pm/agents/devops-agent/skills/deployment-planner/PRD.md
+++ b/docs/pm/agents/devops-agent/skills/deployment-planner/PRD.md
@@ -66,7 +66,7 @@ changelog:
 | FR-S01 | Trigger Matching | `deployment-planner` 必须覆盖当前实现的触发场景，而不是只复述 frontmatter 摘要。 | P0 | 匹配场景与 parent dispatcher 和 `deployment-planner` SKILL.md 一致。 |
 | FR-S02 | Context Intake | 服务结构、运行方式、scale、staging/production、依赖/外部服务、是否已有 deploy/、repo-wide vs feature-scoped、部署约束；feature-scoped work 还必须消费已确认 `feature_path`、`docs/engineer/{feature_path}/TRD.md` 和 `docs/engineer/{feature_path}/IMPLEMENTATION_PLAN.md`。 | P0 | 缺少真正阻塞的上下文时才澄清或 blocked；`feature_path` 或 Engineer 文档不清时回 PM/Engineer，不自建同义顶层目录。 |
 | FR-S03 | Workflow Execution | 必须按当前实现工作流执行，并保留已实现的 gate、phase 或 mode。 | P0 | Mermaid 流程和工作流条目覆盖关键阶段。 |
-| FR-S04 | Artifact Output | 创建或更新实际 deploy/ 文件：deploy/local、deploy/docker、deploy/helm；feature-scoped 部署说明或 readiness notes 写入 `docs/devops/{feature_path}/...`；只有只读/缺上下文/用户限制时才 blocked 或给计划。 | P0 | 未阻塞时产出指定 artifact；blocked 时说明原因、缺口和 next owner。 |
+| FR-S04 | Artifact Output | 按已确认的部署目标矩阵创建或更新对应 deploy/ 文件；deploy/local、deploy/docker、deploy/helm 是可选目标而非默认组合，禁止默认同时生成三套。目标由 TRD 或 PM handoff packet 明确时只生成这些目标；仅当现有部署资产提供充分证据时才推断目标；两者都不明确时向用户确认目标。feature-scoped 部署说明或 readiness notes 写入 `docs/devops/{feature_path}/...`；只有只读/缺上下文/用户限制时才 blocked 或给计划。 | P0 | 未阻塞时产出与确认目标矩阵一致的 artifact；blocked 时说明原因、缺口和 next owner。 |
 | FR-S05 | Boundary Guard | 不接管 `devops-agent` 之外角色的职责；不在上下文不足时伪造结论。 | P0 | 越界事项转交 owning skill/agent，不在本 skill 内扩大范围。 |
 | FR-S06 | Handoff | CI/CD 到 cicd-bootstrap；配置完整性到 env-config-auditor；运行手册到 incident-playbook-writer；代码/安全问题到 Engineer/Security。 | P0 | Handoff 目标具体到 skill/agent/owner，并携带输入包、证据和期望结果。 |
 | FR-S07 | Traceability | PRD 必须引用执行契约来源。 | P1 | related_docs、Dependencies、API Touchpoints 能覆盖关键实现来源。 |
@@ -76,7 +76,7 @@ changelog:
 ### 当前实现工作流
 
 - 检查现有 deploy/ 资产
-- 判断范围和部署目标
+- 确认范围和部署目标矩阵（TRD/handoff 明确的目标优先；证据不足时向用户确认，不默认生成三套）
 - 已有 deploy/ 时 targeted iteration
 - 生成 executable config
 - 验证或说明手动验证步骤

--- a/docs/pm/agents/devops-agent/skills/incident-playbook-writer/PRD.md
+++ b/docs/pm/agents/devops-agent/skills/incident-playbook-writer/PRD.md
@@ -66,7 +66,7 @@ changelog:
 | FR-S01 | Trigger Matching | `incident-playbook-writer` 必须覆盖当前实现的触发场景，而不是只复述 frontmatter 摘要。 | P0 | 匹配场景与 parent dispatcher 和 `incident-playbook-writer` SKILL.md 一致。 |
 | FR-S02 | Context Intake | deploy/ 部署方式、CI/CD 与运维入口、repo-wide/feature/release 范围、已有 runbook；feature-scoped runbook 还必须消费已确认 `feature_path`、`docs/engineer/{feature_path}/TRD.md` 和 `docs/engineer/{feature_path}/IMPLEMENTATION_PLAN.md`；告警线索只在 incident-aftercare 场景必需。 | P0 | 缺少真正阻塞的上下文时才澄清或 blocked；`feature_path` 或 Engineer 文档不清时回 PM/Engineer，不自建同义顶层目录。 |
 | FR-S03 | Workflow Execution | 必须按当前实现工作流执行，并保留已实现的 gate、phase 或 mode。 | P0 | Mermaid 流程和工作流条目覆盖关键阶段。 |
-| FR-S04 | Artifact Output | repo-wide runbook 创建或扩展 deploy/ROLLBACK.md、deploy/INCIDENT_RESPONSE.md、deploy/TROUBLESHOOTING.md、deploy/ON_CALL.md；feature-scoped rollback/release/incident supplement 写入 `docs/devops/{feature_path}/...`。 | P0 | 未阻塞时产出指定 artifact；blocked 时说明原因、缺口和 next owner。 |
+| FR-S04 | Artifact Output | repo-wide runbook 只创建或扩展用户明确选择且证据充分的 deploy/ 文档（候选为 deploy/ROLLBACK.md、deploy/INCIDENT_RESPONSE.md、deploy/TROUBLESHOOTING.md、deploy/ON_CALL.md，不默认全量生成）；证据不足时不生成该文档，报告缺口与所需证据。feature-scoped rollback/release/incident supplement 写入 `docs/devops/{feature_path}/...`。 | P0 | 未阻塞时产出与用户选择一致的 artifact；证据不足或 blocked 时说明原因、缺口和 next owner。 |
 | FR-S05 | Boundary Guard | 不接管 `devops-agent` 之外角色的职责；不在上下文不足时伪造结论。 | P0 | 越界事项转交 owning skill/agent，不在本 skill 内扩大范围。 |
 | FR-S06 | Handoff | DevOps follow-up 到 deployment-planner/cicd-bootstrap/env-config-auditor；越界交 engineer-agent、pm-agent、security-agent。 | P0 | Handoff 目标具体到 skill/agent/owner，并携带输入包、证据和期望结果。 |
 | FR-S07 | Traceability | PRD 必须引用执行契约来源。 | P1 | related_docs、Dependencies、API Touchpoints 能覆盖关键实现来源。 |
@@ -77,7 +77,8 @@ changelog:
 
 - 识别 Docker/Helm/local/custom 部署方式
 - 处理 no deploy/custom/multiple services edge cases
-- 创建或扩展 4 类 deploy 文档
+- 确认用户需要的 playbook（未指定时给出四类候选请用户选择）
+- 只创建或扩展已选择且证据充分的 deploy 文档；证据不足时报告缺口与所需证据
 - 总结运行入口和验证方式
 - feature-scoped runbook 使用 `feature_path` 写入 `docs/devops/{feature_path}/...`
 
@@ -106,8 +107,9 @@ flowchart LR
     Match --> Context["读取/确认实现契约上下文"]
     Context --> Step1["识别 Docker/Helm/local/custom 部署方式"]
     Step1 --> Step2["处理 no deploy/custom/multiple services edge cases"]
-    Step2 --> Step3["创建或扩展 4 类 deploy 文档"]
-    Step3 --> Step4["总结运行入口和验证方式"]
+    Step2 --> Step3["确认用户选择的 playbook"]
+    Step3 --> Step3b["创建或扩展已选择且证据充分的 deploy 文档"]
+    Step3b --> Step4["总结运行入口和验证方式"]
     Step4 --> Artifact["输出具体产物或 blocked 结果"]
     Artifact --> Handoff["交接或结束"]
 ```


### PR DESCRIPTION
## 背景

Fixes #206

PR #203 已将 `deployment-planner` 改为由已确认的部署目标矩阵驱动，PR #204 已将 `incident-playbook-writer` 改为只生成用户明确选择且证据充分的 playbook。两个 PR 均已合并，但产品契约与 Agent 入口文档仍保留旧的全量产物描述，与运行协议冲突。

## 改动

- `docs/pm/agents/devops-agent/skills/deployment-planner/PRD.md`
  - FR-S04：改为按已确认目标矩阵产出对应 deploy/ 文件，明确 local/docker/helm 是可选目标而非默认组合，禁止默认同时生成三套；目标不明确时向用户确认。
  - 当前实现工作流：补「确认部署目标矩阵」环节。
- `docs/pm/agents/devops-agent/skills/incident-playbook-writer/PRD.md`
  - FR-S04：只创建或扩展用户明确选择且证据充分的 deploy/ 文档，四类为候选而非默认全量；证据不足时报告缺口与所需证据。
  - 当前实现工作流与用户流程 Mermaid：新增「确认用户选择的 playbook」环节。
- `agents/devops/README.md` / `README_zh.md`
  - skill 表中两个 skill 的主要产物改为按需语义。
  - 部署产物模型节前补充「local / Docker / Helm 是可选目标，不是默认组合」说明。

## 验证

- `uv run scripts/check_repository_contract.py`：PASS
- `uv run scripts/check_doc_contract.py`：PASS

无行为变更，纯文档对齐。
