### PR TITLE
docs(agents-md): 精简 AGENTS.md 仓库指导，去重合并冗余规则

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,11 +23,10 @@
 
 **文档组织**
 
-- 公开项目文档应遵循 `docs/{agent}/{feature_path}/`，`feature_path` 可包含多级 lower kebab-case 路径段
-- 文档 frontmatter 应包含 `feature`、`version`、`date` 和 `last_updated`
+- 公开项目文档遵循 `docs/{agent}/{feature_path}/`，`feature_path` 可包含多级 lower kebab-case 路径段；不创建基于日期的子目录，也不为同一文档创建多个版本化文件（如 `PRD-v1.md`），版本历史通过 git 追踪
+- 文档 frontmatter 包含 `feature`、`version`、`date` 和 `last_updated`；修改文档时更新 `last_updated`
 - 仓库级发布变更记录按版本归档到 `docs/changelog/changelog-v{version}.md`；根目录 `CHANGELOG.md` 只作为索引，不重复维护 changelog 条目
-- 除发布 changelog 归档外，文档版本历史通过 git 追踪，不要创建多个版本化文件
-- 窄例外（仅限实施计划归档）：`feature-implementor` 的完成态或废弃态实施计划经 closeout 和用户/维护者审批后，可归档到 `docs/engineer/{feature_path}/implementation-plans/archive/IMPLEMENTATION_PLAN-<scope>.md`；`<scope>` 使用 lower kebab-case 描述该次实现范围。当前活跃计划入口仍固定为 `docs/engineer/{feature_path}/IMPLEMENTATION_PLAN.md`。该例外只覆盖实施计划归档，不适用于 PRD、TRD 或其他文档类型
+- 窄例外（仅限实施计划归档）：`feature-implementor` 的完成态或废弃态实施计划经 closeout 和用户/维护者审批后，可归档到 `docs/engineer/{feature_path}/implementation-plans/archive/IMPLEMENTATION_PLAN-<scope>.md`，`<scope>` 使用 lower kebab-case 描述该次实现范围；当前活跃计划入口仍固定为 `docs/engineer/{feature_path}/IMPLEMENTATION_PLAN.md`。该例外只覆盖实施计划归档，不适用于 PRD、TRD 或其他文档类型
 - QA E2E 测试资产统一位于 `docs/qa/e2e/{feature_path}/`；`TEST_SUITE.md` 是功能测试套件索引，`FLOW_INDEX.md` 记录流程覆盖关系，`cases/` 存放 `TC-NNN-<short-slug>.md`，`scripts/` 存放可执行流程脚本片段，`results/` 按 TC 和平台版本追加执行结果，`_reports/{platform-version}/test-reports-{test-time}.md` 存放功能更新汇总报告；发版全量报告位于 `docs/qa/e2e/_reports/{platform-version}/test-reports-{test-time}.md`
 - 文档功能树的全量结构梳理由 `pm-agent -> idea-to-spec:structure-governance` 进入，只读扫描角色过程文档并在运行期 tmp 生成报告；任何拆分或移动仍须提案确认后按 `major` 变更执行
 
@@ -52,23 +51,18 @@ PM / Engineer / QA / DevOps（条件式）→ Docs Agent（正式文档生产 / 
 
 **PM 唯一入口与下游 gate 指针**
 
