### PR TITLE
fix(docs-iteration): 迭代指令补正文收束规则，消除事实型文档设计债务累积

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,6 +204,7 @@ Skill eval 是可用性测试：验证 skill 能被触发、协议可执行、�
 **Eval 执行契约**
 
 - 最终验证必须在与被测会话隔离的全新上下文中执行。全新 Codex subagent 与各自独立启动的 `codex exec` 会话都可接受，本质都是干净上下文。
+- 所有 eval lane（`with_skill` / `without_skill` / 独立 judge）统一使用 `gpt-5.6-luna` 模型并显式传 `model_reasoning_effort="medium"`（成本与速度考量；不用 `gpt-5.6-sol` 等更高成本模型跑 eval，除非维护者明确指定）。模型不可用时 blocked 并询问维护者，不得静默更换模型。
 - 每轮必须重新生成 `without_skill` baseline，**不得复用历史 baseline**，也不得为掩盖执行失败把 baseline 弱化成可选项。
 - 判定由独立评审方（fresh subagent 或独立 judge）对照 assertions 得出。**被测 lane 的自评不算判定**，评审方须独立核对零写入等关键事实。批量 transcript 生成脚本的输出只是诊断产物，不是 pass/fail 事实来源。
 - 运行期文件写隔离 scratch workspace（如 `tmp/eval-runs/...`），不得写入已提交 fixture——历史输出会污染 empty-workspace 这类上下文敏感用例。每轮运行前需清理的路径用 `eval_metadata.json` 的 `execution_cleanup` 声明。

--- a/agents/designer/skills/ui-ux-design/SKILL.md
+++ b/agents/designer/skills/ui-ux-design/SKILL.md
@@ -24,7 +24,9 @@ If the input includes a completed PM spec, treat it as design input only, not as
 When updating an existing design doc, the body states only the current design:
 superseded layouts, journeys, or patterns are rewritten, not kept with
 "deprecated" / "superseded" annotations. Removals are recorded in the doc
-changelog and git history.
+changelog and git history: the doc carries a `## Changelog` section
+(initialized if absent) listing version, date, and change summary, and
+`last_updated` metadata is refreshed when present.
 
 ## PM Handoff Entry Gate
 

--- a/agents/designer/skills/ui-ux-design/SKILL.md
+++ b/agents/designer/skills/ui-ux-design/SKILL.md
@@ -21,6 +21,11 @@ Forbidden actions:
 
 If the input includes a completed PM spec, treat it as design input only, not as permission to implement.
 
+When updating an existing design doc, the body states only the current design:
+superseded layouts, journeys, or patterns are rewritten, not kept with
+"deprecated" / "superseded" annotations. Removals are recorded in the doc
+changelog and git history.
+
 ## PM Handoff Entry Gate
 
 Before creating design deliverables, require a PM/design handoff packet or

--- a/agents/designer/skills/visual-design/SKILL.md
+++ b/agents/designer/skills/visual-design/SKILL.md
@@ -24,6 +24,11 @@ Forbidden actions:
 
 If the input includes a completed PM or UX spec, use it to shape the visual system and stop at design handoff.
 
+When updating an existing visual system, the body states only the current
+design: superseded tokens, colors, or rules are rewritten, not kept with
+"deprecated" annotations. Removals are recorded in the doc changelog and git
+history.
+
 ## PM Handoff Entry Gate
 
 Before creating visual-system deliverables, require a PM/design handoff packet

--- a/agents/designer/skills/visual-design/SKILL.md
+++ b/agents/designer/skills/visual-design/SKILL.md
@@ -27,7 +27,9 @@ If the input includes a completed PM or UX spec, use it to shape the visual syst
 When updating an existing visual system, the body states only the current
 design: superseded tokens, colors, or rules are rewritten, not kept with
 "deprecated" annotations. Removals are recorded in the doc changelog and git
-history.
+history: the doc carries a `## Changelog` section (initialized if absent)
+listing version, date, and change summary, and `last_updated` metadata is
+refreshed when present.
 
 ## PM Handoff Entry Gate
 

--- a/agents/engineer/skills/trd-gen/SKILL.md
+++ b/agents/engineer/skills/trd-gen/SKILL.md
@@ -227,9 +227,12 @@ endpoints, or parameters are deleted or rewritten instead of being kept with
 "deprecated" / "not part of the target architecture" annotations, and removals
 are recorded in the changelog and git history. If the target document has no
 changelog structure, add one to its frontmatter (mirroring the PRD changelog
-convention) so removals stay traceable. Ledger-style docs (`DECISIONS.md`,
-ADRs) keep history — that is their design intent, and the same PM-side rule
-explicitly exempts them.
+convention) so removals stay traceable. Exception for API references: endpoints
+that remain supported while deprecated keep their contract and deprecation
+notice — deprecation is part of the API contract lifecycle, and consolidation
+applies only to endpoints that are truly removed or superseded. Ledger-style
+docs (`DECISIONS.md`, ADRs) keep history — that is their design intent, and the
+same PM-side rule explicitly exempts them.
 
 ## Quality Checks
 

--- a/agents/engineer/skills/trd-gen/SKILL.md
+++ b/agents/engineer/skills/trd-gen/SKILL.md
@@ -219,6 +219,14 @@ The TRD must include:
 When updating a TRD from a gap packet, address each named gap directly or record
 it as an open technical question with the owner and unblock condition.
 
+When updating an existing TRD, follow the body-consolidation rule from
+`agents/product_manager/skills/idea-to-spec/_internal/_shared/gen-conventions.md`:
+the updated body states only the current target state; superseded designs are
+deleted or rewritten instead of being kept with "deprecated" / "not part of the
+target architecture" annotations, and removals are recorded in the changelog and
+git history. Ledger-style docs (`DECISIONS.md`, ADRs) keep history — that is
+their design intent, and the same PM-side rule explicitly exempts them.
+
 ## Quality Checks
 
 Before handoff, verify:
@@ -237,8 +245,11 @@ Before handoff, verify:
    `docs/engineer/{feature_path}/` and do not use only the terminal feature
    name as a parallel top-level directory.
 8. Any inbound TRD gap packet has been resolved or explicitly tracked as open.
-9. The next step is `feature-implementor` only after the Engineer document set
-   is confirmed.
+9. When the TRD was updated, the body states only the current target state:
+   no superseded designs kept with status annotations, and every removal is
+   recorded in the changelog.
+10. The next step is `feature-implementor` only after the Engineer document set
+    is confirmed.
 
 ## Handoff
 

--- a/agents/engineer/skills/trd-gen/SKILL.md
+++ b/agents/engineer/skills/trd-gen/SKILL.md
@@ -219,13 +219,17 @@ The TRD must include:
 When updating a TRD from a gap packet, address each named gap directly or record
 it as an open technical question with the owner and unblock condition.
 
-When updating an existing TRD, follow the body-consolidation rule from
+When updating an existing Engineer-owned current-state document (TRD or API
+reference), follow the body-consolidation rule from
 `agents/product_manager/skills/idea-to-spec/_internal/_shared/gen-conventions.md`:
-the updated body states only the current target state; superseded designs are
-deleted or rewritten instead of being kept with "deprecated" / "not part of the
-target architecture" annotations, and removals are recorded in the changelog and
-git history. Ledger-style docs (`DECISIONS.md`, ADRs) keep history — that is
-their design intent, and the same PM-side rule explicitly exempts them.
+the updated body states only the current target state; superseded designs,
+endpoints, or parameters are deleted or rewritten instead of being kept with
+"deprecated" / "not part of the target architecture" annotations, and removals
+are recorded in the changelog and git history. If the target document has no
+changelog structure, add one to its frontmatter (mirroring the PRD changelog
+convention) so removals stay traceable. Ledger-style docs (`DECISIONS.md`,
+ADRs) keep history — that is their design intent, and the same PM-side rule
+explicitly exempts them.
 
 ## Quality Checks
 
@@ -245,9 +249,10 @@ Before handoff, verify:
    `docs/engineer/{feature_path}/` and do not use only the terminal feature
    name as a parallel top-level directory.
 8. Any inbound TRD gap packet has been resolved or explicitly tracked as open.
-9. When the TRD was updated, the body states only the current target state:
-   no superseded designs kept with status annotations, and every removal is
-   recorded in the changelog.
+9. When an Engineer-owned current-state document (TRD or API reference) was
+   updated, the body states only the current target state: no superseded
+   designs, endpoints, or parameters kept with status annotations, and every
+   removal is recorded in the changelog.
 10. The next step is `feature-implementor` only after the Engineer document set
     is confirmed.
 

--- a/agents/engineer/test/trd-gen/evals/evals.json
+++ b/agents/engineer/test/trd-gen/evals/evals.json
@@ -194,7 +194,7 @@
         {
           "id": "removal_recorded_in_changelog",
           "description": "删除留痕",
-          "text": "轮询方案从正文移除时，删除必须记入文档 changelog（frontmatter 或 inline；原文档无 changelog 结构时新增一个），frontmatter 版本号相应更新"
+          "text": "轮询方案从正文移除时，删除必须记入 frontmatter changelog（原文档无 changelog 结构时在 frontmatter 新增），frontmatter 版本号相应更新"
         },
         {
           "id": "no_implementation_plan_or_code",

--- a/agents/engineer/test/trd-gen/evals/evals.json
+++ b/agents/engineer/test/trd-gen/evals/evals.json
@@ -194,7 +194,7 @@
         {
           "id": "removal_recorded_in_changelog",
           "description": "删除留痕",
-          "text": "轮询方案从正文移除时，更新记入文档变更留痕：frontmatter 版本号与 last_updated 相应更新；若文档本身有 changelog 结构则必须记录"
+          "text": "轮询方案从正文移除时，删除必须记入文档 changelog（frontmatter 或 inline；原文档无 changelog 结构时新增一个），frontmatter 版本号相应更新"
         },
         {
           "id": "no_implementation_plan_or_code",

--- a/agents/engineer/test/trd-gen/evals/evals.json
+++ b/agents/engineer/test/trd-gen/evals/evals.json
@@ -172,6 +172,36 @@
           "text": "将 `last_verified_version: unverified` 视为最低信任，不基于该页面直接确定接口限制或技术方案。"
         }
       ]
+    },
+    {
+      "id": "eval-006-delivery-polling-to-events",
+      "name": "delivery-polling-to-events",
+      "description": "Verifies that trd-gen updates an existing TRD to replace a superseded technical approach, consolidating the body to the current target state.",
+      "prompt": "workspace 的 docs/engineer/delivery-pipeline/TRD.md 描述的投递方案是定时轮询，产品需求已经改为事件驱动。请把这份技术文档更新到与当前需求一致。",
+      "workspace": "workspace/eval-006-delivery-polling-to-events",
+      "expected_output": "更新 docs/engineer/delivery-pipeline/TRD.md：正文直接描述事件驱动方案，轮询旧方案从正文移除并在 changelog 记录，不进入实现计划或代码。",
+      "assertions": [
+        {
+          "id": "updates_existing_trd",
+          "description": "更新目标 TRD 正文",
+          "text": "输出是更新 docs/engineer/delivery-pipeline/TRD.md 的正文与版本，不新建其他 feature 文档，也不把任务路由给别人"
+        },
+        {
+          "id": "body_consolidation",
+          "description": "正文只描述当前目标状态",
+          "text": "更新后的 TRD 正文直接描述事件驱动投递方案，轮询旧方案不以「已废弃」「不属于目标架构」等状态标注保留在正文"
+        },
+        {
+          "id": "removal_recorded_in_changelog",
+          "description": "删除留痕",
+          "text": "轮询方案从正文移除时，更新记入文档变更留痕：frontmatter 版本号与 last_updated 相应更新；若文档本身有 changelog 结构则必须记录"
+        },
+        {
+          "id": "no_implementation_plan_or_code",
+          "description": "不进入实现",
+          "text": "输出不得开始编写 IMPLEMENTATION_PLAN.md、修改代码或补测试"
+        }
+      ]
     }
   ]
 }

--- a/agents/engineer/test/trd-gen/evals/workspace/eval-006-delivery-polling-to-events/README.md
+++ b/agents/engineer/test/trd-gen/evals/workspace/eval-006-delivery-polling-to-events/README.md
@@ -1,0 +1,12 @@
+# Eval 6: Update Existing TRD (Polling → Event-Driven)
+
+This workspace holds a delivery-pipeline TRD (v1.1.0) whose delivery approach is
+a fixed-interval poller, while the confirmed PRD (v1.2.0) already states an
+event-driven target.
+
+The regression target: when updating the TRD to match the confirmed
+requirements, the body must be consolidated to the current target state — the
+polling approach is rewritten into an event-driven design instead of being kept
+with "deprecated" / "not part of the target architecture" annotations, and
+removals are recorded in the changelog with a version bump. The update stays a
+document change; it must not drift into implementation plans or code.

