### PR TITLE
chore(evals): 清理 change-map header 的废弃 doc_type 与空 related_code

### DIFF
--- a/agents/devops/test/cicd-bootstrap/evals/workspace/eval-002-mapped-doc-cicd/docs/site/standards/change-map.yaml
+++ b/agents/devops/test/cicd-bootstrap/evals/workspace/eval-002-mapped-doc-cicd/docs/site/standards/change-map.yaml
@@ -1,6 +1,6 @@
 title: Documentation change map
 visibility: internal
-doc_type: standard
+doc_type: design
 stage: dev
 owners: [docs]
 related_code: [src/build/pipeline.rules]

--- a/agents/devops/test/deployment-planner/evals/workspace/eval-003-mapped-doc-deployment/docs/site/standards/change-map.yaml
+++ b/agents/devops/test/deployment-planner/evals/workspace/eval-003-mapped-doc-deployment/docs/site/standards/change-map.yaml
@@ -1,6 +1,6 @@
 title: Documentation change map
 visibility: internal
-doc_type: standard
+doc_type: design
 stage: dev
 owners: [docs]
 related_code: [src/runtime/server.conf]

--- a/agents/devops/test/env-config-auditor/evals/workspace/eval-003-mapped-doc-config-audit/docs/site/standards/change-map.yaml
+++ b/agents/devops/test/env-config-auditor/evals/workspace/eval-003-mapped-doc-config-audit/docs/site/standards/change-map.yaml
@@ -1,6 +1,6 @@
 title: Documentation change map
 visibility: internal
-doc_type: standard
+doc_type: design
 stage: dev
 owners: [docs]
 related_code: [src/config/required.env]

--- a/agents/devops/test/incident-playbook-writer/evals/workspace/eval-002-mapped-doc-incident-playbook/docs/site/standards/change-map.yaml
+++ b/agents/devops/test/incident-playbook-writer/evals/workspace/eval-002-mapped-doc-incident-playbook/docs/site/standards/change-map.yaml
@@ -1,6 +1,6 @@
 title: Documentation change map
 visibility: internal
-doc_type: standard
+doc_type: design
 stage: dev
 owners: [docs]
 related_code: [src/runtime/health.rules]

--- a/agents/docs/test/docs-audit/evals/workspace/eval-001-audit-mismatch/docs/site/standards/change-map.yaml
+++ b/agents/docs/test/docs-audit/evals/workspace/eval-001-audit-mismatch/docs/site/standards/change-map.yaml
@@ -1,10 +1,11 @@
 title: Documentation change map
 visibility: internal
-doc_type: standard
+doc_type: design
 stage: release
 owners:
   - documentation-team
-related_code: []
+related_code:
+  - docs/site
 last_verified_version: v1.0.0
 
 change_map:

--- a/agents/docs/test/docs-audit/evals/workspace/eval-002-audit-stale-doc/docs/site/standards/change-map.yaml
+++ b/agents/docs/test/docs-audit/evals/workspace/eval-002-audit-stale-doc/docs/site/standards/change-map.yaml
@@ -1,10 +1,11 @@
 title: Documentation change map
 visibility: internal
-doc_type: standard
+doc_type: design
 stage: release
 owners:
   - documentation-team
-related_code: []
+related_code:
+  - docs/site
 last_verified_version: v1.0.0
 
 change_map:

--- a/agents/docs/test/docs-audit/evals/workspace/eval-003-audit-pure-refactor/docs/site/standards/change-map.yaml
+++ b/agents/docs/test/docs-audit/evals/workspace/eval-003-audit-pure-refactor/docs/site/standards/change-map.yaml
@@ -1,10 +1,11 @@
 title: Documentation change map
 visibility: internal
-doc_type: standard
+doc_type: design
 stage: release
 owners:
   - documentation-team
-related_code: []
+related_code:
+  - docs/site
 last_verified_version: v1.0.0
 
 change_map:

--- a/agents/docs/test/docs-audit/evals/workspace/eval-004-audit-all-verified/docs/site/standards/change-map.yaml
+++ b/agents/docs/test/docs-audit/evals/workspace/eval-004-audit-all-verified/docs/site/standards/change-map.yaml
@@ -1,10 +1,11 @@
 title: Documentation change map
 visibility: internal
-doc_type: standard
+doc_type: design
 stage: release
 owners:
   - documentation-team
-related_code: []
+related_code:
+  - docs/site
 last_verified_version: v1.0.0
 
 change_map:

--- a/agents/docs/test/docs-audit/evals/workspace/eval-005-audit-doc-only-error/docs/site/standards/change-map.yaml
+++ b/agents/docs/test/docs-audit/evals/workspace/eval-005-audit-doc-only-error/docs/site/standards/change-map.yaml
@@ -1,10 +1,11 @@
 title: Documentation change map
 visibility: internal
-doc_type: standard
+doc_type: design
 stage: release
 owners:
   - documentation-team
-related_code: []
+related_code:
+  - docs/site
 last_verified_version: v1.0.0
 
 change_map:

--- a/agents/docs/test/docs-audit/evals/workspace/eval-006-audit-no-version-anchor/docs/site/standards/change-map.yaml
+++ b/agents/docs/test/docs-audit/evals/workspace/eval-006-audit-no-version-anchor/docs/site/standards/change-map.yaml
@@ -1,10 +1,11 @@
 title: Documentation change map
 visibility: internal
-doc_type: standard
+doc_type: design
 stage: dev
 owners:
   - documentation-team
-related_code: []
+related_code:
+  - docs/site
 
 change_map:
   "src/catalog/**":

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-001-sync-feature-api/docs/site/standards/change-map.yaml
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-001-sync-feature-api/docs/site/standards/change-map.yaml
@@ -1,10 +1,11 @@
 title: 文档变更映射
 visibility: internal
-doc_type: standard
+doc_type: design
 stage: dev
 owners:
   - docs
-related_code: []
+related_code:
+  - docs/site
 last_verified_version: unverified
 
 change_map:

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-003-design-gate-incomplete-scope/docs/site/standards/change-map.yaml
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-003-design-gate-incomplete-scope/docs/site/standards/change-map.yaml
@@ -1,10 +1,11 @@
 title: Documentation Change Map
 visibility: internal
-doc_type: standard
+doc_type: design
 stage: dev
 owners:
   - docs
-related_code: []
+related_code:
+  - docs/site
 last_verified_version: unverified
 
 change_map:

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-004-design-gate-failing-tests/docs/site/standards/change-map.yaml
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-004-design-gate-failing-tests/docs/site/standards/change-map.yaml
@@ -1,10 +1,11 @@
 title: Documentation Change Map
 visibility: internal
-doc_type: standard
+doc_type: design
 stage: dev
 owners:
   - docs
-related_code: []
+related_code:
+  - docs/site
 last_verified_version: unverified
 
 change_map:

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-005-design-gate-mismatched-evidence/docs/site/standards/change-map.yaml
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-005-design-gate-mismatched-evidence/docs/site/standards/change-map.yaml
@@ -1,10 +1,11 @@
 title: Documentation Change Map
 visibility: internal
-doc_type: standard
+doc_type: design
 stage: dev
 owners:
   - docs
-related_code: []
+related_code:
+  - docs/site
 last_verified_version: unverified
 
 change_map:

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-006-design-gate-all-passed/docs/site/standards/change-map.yaml
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-006-design-gate-all-passed/docs/site/standards/change-map.yaml
@@ -1,10 +1,11 @@
 title: Documentation Change Map
 visibility: internal
-doc_type: standard
+doc_type: design
 stage: dev
 owners:
   - docs
-related_code: []
+related_code:
+  - docs/site
 last_verified_version: unverified
 
 change_map:

--- a/agents/qa/test/bug-analyzer/evals/workspace/eval-3-mapped-doc-bug-analysis/docs/site/standards/change-map.yaml
+++ b/agents/qa/test/bug-analyzer/evals/workspace/eval-3-mapped-doc-bug-analysis/docs/site/standards/change-map.yaml
@@ -1,6 +1,6 @@
 title: Documentation change map
 visibility: internal
-doc_type: standard
+doc_type: design
 stage: dev
 owners: [docs]
 related_code: [src/notifications/retry.rules]

--- a/agents/qa/test/exploratory-tester/evals/workspace/eval-3-mapped-doc-exploration/docs/site/standards/change-map.yaml
+++ b/agents/qa/test/exploratory-tester/evals/workspace/eval-3-mapped-doc-exploration/docs/site/standards/change-map.yaml
@@ -1,6 +1,6 @@
 title: Documentation change map
 visibility: internal
-doc_type: standard
+doc_type: design
 stage: dev
 owners: [docs]
 related_code: [src/checkout/session.rules]

--- a/agents/qa/test/regression-suite/evals/workspace/eval-3-mapped-doc-regression/docs/site/standards/change-map.yaml
+++ b/agents/qa/test/regression-suite/evals/workspace/eval-3-mapped-doc-regression/docs/site/standards/change-map.yaml
@@ -1,6 +1,6 @@
 title: Documentation change map
 visibility: internal