-- 用户侧新需求、变更、bug、测试、部署、安全、交付或仓库状态诉求默认先进入 `pm-agent` 分类；下游 role router 和 specialist 只在 PM handoff packet 或等效已确认文档链存在时承接。
-- 用户未显式点名任何 skill 或 agent 时，默认进入 `pm-agent`；用户显式点名某个 skill 或 agent 时，这是受支持的直达路径，但仍必须经过对应入口 gate 的安全网。
-- PM handoff packet 字段定义以 `agents/product_manager/skills/idea-to-spec/_internal/_shared/skill-map.md` 为权威；`AGENTS.md` 不复制字段清单。
-- 下游安全网包含前置与收尾两面：缺少 PM handoff packet、等效已确认文档链或 specialist entry basis 时，温和引导用户经 `pm-agent` 补齐前置；完成当前事项后，主动建议协作链下一步并等待确认，用户已授权 `auto-continue` 时可连续推进直到链路结束或用户喊停。
-- 跨角色收尾与 `auto-continue` 的权威定义在 `agents/product_manager/skills/idea-to-spec/_internal/_shared/skill-map.md` 的 `Safety-Net Closeout and Auto-Continue` 节；`AGENTS.md` 只保留入口契约和指针。
+- 用户侧新需求、变更、bug、测试、部署、安全、交付或仓库状态诉求默认先进入 `pm-agent` 分类；用户未显式点名任何 skill 或 agent 时同样默认进入 `pm-agent`，显式点名是受支持的直达路径，但仍必须经过对应入口 gate 的安全网。下游 role router 和 specialist 只在 PM handoff packet 或等效已确认文档链存在时承接。
+- 下游安全网包含前置与收尾两面：缺少 PM handoff packet、等效已确认文档链或 specialist entry basis 时，不执行下游协议，温和引导用户经 `pm-agent` 补齐前置并完成入口分类（脚手架请求同样走正常 PM 分类）；完成当前事项后，主动建议协作链下一步并等待确认，用户已授权 `auto-continue` 时可连续推进直到链路结束或用户喊停。
 - SKILL.md frontmatter 的 `visibility: internal` 是声明层标记，Claude Code 与 Codex 都不消费该字段，不隐藏 slash 命令也不阻止显式直调；`pm-agent` 是默认入口，下游标记为 `internal` 仅表示非默认入口。
 - 6 个 role router 只保留入口凭据检查和分流指针，其中 `docs-agent` 分流正式文档站点 bootstrap、API/database/design/ops/product 当前事实 sync、基于运行界面截图的图文用户操作手册、站内 Release Notes 和 audit；PM `github-release-generator` 按 SKILL.md 的宿主文档站适用性判断生成 GitHub Release：有文档站宿主要求站内 Release Notes 已确认且 docs-audit 门禁通过；无文档站宿主降级为维护者确认的版本事实源与维护者显式批准；具体执行 gate 的权威副本留在对应 specialist `SKILL.md`，例如 `feature-implementor` 的 PRD/TRD/plan/archive gate、`debugger` 的 expected-behavior gate、QA specialist 的 E2E gate，以及 Designer/DevOps/Security/Docs specialist 的 feature-scope gate。
-- 直接调用下游且没有 PM handoff packet、等效已确认文档链或 specialist entry basis 时，不执行下游协议，应温和引导用户经 `pm-agent` 补齐前置并完成入口分类；脚手架请求同样走正常 PM 分类。
 
 **文档依赖**
 
-- 6 个现有 Agent 按 `agents/product_manager/skills/idea-to-spec/_internal/_shared/consumption-contract.md` 消费宿主正式文档
+- 下游协议的权威定义统一放在 `agents/product_manager/skills/idea-to-spec/_internal/_shared/`：6 个现有 Agent 按 `consumption-contract.md` 消费宿主正式文档；`skill-map.md` 定义 PM handoff packet 字段、跨角色收尾与 `auto-continue`（`Safety-Net Closeout and Auto-Continue` 节）以及 Security 结论升级（`Security Conclusion Escalation to PM` 节）。`AGENTS.md` 不复制字段清单，只保留入口契约和指针。
+- Security 的确认结论（审查发现，或对整改已落地的复审确认）改变正式文档事实、对外行为、运维事实或发版就绪状态时，按 `skill-map.md` 的 `Security Conclusion Escalation to PM` 规则把结论与证据回交 `pm-agent` 分类并提 issue；后续 Docs / Engineer / 发版工作由 `pm-agent` 通过正常 handoff packet 分派，各 specialist 按既有门禁执行
 - Docs Agent 读取 `docs/pm/{feature_path}/`、`docs/engineer/{feature_path}/TRD.md` 与代码证据
-- Security 的确认结论（审查发现，或对整改已落地的复审确认）改变正式文档事实、对外行为、运维事实或发版就绪状态时，按 `agents/product_manager/skills/idea-to-spec/_internal/_shared/skill-map.md` 的 `Security Conclusion Escalation to PM` 规则把结论与证据回交 `pm-agent` 分类并提 issue；后续 Docs / Engineer / 发版工作由 `pm-agent` 通过正常 handoff packet 分派，各 specialist 按既有门禁执行
 - Engineer 读取 `docs/pm/{feature_path}/` 和 `docs/design/{feature_path}/`
 - QA 读取 `docs/pm/{feature_path}/` 和实现代码
