### PR TITLE
docs: 清理 Release Notes 产物路径与角色归属旧契约残留 (#207)

### DIFF
--- a/agents/product_manager/README.md
+++ b/agents/product_manager/README.md
@@ -15,7 +15,7 @@
 | Entry skill | `pm-agent` |
 | Specialist skills | 7 |
 | Main inputs | User ideas, local `docs/`, repository state, GitHub Issues / PRs / Milestones / Releases |
-| Main outputs | `docs/pm/{feature_path}/`, `docs/roadmap.md`, `docs/changelog/changelog-v{version}.md`, `docs/release-notes/` |
+| Main outputs | `docs/pm/{feature_path}/`, `docs/roadmap.md`, `docs/changelog/changelog-v{version}.md` |
 | Downstream agents | `designer-agent`, `engineer-agent` |
 
 ## Skills
@@ -79,7 +79,10 @@ Repository-level PM artifacts can use:
 
 - `docs/roadmap.md`
 - `docs/changelog/changelog-v{version}.md`
-- `docs/release-notes/`
+
+Site Release Notes are owned by `docs-agent:release-notes-generator` under the
+host site's `docs/site/release-notes/`; PM only produces GitHub Releases via
+`github-release-generator`.
 
 ## Collaboration Boundary
 

--- a/agents/product_manager/README_zh.md
+++ b/agents/product_manager/README_zh.md
@@ -15,7 +15,7 @@
 | 入口 skill | `pm-agent` |
 | Specialist skills | 7 个 |
 | 主要输入 | 用户想法、本地 `docs/`、代码库现状、GitHub Issues / PRs / Milestones / Releases |
-| 主要输出 | `docs/pm/{feature_path}/`、`docs/roadmap.md`、`docs/changelog/changelog-v{version}.md`、`docs/release-notes/` |
+| 主要输出 | `docs/pm/{feature_path}/`、`docs/roadmap.md`、`docs/changelog/changelog-v{version}.md` |
 | 下游协作 | `designer-agent`、`engineer-agent` |
 
 ## Skill 清单
@@ -79,7 +79,9 @@ Repo 级 PM 产物可以放在：
 
 - `docs/roadmap.md`
 - `docs/changelog/changelog-v{version}.md`
-- `docs/release-notes/`
+
+站内 Release Notes 归 `docs-agent:release-notes-generator`，写入宿主站点的
+`docs/site/release-notes/`；PM 只通过 `github-release-generator` 产出 GitHub Release。
 
 ## 协作边界
 

--- a/docs/engineer/agents/docs-agent/IMPLEMENTATION_PLAN.md
+++ b/docs/engineer/agents/docs-agent/IMPLEMENTATION_PLAN.md
@@ -5,7 +5,7 @@ version: "0.6.0"
 status: Draft
 author: "Neplich Claude"
 date: "2026-07-15"
-last_updated: "2026-07-19"
+last_updated: "2026-08-03"
 feature: "agent-docs-agent"
 feature_path: "agents/docs-agent"
 parent_feature: "agents"
@@ -101,7 +101,7 @@ TRD 第 13 节的两个 Open Question 在本计划中落定如下：
 | 修改 | `agents/designer/skills/ui-ux-design/SKILL.md` | 为需要读取现有产品与界面事实的 Designer specialist 增加一行消费契约指针。 |
 | 修改 | `agents/security/skills/{appsec-checklist,authz-reviewer,dependency-risk-auditor,privacy-surface-mapper}/SKILL.md` | 为 4 个 Security specialist 增加一行消费契约指针。 |
 | 修改 | `agents/engineer/skills/debugger/SKILL.md` | 在通用指针之外，把命中的 API contract 纳入 expected-behavior 依据来源之一，并保留与 Approved PRD/TRD、测试和代码证据的一致性门禁。 |
-| 修改 | `agents/product_manager/skills/release-notes-generator/SKILL.md` | 仅按 `docs/site/release-notes/` 存在性切换 release-notes 输出目标；站点不存在时保持原路径和行为。 |
+| 修改 | `agents/docs/skills/release-notes-generator/SKILL.md`（已从 PM 迁入 docs-agent） | release-notes 输出目标固定为宿主站点 `docs/site/release-notes/`；站点基础缺失时不初始化该路径，无站点宿主由 PM `github-release-generator` 消费维护者确认的版本事实源。 |
 | 修改 | `agents/product_manager/test/{feature-catalog,github-reader,idea-to-spec,release-notes-generator}/evals/evals.json`、`agents/engineer/test/{codebase-analyzer,trd-gen,feature-implementor,debugger,test-writer}/evals/evals.json`、`agents/qa/test/{spec-based-tester,exploratory-tester,bug-analyzer,regression-suite}/evals/evals.json`、`agents/devops/test/{deployment-planner,env-config-auditor,incident-playbook-writer,cicd-bootstrap}/evals/evals.json`、`agents/designer/test/ui-ux-design/evals/evals.json`、`agents/security/test/{appsec-checklist,authz-reviewer,dependency-risk-auditor,privacy-surface-mapper}/evals/evals.json` | 为上述消费侧 skill 增补命中 change-map、无站点、旧版本三类语义 assertions；这些 eval 定义当前均存在。 |
 | 新增 | 上述 eval 目录各自的 `workspace/<新增消费回归用例>/**`（含 durable `comparison.md`） | 为三类消费行为建立隔离 fixture；新用例编号在 PR 1 依据各 `evals.json` 的现有最大编号顺延，避免覆盖既有 workspace。 |
 | 修改 | `skills-lock.json` | 刷新 PR 1 中所有被修改 skill 的 `computedHash`。 |

--- a/docs/pm/agents/docs-agent/PRD.md
+++ b/docs/pm/agents/docs-agent/PRD.md
@@ -268,7 +268,7 @@ Error flow：宿主项目无文档站时，sync 与 audit 提示可先执行 boo
 | 2 | audit 报告归档路径：沿用 QA `_reports/{platform-version}/` 先例，还是站点 `.meta/` 或 `docs/docs/`？ | Maintainer | 2026-07-14 | 归档到宿主站点 `docs/site/.meta/audit/audit-{version}.md`；`.meta/` 为机器消费区，不进导航、不受 frontmatter 校验约束 |
 | 3 | `visibility` 双站点是否进入 MVP，还是先单站点、双站点后置？ | Maintainer | 2026-07-14 | visibility 双站点全进 MVP：bootstrap 骨架内置 visibility 过滤生成脚本、public / internal 双首页与双站点配置 |
 | 4 | bootstrap 是否额外生成宿主项目本地维护 skill（仿 `hub-docs-maintainer`），还是逻辑全部留在 marketplace skill？ | Maintainer | 2026-07-14 | 不生成宿主本地维护 skill；逻辑全部留在 marketplace 的 `formal-docs-sync`，宿主差异落 `standards/` 与 change-map 数据层 |
-| 5 | `pm-agent` release 类 skill 输出目标切换到站点 `release-notes/` 的触发条件与向后兼容方式？ | Maintainer | 2026-07-14 | 按站点存在性自动切换：宿主存在 `docs/site/release-notes/` 时 release 类 skill 输出指向站点目录，不存在时维持现状，无配置项；切换范围仅限 release-notes 输出，changelog 归档路径不变 |
+| 5 | `pm-agent` release 类 skill 输出目标切换到站点 `release-notes/` 的触发条件与向后兼容方式？ | Maintainer | 2026-07-14 | release 类产物按 owner 拆分：站内 Release Notes 固定由 `docs-agent:release-notes-generator` 写入 `docs/site/release-notes/`，站点基础缺失时不初始化该路径；GitHub Release 由 PM `github-release-generator` 生成；无文档站宿主时使用维护者确认的版本事实源，不再回退到旧 `docs/release-notes/` 路径；changelog 归档路径不变 |
 | 6 | MVP 的 sync 链路只覆盖 api 文档是否成立，database / ops 的迭代切分点？ | Maintainer | 2026-07-14 | MVP 仅覆盖 api 链路（feature 落地节点）；database、ops 作为后续两次迭代 |
 | 7 | 存量回填落在 bootstrap、独立 skill 还是 sync 模式？ | Maintainer | 2026-07-14 | 作为 formal-docs-sync 的第四模式；复用同一套模板映射、写作纪律与 change-map 生长逻辑 |
 | 8 | 存量回填是否进 MVP，覆盖范围如何切？ | Maintainer | 2026-07-14 | 进 MVP，api 链路先行；database、ops 回填随各自迭代补齐 |

--- a/docs/pm/agents/pm-agent/PRD.md
+++ b/docs/pm/agents/pm-agent/PRD.md
@@ -72,7 +72,7 @@ changelog:
 | FR-A00 | Entry Dispatcher | `pm-agent` 必须作为入口 dispatcher，负责激活角色级流程。 | P0 | README、marketplace 和 entry SKILL 都指向 `pm-agent`。 |
 | FR-A01 | Route Matrix | Dispatcher 默认选择一个最小主 route；只有用户明确要求或目标强烈暗示更广 PM 链路时，才定义后续 multi-skill chain。 | P0 | 主 route 属于 `idea-to-spec`, `competitive-brief`, `changelog-generator`, `github-release-generator`, `roadmap-generator`, `github-reader`，不包含 `pm-agent` 自身。 |
 | FR-A02 | Context Boundary | Dispatcher 只收集路由所需上下文；实现/审查/测试细节由被选 specialist 收集。 | P0 | 缺少内容级上下文不会让入口停在元路由。 |
-| FR-A03 | Artifact Ownership | 下游 specialist 拥有具体产物写入和验证责任；PM 主输出路径必须覆盖 `docs/pm/{feature_path}/`、`docs/roadmap.md`、`docs/changelog/changelog-v{version}.md` 和 `docs/release-notes/`。 | P0 | Dispatcher 输出预期产物路径和类型，不伪装成 specialist report。 |
+| FR-A03 | Artifact Ownership | 下游 specialist 拥有具体产物写入和验证责任；PM 主输出路径必须覆盖 `docs/pm/{feature_path}/`、`docs/roadmap.md` 和 `docs/changelog/changelog-v{version}.md`。站内 Release Notes 归 `docs-agent:release-notes-generator`（`docs/site/release-notes/`），PM 侧 `github-release-generator` 只消费已确认的版本事实。 | P0 | Dispatcher 输出预期产物路径和类型，不伪装成 specialist report。 |
 | FR-A04 | Handoff | UI/UX 产物交给 designer-agent；PM 范围稳定后通过 engineer-agent:trd-gen 进入工程；非 PM 范围按 owning agent 转交。 | P0 | Handoff 指向 owning skill/agent，并说明输入包、`feature_path` 证据和期望输出。 |
 | FR-A05 | Feature Path Routing | 当请求需要 PRD/BRD/DECISIONS/design.md 时，PM 入口必须把请求交给 `idea-to-spec` 解析合法多级 `feature_path`。 | P0 | 子功能不直接生成并列顶层 PM 目录；父功能不清楚时 blocked 或澄清。 |
 

--- a/docs/pm/repository-ci-governance/CI_PLAN.md
+++ b/docs/pm/repository-ci-governance/CI_PLAN.md
@@ -221,7 +221,7 @@ uv run agents/qa/test/run_all_evals.py
 - [ ] 确认 `docs/changelog/changelog-v{version}.md` 存在并记录对应版本变更。
 - [ ] 根目录 `CHANGELOG.md` 只作为版本索引。
 - [ ] 必要时手动触发 eval workflow 并记录结果。
-- [ ] 必要时生成 `docs/release-notes/` 下的 release notes。
+- [ ] 按 `pm-agent → github-release-generator` 流程创建 GitHub Release draft 并交维护者审批；本仓无文档站宿主，使用维护者确认的版本事实源，不生成 `docs/release-notes/`。
 
 暂不实现：
 


### PR DESCRIPTION
## 背景

Fixes #207

当前协作链已把站内 Release Notes 与 GitHub Release 分给不同 owner：`docs-agent:release-notes-generator` 负责 `docs/site/release-notes/`，PM `github-release-generator` 只消费已确认的版本事实；无文档站宿主使用维护者确认的版本事实源。部分 PM/Docs 文档仍保留旧的 `docs/release-notes/` 产物与 fallback 描述。

## 改动

- `agents/product_manager/README.md` / `README_zh.md`：主要输出与 repo 级产物清单移除 `docs/release-notes/`，补充 Release Notes 角色归属说明。
- `docs/pm/agents/pm-agent/PRD.md` FR-A03：PM 主输出路径不再包含 `docs/release-notes/`，补 owner 归属。
- `docs/pm/agents/docs-agent/PRD.md` 决策记录 Q5：更新为当前 owner 拆分与无站点降级（维护者确认的版本事实源）。
- `docs/engineer/agents/docs-agent/IMPLEMENTATION_PLAN.md`：release-notes-generator 行更新为当前事实（skill 已迁入 docs-agent），`last_updated` 刷新为 2026-08-03。
- `docs/pm/repository-ci-governance/CI_PLAN.md`：发版检查项「生成 `docs/release-notes/`」改为 `pm-agent → github-release-generator` 流程（全仓排查发现的同类残留，随本 issue 一并清理）。

## 验证

- 全仓 `grep docs/release-notes`：修改后无残留。
- `uv run scripts/check_repository_contract.py`：PASS
- `uv run scripts/check_doc_contract.py`：PASS

无行为变更，纯文档对齐。