--- a/agents/engineer/test/trd-gen/evals/workspace/eval-006-delivery-polling-to-events/comparison.md
+++ b/agents/engineer/test/trd-gen/evals/workspace/eval-006-delivery-polling-to-events/comparison.md
@@ -7,7 +7,7 @@
 - Eval: `eval-006-delivery-polling-to-events`
 - Test case: delivery-polling-to-events
 - Workspace: `workspace/eval-006-delivery-polling-to-events`
-- Latest result: PASS - 2026-08-06 third fresh paired validation completed（frontmatter changelog 口径）；with_skill 4/4 assertions passed，without_skill 3/4。
+- Latest result: PASS - 2026-08-06 final-harness fresh paired validation completed（frontmatter changelog 口径）；with_skill 4/4 assertions passed，without_skill 3/4。
 - Behavior result: PASS — with_skill 实际触达路径满足全部 4 条断言（正文、版本与 changelog 事实一致）。
 - Coverage result: FULL — 4/4 assertion scenarios were exercised; no `NOT EXERCISED` items.
 Overall result: PASS
@@ -17,7 +17,7 @@ Overall result: PASS
 - Schema: `evals.json` v1.0
 - Fixture: delivery-pipeline PRD v1.2.0（事件驱动已确认）与 TRD v1.1.0（定时轮询旧方案：60 秒扫描、`poller.ts` / `batch.ts`）
 - Expected output: 更新 docs/engineer/delivery-pipeline/TRD.md：正文直接描述事件驱动方案，轮询旧方案从正文移除并留痕，不进入实现计划或代码。
-- Fresh run: `2026-08-06`（issue #233 新增 eval，三轮重跑，codex exec `gpt-5.6-luna` + `model_reasoning_effort=medium`，仓库外 workspace 拷贝隔离，两 lane 独立拷贝互不可见；independent judge 对照 4 条断言判定；lane 可见素材仅 fixture，README / eval_metadata.json / comparison.md 已物理排除）
+- Fresh run: `2026-08-06`（issue #233 新增 eval，最终 harness 重跑，codex exec `gpt-5.6-luna` + `model_reasoning_effort=medium`；两 lane 独立 workspace，均含剥离 test 的 agents/ 依赖镜像（可见上下文一致），with lane 额外在 `.agents/skills` 暴露入口 skill；HOME + CODEX_HOME 隔离（auth 从活跃 CODEX_HOME 复制）；README / eval_metadata.json / comparison.md 已物理排除；independent judge 对照 4 条断言判定）
 - Runtime directory: `tmp/eval-runs/fix-233/trd-gen-eval-006-delivery-polling-to-events/`（不入 git）
 
 ## Assertions

--- a/agents/engineer/test/trd-gen/evals/workspace/eval-006-delivery-polling-to-events/comparison.md
+++ b/agents/engineer/test/trd-gen/evals/workspace/eval-006-delivery-polling-to-events/comparison.md
@@ -7,8 +7,8 @@
 - Eval: `eval-006-delivery-polling-to-events`
 - Test case: delivery-polling-to-events
 - Workspace: `workspace/eval-006-delivery-polling-to-events`
-- Latest result: PASS - 2026-08-06 fresh paired validation completed（重跑轮，按 codex review 收紧后的断言）；with_skill 4/4 assertions passed，without_skill 3/4。
-- Behavior result: PASS — with_skill 实际触达路径满足全部 4 条断言。
+- Latest result: PASS - 2026-08-06 third fresh paired validation completed（frontmatter changelog 口径）；with_skill 4/4 assertions passed，without_skill 3/4。
+- Behavior result: PASS — with_skill 实际触达路径满足全部 4 条断言（正文、版本与 changelog 事实一致）。
 - Coverage result: FULL — 4/4 assertion scenarios were exercised; no `NOT EXERCISED` items.
 Overall result: PASS
 
@@ -24,12 +24,12 @@ Overall result: PASS
 
 - PASS `updates_existing_trd`: 两条 lane 均更新目标 `docs/engineer/delivery-pipeline/TRD.md`，未新建 feature 文档或转交任务。
 - PASS `body_consolidation`: 两份正文均改写为事件驱动方案；60 秒扫描、`poller.ts`、`batch.ts` 旧方案细节已移除，仅保留「不再使用轮询」的当前约束，无「已废弃」等状态标注。
-- PASS `removal_recorded_in_changelog`（with）/ FAIL（without）: with_skill 在无 changelog 结构的 TRD 上新增 inline「变更记录」表并同步版本 `1.1.0 -> 1.2.0`（对应 trd-gen SKILL.md「无 changelog 结构则新增」指令）；without_skill 仅更新版本号，无 changelog 留痕。该断言在收紧口径下具备判别力。
+- PASS `removal_recorded_in_changelog`（with）/ FAIL（without）: with_skill 在 frontmatter 新增 `changelog` 结构（version/date/summary）记录删除并同步版本 `1.1.0 -> 1.2.0`（对应 trd-gen SKILL.md「无 changelog 结构则新增到 frontmatter」指令）；without_skill 仅更新版本号，无 changelog 留痕。该断言在 frontmatter 口径下具备判别力。
 - PASS `no_implementation_plan_or_code`: 两条 lane 均未生成 `IMPLEMENTATION_PLAN.md`、修改代码或补测试。
 
 ## With Skill
 
-重跑（收紧断言 + SKILL.md 补「无 changelog 结构则新增」指令）：更新后的 TRD 与已确认 PRD 对齐，`delivery.created` 事件驱动方案、状态机、重试队列与 dead-letter；正文直接改写；**新增 inline「变更记录」表**记录删除内容并同步版本 `1.1.0 -> 1.2.0`；未进入实现。
+第三轮重跑（frontmatter 口径 + SKILL.md「无 changelog 结构则新增到 frontmatter」指令）：更新后的 TRD 与已确认 PRD 对齐，`delivery.created` 事件驱动方案、状态机、重试队列与 dead-letter；正文直接改写；**frontmatter 新增 `changelog` 结构**（version/date/summary）记录删除并同步版本 `1.1.0 -> 1.2.0`；未进入实现。
 
 ## Without Skill
 
@@ -39,7 +39,7 @@ Overall result: PASS
 
 **Skill impact:** MEDIUM
 
-收紧后的 `removal_recorded_in_changelog` 断言具备判别力（with PASS / without FAIL）：skill 加载后按「无 changelog 结构则新增」指令补留痕，baseline 遗漏。事件驱动改写与正文收束仍属模型基线能力（两条 lane 均满足），但删除留痕纪律是 skill 带来的可观测差异。该 eval 保留为正文收束与删除留痕的回归覆盖。
+frontmatter 口径下 `removal_recorded_in_changelog` 断言具备判别力（with PASS / without FAIL）：skill 加载后按「无 changelog 结构则新增到 frontmatter」指令补留痕，baseline 遗漏。事件驱动改写与正文收束仍属模型基线能力（两条 lane 均满足），但删除留痕纪律是 skill 带来的可观测差异。该 eval 保留为正文收束与删除留痕的回归覆盖。
 
 ## Runtime Artifact(s) Policy
 

--- a/agents/engineer/test/trd-gen/evals/workspace/eval-006-delivery-polling-to-events/comparison.md
+++ b/agents/engineer/test/trd-gen/evals/workspace/eval-006-delivery-polling-to-events/comparison.md
@@ -17,7 +17,7 @@ Overall result: PASS
 - Schema: `evals.json` v1.0
 - Fixture: delivery-pipeline PRD v1.2.0（事件驱动已确认）与 TRD v1.1.0（定时轮询旧方案：60 秒扫描、`poller.ts` / `batch.ts`）
 - Expected output: 更新 docs/engineer/delivery-pipeline/TRD.md：正文直接描述事件驱动方案，轮询旧方案从正文移除并留痕，不进入实现计划或代码。
-- Fresh run: `2026-08-06`（issue #233 新增 eval 首跑，codex exec `gpt-5.6-luna` + `model_reasoning_effort=medium`，仓库外 workspace 拷贝隔离，两 lane 独立拷贝互不可见；independent judge 对照 4 条断言判定）
+- Fresh run: `2026-08-06`（issue #233 新增 eval，三轮重跑，codex exec `gpt-5.6-luna` + `model_reasoning_effort=medium`，仓库外 workspace 拷贝隔离，两 lane 独立拷贝互不可见；independent judge 对照 4 条断言判定；lane 可见素材仅 fixture，README / eval_metadata.json / comparison.md 已物理排除）
 - Runtime directory: `tmp/eval-runs/fix-233/trd-gen-eval-006-delivery-polling-to-events/`（不入 git）
 
 ## Assertions

--- a/agents/engineer/test/trd-gen/evals/workspace/eval-006-delivery-polling-to-events/comparison.md
+++ b/agents/engineer/test/trd-gen/evals/workspace/eval-006-delivery-polling-to-events/comparison.md
@@ -7,7 +7,10 @@
 - Eval: `eval-006-delivery-polling-to-events`
 - Test case: delivery-polling-to-events
 - Workspace: `workspace/eval-006-delivery-polling-to-events`
-- Latest result: PASS - 2026-08-06 fresh paired validation completed; with_skill and fresh without_skill both satisfied 4/4 assertions.
+- Latest result: PASS - 2026-08-06 fresh paired validation completed（重跑轮，按 codex review 收紧后的断言）；with_skill 4/4 assertions passed，without_skill 3/4。
+- Behavior result: PASS — with_skill 实际触达路径满足全部 4 条断言。
+- Coverage result: FULL — 4/4 assertion scenarios were exercised; no `NOT EXERCISED` items.
+Overall result: PASS
 
 ## Test Set / Fixture Version
 
@@ -20,23 +23,23 @@
 ## Assertions
 
 - PASS `updates_existing_trd`: 两条 lane 均更新目标 `docs/engineer/delivery-pipeline/TRD.md`，未新建 feature 文档或转交任务。
-- PASS `body_consolidation`: 两份正文均改写为事件驱动方案；60 秒扫描、`poller.ts`、`batch.ts` 旧方案细节已移除，仅保留「不再使用轮询」的当前约束（with 的「非目标」节与 without 的「实施约束」节），无「已废弃」等状态标注。
-- PASS `removal_recorded_in_changelog`: 原始 TRD 无 changelog 结构（TRD schema 不含 changelog 字段），按断言适配口径以版本号 `1.1.0 -> 1.2.0` 与 `last_updated` 更新作为删除留痕。
+- PASS `body_consolidation`: 两份正文均改写为事件驱动方案；60 秒扫描、`poller.ts`、`batch.ts` 旧方案细节已移除，仅保留「不再使用轮询」的当前约束，无「已废弃」等状态标注。
+- PASS `removal_recorded_in_changelog`（with）/ FAIL（without）: with_skill 在无 changelog 结构的 TRD 上新增 inline「变更记录」表并同步版本 `1.1.0 -> 1.2.0`（对应 trd-gen SKILL.md「无 changelog 结构则新增」指令）；without_skill 仅更新版本号，无 changelog 留痕。该断言在收紧口径下具备判别力。
 - PASS `no_implementation_plan_or_code`: 两条 lane 均未生成 `IMPLEMENTATION_PLAN.md`、修改代码或补测试。
 
 ## With Skill
 
-更新后的 TRD 与已确认 PRD 对齐：`delivery.created` 事件发布、异步消费者、状态机（pending → processing → delivered）、重试队列与 dead-letter、验证项与 P0 目标；正文直接改写、版本 bump、未进入实现。
+重跑（收紧断言 + SKILL.md 补「无 changelog 结构则新增」指令）：更新后的 TRD 与已确认 PRD 对齐，`delivery.created` 事件驱动方案、状态机、重试队列与 dead-letter；正文直接改写；**新增 inline「变更记录」表**记录删除内容并同步版本 `1.1.0 -> 1.2.0`；未进入实现。
 
 ## Without Skill
 
-同一 prompt 与 fixture 下新建 baseline（codex `gpt-5.6-luna`，workspace 无 skill 文档）。baseline 同样完成事件驱动改写与版本 bump，产物更泛化（中间件留待实现阶段确定），并编造了 frontmatter `author: 用户 / Codex` 字段（原始 fixture 无 author）；未进入实现。baseline 回复提及 `pm-agent` / `trd-gen` 名称——该仓库为公开仓库，模型先验知识中存在 skill 体系名称，非 lane 泄漏。
+同一 prompt 与 fixture 下新建 baseline（codex `gpt-5.6-luna`，workspace 无 skill 文档）。baseline 同样完成事件驱动改写与版本 bump，但**未新增 changelog 留痕**（仅版本号与 last_updated 更新）。baseline 回复提及 `pm-agent` / `trd-gen` 名称——该仓库为公开仓库，模型先验知识中存在 skill 体系名称，非 lane 泄漏。
 
 ## Conclusion
 