-- QA 在进行广泛项目探索前，先读取已有的 `docs/qa/e2e/{feature_path}/TEST_SUITE.md`、`FLOW_INDEX.md`、`cases/*.md` 和 `scripts/*.spec.md`
 - DevOps 读取 `docs/engineer/{feature_path}/TRD.md`
 - Designer 读取 `docs/pm/{feature_path}/PRD.md`
 - Security 读取 `docs/pm/{feature_path}/` 和代码库
@@ -94,7 +88,7 @@ PM / Engineer / QA / DevOps（条件式）→ Docs Agent（正式文档生产 / 
 - 维护变更不得直接在 `main` 上进行；开始修改前先创建工作分支，完成后通过 PR 合入。
 - PR 创建后的更新默认追加新 commit 并普通 push；除非用户明确要求整理提交历史，否则不要 amend、rebase 或 force push。
 - 创建 PR 后不要直接合并；必须等待维护者明确确认“可以合并”后再执行 merge / squash / rebase 合并操作。
-- 当前仓库仍处于早期维护阶段，暂不新增 Release CI；发布前使用手动 release checklist：确认 `.claude-plugin/marketplace.json` 的 `metadata.version` 已更新为目标版本且不带 `v` 前缀，确认 `docs/changelog/changelog-v{version}.md` 存在并已被根 `CHANGELOG.md` 索引，tag 使用 `v` 前缀 SemVer，PR 必跑 CI 全部通过，必要时手动触发 eval workflow 并记录结果；每次使用 tag 发版时，按 skill 维度汇总 skill eval 后的 `comparison.md` 最新结论。每次 tag 发版后，由 `pm-agent → github-release-generator` 使用 skill 流程自动创建 GitHub Release draft，并直接交维护者审批；draft 的发布（publish）仍必须等待维护者显式批准。不要自动上传 marketplace package，也不要配置 release bot bypass tag ruleset。
+- 当前仓库仍处于早期维护阶段，暂不新增 Release CI；发布前使用手动 release checklist：按「市场注册」节的版本规则核对 `metadata.version` 与 `.kimi-plugin/plugin.json` 的 `version`，确认对应 `docs/changelog/changelog-v{version}.md` 存在并被根 `CHANGELOG.md` 索引，tag 使用 `v` 前缀 SemVer，PR 必跑 CI 全部通过，必要时手动触发 eval workflow 并记录结果；每次使用 tag 发版时，按 skill 维度汇总 skill eval 后的 `comparison.md` 最新结论。每次 tag 发版后，由 `pm-agent → github-release-generator` 使用 skill 流程自动创建 GitHub Release draft，并直接交维护者审批；draft 的发布（publish）仍必须等待维护者显式批准。不要自动上传 marketplace package，也不要配置 release bot bypass tag ruleset。
 
 ### 变更分级契约
 
@@ -128,10 +122,7 @@ skill eval 的 Fresh Sub-Agent 门禁作用于 skill 自身的测试流程，不
 
 2. 按现有 Agent 模式创建 `agents/{agent-name}/README.md`
 
-3. 为每个 skill 创建：
-   - `skills/{skill-name}/SKILL.md`
-   - `test/{skill-name}/evals/evals.json`
-   - 仅在需要渐进加载时创建 `skills/{skill-name}/_internal/`
+3. 为每个 skill 创建 `skills/{skill-name}/SKILL.md` 与 `test/{skill-name}/evals/evals.json`，仅在需要渐进加载时创建 `skills/{skill-name}/_internal/`
 
 4. 在 `.claude-plugin/marketplace.json` 注册 Agent：
    ```json
@@ -141,21 +132,19 @@ skill eval 的 Fresh Sub-Agent 门禁作用于 skill 自身的测试流程，不
      "skills": ["./agents/{agent-name}/skills/{skill-name}"]
    }
    ```
