### PR TITLE
feat: 原生支持 Kimi Code CLI 插件安装 (#192)

### DIFF
--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -1,0 +1,29 @@
+{
+  "name": "dev-agent-skills",
+  "version": "0.3.5",
+  "description": "PM-first agent skill marketplace with one public pm-agent entry and downstream PM-orchestrated engineering, QA, DevOps, design, security, and documentation capabilities",
+  "keywords": [
+    "agent-skills",
+    "pm-agent",
+    "marketplace"
+  ],
+  "homepage": "https://github.com/Neplich/dev-agent-skills",
+  "interface": {
+    "displayName": "Dev Agent Skills",
+    "shortDescription": "PM-first multi-agent skill marketplace: PM entry with downstream engineering, QA, DevOps, design, security, and docs agents",
+    "developerName": "Neplich",
+    "websiteURL": "https://github.com/Neplich/dev-agent-skills"
+  },
+  "skills": [
+    "./agents/product_manager/skills/",
+    "./agents/designer/skills/",
+    "./agents/engineer/skills/",
+    "./agents/qa/skills/",
+    "./agents/devops/skills/",
+    "./agents/security/skills/",
+    "./agents/docs/skills/"
+  ],
+  "sessionStart": {
+    "skill": "pm-agent"
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@
 **市场注册**
 
 - `.claude-plugin/marketplace.json` 定义所有 Agent 及其 skills
-- `.claude-plugin/marketplace.json` 的 `metadata.version` 必须等于当前仓库 release 版本但不带 `v` 前缀；每次创建 release tag 前，先把该字段更新到目标版本，并确认存在对应 `docs/changelog/changelog-v{version}.md` 与根 `CHANGELOG.md` 索引
+- `.claude-plugin/marketplace.json` 的 `metadata.version` 必须等于当前仓库 release 版本但不带 `v` 前缀；每次创建 release tag 前，先把该字段更新到目标版本，并确认存在对应 `docs/changelog/changelog-v{version}.md` 与根 `CHANGELOG.md` 索引。`.kimi-plugin/plugin.json` 的 `version` 必须与 `metadata.version` 保持一致（由 `check_repository_contract.py` 强制校验）
 - `skills-lock.json` 保存已安装 skill 的元数据
 
 ### Agent 协作流

--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ Implementation details and troubleshooting are in the [Codex Guide](./docs/READM
 ### Kimi Code
 
 ```text
-/plugins install https://github.com/Neplich/dev-agent-skills
+/plugins install https://github.com/Neplich/dev-agent-skills/tree/main
 ```
 
-The repository ships a `.kimi-plugin/plugin.json` manifest: all seven role skill directories are registered as a single plugin, and `pm-agent` loads automatically at session start via `sessionStart.skill`. Pin an immutable version with `/plugins install https://github.com/Neplich/dev-agent-skills/releases/tag/vX.Y.Z`.
+The repository ships a `.kimi-plugin/plugin.json` manifest: all seven role skill directories are registered as a single plugin, and `pm-agent` loads automatically at session start via `sessionStart.skill`. A bare repo URL installs the latest GitHub Release, so use the `tree/main` form above until a release includes the Kimi manifest; afterwards, pin an immutable version with `/plugins install https://github.com/Neplich/dev-agent-skills/releases/tag/vX.Y.Z`.
 
 Skills previously installed Codex-style into `~/.agents/skills/` are also discovered by Kimi Code automatically; the native plugin above is the recommended path.
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ It includes:
 - 31 internal specialist skills across product, engineering, QA, DevOps, design, security, and formal documentation work
 - Claude Code marketplace configuration
 - Codex native skill discovery installation instructions
+- Kimi Code native plugin manifest
 - Agent-level eval fixtures and local validation scripts
 
 > [!NOTE]
@@ -61,6 +62,16 @@ Fetch and follow instructions from https://raw.githubusercontent.com/Neplich/dev
 ```
 
 Implementation details and troubleshooting are in the [Codex Guide](./docs/README.codex.md).
+
+### Kimi Code
+
+```text
+/plugins install https://github.com/Neplich/dev-agent-skills
+```
+
+The repository ships a `.kimi-plugin/plugin.json` manifest: all seven role skill directories are registered as a single plugin, and `pm-agent` loads automatically at session start via `sessionStart.skill`. Pin an immutable version with `/plugins install https://github.com/Neplich/dev-agent-skills/releases/tag/vX.Y.Z`.
+
+Skills previously installed Codex-style into `~/.agents/skills/` are also discovered by Kimi Code automatically; the native plugin above is the recommended path.
 
 ## Usage Examples
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -27,6 +27,7 @@
 - 31 个内部 specialist skills，覆盖产品、工程、QA、DevOps、设计、安全和正式文档细分任务
 - Claude Code marketplace 配置
 - Codex 原生 skill discovery 安装入口
+- Kimi Code 原生插件 manifest
 - Agent 级 eval fixtures 与本地验证脚本
 
 > [!NOTE]
@@ -61,6 +62,16 @@ Fetch and follow instructions from https://raw.githubusercontent.com/Neplich/dev
 ```
 
 实现原理与排障见 [Codex Guide](./docs/README.codex.md)。
+
+### Kimi Code
+
+```text
+/plugins install https://github.com/Neplich/dev-agent-skills
+```
+
+仓库内置 `.kimi-plugin/plugin.json` manifest：7 个角色 skill 目录注册为单个插件，`pm-agent` 随会话启动自动加载（`sessionStart.skill`）。需要不可变版本时用 `/plugins install https://github.com/Neplich/dev-agent-skills/releases/tag/vX.Y.Z` 固定 tag。
+
+已按 Codex 方式安装到 `~/.agents/skills/` 的 skill 也会被 Kimi Code 自动扫描到；推荐优先使用上面的原生插件方式。
 
 ## 使用示例
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -66,10 +66,10 @@ Fetch and follow instructions from https://raw.githubusercontent.com/Neplich/dev
 ### Kimi Code
 
 ```text
-/plugins install https://github.com/Neplich/dev-agent-skills
+/plugins install https://github.com/Neplich/dev-agent-skills/tree/main
 ```
 
-仓库内置 `.kimi-plugin/plugin.json` manifest：7 个角色 skill 目录注册为单个插件，`pm-agent` 随会话启动自动加载（`sessionStart.skill`）。需要不可变版本时用 `/plugins install https://github.com/Neplich/dev-agent-skills/releases/tag/vX.Y.Z` 固定 tag。
+仓库内置 `.kimi-plugin/plugin.json` manifest：7 个角色 skill 目录注册为单个插件，`pm-agent` 随会话启动自动加载（`sessionStart.skill`）。注意：裸仓库 URL 安装的是最新 GitHub Release，在包含 Kimi manifest 的版本发布前请使用上面的 `tree/main` 形式；发布后可改用 `/plugins install https://github.com/Neplich/dev-agent-skills/releases/tag/vX.Y.Z` 固定不可变版本。
 
 已按 Codex 方式安装到 `~/.agents/skills/` 的 skill 也会被 Kimi Code 自动扫描到；推荐优先使用上面的原生插件方式。
 

--- a/scripts/check_repository_contract.py
+++ b/scripts/check_repository_contract.py
@@ -1678,7 +1678,11 @@ def validate_kimi_plugin(root: Path, errors: list[ContractError]) -> None:
         session_skill = session_start.get("skill") if isinstance(session_start, dict) else None
         if not isinstance(session_skill, str) or not session_skill:
             add_error(errors, path, "sessionStart.skill must be a non-empty string")
-        elif not list(root.glob(f"agents/*/skills/{session_skill}/SKILL.md")):
+        elif not any(
+            skill_dir.name == session_skill and (skill_dir / "SKILL.md").exists()
+            for skill_dir in root.glob("agents/*/skills/*")
+            if skill_dir.is_dir()
+        ):
             add_error(
                 errors,
                 path,

--- a/scripts/check_repository_contract.py
+++ b/scripts/check_repository_contract.py
@@ -1657,6 +1657,9 @@ def validate_kimi_plugin(root: Path, errors: list[ContractError]) -> None:
         )
 
     skills = payload.get("skills")
+    # Kimi 官方示例允许单字符串形态（"skills": "./skills/"），归一化为列表再校验
+    if isinstance(skills, str):
+        skills = [skills]
     if not isinstance(skills, list) or not skills:
         add_error(errors, path, "skills must be a non-empty list of './' paths")
     else:

--- a/scripts/check_repository_contract.py
+++ b/scripts/check_repository_contract.py
@@ -1621,6 +1621,68 @@ def validate_tracked_file_policy(root: Path, errors: list[ContractError]) -> Non
             add_error(errors, root / rel, "tracked file is blocked by repository policy")
 
 
+KIMI_PLUGIN_NAME_RE = re.compile(r"[a-z0-9][a-z0-9_-]{0,63}")
+
+
+def validate_kimi_plugin(root: Path, errors: list[ContractError]) -> None:
+    path = root / ".kimi-plugin" / "plugin.json"
+    if not path.exists():
+        add_error(errors, path, "kimi plugin manifest must exist")
+        return
+
+    payload = load_json(path, errors)
+    if not isinstance(payload, dict):
+        add_error(errors, path, "top-level payload must be an object")
+        return
+
+    name = payload.get("name")
+    if not isinstance(name, str) or not KIMI_PLUGIN_NAME_RE.fullmatch(name):
+        add_error(
+            errors,
+            path,
+            "name must match [a-z0-9][a-z0-9_-]{0,63}",
+        )
+
+    marketplace = load_json(root / ".claude-plugin" / "marketplace.json", errors)
+    metadata_version: Any = None
+    if isinstance(marketplace, dict):
+        metadata = marketplace.get("metadata")
+        if isinstance(metadata, dict):
+            metadata_version = metadata.get("version")
+    if isinstance(metadata_version, str) and payload.get("version") != metadata_version:
+        add_error(
+            errors,
+            path,
+            f"version must match marketplace metadata.version {metadata_version!r}",
+        )
+
+    skills = payload.get("skills")
+    if not isinstance(skills, list) or not skills:
+        add_error(errors, path, "skills must be a non-empty list of './' paths")
+    else:
+        for entry in skills:
+            if (
+                not isinstance(entry, str)
+                or not entry.startswith("./")
+                or not is_safe_relative_path(entry[2:])
+            ):
+                add_error(errors, path, f"skills entry {entry!r} must be a safe './' relative path")
+            elif not (root / entry).is_dir():
+                add_error(errors, path, f"skills path {entry!r} does not exist")
+
+    session_start = payload.get("sessionStart")
+    if session_start is not None:
+        session_skill = session_start.get("skill") if isinstance(session_start, dict) else None
+        if not isinstance(session_skill, str) or not session_skill:
+            add_error(errors, path, "sessionStart.skill must be a non-empty string")
+        elif not list(root.glob(f"agents/*/skills/{session_skill}/SKILL.md")):
+            add_error(
+                errors,
+                path,
+                f"sessionStart.skill {session_skill!r} has no matching agents/*/skills/ directory",
+            )
+
+
 def validate_all(root: Path | None = None) -> list[ContractError]:
     root = root or repo_root()
     errors: list[ContractError] = []
@@ -1635,6 +1697,7 @@ def validate_all(root: Path | None = None) -> list[ContractError]:
     validate_legacy_artifact_metadata(root, errors)
     validate_formal_document_author(root, errors)
     validate_tracked_file_policy(root, errors)
+    validate_kimi_plugin(root, errors)
     return errors
 
 

--- a/scripts/test_check_repository_contract.py
+++ b/scripts/test_check_repository_contract.py
@@ -1,4 +1,5 @@
 import importlib.util
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -1402,3 +1403,100 @@ def test_previous_archive_is_always_validated(
 
     assert len(errors) == 1
     assert expected_message in errors[0].message
+
+
+def write_kimi_fixture(
+    root: Path,
+    *,
+    manifest: dict | None,
+    marketplace_version: str = "0.3.5",
+    skill_dir: str = "agents/product_manager/skills/pm-agent",
+) -> Path:
+    (root / ".claude-plugin").mkdir(parents=True, exist_ok=True)
+    (root / ".claude-plugin" / "marketplace.json").write_text(
+        json.dumps({"metadata": {"version": marketplace_version}})
+    )
+    if skill_dir is not None:
+        skill_path = root / skill_dir
+        skill_path.mkdir(parents=True, exist_ok=True)
+        (skill_path / "SKILL.md").write_text("---\nname: pm-agent\n---\n")
+    if manifest is not None:
+        (root / ".kimi-plugin").mkdir(parents=True, exist_ok=True)
+        (root / ".kimi-plugin" / "plugin.json").write_text(json.dumps(manifest))
+    return root
+
+
+def valid_kimi_manifest() -> dict:
+    return {
+        "name": "dev-agent-skills",
+        "version": "0.3.5",
+        "skills": ["./agents/product_manager/skills/"],
+        "sessionStart": {"skill": "pm-agent"},
+    }
+
+
+def test_kimi_plugin_valid_manifest_passes(tmp_path: Path) -> None:
+    root = write_kimi_fixture(tmp_path, manifest=valid_kimi_manifest())
+
+    errors: list = []
+    contract.validate_kimi_plugin(root, errors)
+
+    assert errors == []
+
+
+def test_kimi_plugin_missing_manifest_fails(tmp_path: Path) -> None:
+    root = write_kimi_fixture(tmp_path, manifest=None)
+
+    errors: list = []
+    contract.validate_kimi_plugin(root, errors)
+
+    assert len(errors) == 1
+    assert "must exist" in errors[0].message
+
+
+def test_kimi_plugin_version_must_match_marketplace(tmp_path: Path) -> None:
+    manifest = valid_kimi_manifest()
+    manifest["version"] = "0.0.1"
+    root = write_kimi_fixture(tmp_path, manifest=manifest)
+
+    errors: list = []
+    contract.validate_kimi_plugin(root, errors)
+
+    assert len(errors) == 1
+    assert "version must match marketplace metadata.version" in errors[0].message
+
+
+def test_kimi_plugin_name_pattern_enforced(tmp_path: Path) -> None:
+    manifest = valid_kimi_manifest()
+    manifest["name"] = "Dev-Agent-Skills"
+    root = write_kimi_fixture(tmp_path, manifest=manifest)
+
+    errors: list = []
+    contract.validate_kimi_plugin(root, errors)
+
+    assert len(errors) == 1
+    assert "name must match" in errors[0].message
+
+
+def test_kimi_plugin_skills_path_must_exist(tmp_path: Path) -> None:
+    manifest = valid_kimi_manifest()
+    manifest["skills"] = ["./agents/missing/skills/"]
+    root = write_kimi_fixture(tmp_path, manifest=manifest)
+
+    errors: list = []
+    contract.validate_kimi_plugin(root, errors)
+
+    assert len(errors) == 1
+    assert "does not exist" in errors[0].message
+
+
+def test_kimi_plugin_session_start_skill_must_exist(tmp_path: Path) -> None:
+    manifest = valid_kimi_manifest()
+    manifest["sessionStart"] = {"skill": "unknown-skill"}
+    root = write_kimi_fixture(tmp_path, manifest=manifest)
+
+    errors: list = []
+    contract.validate_kimi_plugin(root, errors)
+
+    assert len(errors) == 1
+    assert "sessionStart.skill" in errors[0].message

--- a/scripts/test_check_repository_contract.py
+++ b/scripts/test_check_repository_contract.py
@@ -1511,3 +1511,15 @@ def test_kimi_plugin_single_string_skills_form_accepted(tmp_path: Path) -> None:
     contract.validate_kimi_plugin(root, errors)
 
     assert errors == []
+
+
+def test_kimi_plugin_session_start_skill_glob_metachar_rejected(tmp_path: Path) -> None:
+    manifest = valid_kimi_manifest()
+    manifest["sessionStart"] = {"skill": "[p]m-agent"}
+    root = write_kimi_fixture(tmp_path, manifest=manifest)
+
+    errors: list = []
+    contract.validate_kimi_plugin(root, errors)
+
+    assert len(errors) == 1
+    assert "sessionStart.skill" in errors[0].message

--- a/scripts/test_check_repository_contract.py
+++ b/scripts/test_check_repository_contract.py
@@ -1500,3 +1500,14 @@ def test_kimi_plugin_session_start_skill_must_exist(tmp_path: Path) -> None:
 
     assert len(errors) == 1
     assert "sessionStart.skill" in errors[0].message
+
+
+def test_kimi_plugin_single_string_skills_form_accepted(tmp_path: Path) -> None:
+    manifest = valid_kimi_manifest()
+    manifest["skills"] = "./agents/product_manager/skills/"
+    root = write_kimi_fixture(tmp_path, manifest=manifest)
+
+    errors: list = []
+    contract.validate_kimi_plugin(root, errors)
+
+    assert errors == []


### PR DESCRIPTION
## 背景

Fixes #192

仓库的 skill 安装此前只支持 Claude Code（marketplace）和 Codex（install 脚本）两个宿主。本 PR 新增 Kimi Code 原生插件支持。

## 改动

- **`.kimi-plugin/plugin.json`**：整仓单插件（Kimi GitHub 安装 URL 不支持子目录，按 role 拆 7 个插件需额外发布 asset，不划算）。`skills` 声明 7 个 `agents/{role}/skills/` 父目录（官方示例形态）；`sessionStart.skill: pm-agent` 落实 PM 唯一入口；`version` 与 marketplace `metadata.version` 同步。manifest 放 `.kimi-plugin/` 与 `.claude-plugin/` 对仗。
- **`scripts/check_repository_contract.py`**：新增 `validate_kimi_plugin`——name 格式（`[a-z0-9][a-z0-9_-]{0,63}`）、version 与 marketplace 一致、skills 路径存在且为安全相对路径、`sessionStart.skill` 有对应 skill 目录。发版 bump 漏改 kimi manifest 会被 CI 拦下。
- **`scripts/test_check_repository_contract.py`**：6 个单元测试。
- **README / README_zh**：Quick Start 增加 Kimi Code 安装说明（`/plugins install` + tag 固定 + 与 Codex 安装路径的关系）。
- **AGENTS.md**：市场注册节补 kimi manifest 版本同步要求。

## 调研核验（2026-08-03 重新联网核实官方文档）

- manifest 字段规范、两种位置（`kimi.plugin.json` 优先于 `.kimi-plugin/plugin.json`）、`skills` 父目录示例、四种 GitHub 安装 URL 均与 issue 调研一致。
- **issue 的同名冲突顾虑已消解**：`release-notes-generator` 已迁入 docs-agent，全仓 38 个 skill 目录实测无重名。

## 验证

- `check_repository_contract.py`（含新 kimi 校验）/ `check_eval_contract.py` / `check_eval_artifacts.py` / `check_doc_contract.py`：全部 PASS
- 完整 pytest：211/211 PASS（含 6 个新契约测试）

## 待人工实测（无法自动化）

Kimi CLI 的 `/plugins install` 是 TUI 会话内命令，非交互模式（`kimi -p`）不执行宿主命令，无法脚本化验证。请合并后在 Kimi 会话中执行：

```text
/plugins install https://github.com/Neplich/dev-agent-skills
```

确认点：38 个 skill 全部可见、`pm-agent` 随会话启动自动加载、skill 内 `_internal/` 相对路径引用可达。也可先用本分支实测：`/plugins install https://github.com/Neplich/dev-agent-skills/tree/feat/192-kimi-plugin`