-**Skill impact:** LOW
+**Skill impact:** MEDIUM
 
-本次断言下未形成 with/without 行为差异：两条 lane 均满足全部 4 条断言。事件驱动改写、正文收束、版本留痕属于模型基线能力已覆盖的行为（对应 AGENTS.md 判定表「模型基线能力已覆盖该行为 → 记为 skill 生命周期信号」）。skill 加载后的可观测差异在产物细节：with 产出具体模块结构（publisher/consumer/retry/status）与状态机，baseline 为泛化模板且编造 frontmatter 字段。该 eval 保留为正文收束与不越界的回归覆盖，判别力观察点可考虑后续增强（如断言覆盖模块具体性或不编造字段纪律）。
+收紧后的 `removal_recorded_in_changelog` 断言具备判别力（with PASS / without FAIL）：skill 加载后按「无 changelog 结构则新增」指令补留痕，baseline 遗漏。事件驱动改写与正文收束仍属模型基线能力（两条 lane 均满足），但删除留痕纪律是 skill 带来的可观测差异。该 eval 保留为正文收束与删除留痕的回归覆盖。
 
 ## Runtime Artifact(s) Policy
 

--- a/agents/engineer/test/trd-gen/evals/workspace/eval-006-delivery-polling-to-events/comparison.md
+++ b/agents/engineer/test/trd-gen/evals/workspace/eval-006-delivery-polling-to-events/comparison.md
@@ -1,0 +1,43 @@
+# Eval Result: eval-006-delivery-polling-to-events
+
+## Evaluation Target
+
+- Agent: `engineer`
+- Skill: `trd-gen`
+- Eval: `eval-006-delivery-polling-to-events`
+- Test case: delivery-polling-to-events
+- Workspace: `workspace/eval-006-delivery-polling-to-events`
+- Latest result: PASS - 2026-08-06 fresh paired validation completed; with_skill and fresh without_skill both satisfied 4/4 assertions.
+
+## Test Set / Fixture Version
+
+- Schema: `evals.json` v1.0
+- Fixture: delivery-pipeline PRD v1.2.0（事件驱动已确认）与 TRD v1.1.0（定时轮询旧方案：60 秒扫描、`poller.ts` / `batch.ts`）
+- Expected output: 更新 docs/engineer/delivery-pipeline/TRD.md：正文直接描述事件驱动方案，轮询旧方案从正文移除并留痕，不进入实现计划或代码。
+- Fresh run: `2026-08-06`（issue #233 新增 eval 首跑，codex exec `gpt-5.6-luna` + `model_reasoning_effort=medium`，仓库外 workspace 拷贝隔离，两 lane 独立拷贝互不可见；independent judge 对照 4 条断言判定）
+- Runtime directory: `tmp/eval-runs/fix-233/trd-gen-eval-006-delivery-polling-to-events/`（不入 git）
+
+## Assertions
+
+- PASS `updates_existing_trd`: 两条 lane 均更新目标 `docs/engineer/delivery-pipeline/TRD.md`，未新建 feature 文档或转交任务。
+- PASS `body_consolidation`: 两份正文均改写为事件驱动方案；60 秒扫描、`poller.ts`、`batch.ts` 旧方案细节已移除，仅保留「不再使用轮询」的当前约束（with 的「非目标」节与 without 的「实施约束」节），无「已废弃」等状态标注。
+- PASS `removal_recorded_in_changelog`: 原始 TRD 无 changelog 结构（TRD schema 不含 changelog 字段），按断言适配口径以版本号 `1.1.0 -> 1.2.0` 与 `last_updated` 更新作为删除留痕。
+- PASS `no_implementation_plan_or_code`: 两条 lane 均未生成 `IMPLEMENTATION_PLAN.md`、修改代码或补测试。
+
+## With Skill
+
+更新后的 TRD 与已确认 PRD 对齐：`delivery.created` 事件发布、异步消费者、状态机（pending → processing → delivered）、重试队列与 dead-letter、验证项与 P0 目标；正文直接改写、版本 bump、未进入实现。
+
+## Without Skill
+
+同一 prompt 与 fixture 下新建 baseline（codex `gpt-5.6-luna`，workspace 无 skill 文档）。baseline 同样完成事件驱动改写与版本 bump，产物更泛化（中间件留待实现阶段确定），并编造了 frontmatter `author: 用户 / Codex` 字段（原始 fixture 无 author）；未进入实现。baseline 回复提及 `pm-agent` / `trd-gen` 名称——该仓库为公开仓库，模型先验知识中存在 skill 体系名称，非 lane 泄漏。
+
+## Conclusion
+
+**Skill impact:** LOW
+
+本次断言下未形成 with/without 行为差异：两条 lane 均满足全部 4 条断言。事件驱动改写、正文收束、版本留痕属于模型基线能力已覆盖的行为（对应 AGENTS.md 判定表「模型基线能力已覆盖该行为 → 记为 skill 生命周期信号」）。skill 加载后的可观测差异在产物细节：with 产出具体模块结构（publisher/consumer/retry/status）与状态机，baseline 为泛化模板且编造 frontmatter 字段。该 eval 保留为正文收束与不越界的回归覆盖，判别力观察点可考虑后续增强（如断言覆盖模块具体性或不编造字段纪律）。
+
+## Runtime Artifact(s) Policy
+
+- with/without lane 产物、workspace 更新后的 TRD、judge verdict 均在 `tmp/eval-runs/fix-233/` 下，不入 git。

--- a/agents/engineer/test/trd-gen/evals/workspace/eval-006-delivery-polling-to-events/docs/engineer/delivery-pipeline/TRD.md
+++ b/agents/engineer/test/trd-gen/evals/workspace/eval-006-delivery-polling-to-events/docs/engineer/delivery-pipeline/TRD.md
@@ -1,0 +1,27 @@
+---
+type: TRD
+feature: delivery-pipeline
+feature_path: delivery-pipeline
+parent_feature: N/A
+feature_level: 1
+version: 1.1.0
+date: 2026-07-20
+last_updated: 2026-07-20
+related_prd: docs/pm/delivery-pipeline/PRD.md
+---
+
+# Delivery Pipeline TRD
+
+## 投递方案：定时轮询
+
+系统每 60 秒轮询待投递消息表，扫描 `status = pending` 的记录，按渠道批量投递，批大小 100。轮询间隔导致投递延迟平均 30 秒、峰值 60 秒。
+
+## 模块
+
+- `src/delivery/poller.ts`：轮询调度与扫描
+- `src/delivery/batch.ts`：批量投递
+
+## 验证
+
+- 轮询频率与扫描边界单测
+- 投递批次与重试单测

--- a/agents/engineer/test/trd-gen/evals/workspace/eval-006-delivery-polling-to-events/docs/pm/delivery-pipeline/PRD.md
+++ b/agents/engineer/test/trd-gen/evals/workspace/eval-006-delivery-polling-to-events/docs/pm/delivery-pipeline/PRD.md
@@ -1,0 +1,22 @@
+---
+feature: delivery-pipeline
+feature_path: delivery-pipeline
+parent_feature: N/A
+feature_level: 1
+version: 1.2.0
+date: 2026-08-01
+last_updated: 2026-08-06
+---
+
+# Delivery Pipeline
+
+## 已确认范围
+
+- 消息通过事件驱动投递：新消息发布 `delivery.created` 事件，消费者异步按渠道投递。
+- 失败消息进入重试队列，重试耗尽进入 dead-letter。
+- pending、processing 和 delivered 状态可观测。
+
+## P0 验收
+
+- 投递延迟目标小于 30 秒。
+- 失败投递不会丢失原始消息和关联 ID。

--- a/agents/engineer/test/trd-gen/evals/workspace/eval-006-delivery-polling-to-events/eval_metadata.json
+++ b/agents/engineer/test/trd-gen/evals/workspace/eval-006-delivery-polling-to-events/eval_metadata.json
@@ -1,0 +1,10 @@
+{
+  "eval_id": "eval-006-delivery-polling-to-events",
+  "eval_name": "delivery-polling-to-events",
+  "workspace_root": "agents/engineer/test/trd-gen/evals/workspace/eval-006-delivery-polling-to-events",
+  "prompt": "workspace 的 docs/engineer/delivery-pipeline/TRD.md 描述的投递方案是定时轮询，产品需求已经改为事件驱动。请把这份技术文档更新到与当前需求一致。",
+  "fixture_context": [
+    "docs/pm/delivery-pipeline/PRD.md",
+    "docs/engineer/delivery-pipeline/TRD.md"
+  ]
+}

--- a/agents/product_manager/skills/idea-to-spec/_internal/_shared/gen-conventions.md
+++ b/agents/product_manager/skills/idea-to-spec/_internal/_shared/gen-conventions.md
@@ -1,7 +1,8 @@
 # Gen Skill Conventions
 
 > Standard workflow, safety, and failure handling rules shared by all document
-> generation skills under `gen/`. Each gen skill MUST follow these conventions
+> generation skills under `gen/` and all iteration modules under
+> `iteration/`. Each gen and iteration skill MUST follow these conventions
 > unless explicitly overridden.
 
 ## Standard Workflow
@@ -32,7 +33,14 @@ Every gen skill follows this 6-step workflow:
 
 5. **Consolidate**: Rewrite any process notes, tentative correction phrasing, or
    chat-like fragments into stable document prose. The document body should
-   state the current design directly.
+   state the current design directly. This applies to generation and iteration
+   alike: when an iteration replaces or retires a design, delete or rewrite the
+   superseded content in the body instead of keeping it with annotations such as
+   "deprecated" or "not part of the target architecture". Removals are recorded
+   in the changelog and git history — "never silently remove" means "removals
+   must leave a trace", not "avoid removing". Ledger-style documents
+   (`DECISIONS.md`, ADRs, changelogs, QA `results/`) are exempt: preserving
+   history and rejected options is their design intent.
 
 6. **Self-check**: Validate the output against
    `_internal/_shared/quality-rules.md`

--- a/agents/product_manager/skills/idea-to-spec/_internal/iteration/prd-iteration/INSTRUCTIONS.md
+++ b/agents/product_manager/skills/idea-to-spec/_internal/iteration/prd-iteration/INSTRUCTIONS.md
@@ -41,6 +41,10 @@ Apply changes to an existing PRD while maintaining version history and quality s
    - Scope changes (may require MAJOR version bump)
 
 3. **Apply changes**: Modify affected sections while preserving unchanged content.
+   The body must state only the current target state: delete or rewrite
+   superseded designs instead of keeping them with "deprecated" / "not part of
+   the target architecture" annotations. Record removals in the changelog (see
+   the body-consolidation rule in `_internal/_shared/gen-conventions.md`).
    If the change would move the PRD to a child feature path or reveals an
    existing parallel directory is misplaced, stop and present a path conflict
    summary instead of silently editing the wrong PRD.
@@ -89,7 +93,12 @@ Apply changes to an existing PRD while maintaining version history and quality s
 ## Safety Boundaries
 
 - Always preserve unchanged sections exactly as-is
-- Never silently remove content — track all deletions in changelog
+- Body consolidation: the body states only the current target state; superseded
+  designs are deleted or rewritten, not annotated as deprecated in the body
+- "Never silently remove content" means removals must be recorded in the
+  changelog and git history — not that content should be kept with status
+  annotations; exceptions are ledger-style docs (`DECISIONS.md`, ADRs,
+  changelogs, QA `results/`) where history is the design intent
 - Confirm with user before MAJOR version bumps
 - Do not modify files on disk unless explicitly instructed
 

--- a/agents/product_manager/skills/idea-to-spec/_internal/iteration/trd-iteration/INSTRUCTIONS.md
+++ b/agents/product_manager/skills/idea-to-spec/_internal/iteration/trd-iteration/INSTRUCTIONS.md
@@ -52,6 +52,11 @@ revision is needed and hands the work to `engineer-agent:trd-gen`.
    - source evidence
    - related PRD / DECISIONS impact
    - validator findings or review comments
+   - an explicit requirement that the updated TRD body states only the current
+     target state: superseded designs are deleted or rewritten, removals are
+     recorded in the changelog and git history, and ledger-style docs
+     (`DECISIONS.md`, ADRs) keep history per the body-consolidation rule in
+     `_internal/_shared/gen-conventions.md`
 5. **Check cross-document impact**:
    - If the change alters a technical decision materially, route ADR creation
      or revision to `engineer-agent:trd-gen`
@@ -79,7 +84,9 @@ revision is needed and hands the work to `engineer-agent:trd-gen`.
 
 ## Safety Boundaries
 