+   随后用新 skill 元数据更新 `skills-lock.json`
 
-5. 使用新 skill 元数据更新 `skills-lock.json`
-
-6. 添加 eval 测试，并对比使用 skill 与不使用 skill 的结果
+5. 添加 eval 测试并对比使用 skill 与不使用 skill 的结果，再按下节「新增或重命名 Skill 的同步面」逐面核对遗漏项
 
 ### 新增或重命名 Skill 的同步面
 
-向既有 Agent 增加一个 specialist 时，改动会扇出到注册、路由、发现、文档、eval 和过程文档六个面。任一面漏改都不会被契约脚本拦住，但会让 skill 在实际使用中不可达或不可信。按下表逐项核对，不要只改「主要」文件。
+向既有 Agent 增加一个 specialist 时，改动会扇出到注册、路由、发现、Agent 文档、顶层入口、eval 和过程文档多个面。任一面漏改都不会被契约脚本拦住，但会让 skill 在实际使用中不可达或不可信。按下表逐项核对，不要只改「主要」文件。
 
 | 面 | 必改项 |
 | --- | --- |
 | 注册 | `.claude-plugin/marketplace.json` 的 `skills` 数组；`skills-lock.json` 条目与 `computedHash` |
 | 路由 | router `SKILL.md` 的 Available Skills、Routing Signals、Specialist Gate Pointers、Role Boundary 中列举 specialist 的那句 |
 | **发现** | `.claude-plugin/marketplace.json` 的 agent `description`；router `SKILL.md` 的 frontmatter `description`；`AGENTS.md` 中描述该 router 分流范围的根路由指针句 |
-| 仓库指导 | `AGENTS.md` 的该 Agent specialist 计数与 Specialist skills 总数 |
 | Agent 文档 | `agents/{agent}/README.md` 的 skills 表、计数与 **Routing Rules 小节**；`README_zh.md` 同步 |
 | 顶层入口 | 根 `README.md` / `README_zh.md` 的 Agent 表计数与能力描述；**`pm-agent/SKILL.md` 的 handoff targets、请求分类行与 Default Routes** |
 | eval | 新 skill 自己的 evals；**router 的路由 eval**；被本次改动影响的既有 skill 的断言与其 durable `comparison.md` |
@@ -185,7 +174,7 @@ skill eval 的 Fresh Sub-Agent 门禁作用于 skill 自身的测试流程，不
 
 - 先确认测试场景：`feature-update` 表示功能更新，在开发环境本地验证更新功能和直接影响路径；`release` 表示发版，在发版版本测试环境执行全部 active E2E 用例
 - 先确认测试平台版本；缺失时必须 blocked 并询问用户，不得使用 `unknown` 目录归档
-- 先读取 `docs/qa/e2e/{feature_path}/TEST_SUITE.md`、`FLOW_INDEX.md`、`cases/*.md`、`scripts/*.spec.md`、历史 `results/` 和 `_reports/`
+- 先读取「文档组织」节列出的 `docs/qa/e2e/{feature_path}/` 下索引、用例、脚本与历史结果（`TEST_SUITE.md`、`FLOW_INDEX.md`、`cases/*.md`、`scripts/*.spec.md`、`results/`、`_reports/`）
 - 基于 PRD/TRD 生成 E2E 测试时，直接按 `docs/qa/e2e/{feature_path}/` 分类和记录，不再新增 `docs/qa/{feature}` 入口
 - 每个 E2E 测试用例单独存为 Markdown 文件，放在功能目录的 `cases/` 下，命名为 `TC-NNN-<short-slug>.md`；对应流程脚本放在 `scripts/TC-NNN-<short-slug>.spec.md`
 - `scripts/*.spec.md` 可以保存可执行脚本片段以保证重复执行一致，但不得包含明文账号、密码、token、cookie、session、SSH 密码或 SSH key 内容
