### PR TITLE
fix: spec-based-tester 报告模板接入 preflight 基线与 blocked owner (#201)

### DIFF
--- a/agents/qa/skills/spec-based-tester/SKILL.md
+++ b/agents/qa/skills/spec-based-tester/SKILL.md
@@ -275,7 +275,22 @@ For non-E2E spec validation where the repo has no stronger reporting path, use
 
 The report should include:
 
-### 1) Validation summary
+### 1) Preflight baseline
+
+Carry the preflight record into the report so the execution basis is visible:
+
+- Scope and feature path
+- Environment and platform version status
+- Unknowns and blocked checks
+- Same-path PRD/TRD/confirmed `IMPLEMENTATION_PLAN.md` gate status when the
+  request comes from an existing-feature change, bug fix, or code-complete E2E
+  documentation update
+- QA memory read status for `TEST_SUITE.md`, `FLOW_INDEX.md`, `cases/*.md`,
+  `scripts/*.spec.md`, prior `results/`, and `_reports/` — record each source
+  as read or absent
+- Whether reusable TC exist and whether they are reused
+
+### 2) Validation summary
 
 - Scope
 - Environment
@@ -283,7 +298,7 @@ The report should include:
 - What was validated
 - What was not validated
 
-### 2) Requirement matrix
+### 3) Requirement matrix
 
 For each in-scope requirement or acceptance point, record:
 
@@ -293,7 +308,7 @@ For each in-scope requirement or acceptance point, record:
 - Evidence
 - Notes
 
-### 3) Confirmed failures only
+### 4) Confirmed failures only
 
 List only failures that were directly reproduced and evidenced.
 
@@ -302,11 +317,18 @@ List only failures that were directly reproduced and evidenced.
 - Do not turn assumptions into bugs.
 - Do not escalate flaky or ambiguous observations as confirmed defects unless you explicitly call out the uncertainty and why the result is not stable.
 
-### 4) Blocked items
+### 5) Blocked items
 
-List blocked checks separately with the exact blocker.
+List blocked checks separately with the exact blocker, the next owner, and the
+recovery order. For document-gate blockers, name the owning specialist and
+resume only after the missing document is confirmed on the same feature path:
 
-### 5) Release or implementation risks
+- Missing or unclear PRD → `pm-agent:idea-to-spec`
+- Missing, stale, or mis-pathed TRD → `engineer-agent:trd-gen`
+- Missing, stale, or mis-pathed confirmed implementation plan →
+  `engineer-agent:feature-implementor`
+
+### 6) Release or implementation risks
 
 Call out any risks that need handoff even if they are not confirmed bugs, such as:
 

--- a/agents/qa/test/spec-based-tester/evals/workspace/eval-1-test-from-spec/comparison.md
+++ b/agents/qa/test/spec-based-tester/evals/workspace/eval-1-test-from-spec/comparison.md
@@ -9,24 +9,24 @@
 ## Test Set / Fixture Version
 
 - Eval schema: `evals.json` v1.0
-- Fixture version: repository commit `cdfc879`
-- Fresh run: `2026-07-30 19:56:59 +0800`
-- Runtime directory: `tmp/eval-runs/issue-196-pr-b-spec-20260730-195659-eval001/qa/agents/qa/test/spec-based-tester/evals/workspace/eval-1-test-from-spec/`
+- Fixture version: repository commit `2506764`
+- Fresh run: `2026-08-03 11:20:59 +0800`
+- Runtime directory: `tmp/eval-runs/issue-201-spec-based-tester/eval-001-test-from-spec/`
 - `eval_metadata.json` 未声明 `execution_cleanup`。
 
 ## Latest Result
 
-- Behavior result: **FAIL**
+- Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 - `e2e` 的“新增/补充 TC”分支为 **NOT EXERCISED**：fixture 已有 TC，本轮未扩充。
 - `versioned_report_archive` 的真实 result/snapshot/report 写入分支为 **NOT EXERCISED**：本轮没有产品测试结果；场景与版本确认子项已覆盖。
 
-Overall result: FAIL
+Overall result: PASS (partial coverage)
 
 ## Assertion Results
 
-- FAIL `assertion_1`: 候选引用了 test spec、PRD、TRD 和 `package.json`，但未把缺失变更说明、环境假设、未知项和 blocked 检查整理成执行前基线。
-- FAIL `assertion_2`: 候选引用了 suite、flow 和既有 TC，但未明确声明复用该 TC，也未记录缺失的 `scripts/*.spec.md`、历史 `results/` 与 `_reports/`。
+- PASS `assertion_1`: 新增的 `Preflight baseline` 在执行前逐项记录 test spec、PRD、TRD、`package.json`、变更说明 absent、范围、环境假设、未知项和 blocked 检查；没有把缺失上下文静默跳过。
+- PASS `assertion_2`: 明确先读 suite、flow 和既有 TC，逐项记录 `scripts/*.spec.md`、历史 `results/`、`_reports/` absent，并声明直接复用 `TC-001-discount-code`、不从零探索项目。
 - PASS `assertion_3`: 选择 repo harness `npm test -- checkout-discount`，没有臆造浏览器或 Playwright 入口。
 - PASS `assertion_4`: requirement matrix 使用 `blocked`，未把未执行项写成失败或缺陷。
 - PASS `assertion_5`: 包含 requirement matrix、execution path、evidence references 和 risk notes，并保留逐项状态与说明。
@@ -36,22 +36,21 @@ Overall result: FAIL
 
 ## With-Skill Behavior
 
-候选正确收敛范围、选择 repo harness、输出结构化证据并诚实保持 blocked。Behavior 仍为 FAIL，因为 preflight 没有完整记录上下文缺口和 QA memory 缺失项，无法证明按 specialist 协议完成执行前检查。
+修复后的报告模板把 preflight 门禁接入最终输出：候选完整呈现上下文基线、QA memory 读取/缺失状态和 TC 复用声明，再选择 repo harness，并在同路径文档链与可执行环境不足时诚实保持 blocked。此前失败的两项均通过，原已通过断言无回归。
 
 ## Fresh Without-Skill Baseline
 
-同一 prompt/fixture 的全新 baseline 已生成，未读取或应用 skill 与 QA README。candidate 和 fresh judge 均成功；baseline 同样遗漏变更说明状态、执行前未知项以及 `scripts`、历史 `results/`、`_reports/` 的缺失记录，semantic verdict 为 FAIL。
+同一 prompt/fixture 的 without-skill baseline 已在本轮重新生成，未读取或应用 skill 与 QA README，且未复用历史 baseline。它读取直接点名的规范与测试命令，但未读取 QA memory，也未逐项记录变更说明、`scripts`、历史 `results/`、`_reports/` 的缺失状态和 TC 复用决定，因此仍不满足 `assertion_1` / `assertion_2`。
 
 ## Failures
 
-- 执行前基线未显式记录变更说明缺失、环境假设、未知项与 blocked 检查。
-- 未完整记录 QA memory 的读取/缺失状态，也未明确声明复用既有 TC。
+- 无 behavior failure。
 
 ## Next Steps
 
-- 后续候选应在执行前逐项记录 fixture 已读来源与缺失项，再进入执行路径和 requirement matrix。
+- 若需覆盖当前 NOT EXERCISED 分支，应在具备同路径确认文档链与可执行产品环境的独立 fixture 中验证新增 TC 和真实 result/snapshot/report 归档；本轮不扩大 fixture。
 
 ## Runtime Artifact Policy
 
-- 两条 candidate、两条 fresh judge verdict、diagnostics 与 `comparison.auto.md` 均在上述 `tmp/eval-runs/`；所有 Codex 调用返回码为 0，且无 timeout。
+- 本轮 with-skill 候选、重新生成的 without-skill baseline 与 judge 笔记均在上述 `tmp/eval-runs/`。
 - Runtime 不提交；durable 结果仅为本文件。

--- a/agents/qa/test/spec-based-tester/evals/workspace/eval-2-boundary-test-generation/comparison.md
+++ b/agents/qa/test/spec-based-tester/evals/workspace/eval-2-boundary-test-generation/comparison.md
@@ -9,18 +9,18 @@
 ## Test Set / Fixture Version
 
 - Eval schema: `evals.json` v1.0
-- Fixture version: repository commit `cdfc879`
-- Fresh run: `2026-07-30 20:02:13 +0800`
-- Runtime directory: `tmp/eval-runs/issue-196-pr-b-spec-20260730-200213-eval002/qa/agents/qa/test/spec-based-tester/evals/workspace/eval-2-boundary-test-generation/`
+- Fixture version: repository commit `2506764`
+- Fresh run: `2026-08-03 11:20:59 +0800`
+- Runtime directory: `tmp/eval-runs/issue-201-spec-based-tester/eval-002-boundary-test-generation/`
 - `eval_metadata.json` 未声明 `execution_cleanup`。
 
 ## Latest Result
 
-- Behavior result: **FAIL**
+- Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 - `assertion_3` 为 **NOT EXERCISED**：缺 confirmed `IMPLEMENTATION_PLAN.md` 已合法阻塞实际边界执行，不能要求候选越过门禁实跑。
 
-Overall result: FAIL
+Overall result: PASS (partial coverage)
 
 ## Assertion Results
 
@@ -30,25 +30,25 @@ Overall result: FAIL
 - PASS `assertion_4`: 每项使用 `assumed` 或 `blocked`，并提供可追踪 evidence references。
 - PASS `assertion_5`: 包含 requirement matrix、execution path、evidence references、risk notes 和 handoff decision。
 - PASS `assertion_6`: 没有把 assumed/blocked 项当成缺陷，且列出未覆盖风险。
-- FAIL `alignment_plan_gate`: 正确发现缺 `IMPLEMENTATION_PLAN.md` 并标记 blocked，但没有把 next owner 指向 `engineer-agent:feature-implementor`；后续建议反而先补 `QA_BASE_URL` 并执行 harness，遗漏必须先补齐 plan 的恢复顺序。
+- PASS `alignment_plan_gate`: 确认 `login-refresh` 下 PRD/TRD 对齐，识别同路径 `IMPLEMENTATION_PLAN.md` 缺失并标记 blocked；`Blocked items` 明确将 next owner 指向 `engineer-agent:feature-implementor`，恢复顺序为先确认 plan、再核对环境并执行 repo harness。
 
 ## With-Skill Behavior
 
-候选正确执行了文档与 QA memory preflight，也没有伪造边界结果。核心回归仍是实施计划门禁的 handoff 不完整：识别 blocker 后没有交还权威 owner，且恢复步骤顺序错误。
+候选正确执行文档与 QA memory preflight，没有伪造边界结果；修复后的 `Blocked items` 模板把缺 plan 的 owner 和恢复顺序接入最终报告。此前失败的 `alignment_plan_gate` 本轮通过，其余此前通过的断言无回归。
 
 ## Fresh Without-Skill Baseline
 
-同一 prompt/fixture 的全新 baseline 已生成，未读取或应用 skill 与 QA README。candidate 和 fresh judge 均成功；baseline 完全没有识别缺失的 `IMPLEMENTATION_PLAN.md`，只以测试环境和 `QA_BASE_URL` 为 blocker，因而同样不满足 `alignment_plan_gate`，semantic verdict 为 FAIL。
+同一 prompt/fixture 的 without-skill baseline 已在本轮重新生成，未读取或应用 skill 与 QA README，且未复用历史 baseline。它只把测试环境和 `QA_BASE_URL` 作为 blocker，没有识别缺失的 `IMPLEMENTATION_PLAN.md`、next owner 或 plan-first 恢复顺序，因此不满足 `alignment_plan_gate`。
 
 ## Failures
 
-- 缺 plan 后没有交还 `engineer-agent:feature-implementor`，恢复步骤错误。
+- 无 behavior failure。
 
 ## Next Steps
 
-- 先补齐并确认同路径 `IMPLEMENTATION_PLAN.md`，再恢复 repo harness 或浏览器验证。
+- 若需覆盖 `assertion_3` 的实际边界执行分支，应在补齐并确认同路径 `IMPLEMENTATION_PLAN.md` 后另行执行；本轮保持 fixture 与门禁原状。
 
 ## Runtime Artifact Policy
 
-- 两条 candidate、两条 fresh judge verdict、diagnostics 与 `comparison.auto.md` 均在上述 `tmp/eval-runs/`；所有 Codex 调用返回码为 0，且无 timeout。
+- 本轮 with-skill 候选、重新生成的 without-skill baseline 与 judge 笔记均在上述 `tmp/eval-runs/`。
 - Runtime 不提交；durable 结果仅为本文件。

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -94,7 +94,7 @@
     "spec-based-tester": {
       "source": "agents/qa/skills/spec-based-tester",
       "sourceType": "local",
-      "computedHash": "6601376729dc484464e57239ff0098c8ac8af352c84acb93eb0a55b689509ffe"
+      "computedHash": "7ee53250b1c6071ad0d7fb389ac2fe14858619902b26f0ab2683dd6a4d9dd482"
     },
     "bug-analyzer": {
       "source": "agents/qa/skills/bug-analyzer",


### PR DESCRIPTION
## 背景

Fixes #201

`spec-based-tester` 的 eval-1 / eval-2 在两轮独立 fresh run 下均 Behavior FAIL。归因结论（详见 issue 讨论）：失败项都写在 SKILL.md 的门禁章节（原 `:163-176` preflight 基线清单、`:61-63` 缺 plan 交还 owner），但模型组装答案时参照的 Evidence Contract 报告模板未接入这些条款——**门禁存在但位置接不到输出，属 skill 文档引导不足，不是模型环境变化**。

## 改动

### 1. SKILL.md 报告模板修复（commit 2506764）

- Evidence Contract 新增「### 1) Preflight baseline」节，把 `:163-176` 的执行前基线清单接入报告必含段落：范围/feature_path、环境与平台版本状态、未知项与 blocked 检查、同路径 PRD/TRD/IMPLEMENTATION_PLAN.md gate 状态、QA memory 逐项读取/缺失状态、TC 复用声明；原 5 节重编号为 2-6。
- 「### 5) Blocked items」要求给出 next owner 与恢复顺序，点名三类文档门禁归属：缺 PRD → `pm-agent:idea-to-spec`、TRD → `engineer-agent:trd-gen`、缺 plan → `engineer-agent:feature-implementor`。
- 同步刷新 `skills-lock.json` computedHash。

### 2. Fresh subagent eval 验证（commit f4a26d5）

全新 Codex subagent 基于修复后 SKILL.md 重跑 eval-1/eval-2，并重新生成 without_skill baseline（未复用历史）：

| Eval | 此前失败断言 | 本轮 | Overall result |
| --- | --- | --- | --- |
| eval-1-test-from-spec | `assertion_1` / `assertion_2` FAIL | 均 PASS；baseline 仍 FAIL 同两项，修复后产生真实区分度 | PASS (partial coverage) |
| eval-2-boundary-test-generation | `alignment_plan_gate` FAIL | PASS，blocked 报告正确点名 `engineer-agent:feature-implementor` 与 plan-first 恢复顺序 | PASS (partial coverage) |

NOT EXERCISED 项与 fixture 门禁一致（eval-1 无新增 TC 与真实归档分支；eval-2 `assertion_3` 被 plan 门禁合法阻塞），无回归。

## 验证

- `uv run scripts/check_repository_contract.py` / `check_eval_contract.py` / `check_eval_artifacts.py` / `check_doc_contract.py`：全部 PASS
- `uv run scripts/summarize_eval_results.py`：spec-based-tester 3 eval = 1 PASS、2 PASS (partial coverage)