-- Never silently remove endpoints, NFR targets, or security controls
+- Never silently remove endpoints, NFR targets, or security controls — "never
+  silently" means removals must be recorded in the changelog and git history,
+  not that superseded content stays in the body with status annotations
 - Do not modify TRD files on disk from PM instructions
 - Do not authorize a PM directory move until the downstream mirror impact list
   and mirror handling decision are confirmed

--- a/agents/product_manager/skills/idea-to-spec/_internal/iteration/tspecs-iteration/INSTRUCTIONS.md
+++ b/agents/product_manager/skills/idea-to-spec/_internal/iteration/tspecs-iteration/INSTRUCTIONS.md
@@ -51,7 +51,10 @@ history, traceability, and versioning.
    - Maintain positive, negative, and boundary coverage for P0 items
    - Update NFR, regression, and smoke-pack sections when release criteria
      change
-   - Preserve unchanged cases exactly
+   - Preserve unchanged cases exactly; rewrite replaced cases to state the
+     current expected behavior instead of keeping the superseded steps with
+     annotations (body-consolidation rule in
+     `_internal/_shared/gen-conventions.md`)
 4. **Repair traceability**:
    - Keep Coverage Summary and Traceability Matrix synchronized
    - Mark retired tests explicitly and note replacement coverage if any
@@ -87,7 +90,12 @@ history, traceability, and versioning.
 
 - Preserve unchanged test cases exactly
 - Preserve unchanged E2E case files exactly
-- Never silently drop coverage for a requirement, endpoint, or NFR
+- Body consolidation: replaced cases are rewritten to the current expected
+  behavior, not kept with status annotations; retirement is recorded in the
+  coverage summary / traceability layer, not by preserving the old case body
+- "Never silently drop coverage" means removals must be recorded in the
+  changelog and coverage summary — not that superseded case bodies stay in
+  the document
 - Confirm with the user before MAJOR version bumps or broad test-case
   retirements
 - Do not modify files on disk unless explicitly instructed

--- a/agents/product_manager/test/idea-to-spec/evals/evals.json
+++ b/agents/product_manager/test/idea-to-spec/evals/evals.json
@@ -265,6 +265,11 @@
           "id": "rejection_keeps_current_flow",
           "description": "拒绝语义",
           "text": "说明或体现用户拒绝提案时保持当前 feature_path 并按现流程继续（版本 bump 与校验）"
+        },
+        {
+          "id": "body_consolidation",
+          "description": "更新后正文只描述当前目标状态",
+          "text": "更新后的 PRD 正文直接把轮询策略改写为事件驱动方案，不以「已废弃」「不属于目标架构」等状态标注保留轮询描述"
         }
       ]
     }

--- a/agents/product_manager/test/idea-to-spec/test_transcript_runner.py
+++ b/agents/product_manager/test/idea-to-spec/test_transcript_runner.py
@@ -23,18 +23,21 @@ def load_runner_module():
 
 
 class TranscriptRunnerTests(unittest.TestCase):
-    def test_build_claude_command_supports_custom_entry_command(self):
+    def test_build_codex_command_uses_mandated_model_and_effort(self):
         runner = load_runner_module()
 
-        command = runner.build_claude_command(
+        command = runner.build_codex_command(
             "我想做一个 AI 对话助手",
-            with_skill=True,
-            entry_command="/pm-agent",
-            plugin_dir="agents/product_manager",
+            cwd=Path("/tmp/ws"),
+            output_path=Path("/tmp/ws/result.txt"),
         )
 
-        self.assertIn("--plugin-dir", command)
-        self.assertEqual(command[-1], "/pm-agent 我想做一个 AI 对话助手")
+        self.assertIn("-m", command)
+        self.assertEqual(command[command.index("-m") + 1], "gpt-5.6-luna")
+        self.assertIn('model_reasoning_effort="medium"', command)
+        self.assertIn("-o", command)
+        self.assertEqual(command[command.index("-o") + 1], "/tmp/ws/result.txt")
+        self.assertEqual(command[-1], "我想做一个 AI 对话助手")
 
     def test_prepare_execution_workspace_removes_reserved_and_custom_outputs(self):
         runner = load_runner_module()
@@ -66,22 +69,21 @@ class TranscriptRunnerTests(unittest.TestCase):
             self.assertFalse((exec_root / "comparison.auto.md").exists())
             self.assertFalse((exec_root / "PRD.md").exists())
 
-    def test_extract_result_text_reads_json_payload(self):
+    def test_read_result_file_reads_codex_output(self):
         runner = load_runner_module()
 
-        payload = json.dumps(
-            {
-                "type": "result",
-                "subtype": "success",
-                "result": "structured transcript",
-            },
-            ensure_ascii=False,
-        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            result_path = Path(temp_dir) / "result.txt"
+            result_path.write_text("structured transcript")
 
-        self.assertEqual(
-            runner.extract_result_text(payload),
-            "structured transcript",
-        )
+            self.assertEqual(
+                runner.read_result_file(result_path),
+                "structured transcript",
+            )
+
+            missing_path = Path(temp_dir) / "missing.txt"
+            with self.assertRaises(ValueError):
+                runner.read_result_file(missing_path)
 
     def test_sync_declared_outputs_copies_existing_candidates(self):
         runner = load_runner_module()
@@ -135,9 +137,12 @@ class TranscriptRunnerTests(unittest.TestCase):
                 )
             )
 
-            def fake_run_claude(command, cwd, timeout_seconds):
-                label = "with_skill" if "--plugin-dir" in command else "without_skill"
+            def fake_run_codex(command, cwd, timeout_seconds):
+                output_path = Path(command[command.index("-o") + 1])
+                label = "with_skill" if "with_skill" in str(output_path) else "without_skill"
+                output_path.parent.mkdir(parents=True, exist_ok=True)
                 transcript = f"{label} transcript"
+                output_path.write_text(transcript)
                 return transcript, {
                     "command": command,
                     "cwd": str(cwd),
@@ -149,14 +154,14 @@ class TranscriptRunnerTests(unittest.TestCase):
                     "result_length": len(transcript),
                 }
 
-            old_run_claude = runner.run_claude
+            old_run_codex = runner.run_codex
             old_output_dir = os.environ.get("EVAL_RUN_OUTPUT_DIR")
-            runner.run_claude = fake_run_claude
+            runner.run_codex = fake_run_codex
             os.environ["EVAL_RUN_OUTPUT_DIR"] = str(temp_root / "runs")
             try:
                 runner.generate_eval_outputs(metadata)
             finally:
-                runner.run_claude = old_run_claude
+                runner.run_codex = old_run_codex
                 if old_output_dir is None:
                     os.environ.pop("EVAL_RUN_OUTPUT_DIR", None)
                 else:

--- a/agents/product_manager/test/idea-to-spec/test_transcript_runner.py
+++ b/agents/product_manager/test/idea-to-spec/test_transcript_runner.py
@@ -55,6 +55,7 @@ class TranscriptRunnerTests(unittest.TestCase):
             (eval_root / "PRD.md").write_text("stale-prd")
             (eval_root / "docs/input/fixture.md").write_text("fixture")
             (eval_root / "README.md").write_text("readme")
+            (eval_root / "eval_metadata.json").write_text("{}")
 
             runner.prepare_execution_workspace(
                 eval_root,
@@ -62,7 +63,8 @@ class TranscriptRunnerTests(unittest.TestCase):
                 cleanup_paths=["PRD.md"],
             )
 
-            self.assertTrue((exec_root / "README.md").exists())
+            self.assertFalse((exec_root / "README.md").exists())
+            self.assertFalse((exec_root / "eval_metadata.json").exists())
             self.assertTrue((exec_root / "docs/input/fixture.md").exists())
             self.assertFalse((exec_root / "with_skill").exists())
             self.assertFalse((exec_root / "without_skill").exists())

--- a/agents/product_manager/test/idea-to-spec/test_transcript_runner.py
+++ b/agents/product_manager/test/idea-to-spec/test_transcript_runner.py
@@ -139,7 +139,7 @@ class TranscriptRunnerTests(unittest.TestCase):
                 )
             )
 
-            def fake_run_codex(command, cwd, timeout_seconds):
+            def fake_run_codex(command, cwd, timeout_seconds, env=None):
                 output_path = Path(command[command.index("-o") + 1])
                 label = "with_skill" if "with_skill" in str(output_path) else "without_skill"
                 output_path.parent.mkdir(parents=True, exist_ok=True)

--- a/agents/product_manager/test/idea-to-spec/transcript_runner.py
+++ b/agents/product_manager/test/idea-to-spec/transcript_runner.py
@@ -141,38 +141,60 @@ def resolve_skill_dir(meta: dict) -> str:
     return f"{plugin}/skills/{entry}"
 
 
-def install_skill_documents(execution_root: Path, skill_dir: str) -> None:
-    # Full agents/ mirror so literal `agents/...` references inside skill
-    # documents resolve and router-to-specialist delegation chains (e.g.
-    # pm-agent -> idea-to-spec) keep working in the lane workspace. Agent
-    # test directories are stripped, matching docs/README.codex.md, so eval
-    # assertions and prior comparison results never enter a lane.
+# Routers whose entry skill delegates to a specialist that must also be
+# discoverable for the delegation chain to execute in the lane.
+ROUTER_SPECIALISTS = {
+    "agents/product_manager/skills/pm-agent": [
+        "agents/product_manager/skills/idea-to-spec",
+    ],
+}
+
+
+def mirror_dependency_documents(execution_root: Path) -> None:
+    """Stripped agents/ mirror shared by both lanes (identical visible context).
+
+    Literal `agents/...` references inside skill documents and router-to-
+    specialist delegation chains resolve from this tree; agent test
+    directories are stripped (matching docs/README.codex.md) so eval
+    assertions and prior comparison results never enter a lane. Both lanes
+    receive the same mirror — only the discovery/loading of the entry skill
+    differs, keeping the lane-isolation contract intact.
+    """
     shutil.copytree(
         repo_root() / "agents",
         execution_root / "agents",
         ignore=shutil.ignore_patterns("test"),
     )
-    # Entry skill exposed at the Codex discovery path.
+
+
+def install_entry_skill(execution_root: Path, skill_dir: str) -> None:
+    """Expose the entry skill (and routed specialists) at Codex discovery."""
     entry_source = Path(skill_dir)
     if not entry_source.is_absolute():
         entry_source = repo_root() / entry_source
-    target = execution_root / ".agents" / "skills" / entry_source.name
-    target.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copytree(entry_source, target)
+    for skill_path in [str(entry_source.relative_to(repo_root()))] + ROUTER_SPECIALISTS.get(
+        skill_dir, []
+    ):
+        source = repo_root() / skill_path
+        target = execution_root / ".agents" / "skills" / source.name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(source, target)
 
 
 def build_isolated_env(temp_root: Path) -> tuple[dict, Path]:
     """Isolate the lane from user-level Codex skills (~/.agents/skills).
 
     Codex resolves user skills under $HOME/.agents/skills and the auth store
-    under $HOME/.codex; pointing HOME at a fresh directory (with a copied
-    auth.json) drops personal skills while keeping authentication. Built-in
-    Codex skills still load — they are unrelated to repo skills.
+    under $CODEX_HOME (default $HOME/.codex); pointing HOME and CODEX_HOME at
+    fresh directories (with the auth.json copied from the active CODEX_HOME)
+    drops personal skills while keeping authentication. Built-in Codex skills
+    still load — they are unrelated to repo skills.
     """
     home = temp_root / "codex-home"
     codex_home = home / ".codex"
     codex_home.mkdir(parents=True, exist_ok=True)
-    auth_src = Path.home() / ".codex" / "auth.json"
+    active_codex_home = os.environ.get("CODEX_HOME") or str(Path.home() / ".codex")
+    auth_src = Path(active_codex_home) / "auth.json"
     if auth_src.exists():
         shutil.copy2(auth_src, codex_home / "auth.json")
     env = dict(os.environ)