@@ -193,8 +182,8 @@ skill eval 的 Fresh Sub-Agent 门禁作用于 skill 自身的测试流程，不
 - 平台账号和 SSH 账号统一存放在本地 `.qa/e2e/accounts.local.json`，该文件必须被 `.gitignore` 屏蔽；账号落盘格式遵循 `agents/qa/skills/qa-agent/references/e2e-credential-store.md`
 - 执行入口优先级为 repo harness > Chrome plugin / browser connector > Playwright fallback；repo harness 存在且覆盖当前 TC 时必须优先使用
 - 单个 E2E 测试任务默认由 subagent 执行，主 agent 负责范围确认、拆分、结果确认和按 `agents/qa/skills/qa-agent/references/e2e-test-report.md` 生成汇总报告
-- 现有功能变更或 bug 修复触发 E2E 文档更新前，必须先完成 PRD/TRD 预期对齐；预期变化回 PM，TRD gap 回 `trd-gen`，文档缺失或预期不清时 blocked；门禁强度按「变更分级契约」的 `change_tier` 取值，`hotfix` 只要求验证直接影响路径并追加结果，`standard` 以上维持预期对齐门禁
-- 代码完成后的 E2E 文档补充必须引用已确认的 `docs/engineer/{feature_path}/IMPLEMENTATION_PLAN.md`；任何等级都不能跳过实施计划门禁，`hotfix` 可引用「变更分级契约」允许的轻量计划形态
+- 现有功能变更或 bug 修复触发 E2E 文档更新前，必须先完成 PRD/TRD 预期对齐；预期变化回 PM，TRD gap 回 `trd-gen`，文档缺失或预期不清时 blocked；门禁强度按「变更分级契约」的 `change_tier` 取值
+- 代码完成后的 E2E 文档补充必须引用已确认的 `docs/engineer/{feature_path}/IMPLEMENTATION_PLAN.md`；任何等级都不能跳过实施计划门禁（`hotfix` 轻量形态按「变更分级契约」）
 - 已有 E2E 测试基于功能更新增量更新，历史结果只追加不覆盖
 
 ### Skill 测试
@@ -207,10 +196,8 @@ Skill eval 是可用性测试：验证 skill 能被触发、协议可执行、�
 
 **Eval 定义契约**
 
-- 使用共享 `evals.json` schema version `1.0`，不允许 Agent 专属例外
-- 位于 `agents/{agent}/test/{skill-name}/evals/evals.json`，顶层含 `schema_version`、`agent`、`skill_name`、非空 `evals`；`skill_name` 与对应 `SKILL.md` 对齐
-- 每个 eval item 含 `id`（格式 `eval-NNN-short-slug`）、非空 `name`/`description`/`prompt`/`expected_output`、显式 `workspace`（值为 `workspace/...`）、非空对象形式 assertions
-- 每个 assertion 含 lower snake_case `id`、非空 `description` 和非空语义化 `text`；不允许纯字符串 assertion
+- 使用共享 `evals.json` schema version `1.0`，不允许 Agent 专属例外；文件位于 `agents/{agent}/test/{skill-name}/evals/evals.json`，顶层含 `schema_version`、`agent`、`skill_name`、非空 `evals`，`skill_name` 与对应 `SKILL.md` 对齐
+- 每个 eval item 含 `id`（格式 `eval-NNN-short-slug`）、非空 `name`/`description`/`prompt`/`expected_output`、显式 `workspace`（值为 `workspace/...`）、非空对象形式 assertions；每个 assertion 含 lower snake_case `id`、非空 `description` 和非空语义化 `text`，不允许纯字符串 assertion
 - 优先语义断言，避免脆弱的精确字符串检查。语言或格式可合理变化时（如本地化、等价的 lane label），保持预期语义即可
 - 提交前运行 `uv run scripts/check_eval_contract.py`
 
@@ -278,45 +265,10 @@ Baseline 是 comparison 的对照输入，不是独立的机器判定对象。�
 - PR 必跑顺序：`repository-contract` → `eval-contract` → `doc-contract` → `python-tests`，即 `check_repository_contract.py` → `check_eval_contract.py` 与 `check_eval_artifacts.py` → `check_doc_contract.py` → 确定性 pytest
 - 模型 eval 不作 required status check。涉及 skill 行为、routing、eval fixture 或发版前变更时，管理员应在合并前手动触发 eval workflow，把 transcript 与 subagent validation 结果一并作为 merge 依据
 