-doc_type: standard
+doc_type: design
 stage: dev
 owners: [docs]
 related_code: [src/search/query.rules]

--- a/agents/qa/test/spec-based-tester/evals/workspace/eval-3-mapped-doc-acceptance/docs/site/standards/change-map.yaml
+++ b/agents/qa/test/spec-based-tester/evals/workspace/eval-3-mapped-doc-acceptance/docs/site/standards/change-map.yaml
@@ -1,6 +1,6 @@
 title: Documentation change map
 visibility: internal
-doc_type: standard
+doc_type: design
 stage: dev
 owners: [docs]
 related_code: [src/profile/validation.rules]


### PR DESCRIPTION
Closes #228

## 变更内容

清理 19 个 eval fixture 的 `docs/site/standards/change-map.yaml` 描述性 header 中的废弃契约值：

- 19 处 `doc_type: standard` → `doc_type: design`，对齐 `frontmatter-contract.md:23,31-34`（`standard` 已于 #124 从合法枚举移除，change-map header 约定用 `design`）
- 11 处 `related_code: []` → `related_code: [docs/site]`，对齐"全类型 `related_code` 非空"契约

分布：docs-audit 6、formal-docs-sync 5、qa 4、devops 4。

## 与 issue 原文的一处偏离

issue 给的对齐目标是 19 个统一改成 `doc_type: design` + `related_code: [docs/site]`。本 PR 只对 **11 个空值** 填充 `related_code`，qa / devops 那 8 个保持原样。

理由：那 8 个的 `related_code` 已是非空（如 `[src/build/pipeline.rules]`、`[src/notifications/retry.rules]`），不违反任何现行契约，且其取值是各自 eval 场景中被映射源码的一部分，改成 `docs/site` 属于没有契约依据的顺手改动并会丢失 fixture 场景语义。issue 验收标准卡的是 `doc_type` 全量对齐，本 PR 满足。

已与维护者确认采用此处理方式。

## 明确保留的 3 处例外（与 issue 一致）

- `agents/docs/test/docs-audit/evals/workspace/eval-007-frontmatter-contract-fixtures/docs/site/api/invalid-standard-doc-type.md` — 专门的非法负例 fixture
- `agents/docs/test/docs-site-bootstrap/evals/workspace/eval-003-block-bootstrap-conflict/docs/site/standards/index.md` — #124 明确保持刻意分歧的冲突 fixture
- `docs/engineer/agents/docs-agent/IMPLEMENTATION_PLAN.md:448` — 过程文档的历史记录

改动后全仓除上述三处及 `eval-007/comparison.md` 中对负例的文字引用外，再无 `doc_type: standard`。

## eval 影响判定

**结论：本批改动不进入任何现有 eval 的判定路径，`comparison.md` 全部保持不变。**

依据：逐条核查 10 个受影响 skill 的 `evals.json`，引用 `doc_type` / `related_code` 的 assertion 共 4 条，全部指向 `docs/site/**/*.md` 的**页面 frontmatter**，而非 `standards/change-map.yaml` 的 header：

- `docs-audit` `uses_related_code_for_fact_check` — 用的是 API 页面 `related_code` 圈定 `src/catalog/routes.txt`
- `docs-audit` `rejects_standard_doc_type` / `rejects_empty_related_code` — 用的是 eval-007 中刻意保留的非法负例页面，本 PR 未改动
- `formal-docs-sync` eval-015 的层级判定依据 — 用的是页面 frontmatter，且其 change-map 已在 #227 修正，不在本轮范围

全仓 `evals.json` 与 `comparison.md` 中检索 change-map header 字段的引用，结果为空。

此外 change-map header 本身处于门禁之外：宿主 `check-frontmatter.mjs` 只扫 `**/*.md`（`assets/docs/site/scripts/lib/pages.mjs:33-34`），change-map 是 `.yaml`；`frontmatter-contract.md:36-38` 也明确其归 change-map 工具链（#122）。

## 验证

```
uv run scripts/check_repository_contract.py   PASS
uv run scripts/check_eval_contract.py         PASS
uv run scripts/check_eval_artifacts.py        PASS
uv run scripts/check_doc_contract.py          PASS
uv run --with pytest pytest <CI 全量清单>      213 passed, 3 subtests passed
```

未触发 skill eval 重跑：本 PR 只改 fixture 中不参与任何 assertion 的描述性 header，未改动任何 `SKILL.md`、内部指令或参与判定的 fixture 内容。
