### PR TITLE
fix(docs-agent): API 文档默认收紧为 internal

### DIFF
--- a/agents/docs/skills/docs-site-bootstrap/assets/docs/site/.vitepress/config.public.ts
+++ b/agents/docs/skills/docs-site-bootstrap/assets/docs/site/.vitepress/config.public.ts
@@ -7,7 +7,6 @@ export default mergeConfig(shared, defineConfig({
   themeConfig: {
     nav: [
       { text: '产品', link: '/product/' },
-      { text: 'API', link: '/api/' },
       { text: '发布说明', link: '/release-notes/' }
     ],
     sidebar

--- a/agents/docs/skills/docs-site-bootstrap/assets/docs/site/api/index.md
+++ b/agents/docs/skills/docs-site-bootstrap/assets/docs/site/api/index.md
@@ -1,6 +1,6 @@
 ---
 title: API 文档
-visibility: both
+visibility: internal
 doc_type: landing
 stage: dev
 owners:

--- a/agents/docs/skills/docs-site-bootstrap/assets/docs/site/index.public.md
+++ b/agents/docs/skills/docs-site-bootstrap/assets/docs/site/index.public.md
@@ -18,5 +18,4 @@ last_verified_version: unverified
 ## 内容入口
 
 - [产品说明](/product/)
-- [API 文档](/api/)
 - [发布说明](/release-notes/)

--- a/agents/docs/skills/formal-docs-sync/_internal/types/api/INSTRUCTIONS.md
+++ b/agents/docs/skills/formal-docs-sync/_internal/types/api/INSTRUCTIONS.md
@@ -31,6 +31,10 @@ responses, errors, and evidence that actually apply. Remove empty placeholder
 sections or rows rather than presenting them as facts. Keep API pages and their
 API change-map entries in the same confirmed write/read-back scope.
 
+Set `visibility: internal` for new or synced API pages and indexes, including
+`docs/site/api/index.md`, unless the confirmed write scope explicitly
+authorizes external developer access and states `public` or `both`.
+
 ## Information Architecture
 
 Derive the path hierarchy from confirmed `feature_path` or feature catalog

--- a/agents/docs/skills/formal-docs-sync/_internal/types/api/INSTRUCTIONS.md
+++ b/agents/docs/skills/formal-docs-sync/_internal/types/api/INSTRUCTIONS.md
@@ -33,7 +33,11 @@ API change-map entries in the same confirmed write/read-back scope.
 
 Set `visibility: internal` for new or synced API pages and indexes, including
 `docs/site/api/index.md`, unless the confirmed write scope explicitly
-authorizes external developer access and states `public` or `both`.
+authorizes external developer access and states `public` or `both`. For an
+existing ancestor index, this default applies only when the ancestor has no
+existing `public` or `both` descendant outside the current batch; otherwise
+keep the ancestor's existing visibility so out-of-batch public pages remain
+reachable from the API root through public navigation.
 
 ## Information Architecture
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -179,12 +179,12 @@
     "docs-site-bootstrap": {
       "source": "agents/docs/skills/docs-site-bootstrap",
       "sourceType": "local",
-      "computedHash": "1303dcb43f39c94a348368f4338517a7e036f5b054bcd64de2de5d57964b5ed9"
+      "computedHash": "4c9b804876fe52c817cbc2a989e2958618ec878031ff71ec533af92eb97c6f97"
     },
     "formal-docs-sync": {
       "source": "agents/docs/skills/formal-docs-sync",
       "sourceType": "local",
-      "computedHash": "10aa84f55734e6cacd55c933a4aab95eb257c02e27277f585a92b1a17e39552e"
+      "computedHash": "140c5dc59ab5cc404098696614e2161c880d9ad6739e94eef48247b07f7289c8"
     },
     "docs-audit": {
       "source": "agents/docs/skills/docs-audit",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -179,12 +179,12 @@
     "docs-site-bootstrap": {
       "source": "agents/docs/skills/docs-site-bootstrap",
       "sourceType": "local",
-      "computedHash": "4c9b804876fe52c817cbc2a989e2958618ec878031ff71ec533af92eb97c6f97"
+      "computedHash": "c821476671fc3b423fee4c7d3f586d555ad2329998c58ae21b3491f39ce65cde"
     },
     "formal-docs-sync": {
       "source": "agents/docs/skills/formal-docs-sync",
       "sourceType": "local",
-      "computedHash": "140c5dc59ab5cc404098696614e2161c880d9ad6739e94eef48247b07f7289c8"
+      "computedHash": "96b8f374b5c32d55413c1b0b9fd68f05e7f1dfe6ba9c8d001e3b92ef635dc9f2"
     },
     "docs-audit": {
       "source": "agents/docs/skills/docs-audit",


### PR DESCRIPTION
## Summary
- `docs-site-bootstrap` 内置 `docs/site/api/index.md` 默认 `visibility` 从 `both` 收紧为 `internal`，并从公开首页 `index.public.md` 移除 API 入口链接。
- `formal-docs-sync` 的 API 类型指令模块补充显式规则：新建或同步的 API 页面（含 `api/index.md`）默认 `visibility: internal`，仅在确认范围明确授权外部开发者访问时才使用 `public`/`both`。
- 同步刷新 `skills-lock.json` 中 `docs-site-bootstrap` 与 `formal-docs-sync` 的 `computedHash`。

## Why
排查用户反馈"文档站把 API 放进了外部 docs"时发现：这是 `docs-site-bootstrap` 的既有默认设计，而非某次生成的疏漏。用户确认应将 API 文档默认收紧为仅 internal。

## Test plan
- [x] `uv run scripts/check_repository_contract.py`
- [x] `uv run scripts/check_eval_contract.py`
- [x] `uv run scripts/check_eval_artifacts.py`
- [x] `uv run scripts/check_doc_contract.py`
- [x] CI required pytest 套件（`agents/**`、`scripts/**` 全部指定测试文件）本地全绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)