-### 文档版本维护
-
-**建议**
-
-- 使用 feature-based 目录，例如 `docs/{agent}/{feature_path}/`
-- 添加包含 version metadata 的 frontmatter
-- 面向用户或开发者的发布变更记录写入 `docs/changelog/changelog-v{version}.md`
-- 依赖 git history 追踪版本历史
-- 修改文档时更新 `last_updated`
-
-**避免**
-
-- 不要创建基于日期的子目录
-- 不要为 feature 文档创建多个版本化文件，例如 `PRD-v1.md` 和 `PRD-v2.md`
-
-## 当前状态
-
-**已实现 Agent（7 个）**
-
-- `pm-agent` - 7 个 specialist skills
-- `engineer-agent` - 6 个 specialist skills
-- `qa-agent` - 4 个 specialist skills
-- `devops-agent` - 4 个 specialist skills
-- `designer-agent` - 2 个 specialist skills
-- `security-agent` - 4 个 specialist skills
-- `docs-agent` - 5 个 specialist skills
-
-**Specialist skills 总数：** 32
-
-**计划中的 Agent**
-
-- `growth_ops`（P1）- analytics、funnel analysis、feedback synthesis
-- `orchestrator`（P2）- request routing、project status summarization
-
 ## 重要文件
 
 - `.claude-plugin/marketplace.json` - Agent 和 skill registry
 - `scripts/install_codex_skills.py` - Codex 复制式 skill 安装脚本，避免祖先 plugin manifest 造成 namespace 前缀
 - `skills-lock.json` - 已安装 skill metadata
 - `AGENTS.md` - 仓库指导的唯一来源
-- `CLAUDE.md` - 指向 `AGENTS.md` 的相对软链接，用于 Claude Code 兼容
 - `agents/{agent}/README.md` - Agent 级文档


### PR DESCRIPTION
## 背景

`AGENTS.md` 仓库指导已膨胀到 322 行 / 28KB，存在多处同一规则重复表述的问题。本次按确认方案做去重合并与压缩，净减 48 行。

## 改动摘要（仅 `AGENTS.md` 一个文件）

**合并重复规则（8 处）**

| 重复内容 | 处理 |
| --- | --- |
| marketplace `metadata.version` 版本规则（原出现于「市场注册」与 release checklist 两处） | release checklist 改为引用「市场注册」节 |
| 文档组织规则（feature-based 目录、frontmatter、版本化文件禁令） | 「文档版本维护」整节删除，独有信息并入「文档组织」 |
| PM 入口默认规则三处重叠 | 8 条合并为 4 条（入口默认 / 安全网 / internal 标记 / router 分流） |
| 权威定义指针（skill-map、consumption-contract、Security 升级规则） | 合并为「文档依赖」节一条通则，`AGENTS.md` 只保留指针 |
| 实施计划归档例外 | 压缩句长，路径与 scope 命名保留 |
| QA 读取路径列举 | 删除与「QA E2E 测试用例持久化」节重复的一条 |
| CLAUDE.md 软链接说明 | 保留 IMPORTANT 块，删「重要文件」节重复条目 |
| 新增 Agent 步骤 3/4/5 | 合并子项，第 5 步引用同步面表格 |

**删除整节**

- 「文档版本维护」：内容并入「文档组织」，无信息损失
- 「当前状态」：agent 计数与根 README 的 "32 internal specialist skills" 重复，且每次新增 skill 都要手动同步；同步面表格中「仓库指导」计数行一并移除

**其他**

- Eval 定义契约 6 条合并为 4 条（字段细节保留）
- QA E2E 两条去掉与「变更分级契约」复述的短语，改为引用
- 「变更分级契约」章节（10+ skill 引用）与「Eval prompt 与 lane 隔离契约」章节名（eval comparison.md 引用）保持不变

## 验证

- 行数：322 → 274（净减 48 行，28KB → 26.4KB）
- `check_repository_contract.py` / `check_doc_contract.py` / `check_eval_contract.py` 全部 PASS
- 外部引用核对：被 skill 引用的章节名与结构均保留

## 待观察

- 部分 PRD 触点表提到 AGENTS.md 的 specialist 计数（如 docs-agent/manual-gen PRD），属过程文档，以实际 diff 为准（AGENTS.md 自身契约要求）