@@ -269,8 +291,9 @@ def generate_eval_outputs(
         for label, outputs, with_skill in runs:
             execution_root = Path(temp_dir) / "workspace" / label
             prepare_execution_workspace(eval_root, execution_root, cleanup_paths=cleanup_paths)
+            mirror_dependency_documents(execution_root)
             if with_skill:
-                install_skill_documents(execution_root, skill_dir)
+                install_entry_skill(execution_root, skill_dir)
             output_path = execution_root / label / "outputs/result.txt"
             output_path.parent.mkdir(parents=True, exist_ok=True)
             command = build_codex_command(

--- a/agents/product_manager/test/idea-to-spec/transcript_runner.py
+++ b/agents/product_manager/test/idea-to-spec/transcript_runner.py
@@ -142,19 +142,17 @@ def resolve_skill_dir(meta: dict) -> str:
 
 
 def install_skill_documents(execution_root: Path, skill_dir: str) -> None:
-    source = Path(skill_dir)
-    if not source.is_absolute():
-        source = repo_root() / source
-    skill_name = source.name
-    # Codex discovery tree (mirrors install_codex_skills.py semantics).
-    target = execution_root / ".agents" / "skills" / skill_name
+    # Full agents/ mirror so literal `agents/...` references inside skill
+    # documents resolve and router-to-specialist delegation chains (e.g.
+    # pm-agent -> idea-to-spec) keep working in the lane workspace.
+    shutil.copytree(repo_root() / "agents", execution_root / "agents")
+    # Entry skill exposed at the Codex discovery path.
+    entry_source = Path(skill_dir)
+    if not entry_source.is_absolute():
+        entry_source = repo_root() / entry_source
+    target = execution_root / ".agents" / "skills" / entry_source.name
     target.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copytree(source, target)
-    # Repository-relative copy so literal `agents/...` references inside the
-    # skill documents keep resolving (e.g. _internal/_shared includes).
-    target = execution_root / skill_dir
-    target.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copytree(source, target)
+    shutil.copytree(entry_source, target)
 
 
 def build_isolated_env(temp_root: Path) -> tuple[dict, Path]:

--- a/agents/product_manager/test/idea-to-spec/transcript_runner.py
+++ b/agents/product_manager/test/idea-to-spec/transcript_runner.py
@@ -22,6 +22,8 @@ RESERVED_CLEANUP_PATHS = (
     "without_skill",
     "comparison.auto.md",
     "comparison.md",
+    "README.md",
+    "eval_metadata.json",
 )
 
 DEFAULT_TIMEOUT_SECONDS = 180
@@ -134,7 +136,8 @@ def install_skill_documents(execution_root: Path, skill_dir: str) -> None:
     source = Path(skill_dir)
     if not source.is_absolute():
         source = repo_root() / source
-    target = execution_root / skill_dir
+    skill_name = source.name
+    target = execution_root / ".agents" / "skills" / skill_name
     target.parent.mkdir(parents=True, exist_ok=True)
     shutil.copytree(source, target)
 
@@ -209,9 +212,6 @@ def generate_eval_outputs(
     reset_directory(runtime_root)
 
     with tempfile.TemporaryDirectory(prefix="idea-to-spec-eval-") as temp_dir:
-        execution_root = Path(temp_dir) / "workspace"
-        prepare_execution_workspace(eval_root, execution_root, cleanup_paths=cleanup_paths)
-
         skill_dir = meta.get("skill_dir", DEFAULT_SKILL_DIR)
 
         runs = [
@@ -220,10 +220,10 @@ def generate_eval_outputs(
         ]
 
         for label, outputs, with_skill in runs:
+            execution_root = Path(temp_dir) / "workspace" / label
+            prepare_execution_workspace(eval_root, execution_root, cleanup_paths=cleanup_paths)
             if with_skill:
                 install_skill_documents(execution_root, skill_dir)
-            else:
-                remove_path(execution_root / skill_dir)
             output_path = execution_root / label / "outputs/result.txt"
             output_path.parent.mkdir(parents=True, exist_ok=True)
             command = build_codex_command(

--- a/agents/product_manager/test/idea-to-spec/transcript_runner.py
+++ b/agents/product_manager/test/idea-to-spec/transcript_runner.py
@@ -25,6 +25,9 @@ RESERVED_CLEANUP_PATHS = (
 )
 
 DEFAULT_TIMEOUT_SECONDS = 180
+DEFAULT_MODEL = "gpt-5.6-luna"
+DEFAULT_REASONING_EFFORT = "medium"
+DEFAULT_SKILL_DIR = "agents/product_manager/skills/idea-to-spec"
 
 
 class TranscriptRunError(RuntimeError):
@@ -61,19 +64,11 @@ def prepare_execution_workspace(
         remove_path(execution_root / rel)
 
 
-def extract_result_text(stdout: str) -> str:
-    if not stdout.strip():
-        raise ValueError("Claude returned empty stdout")
+def read_result_file(path: Path) -> str:
+    if not path.exists() or not path.read_text().strip():
+        raise ValueError(f"Codex result file is missing or empty: {path}")
 
-    payload = json.loads(stdout)
-    if payload.get("is_error"):
-        raise ValueError(payload.get("result") or "Claude returned an error payload")
-
-    result = payload.get("result")
-    if not isinstance(result, str) or not result.strip():
-        raise ValueError("Claude JSON payload does not contain a non-empty result")
-
-    return result
+    return path.read_text()
 
 
 def iter_output_paths(outputs: list) -> list[str]:
@@ -112,41 +107,39 @@ def repo_root() -> Path:
     return Path(__file__).resolve().parents[4]
 
 
-def build_claude_command(
+def build_codex_command(
     prompt: str,
     *,
-    with_skill: bool,
-    entry_command: str = "/idea-to-spec",
-    plugin_dir: str = "agents/product_manager",
+    cwd: Path,
+    output_path: Path,
 ) -> list[str]:
-    command = [
-        "claude",
-        "-p",
-        "--no-session-persistence",
-        "--permission-mode",
-        "bypassPermissions",
-        "--output-format",
-        "json",
+    return [
+        "codex",
+        "exec",
+        "-C",
+        str(cwd),
+        "-s",
+        "workspace-write",
+        "-m",
+        DEFAULT_MODEL,
+        "-c",
+        f'model_reasoning_effort="{DEFAULT_REASONING_EFFORT}"',
+        "-o",
+        str(output_path),
+        prompt,
     ]
 
-    if with_skill:
-        plugin_root = Path(plugin_dir)
-        if not plugin_root.is_absolute():
-            plugin_root = repo_root() / plugin_root
 
-        normalized_entry = entry_command.strip()
-        if not normalized_entry.startswith("/"):
-            normalized_entry = f"/{normalized_entry}"
-
-        command.extend(["--plugin-dir", str(plugin_root)])
-        command.append(f"{normalized_entry} {prompt}")
-        return command
-
-    command.append(prompt)
-    return command
+def install_skill_documents(execution_root: Path, skill_dir: str) -> None:
+    source = Path(skill_dir)
+    if not source.is_absolute():
+        source = repo_root() / source
+    target = execution_root / skill_dir
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(source, target)
 
 
-def run_claude(command: list[str], cwd: Path, timeout_seconds: int) -> tuple[str, dict]:
+def run_codex(command: list[str], cwd: Path, timeout_seconds: int) -> tuple[str, dict]:
     started = time.time()
     try:
         completed = subprocess.run(
@@ -166,7 +159,7 @@ def run_claude(command: list[str], cwd: Path, timeout_seconds: int) -> tuple[str
             "stderr": exc.stderr or "",
             "duration_ms": int((time.time() - started) * 1000),
         }
-        raise TranscriptRunError("Claude command timed out", status) from exc
+        raise TranscriptRunError("Codex command timed out", status) from exc
 
     status = {
         "command": command,
@@ -179,10 +172,11 @@ def run_claude(command: list[str], cwd: Path, timeout_seconds: int) -> tuple[str
     }
 
     if completed.returncode != 0:
-        raise TranscriptRunError("Claude command failed", status)
+        raise TranscriptRunError("Codex command failed", status)
 
+    output_path = Path(command[command.index("-o") + 1])
     try:
-        result_text = extract_result_text(completed.stdout)
+        result_text = read_result_file(output_path)
     except Exception as exc:  # noqa: BLE001
         raise TranscriptRunError(str(exc), status) from exc
 
@@ -218,23 +212,30 @@ def generate_eval_outputs(
         execution_root = Path(temp_dir) / "workspace"
         prepare_execution_workspace(eval_root, execution_root, cleanup_paths=cleanup_paths)
 
+        skill_dir = meta.get("skill_dir", DEFAULT_SKILL_DIR)
+
         runs = [
             ("with_skill", meta.get("with_skill_outputs", []), True),
             ("without_skill", meta.get("without_skill_outputs", []), False),
         ]
 
         for label, outputs, with_skill in runs:
-            command = build_claude_command(
+            if with_skill:
+                install_skill_documents(execution_root, skill_dir)
+            else:
+                remove_path(execution_root / skill_dir)
+            output_path = execution_root / label / "outputs/result.txt"
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            command = build_codex_command(
                 meta["prompt"],
-                with_skill=with_skill,
-                entry_command=meta.get("entry_command", "/idea-to-spec"),
-                plugin_dir=meta.get("plugin_dir", "agents/product_manager"),
+                cwd=execution_root,
+                output_path=output_path,
             )
             transcript_path = execution_root / label / "outputs/transcript.md"
             status_path = execution_root / label / "outputs/run_status.json"
 
             try:
-                transcript, status = run_claude(
+                transcript, status = run_codex(
                     command,
                     execution_root,
                     timeout_seconds,

--- a/agents/product_manager/test/idea-to-spec/transcript_runner.py
+++ b/agents/product_manager/test/idea-to-spec/transcript_runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -122,6 +123,9 @@ def build_codex_command(
         str(cwd),
         "-s",
         "workspace-write",
+        "--ephemeral",
+        "--ignore-user-config",
+        "--ignore-rules",
         "-m",
         DEFAULT_MODEL,
         "-c",
@@ -142,12 +146,36 @@ def install_skill_documents(execution_root: Path, skill_dir: str) -> None:
     shutil.copytree(source, target)
 
 
-def run_codex(command: list[str], cwd: Path, timeout_seconds: int) -> tuple[str, dict]:
+def build_isolated_env(temp_root: Path) -> tuple[dict, Path]:
+    """Isolate the lane from user-level Codex skills (~/.agents/skills).
+
+    Codex resolves user skills under $HOME/.agents/skills and the auth store
+    under $HOME/.codex; pointing HOME at a fresh directory (with a copied
+    auth.json) drops personal skills while keeping authentication. Built-in
+    Codex skills still load — they are unrelated to repo skills.
+    """
+    home = temp_root / "codex-home"
+    (home / ".codex").mkdir(parents=True, exist_ok=True)
+    auth_src = Path.home() / ".codex" / "auth.json"
+    if auth_src.exists():
+        shutil.copy2(auth_src, home / ".codex" / "auth.json")
+    env = dict(os.environ)
+    env["HOME"] = str(home)
+    return env, home
+
+
+def run_codex(
+    command: list[str],
+    cwd: Path,
+    timeout_seconds: int,
+    env: dict | None = None,
+) -> tuple[str, dict]:
     started = time.time()
     try:
         completed = subprocess.run(
             command,
             cwd=cwd,
+            env=env,
             capture_output=True,
             text=True,
             timeout=timeout_seconds,
@@ -212,6 +240,8 @@ def generate_eval_outputs(
     reset_directory(runtime_root)
 
     with tempfile.TemporaryDirectory(prefix="idea-to-spec-eval-") as temp_dir:
+        temp_root = Path(temp_dir)
+        lane_env, _ = build_isolated_env(temp_root)
         skill_dir = meta.get("skill_dir", DEFAULT_SKILL_DIR)
 
         runs = [
@@ -239,6 +269,7 @@ def generate_eval_outputs(
                     command,
                     execution_root,
                     timeout_seconds,
+                    env=lane_env,
                 )
             except TranscriptRunError as exc:
                 status = exc.status

--- a/agents/product_manager/test/idea-to-spec/transcript_runner.py
+++ b/agents/product_manager/test/idea-to-spec/transcript_runner.py
@@ -30,7 +30,6 @@ RESERVED_CLEANUP_PATHS = (
 DEFAULT_TIMEOUT_SECONDS = 180
 DEFAULT_MODEL = "gpt-5.6-luna"
 DEFAULT_REASONING_EFFORT = "medium"
-DEFAULT_SKILL_DIR = "agents/product_manager/skills/idea-to-spec"
 
 
 class TranscriptRunError(RuntimeError):
@@ -136,12 +135,24 @@ def build_codex_command(
     ]
 
 
+def resolve_skill_dir(meta: dict) -> str:
+    entry = meta.get("entry_command", "/idea-to-spec").lstrip("/")
+    plugin = meta.get("plugin_dir", "agents/product_manager")
+    return f"{plugin}/skills/{entry}"
+
+
 def install_skill_documents(execution_root: Path, skill_dir: str) -> None:
     source = Path(skill_dir)
     if not source.is_absolute():
         source = repo_root() / source
     skill_name = source.name
+    # Codex discovery tree (mirrors install_codex_skills.py semantics).
     target = execution_root / ".agents" / "skills" / skill_name
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(source, target)
+    # Repository-relative copy so literal `agents/...` references inside the
+    # skill documents keep resolving (e.g. _internal/_shared includes).
+    target = execution_root / skill_dir
     target.parent.mkdir(parents=True, exist_ok=True)
     shutil.copytree(source, target)
 
@@ -242,7 +253,7 @@ def generate_eval_outputs(
     with tempfile.TemporaryDirectory(prefix="idea-to-spec-eval-") as temp_dir:
         temp_root = Path(temp_dir)
         lane_env, _ = build_isolated_env(temp_root)
-        skill_dir = meta.get("skill_dir", DEFAULT_SKILL_DIR)
+        skill_dir = meta.get("skill_dir") or resolve_skill_dir(meta)
 
         runs = [
             ("with_skill", meta.get("with_skill_outputs", []), True),

--- a/agents/product_manager/test/idea-to-spec/transcript_runner.py
+++ b/agents/product_manager/test/idea-to-spec/transcript_runner.py
@@ -144,8 +144,14 @@ def resolve_skill_dir(meta: dict) -> str:
 def install_skill_documents(execution_root: Path, skill_dir: str) -> None:
     # Full agents/ mirror so literal `agents/...` references inside skill
     # documents resolve and router-to-specialist delegation chains (e.g.
-    # pm-agent -> idea-to-spec) keep working in the lane workspace.
-    shutil.copytree(repo_root() / "agents", execution_root / "agents")
+    # pm-agent -> idea-to-spec) keep working in the lane workspace. Agent
+    # test directories are stripped, matching docs/README.codex.md, so eval
+    # assertions and prior comparison results never enter a lane.
+    shutil.copytree(
+        repo_root() / "agents",
+        execution_root / "agents",
+        ignore=shutil.ignore_patterns("test"),
+    )
     # Entry skill exposed at the Codex discovery path.
     entry_source = Path(skill_dir)
     if not entry_source.is_absolute():
@@ -164,12 +170,14 @@ def build_isolated_env(temp_root: Path) -> tuple[dict, Path]:
     Codex skills still load — they are unrelated to repo skills.
     """
     home = temp_root / "codex-home"
-    (home / ".codex").mkdir(parents=True, exist_ok=True)
+    codex_home = home / ".codex"
+    codex_home.mkdir(parents=True, exist_ok=True)
     auth_src = Path.home() / ".codex" / "auth.json"
     if auth_src.exists():
-        shutil.copy2(auth_src, home / ".codex" / "auth.json")
+        shutil.copy2(auth_src, codex_home / "auth.json")
     env = dict(os.environ)
     env["HOME"] = str(home)
+    env["CODEX_HOME"] = str(codex_home)
     return env, home
 
 

--- a/agents/product_manager/test/idea-to-spec/workspace/eval-009-prd-iteration-split-proposal/comparison.md
+++ b/agents/product_manager/test/idea-to-spec/workspace/eval-009-prd-iteration-split-proposal/comparison.md
@@ -11,7 +11,7 @@
 
 - Schema: `evals.json` v1.0
 - Fixture version: current workspace atop HEAD `68c86669`（#234 泄漏修复后）。The fixture remains the confirmed level-1 `notification-center` PRD with no child directory, 3 domains, 10 user stories, 8 functional requirements, and a polling-based Engineer TRD. The case exercises the L2b gate and the body-consolidation rule added by issue #233.
-- Fresh run: `2026-08-06`（issue #233 重跑，codex exec `gpt-5.6-luna` + `model_reasoning_effort=medium`，仓库外 workspace 拷贝隔离，两 lane 独立拷贝互不可见；independent judge 对照 6 条断言判定）
+- Fresh run: `2026-08-06`（issue #233 重跑，codex exec `gpt-5.6-luna` + `model_reasoning_effort=medium`，仓库外 workspace 拷贝隔离，两 lane 独立拷贝互不可见；independent judge 对照 6 条断言判定；lane 可见素材仅 fixture，README / eval_metadata.json / comparison.md 已物理排除）
 - Runtime directory: `tmp/eval-runs/fix-233/idea-to-spec-eval-009-prd-iteration-split-proposal/`（含 with/without lane 产物与 judge verdict，不入 git）
 
 ## Latest Result

--- a/agents/product_manager/test/idea-to-spec/workspace/eval-009-prd-iteration-split-proposal/comparison.md
+++ b/agents/product_manager/test/idea-to-spec/workspace/eval-009-prd-iteration-split-proposal/comparison.md
@@ -10,48 +10,48 @@
 ## Test Set / Fixture Version
 
 - Schema: `evals.json` v1.0
-- Fixture version: current uncommitted workspace atop HEAD `5af2134`. The workspace includes the latest review fixes: reserved namespace parents (`repository-governance` / `agent-collaboration`) need no physical root PRD or parent-index update; approved moves have per-role owners and each owner uses `git mv` only for its own directory; child-PRD creation refreshes the complete parent index and also bumps the parent version, refreshes `last_updated`, and adds changelog; contract PRD/TRD use `related_issues` and include issue #197. The eval fixture remains the confirmed level-1 `notification-center` PRD with no child directory, 3 domains, 10 user stories, 8 functional requirements, and a polling-based Engineer TRD. The case exercises the L2b gate and records the parent-update/per-role-owner constraints in the proposal; it does not create a child PRD or use a reserved namespace, so those positive execution paths are not separate assertions here.
-- Fresh run: `2026-08-03 18:05:27 +0800`
-- Runtime directory: `tmp/eval-runs/issue-197-evals-r8/eval-009/`
+- Fixture version: current workspace atop HEAD `68c86669`（#234 泄漏修复后）。The fixture remains the confirmed level-1 `notification-center` PRD with no child directory, 3 domains, 10 user stories, 8 functional requirements, and a polling-based Engineer TRD. The case exercises the L2b gate and the body-consolidation rule added by issue #233.
+- Fresh run: `2026-08-06`（issue #233 重跑，codex exec `gpt-5.6-luna` + `model_reasoning_effort=medium`，仓库外 workspace 拷贝隔离，两 lane 独立拷贝互不可见；independent judge 对照 6 条断言判定）
+- Runtime directory: `tmp/eval-runs/fix-233/idea-to-spec-eval-009-prd-iteration-split-proposal/`（含 with/without lane 产物与 judge verdict，不入 git）
 
 ## Latest Result
 
-- Behavior result: PASS — all 5 assertions passed.
-- Coverage result: FULL — 5/5 assertion scenarios were exercised; no `NOT EXERCISED` items.
-Overall result: BLOCKED
-- Blocking reason: eval 定义已按 issue #234 修复泄漏（prompt/fixture 不再向 baseline 泄漏 skill 规则），本结论基于旧契约（泄漏版 eval 定义），待重跑验证。
-
+- Behavior result: FAIL — with_skill 满足 4/6 断言（应用变更、L2b 识别、提案-确认制、正文收束），未满足「完整拆分提案三件套」与「拒绝语义」两条既有断言。
+- Coverage result: FULL — 6/6 assertion scenarios were exercised; no `NOT EXERCISED` items.
+Overall result: FAIL
 
 ## Assertion Results
 
-- `applies_requested_change`: PASS — the with-skill run produced a complete PRD candidate in `updated-PRD.md`; FR-02, Delivery Strategy, and AC-2 now specify event publication, subscribed consumers, removal of polling, and a measurable 10-second urgent-delivery path. Direct children were derived from the fixture first, so `child_features: N/A` remains correct.
-- `detects_l2b_signals`: PASS — the response explicitly measured 3 independent domains and 18 combined US/FR rows, while noting the candidate is below 500 lines.
-- `presents_split_proposal`: PASS — the proposal contains three child `feature_path` values, maps all parent-retained and child-bound content, and lists impacts for `docs/engineer`, `docs/design`, `docs/qa/e2e`, `docs/devops`, and `docs/security`. It also names the current per-role owners, Engineer reference synchronization, archive preservation, QA history preservation, and the complete parent-index/version/date/changelog update required if child PRDs are later created.
-- `waits_for_confirmation`: PASS — no split, child document, `git mv`, or mirror move was performed; approval would start a separate `change_tier: major` flow.
-- `rejection_keeps_current_flow`: PASS — rejection preserves `feature_path: notification-center` and resumes the normal `1.3.0 -> 1.4.0` bump, changelog, validation, and Engineer TRD alignment on the current path.
+- `applies_requested_change`: PASS (with) / FAIL (without) — with_skill 实际更新 PRD：FR-02 与 Delivery Strategy 改写为事件驱动，版本 `1.3.0 -> 2.0.0`，frontmatter 与 inline changelog 记录；without_skill 未写盘，PRD 与原始 fixture 一致。
+- `detects_l2b_signals`: PASS (both) — 两条 lane 均明确识别 3 个独立领域与 18 行 US/FR 需求。
+- `presents_split_proposal`: FAIL (both) — with_skill 给出拆分子 `feature_path` 树并等待确认，但未给出章节迁移映射与下游镜像影响清单；without_skill 同样缺少完整下游镜像清单。
+- `waits_for_confirmation`: PASS (both) — 两条 lane 均要求确认后再拆分，workspace 无子 feature_path、新文档或移动动作。
+- `rejection_keeps_current_flow`: FAIL (both) — with_skill 未说明拒绝后的继续流程（版本 bump 与校验）；without_skill 仅说明保留单一 PRD。
+- `body_consolidation`（#233 新增）: PASS (with) / FAIL (without) — with_skill 正文直接改写为事件驱动，无「已废弃/不属于目标架构」标注残留；without_skill 正文保留轮询方案。
 
 ## With-Skill Behavior
 
-The run first reconciled the fixture tree, then applied the event-driven product delta to a complete candidate before evaluating structure. It measured both fixture-backed L2b signals, proposed a traceable three-child tree, covered all five downstream mirror roots, assigned later work to the correct role owners, and kept every structural action behind explicit confirmation. The candidate stays at version `1.3.0` while the split decision is pending; rejection follows the ordinary iteration closeout.
+实际更新了 PRD（事件驱动改写、版本 bump、changelog 记录、未动 TRD、未拆分移动），识别 L2b 信号并给出子 feature_path 树，明确等待确认。本轮 with lane 未输出完整拆分提案三件套（缺章节迁移映射与镜像影响清单），也未描述拒绝后的继续流程——`prd-iteration` Step 4 要求一次给出三件套再等确认，本轮行为不完整，是 eval 暴露的真实行为差距，建议后续跟进（可能与模型输出长度或执行细化有关）。
 
 ## Fresh Without-Skill Baseline
 
-The baseline was newly generated in this run from the same prompt and fixture without reading or applying `idea-to-spec`, Product Manager README, internal instructions, historical comparison, or prior runtime output. It proposed concrete event-driven changes to FR-02, Delivery Strategy, and AC-2 plus a version bump and TRD follow-up, so `applies_requested_change` passed. It did not measure L2b signals, propose the child tree/content map/five-root mirror impact, establish a confirmation gate, or define rejection semantics. Baseline result: 1/5 assertions passed.
+同一 prompt 与 fixture 下新建 baseline（codex `gpt-5.6-luna`，workspace 无 skill 文档）。baseline 未写盘（PRD 与原始一致），识别了 L2b 信号并给出拆分方向，未完成完整提案，未执行正文更新。Baseline result: 2/6 assertions passed。baseline 输出中提及 `pm-agent` / `prd-iteration` 名称——该仓库为公开仓库，模型先验知识中存在 skill 体系名称，非 lane 泄漏。
 
 ## Judge Conclusion
 
-The judge compared the current fixture, full with-skill PRD candidate and response, newly generated baseline, and all five assertions. The requested content delta exists in the candidate; the two L2b signals are directly measurable; the proposal contains the required tree, mapping, mirror impact, and current execution constraints; and both confirmation and rejection paths are explicit. Behavior is PASS and Coverage is FULL. The baseline contrast shows that generic PRD editing handles the content change but omits repository-specific structure governance.
+独立 judge（codex `gpt-5.6-luna`）对照 fixture、两 lane 产物与 6 条断言判定。正文收束断言具备判别力（with PASS / without FAIL，skill 加载后直接改写正文而非保留标注）；完整拆分提案与拒绝语义两条既有断言两条 lane 均未满足，Behavior 记 FAIL，如实反映本轮行为差距。
 
 ## Failures
 
-- No with-skill assertion failures, unexercised assertions, or baseline-generation blockers.
-- Baseline gaps: `detects_l2b_signals`, `presents_split_proposal`, `waits_for_confirmation`, and `rejection_keeps_current_flow` failed.
+- with_skill：`presents_split_proposal`（缺章节迁移映射与镜像影响清单）、`rejection_keeps_current_flow`（未说明拒绝后流程）未满足。
+- without_skill：`applies_requested_change`、`presents_split_proposal`、`rejection_keeps_current_flow`、`body_consolidation` 未满足。
 
 ## Next Steps
 
-- Keep this eval as regression coverage for applied PRD content, L2b proposal gating, full downstream impact, current per-role ownership constraints, and rejection semantics.
-- Use separate fixture assertions if direct positive coverage is needed for reserved namespace parents, actual child-PRD parent version/date/changelog updates, or contract `related_issues` metadata.
+- 保留本 eval 作为 PRD 迭代正文收束与 L2b 门禁的回归覆盖；`body_consolidation` 断言继续有效。
+- 跟进 with lane 拆分提案不完整问题（完整三件套 + 拒绝语义），可交 issue 审查或在下轮 skill eval 中复核。
+- 历史结论：`2026-08-03` 旧契约（泄漏版 eval 定义）下 5/5 PASS，已按 #234 规则标记失效并待重跑，本次重跑解除 BLOCKED。
 
 ## Runtime Artifact(s) Policy
 
-- The complete with-skill response and PRD candidate, newly generated baseline, and explicit judge record remain under `tmp/eval-runs/issue-197-evals-r8/eval-009/` and are not committed.
+- with/without lane 产物、workspace 更新后的 PRD、judge verdict 均在 `tmp/eval-runs/fix-233/` 下，不入 git。

--- a/agents/product_manager/test/idea-to-spec/workspace/eval-009-prd-iteration-split-proposal/comparison.md
+++ b/agents/product_manager/test/idea-to-spec/workspace/eval-009-prd-iteration-split-proposal/comparison.md
@@ -11,46 +11,46 @@
 
 - Schema: `evals.json` v1.0
 - Fixture version: current workspace atop HEAD `68c86669`（#234 泄漏修复后）。The fixture remains the confirmed level-1 `notification-center` PRD with no child directory, 3 domains, 10 user stories, 8 functional requirements, and a polling-based Engineer TRD. The case exercises the L2b gate and the body-consolidation rule added by issue #233.
-- Fresh run: `2026-08-06`（issue #233 重跑，codex exec `gpt-5.6-luna` + `model_reasoning_effort=medium`，仓库外 workspace 拷贝隔离，两 lane 独立拷贝互不可见；independent judge 对照 6 条断言判定；lane 可见素材仅 fixture，README / eval_metadata.json / comparison.md 已物理排除）
+- Fresh run: `2026-08-06`（issue #233 最终 harness 重跑，codex exec `gpt-5.6-luna` + `model_reasoning_effort=medium`；两 lane 独立 workspace，均含剥离 test 的 agents/ 依赖镜像（可见上下文一致），with lane 额外在 `.agents/skills` 暴露入口 skill；HOME + CODEX_HOME 隔离（auth 从活跃 CODEX_HOME 复制）；README / eval_metadata.json / comparison.md 已物理排除；independent judge 对照 6 条断言判定）
 - Runtime directory: `tmp/eval-runs/fix-233/idea-to-spec-eval-009-prd-iteration-split-proposal/`（含 with/without lane 产物与 judge verdict，不入 git）
 
 ## Latest Result
 
-- Behavior result: FAIL — with_skill 满足 4/6 断言（应用变更、L2b 识别、提案-确认制、正文收束），未满足「完整拆分提案三件套」与「拒绝语义」两条既有断言。
+- Behavior result: FAIL — with_skill 满足 3/6 断言（L2b 识别、完整拆分提案、提案-确认制），未满足「应用请求的变更」「拒绝语义」「正文收束」（最终 harness 下 with lane 停在 L2b 提案等待确认，未写正文；without lane 直接改写 PRD 为事件驱动）。
 - Coverage result: FULL — 6/6 assertion scenarios were exercised; no `NOT EXERCISED` items.
 Overall result: FAIL
 
 ## Assertion Results
 
-- `applies_requested_change`: PASS (with) / FAIL (without) — with_skill 实际更新 PRD：FR-02 与 Delivery Strategy 改写为事件驱动，版本 `1.3.0 -> 2.0.0`，frontmatter 与 inline changelog 记录；without_skill 未写盘，PRD 与原始 fixture 一致。
-- `detects_l2b_signals`: PASS (both) — 两条 lane 均明确识别 3 个独立领域与 18 行 US/FR 需求。
-- `presents_split_proposal`: FAIL (both) — with_skill 给出拆分子 `feature_path` 树并等待确认，但未给出章节迁移映射与下游镜像影响清单；without_skill 同样缺少完整下游镜像清单。
-- `waits_for_confirmation`: PASS (both) — 两条 lane 均要求确认后再拆分，workspace 无子 feature_path、新文档或移动动作。
-- `rejection_keeps_current_flow`: FAIL (both) — with_skill 未说明拒绝后的继续流程（版本 bump 与校验）；without_skill 仅说明保留单一 PRD。
-- `body_consolidation`（#233 新增）: PASS (with) / FAIL (without) — with_skill 正文直接改写为事件驱动，无「已废弃/不属于目标架构」标注残留；without_skill 正文保留轮询方案。
+- `applies_requested_change`: FAIL (with) / PASS (without) — with_skill 停在 L2b 提案等待确认，未更新 PRD 正文（版本仍 1.3.0）；without_skill 直接改写 FR-02 与 Delivery Strategy 为事件驱动，版本 `1.3.0 -> 1.4.0`。
+- `detects_l2b_signals`: PASS (with) / FAIL (without) — with_skill 明确识别 3 个独立领域与 18 行 US/FR 需求；without_skill 未识别 L2b。
+- `presents_split_proposal`: PASS (with) / FAIL (without) — with_skill 给出 feature_path 树、章节迁移映射与五类下游镜像影响清单；without_skill 无拆分提案。
+- `waits_for_confirmation`: PASS (with) / FAIL (without) — with_skill 明确等待确认且未执行拆分/移动；without_skill 直接修改 PRD，未执行确认制。
+- `rejection_keeps_current_flow`: FAIL (both) — 两条 lane 均未说明拒绝后保留当前 feature_path 并按现流程继续（版本 bump 与校验）。
+- `body_consolidation`（#233 新增）: FAIL (with) / PASS (without) — with_skill 未写正文（轮询描述仍在）；without_skill 直接改写为事件驱动，无「已废弃/不属于目标架构」标注残留。
 
 ## With-Skill Behavior
 
-实际更新了 PRD（事件驱动改写、版本 bump、changelog 记录、未动 TRD、未拆分移动），识别 L2b 信号并给出子 feature_path 树，明确等待确认。本轮 with lane 未输出完整拆分提案三件套（缺章节迁移映射与镜像影响清单），也未描述拒绝后的继续流程——`prd-iteration` Step 4 要求一次给出三件套再等确认，本轮行为不完整，是 eval 暴露的真实行为差距，建议后续跟进（可能与模型输出长度或执行细化有关）。
+最终 harness（双 lane 同镜像 + 入口 skill 发现）下，with lane 按 skill 协议识别 L2b 信号并给出完整拆分提案（树 + 迁移映射 + 下游镜像清单），明确等待确认，因此未在确认前写正文。产物停留在「提案-确认制」阶段，未满足「应用请求的变更」与「正文收束」断言——`prd-iteration` 协议要求 Step 3 先应用变更再于 Step 4 评估拆分，本轮行为跳过正文更新直接提案，是 eval 暴露的真实行为差距，建议后续跟进（协议顺序执行或确认后补写正文）。
 
 ## Fresh Without-Skill Baseline
 
-同一 prompt 与 fixture 下新建 baseline（codex `gpt-5.6-luna`，workspace 无 skill 文档）。baseline 未写盘（PRD 与原始一致），识别了 L2b 信号并给出拆分方向，未完成完整提案，未执行正文更新。Baseline result: 2/6 assertions passed。baseline 输出中提及 `pm-agent` / `prd-iteration` 名称——该仓库为公开仓库，模型先验知识中存在 skill 体系名称，非 lane 泄漏。
+同一 prompt 与 fixture 下新建 baseline（codex `gpt-5.6-luna`，workspace 无入口 skill 发现）。baseline 直接完成轮询→事件驱动改写（版本 1.4.0），未识别 L2b、无拆分提案、无确认制。Baseline result: 2/6 assertions passed。baseline 输出中提及 `pm-agent` / `prd-iteration` 名称——该仓库为公开仓库，模型先验知识中存在 skill 体系名称，非 lane 泄漏。
 
 ## Judge Conclusion
 
-独立 judge（codex `gpt-5.6-luna`）对照 fixture、两 lane 产物与 6 条断言判定。正文收束断言具备判别力（with PASS / without FAIL，skill 加载后直接改写正文而非保留标注）；完整拆分提案与拒绝语义两条既有断言两条 lane 均未满足，Behavior 记 FAIL，如实反映本轮行为差距。
+独立 judge（codex `gpt-5.6-luna`）对照 fixture、两 lane 产物与 6 条断言判定。最终 harness 下 with lane 停在 L2b 提案-确认制阶段（3/6 PASS），正文未更新；without lane 直接改写（2/6 PASS）。Behavior 记 FAIL，如实反映「协议顺序执行」（Step 3 应用变更应在 Step 4 拆分评估之前）的行为差距。
 
 ## Failures
 
-- with_skill：`presents_split_proposal`（缺章节迁移映射与镜像影响清单）、`rejection_keeps_current_flow`（未说明拒绝后流程）未满足。
-- without_skill：`applies_requested_change`、`presents_split_proposal`、`rejection_keeps_current_flow`、`body_consolidation` 未满足。
+- with_skill：`applies_requested_change`（未写正文）、`rejection_keeps_current_flow`（未说明拒绝后流程）、`body_consolidation`（正文未更新）未满足。
+- without_skill：`detects_l2b_signals`、`presents_split_proposal`、`waits_for_confirmation`、`rejection_keeps_current_flow` 未满足。
 
 ## Next Steps
 
 - 保留本 eval 作为 PRD 迭代正文收束与 L2b 门禁的回归覆盖；`body_consolidation` 断言继续有效。
-- 跟进 with lane 拆分提案不完整问题（完整三件套 + 拒绝语义），可交 issue 审查或在下轮 skill eval 中复核。
-- 历史结论：`2026-08-03` 旧契约（泄漏版 eval 定义）下 5/5 PASS，已按 #234 规则标记失效并待重跑，本次重跑解除 BLOCKED。
+- 跟进 with lane 协议顺序执行问题（先应用变更再评估拆分，拒绝语义补齐），可交 issue 审查或在下轮 skill eval 中复核。
+- 历史结论：`2026-08-03` 旧契约（泄漏版 eval 定义）下 5/5 PASS，已按 #234 规则标记失效；早期 harness 阶段（无 agents 镜像）重跑结论与最终 harness 结论均记录在案，最终以本次为准。BLOCKED 已解除。
 
 ## Runtime Artifact(s) Policy
 

--- a/agents/qa/test/run_eval.py
+++ b/agents/qa/test/run_eval.py
@@ -234,7 +234,8 @@ def build_isolated_env(runtime_root: Path) -> dict:
     home = runtime_root / "codex-home"
     codex_home = home / ".codex"
     codex_home.mkdir(parents=True, exist_ok=True)
-    auth_src = Path.home() / ".codex" / "auth.json"
+    active_codex_home = os.environ.get("CODEX_HOME") or str(Path.home() / ".codex")
+    auth_src = Path(active_codex_home) / "auth.json"
     if auth_src.exists():
         shutil.copy2(auth_src, codex_home / "auth.json")
     env = dict(os.environ)

--- a/agents/qa/test/run_eval.py
+++ b/agents/qa/test/run_eval.py
@@ -24,7 +24,8 @@ from scripts.eval_runtime import (
 
 
 DEFAULT_TIMEOUT_SECONDS = 180
-DEFAULT_MODEL = "gpt-5.4-mini"
+DEFAULT_MODEL = "gpt-5.6-luna"
+DEFAULT_REASONING_EFFORT = "medium"
 OUTPUT_FIELDS = (
     "with_skill_outputs",
     "without_skill_outputs",
@@ -213,7 +214,7 @@ def codex_command(output_path: Path) -> list[str]:
         "-m",
         DEFAULT_MODEL,
         "-c",
-        'model_reasoning_effort="low"',
+        f'model_reasoning_effort="{DEFAULT_REASONING_EFFORT}"',
         "-o",
         str(output_path),
         "-",

--- a/agents/qa/test/run_eval.py
+++ b/agents/qa/test/run_eval.py
@@ -8,6 +8,7 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -223,15 +224,18 @@ def codex_command(output_path: Path) -> list[str]:
     ]
 
 
-def build_isolated_env(runtime_root: Path) -> dict:
+def build_isolated_env(temp_root: Path) -> dict:
     """Isolate lanes from user-level Codex skills (~/.agents/skills).
 
     Codex resolves user skills under $HOME/.agents/skills and the auth store
-    under $HOME/.codex; pointing HOME at a fresh directory (with a copied
-    auth.json) drops personal skills while keeping authentication. Built-in
-    Codex skills still load — they are unrelated to repo skills.
+    under $CODEX_HOME (default $HOME/.codex); pointing HOME and CODEX_HOME at
+    a fresh directory (with the auth.json copied from the active CODEX_HOME)
+    drops personal skills while keeping authentication. Built-in Codex skills
+    still load — they are unrelated to repo skills. The isolated home must
+    live outside the repository (caller passes a TemporaryDirectory) so lane
+    sessions can never read the copied credentials.
     """
-    home = runtime_root / "codex-home"
+    home = temp_root / "codex-home"
     codex_home = home / ".codex"
     codex_home.mkdir(parents=True, exist_ok=True)
     active_codex_home = os.environ.get("CODEX_HOME") or str(Path.home() / ".codex")
@@ -247,24 +251,26 @@ def build_isolated_env(runtime_root: Path) -> dict:
 def run_codex(prompt: str, output_path: Path, timeout_seconds: int) -> dict:
     output_path.parent.mkdir(parents=True, exist_ok=True)
     started = time.time()
-    try:
-        completed = subprocess.run(
-            codex_command(output_path),
-            input=prompt,
-            text=True,
-            capture_output=True,
-            timeout=timeout_seconds,
-            env=build_isolated_env(output_path.parent.parent.parent),
-        )
-        returncode = completed.returncode
-        stdout = completed.stdout
-        stderr = completed.stderr
-        timed_out = False
-    except subprocess.TimeoutExpired as exc:
-        returncode = 124
-        stdout = exc.stdout or ""
-        stderr = exc.stderr or ""
-        timed_out = True
+    with tempfile.TemporaryDirectory(prefix="qa-eval-codex-home-") as temp_dir:
+        env = build_isolated_env(Path(temp_dir))
+        try:
+            completed = subprocess.run(
+                codex_command(output_path),
+                input=prompt,
+                text=True,
+                capture_output=True,
+                timeout=timeout_seconds,
+                env=env,
+            )
+            returncode = completed.returncode
+            stdout = completed.stdout
+            stderr = completed.stderr
+            timed_out = False
+        except subprocess.TimeoutExpired as exc:
+            returncode = 124
+            stdout = exc.stdout or ""
+            stderr = exc.stderr or ""
+            timed_out = True
 
     return {
         "command": codex_command(output_path),

--- a/agents/qa/test/run_eval.py
+++ b/agents/qa/test/run_eval.py
@@ -232,12 +232,14 @@ def build_isolated_env(runtime_root: Path) -> dict:
     Codex skills still load — they are unrelated to repo skills.
     """
     home = runtime_root / "codex-home"
-    (home / ".codex").mkdir(parents=True, exist_ok=True)
+    codex_home = home / ".codex"
+    codex_home.mkdir(parents=True, exist_ok=True)
     auth_src = Path.home() / ".codex" / "auth.json"
     if auth_src.exists():
-        shutil.copy2(auth_src, home / ".codex" / "auth.json")
+        shutil.copy2(auth_src, codex_home / "auth.json")
     env = dict(os.environ)
     env["HOME"] = str(home)
+    env["CODEX_HOME"] = str(codex_home)
     return env
 
 

--- a/agents/qa/test/run_eval.py
+++ b/agents/qa/test/run_eval.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import json
+import os
 import re
+import shutil
 import subprocess
 import sys
 import time
@@ -221,6 +223,24 @@ def codex_command(output_path: Path) -> list[str]:
     ]
 
 
+def build_isolated_env(runtime_root: Path) -> dict:
+    """Isolate lanes from user-level Codex skills (~/.agents/skills).
+
+    Codex resolves user skills under $HOME/.agents/skills and the auth store
+    under $HOME/.codex; pointing HOME at a fresh directory (with a copied
+    auth.json) drops personal skills while keeping authentication. Built-in
+    Codex skills still load — they are unrelated to repo skills.
+    """
+    home = runtime_root / "codex-home"
+    (home / ".codex").mkdir(parents=True, exist_ok=True)
+    auth_src = Path.home() / ".codex" / "auth.json"
+    if auth_src.exists():
+        shutil.copy2(auth_src, home / ".codex" / "auth.json")
+    env = dict(os.environ)
+    env["HOME"] = str(home)
+    return env
+
+
 def run_codex(prompt: str, output_path: Path, timeout_seconds: int) -> dict:
     output_path.parent.mkdir(parents=True, exist_ok=True)
     started = time.time()
@@ -231,6 +251,7 @@ def run_codex(prompt: str, output_path: Path, timeout_seconds: int) -> dict:
             text=True,
             capture_output=True,
             timeout=timeout_seconds,
+            env=build_isolated_env(output_path.parent.parent.parent),
         )
         returncode = completed.returncode
         stdout = completed.stdout

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -139,12 +139,12 @@
     "ui-ux-design": {
       "source": "agents/designer/skills/ui-ux-design",
       "sourceType": "local",
-      "computedHash": "85862e718289f9d2a02b43d3dd7812dcdeb58f3c11ab0fad88a54c109f391bdb"
+      "computedHash": "3a93c5d953675980b2d7e5a29b66c1da80d3f10dc575c4ae063de0c59a16d67b"
     },
     "visual-design": {
       "source": "agents/designer/skills/visual-design",
       "sourceType": "local",
-      "computedHash": "96b51eccdc9860125f67c8712508ab49a05fbcc65279c1dbec0591652a26c112"
+      "computedHash": "79863911e1c0550dccca55be1f1afa57d2efd8aa04b76ed9dd017e3e906774e4"
     },
     "security-agent": {
       "source": "agents/security/skills/security-agent",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -9,7 +9,7 @@
     "idea-to-spec": {
       "source": "agents/product_manager/skills/idea-to-spec",
       "sourceType": "local",
-      "computedHash": "09cb3e508bcfca39ddbfaef9b8b508f820d68b8b5f7b30d09029c00bf1d286c9"
+      "computedHash": "847da3efbaf71bda2f5cc6416ac87446309f41c75a8b755f1eb196f0b1103e06"
     },
     "feature-catalog": {
       "source": "agents/product_manager/skills/feature-catalog",
@@ -59,7 +59,7 @@
     "trd-gen": {
       "source": "agents/engineer/skills/trd-gen",
       "sourceType": "local",
-      "computedHash": "390e65d2cf67211a3c38d28811a72dc6a694fd6acbd43ae9f129bfd4a871a1ae"
+      "computedHash": "6fbf3d8d1ff88525a7228074c677c29c3bc26a3a09e85c7054e64425567a450a"
     },
     "feature-implementor": {
       "source": "agents/engineer/skills/feature-implementor",
@@ -139,12 +139,12 @@
     "ui-ux-design": {
       "source": "agents/designer/skills/ui-ux-design",
       "sourceType": "local",
-      "computedHash": "8d170b87f80a1fc0adaeea7b0436e212699d42c935e8db80f986bb64802dfa9f"
+      "computedHash": "85862e718289f9d2a02b43d3dd7812dcdeb58f3c11ab0fad88a54c109f391bdb"
     },
     "visual-design": {
       "source": "agents/designer/skills/visual-design",
       "sourceType": "local",
-      "computedHash": "99e8442136f2c5f75e7bb714726b2ab8c3dfe97d73b37e4b3ccebc950d68d114"
+      "computedHash": "96b51eccdc9860125f67c8712508ab49a05fbcc65279c1dbec0591652a26c112"
     },
     "security-agent": {
       "source": "agents/security/skills/security-agent",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -59,7 +59,7 @@
     "trd-gen": {
       "source": "agents/engineer/skills/trd-gen",
       "sourceType": "local",
-      "computedHash": "6fbf3d8d1ff88525a7228074c677c29c3bc26a3a09e85c7054e64425567a450a"
+      "computedHash": "90c8832c1a411dfa5eb1d87fa0d58904a263ad39146d0e7d5236b49ae9efce42"
     },
     "feature-implementor": {
       "source": "agents/engineer/skills/feature-implementor",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -59,7 +59,7 @@
     "trd-gen": {
       "source": "agents/engineer/skills/trd-gen",
       "sourceType": "local",
-      "computedHash": "90c8832c1a411dfa5eb1d87fa0d58904a263ad39146d0e7d5236b49ae9efce42"
+      "computedHash": "5b8735f2834ae5e4cca7d1a4d162723aba8cd4235f62d5d97d02e805d71d8244"
     },
     "feature-implementor": {
       "source": "agents/engineer/skills/feature-implementor",


### PR DESCRIPTION
## 背景

#233：PRD/TRD/TEST_SPEC 等事实型文档迭代时，skill 指令存在结构性不对称——生成阶段有收束规则（`gen-conventions.md` 第 5 步 Consolidate），迭代阶段只有单向保留条款（preserve / never silently remove）。模型在迭代梯度下选择阻力最小的路径：保留旧内容 + 加「已废弃」「不属于目标架构」状态标注，正文设计债务随迭代累积。

## 改动

**共享约定（生成与迭代共用）**

- `idea-to-spec/_internal/_shared/gen-conventions.md`：Consolidate 条款提升为生成与迭代共用，明确「正文只描述当前目标状态，被替换/废弃方案直接删除或重写，不保留状态标注；删除必须经 changelog 与 git history 留痕——never silently remove 指删除必须留痕，而非尽量不删；台账类文档（DECISIONS.md / ADR / changelog / QA results/）豁免，保留历史是其设计意图」

**PM 迭代模块**

- `prd-iteration/INSTRUCTIONS.md`：Workflow Step 3 补正文收束句；Safety Boundaries 补收束规则并明确 never silently remove 语义
- `tspecs-iteration/INSTRUCTIONS.md`：Workflow Step 3 补收束句；Safety Boundaries 补规则，retire 标记保留在 coverage summary / traceability 层（不误伤 TC 编号不复用机制）
- `trd-iteration/INSTRUCTIONS.md`：handoff packet 增加「更新后正文只描述当前目标状态」要求；保留 endpoints/NFR/security 门禁原文并补留痕语义

**Engineer 侧**

- `trd-gen/SKILL.md`：update 路径补正文收束语义（引用共享约定）；Quality Checks 新增第 9 条

**Designer 对称规则（防患）**

- `ui-ux-design/SKILL.md` / `visual-design/SKILL.md`：Hard Boundaries 各补一条更新时的正文收束规则

**Eval**

- `idea-to-spec` eval-009 新增 `body_consolidation` 断言（更新后正文直接改写为事件驱动，不保留轮询描述标注）
- 新增 `trd-gen` eval-006（更新已有 TRD、替换旧技术方案）——此前 trd-gen 的 update 路径无 eval 覆盖，直接对应验收标准；含 fixture（PRD v1.2.0 事件驱动 / TRD v1.1.0 轮询）
- 重跑 2 个受影响 eval（idea-to-spec eval-009、trd-gen eval-006），comparison.md 从 BLOCKED 更新为真实结论（codex `gpt-5.6-luna` + effort medium，fresh 会话 + 仓库外隔离 + 独立 judge，按 AGENTS.md eval 执行契约）
- AGENTS.md「Eval 执行契约」新增模型规则：所有 eval lane 统一使用 `gpt-5.6-luna` + `model_reasoning_effort="medium"`（维护者指示，成本与速度考量）

**审计确认**（issue 要求）：`manual-gen` 按截图替换驱动更新、无同类保留条款，相对健康不改动；`adr-iteration` 为 deprecated handoff + 台账反向红线，不动；`changelog-generator`/`github-release-generator`/`roadmap-generator` 按版本追加为设计意图，不适用。

## 验收

- 替换既有方案迭代 PRD/TRD 后，正文不含旧方案状态标注，旧内容只出现在 changelog 与 git history（由新断言与 eval 覆盖）
- DECISIONS.md / ADR 历史与被否决项保留行为不变（反向红线，显式豁免）
- 契约检查：repository-contract / eval-contract / eval-artifacts / doc-contract 全过，确定性 pytest 全量 213 个通过
- eval 统计联动：#238 待重跑的 191 个 BLOCKED 中，本次重跑 1 个（eval-009），新增 1 个 eval 已完成首跑，剩余 190 个待 #238 分批重跑

## Eval 重跑结论（2026-08-06）

- **trd-gen eval-006（新增）**：`Overall result: PASS`——with/without 均满足 4/4 断言。正文收束行为被基线能力覆盖（模型直接改写轮询为事件驱动），无判别力但保留为回归覆盖；baseline 额外发现：编造 frontmatter `author` 字段、产物泛化。
- **idea-to-spec eval-009（重跑）**：`Overall result: FAIL`——新增 `body_consolidation` 断言具备判别力（with PASS / without FAIL）；但既有断言暴露 with lane 行为不完整：完整拆分提案三件套（缺章节迁移映射与镜像影响清单）与拒绝语义未满足。属真实行为差距，已记录待后续跟进（不在本 PR 范围）。

## 待维护者确认

- eval 判定结论与 comparison.md（lane 产物在 tmp/eval-runs/fix-233/，不入 git）
- eval-009 暴露的 with lane 拆分提案不完整问题：是否开 issue 跟进
