### PR TITLE
feat(docs): 文档站侧栏 nav_order 排序机制与 eval 断言增强 (#231, #239)

### DIFF
--- a/agents/docs/skills/docs-agent/_internal/_shared/frontmatter-contract.md
+++ b/agents/docs/skills/docs-agent/_internal/_shared/frontmatter-contract.md
@@ -82,6 +82,8 @@ upgrade) before the field can take effect.
 - `release-notes-gen` must apply this contract to versioned site Release
   Notes and keep `last_verified_version: unverified` until `docs-audit` owns the
   version-stamping sequence.
+- `manual-gen` must apply this contract to every illustrated manual page it
+  creates or updates, including the `nav_order` host-capability gate.
 - `docs-audit` must use this contract for frontmatter decisions. A page with
   invalid frontmatter is `stale`, and a release must not `proceed` while any
   such page remains in scope.

--- a/agents/docs/skills/docs-agent/_internal/_shared/frontmatter-contract.md
+++ b/agents/docs/skills/docs-agent/_internal/_shared/frontmatter-contract.md
@@ -30,12 +30,22 @@ All seven fields are unconditionally required.
 
 | Field | Type / Allowed Values | Rule |
 | --- | --- | --- |
-| `nav_order` | Non-negative integer | Controls the display order of pages inside the same sidebar section. Lower values sort first; pages without `nav_order` fall back to path-slug lexicographic order and sort after any explicit order. Only the immediate section is affected — it never reorders sections, which follow the fixed `SECTION_ORDER`. |
+| `nav_order` | Non-negative safe integer (`≤ 9007199254740991`) | Controls the display order of pages inside the same sidebar section. Lower values sort first; pages without `nav_order` fall back to path-slug lexicographic order and sort after any explicit order. Only the immediate section is affected — it never reorders sections, which follow the fixed `SECTION_ORDER`. The safe-integer bound matches the host validator (`Number.isSafeInteger`); larger integers cannot be represented exactly and are rejected. |
 
 Producers set `nav_order` when a section's pages need a business-logic order
 that path slugs cannot express (for example, keeping overview pages first or
 grouping related feature pages). When a section reads naturally in slug order,
 omit `nav_order` and keep the page set minimal.
+
+Before emitting `nav_order`, every producer (including `formal-docs-sync` and
+`release-notes-gen`) must confirm the host's delivered navigation generator
+supports it: the host `docs/site/scripts/lib/sidebar.mjs` must reference
+`nav_order` in its ordering logic. Delivered bootstrap assets are not upgraded
+automatically — a host bootstrapped before the `nav_order` capability shipped
+would ignore the field while the producer reports an intended sequence. If
+host support is missing, do not write `nav_order`; report in the batch summary
+that the host must rerun `docs-site-bootstrap` (or merge a confirmed bootstrap
+upgrade) before the field can take effect.
 
 ## Notes
 

--- a/agents/docs/skills/docs-agent/_internal/_shared/frontmatter-contract.md
+++ b/agents/docs/skills/docs-agent/_internal/_shared/frontmatter-contract.md
@@ -26,6 +26,17 @@ All seven fields are unconditionally required.
 | `related_code` | Non-empty array of strings | Defines the code and test evidence scope for every page type. |
 | `last_verified_version` | Non-empty string | Stores a version anchor or the literal value `unverified`. |
 
+## Optional Fields
+
+| Field | Type / Allowed Values | Rule |
+| --- | --- | --- |
+| `nav_order` | Non-negative integer | Controls the display order of pages inside the same sidebar section. Lower values sort first; pages without `nav_order` fall back to path-slug lexicographic order and sort after any explicit order. Only the immediate section is affected — it never reorders sections, which follow the fixed `SECTION_ORDER`. |
+
+Producers set `nav_order` when a section's pages need a business-logic order
+that path slugs cannot express (for example, keeping overview pages first or
+grouping related feature pages). When a section reads naturally in slug order,
+omit `nav_order` and keep the page set minimal.
+
 ## Notes
 
 - `standard` is not a valid `doc_type` value. Standards explanation pages

--- a/agents/docs/skills/docs-agent/_internal/_shared/frontmatter-contract.md
+++ b/agents/docs/skills/docs-agent/_internal/_shared/frontmatter-contract.md
@@ -3,9 +3,10 @@
 > Single source of truth owned by `docs-agent` for the default frontmatter
 > contract of formal Markdown pages under `docs/site/`.
 > `docs-site-bootstrap` consumes it for built-in pages, templates, and the
-> validation script delivered to host repositories; `formal-docs-sync` and
-> `release-notes-gen` consume it for created or updated pages; and
-> `docs-audit` consumes it for frontmatter decisions. Producers and auditors
+> validation script delivered to host repositories; `formal-docs-sync`,
+> `release-notes-gen`, and `manual-gen` consume it for created or updated
+> pages; and `docs-audit` consumes it for frontmatter decisions. Producers and
+> auditors
 > must reach the same conclusion for the same page.
 
 The initial rules were migrated from the verified AI Hub implementation for

--- a/agents/docs/skills/docs-audit/_internal/INSTRUCTIONS.md
+++ b/agents/docs/skills/docs-audit/_internal/INSTRUCTIONS.md
@@ -225,9 +225,10 @@ Check the seven required fields and their constraints:
 | `owners` | non-empty string array |
 | `related_code` | non-empty string array of repository-relative paths or globs for every `doc_type` |
 | `last_verified_version` | non-empty version anchor string or `unverified`; always required, including when the host has no version anchor |
+| `nav_order` | optional; when present must be a non-negative integer |
 
-An invalid field, invalid enum, invalid `related_code`, or invalid
-version field makes the page `stale` immediately. The literal `unverified` and
+An invalid field, invalid enum, invalid `related_code`, invalid `nav_order`,
+or invalid version field makes the page `stale` immediately. The literal `unverified` and
 an older release anchor are valid version values, not `stale` conclusions. They
 lower trust and require broader code and test verification; after the complete
 affected set is `verified`, the unified stamp step advances them to the current

--- a/agents/docs/skills/docs-audit/_internal/INSTRUCTIONS.md
+++ b/agents/docs/skills/docs-audit/_internal/INSTRUCTIONS.md
@@ -232,6 +232,15 @@ or invalid version field makes the page `stale` immediately. The literal `unveri
 an older release anchor are valid version values, not `stale` conclusions. They
 lower trust and require broader code and test verification; after the complete
 affected set is `verified`, the unified stamp step advances them to the current
+
+When any affected page declares `nav_order`, also verify the host generator
+supports it: the host `docs/site/scripts/lib/sidebar.mjs` must reference
+`nav_order` in its ordering logic. Delivered bootstrap assets are not upgraded
+automatically, so a host bootstrapped before the capability shipped would
+ignore the field while the audit stamps the page and returns release readiness
+for a navigation order that is not applied. On an unsupported host, stay
+`blocked` and require a `docs-site-bootstrap` rerun (or a confirmed bootstrap
+upgrade merge) before completing the audit.
 version anchor.
 
 ### Step 6: Classify deterministic findings

--- a/agents/docs/skills/docs-audit/_internal/INSTRUCTIONS.md
+++ b/agents/docs/skills/docs-audit/_internal/INSTRUCTIONS.md
@@ -225,7 +225,7 @@ Check the seven required fields and their constraints:
 | `owners` | non-empty string array |
 | `related_code` | non-empty string array of repository-relative paths or globs for every `doc_type` |
 | `last_verified_version` | non-empty version anchor string or `unverified`; always required, including when the host has no version anchor |
-| `nav_order` | optional; when present must be a non-negative integer |
+| `nav_order` | optional; when present must be a non-negative safe integer (`≤ 9007199254740991`) |
 
 An invalid field, invalid enum, invalid `related_code`, invalid `nav_order`,
 or invalid version field makes the page `stale` immediately. The literal `unverified` and

--- a/agents/docs/skills/docs-audit/_internal/INSTRUCTIONS.md
+++ b/agents/docs/skills/docs-audit/_internal/INSTRUCTIONS.md
@@ -232,6 +232,7 @@ or invalid version field makes the page `stale` immediately. The literal `unveri
 an older release anchor are valid version values, not `stale` conclusions. They
 lower trust and require broader code and test verification; after the complete
 affected set is `verified`, the unified stamp step advances them to the current
+version anchor.
 
 When any affected page declares `nav_order`, also verify the host generator
 supports it: the host `docs/site/scripts/lib/sidebar.mjs` must reference
@@ -241,7 +242,6 @@ ignore the field while the audit stamps the page and returns release readiness
 for a navigation order that is not applied. On an unsupported host, stay
 `blocked` and require a `docs-site-bootstrap` rerun (or a confirmed bootstrap
 upgrade merge) before completing the audit.
-version anchor.
 
 ### Step 6: Classify deterministic findings
 

--- a/agents/docs/skills/docs-site-bootstrap/assets/docs/site/scripts/lib/frontmatter.mjs
+++ b/agents/docs/skills/docs-site-bootstrap/assets/docs/site/scripts/lib/frontmatter.mjs
@@ -44,7 +44,7 @@ export function validatePage(page) {
       || data.last_verified_version.trim() === '') {
     errors.push('last_verified_version must be a version anchor or unverified');
   }
-  if ('nav_order' in data && data.nav_order !== null && data.nav_order !== ''
+  if ('nav_order' in data
       && !(Number.isInteger(data.nav_order) && data.nav_order >= 0)) {
     errors.push('nav_order must be a non-negative integer when present');
   }

--- a/agents/docs/skills/docs-site-bootstrap/assets/docs/site/scripts/lib/frontmatter.mjs
+++ b/agents/docs/skills/docs-site-bootstrap/assets/docs/site/scripts/lib/frontmatter.mjs
@@ -44,6 +44,10 @@ export function validatePage(page) {
       || data.last_verified_version.trim() === '') {
     errors.push('last_verified_version must be a version anchor or unverified');
   }
+  if ('nav_order' in data && data.nav_order !== null && data.nav_order !== ''
+      && !(Number.isInteger(data.nav_order) && data.nav_order >= 0)) {
+    errors.push('nav_order must be a non-negative integer when present');
+  }
   return errors;
 }
 

--- a/agents/docs/skills/docs-site-bootstrap/assets/docs/site/scripts/lib/frontmatter.mjs
+++ b/agents/docs/skills/docs-site-bootstrap/assets/docs/site/scripts/lib/frontmatter.mjs
@@ -45,7 +45,7 @@ export function validatePage(page) {
     errors.push('last_verified_version must be a version anchor or unverified');
   }
   if ('nav_order' in data
-      && !(Number.isInteger(data.nav_order) && data.nav_order >= 0)) {
+      && !(Number.isSafeInteger(data.nav_order) && data.nav_order >= 0)) {
     errors.push('nav_order must be a non-negative integer when present');
   }
   return errors;

--- a/agents/docs/skills/docs-site-bootstrap/assets/docs/site/scripts/lib/sidebar.mjs
+++ b/agents/docs/skills/docs-site-bootstrap/assets/docs/site/scripts/lib/sidebar.mjs
@@ -22,10 +22,29 @@ function compareText(left, right) {
 // Section 内排序：显式声明 `nav_order`（非负整数）的页面按值升序、
 // 始终排在无 `nav_order` 的页面之前；无序页面之间回退路径 slug 字典序。
 // 存在性优先，因此任意合法 `nav_order` 取值都不会与「无序」混淆。
-function navOrder(item) {
-  const page = item.page ?? item.child?.page;
+// 无可见 index 页的子树取子树内可见叶子的最小显式 `nav_order`，
+// 使被扁平化的子树保持其内部显式顺序，而不是整体被当作无序。
+function explicitOrder(page) {
   const value = page?.data?.nav_order;
   return Number.isInteger(value) && value >= 0 ? value : null;
+}
+
+function navOrder(item) {
+  const page = item.page ?? item.child?.page;
+  if (page) return explicitOrder(page);
+  const child = item.child;
+  if (child) {
+    let minimum = null;
+    for (const sub of [...child.children.values(), ...child.leaves.values()]) {
+      // sub 为 node（含 children）时递归子树，为 page 时取其显式顺序
+      const subOrder = sub.children ? navOrder({ child: sub }) : explicitOrder(sub);
+      if (subOrder !== null && (minimum === null || subOrder < minimum)) {
+        minimum = subOrder;
+      }
+    }
+    return minimum;
+  }
+  return null;
 }
 
 function sidebarItems(current) {

--- a/agents/docs/skills/docs-site-bootstrap/assets/docs/site/scripts/lib/sidebar.mjs
+++ b/agents/docs/skills/docs-site-bootstrap/assets/docs/site/scripts/lib/sidebar.mjs
@@ -19,12 +19,23 @@ function compareText(left, right) {
   return left < right ? -1 : left > right ? 1 : 0;
 }
 
+// Section 内排序：优先按 frontmatter `nav_order`（非负整数升序），
+// 缺省或相等时回退路径 slug 字典序。
+function navOrder(item) {
+  const page = item.page ?? item.child?.page;
+  const value = Number(page?.data?.nav_order);
+  return Number.isFinite(value) ? value : Number.MAX_SAFE_INTEGER;
+}
+
 function sidebarItems(current) {
   const childItems = [
     ...[...current.children.entries()].map(([key, child]) => ({ key, child })),
     ...[...current.leaves.entries()].map(([key, page]) => ({ key, page }))
   ]
-    .sort(({ key: left }, { key: right }) => compareText(left, right))
+    .sort((a, b) => {
+      const order = navOrder(a) - navOrder(b);
+      return order !== 0 ? order : compareText(a.key, b.key);
+    })
     .flatMap(({ key, child, page }) => {
       const items = page
         ? [{ text: page.data.title, link: page.route }]

--- a/agents/docs/skills/docs-site-bootstrap/assets/docs/site/scripts/lib/sidebar.mjs
+++ b/agents/docs/skills/docs-site-bootstrap/assets/docs/site/scripts/lib/sidebar.mjs
@@ -24,22 +24,24 @@ function compareText(left, right) {
 // 存在性优先，因此任意合法 `nav_order` 取值都不会与「无序」混淆。
 function explicitOrder(page) {
   const value = page?.data?.nav_order;
-  return Number.isInteger(value) && value >= 0 ? value : null;
+  return Number.isSafeInteger(value) && value >= 0 ? value : null;
 }
 
 // 无可见 index 页的子树扁平化到当前层参与排序，使其叶子的显式顺序
 // 与同层条目按同一 comparator 混合，而不是整体作为不可分的块。
-function flattenIndexless(child) {
+// 展开时携带累计路径段作为排序 key，保证字典序回退仍按完整路径 slug 比较。
+function flattenIndexless(child, prefix) {
   const items = [];
   for (const [key, sub] of child.children.entries()) {
+    const path = prefix ? `${prefix}/${key}` : key;
     if (sub.page) {
-      items.push({ key, child: sub });
+      items.push({ key: path, child: sub });
     } else {
-      items.push(...flattenIndexless(sub));
+      items.push(...flattenIndexless(sub, path));
     }
   }
   for (const [key, page] of child.leaves.entries()) {
-    items.push({ key, page });
+    items.push({ key: prefix ? `${prefix}/${key}` : key, page });
   }
   return items;
 }
@@ -50,7 +52,7 @@ function sidebarItems(current) {
     if (child.page) {
       childItems.push({ key, child });
     } else {
-      childItems.push(...flattenIndexless(child));
+      childItems.push(...flattenIndexless(child, key));
     }
   }
   for (const [key, page] of current.leaves.entries()) {

--- a/agents/docs/skills/docs-site-bootstrap/assets/docs/site/scripts/lib/sidebar.mjs
+++ b/agents/docs/skills/docs-site-bootstrap/assets/docs/site/scripts/lib/sidebar.mjs
@@ -20,11 +20,11 @@ function compareText(left, right) {
 }
 
 // Section 内排序：优先按 frontmatter `nav_order`（非负整数升序），
-// 缺省或相等时回退路径 slug 字典序。
+// 缺省、非整数或负值一律回退路径 slug 字典序。
 function navOrder(item) {
   const page = item.page ?? item.child?.page;
-  const value = Number(page?.data?.nav_order);
-  return Number.isFinite(value) ? value : Number.MAX_SAFE_INTEGER;
+  const value = page?.data?.nav_order;
+  return Number.isInteger(value) && value >= 0 ? value : Number.MAX_SAFE_INTEGER;
 }
 
 function sidebarItems(current) {

--- a/agents/docs/skills/docs-site-bootstrap/assets/docs/site/scripts/lib/sidebar.mjs
+++ b/agents/docs/skills/docs-site-bootstrap/assets/docs/site/scripts/lib/sidebar.mjs
@@ -22,39 +22,44 @@ function compareText(left, right) {
 // Section 内排序：显式声明 `nav_order`（非负整数）的页面按值升序、
 // 始终排在无 `nav_order` 的页面之前；无序页面之间回退路径 slug 字典序。
 // 存在性优先，因此任意合法 `nav_order` 取值都不会与「无序」混淆。
-// 无可见 index 页的子树取子树内可见叶子的最小显式 `nav_order`，
-// 使被扁平化的子树保持其内部显式顺序，而不是整体被当作无序。
 function explicitOrder(page) {
   const value = page?.data?.nav_order;
   return Number.isInteger(value) && value >= 0 ? value : null;
 }
 
-function navOrder(item) {
-  const page = item.page ?? item.child?.page;
-  if (page) return explicitOrder(page);
-  const child = item.child;
-  if (child) {
-    let minimum = null;
-    for (const sub of [...child.children.values(), ...child.leaves.values()]) {
-      // sub 为 node（含 children）时递归子树，为 page 时取其显式顺序
-      const subOrder = sub.children ? navOrder({ child: sub }) : explicitOrder(sub);
-      if (subOrder !== null && (minimum === null || subOrder < minimum)) {
-        minimum = subOrder;
-      }
+// 无可见 index 页的子树扁平化到当前层参与排序，使其叶子的显式顺序
+// 与同层条目按同一 comparator 混合，而不是整体作为不可分的块。
+function flattenIndexless(child) {
+  const items = [];
+  for (const [key, sub] of child.children.entries()) {
+    if (sub.page) {
+      items.push({ key, child: sub });
+    } else {
+      items.push(...flattenIndexless(sub));
     }
-    return minimum;
   }
-  return null;
+  for (const [key, page] of child.leaves.entries()) {
+    items.push({ key, page });
+  }
+  return items;
 }
 
 function sidebarItems(current) {
-  const childItems = [
-    ...[...current.children.entries()].map(([key, child]) => ({ key, child })),
-    ...[...current.leaves.entries()].map(([key, page]) => ({ key, page }))
-  ]
+  const childItems = [];
+  for (const [key, child] of current.children.entries()) {
+    if (child.page) {
+      childItems.push({ key, child });
+    } else {
+      childItems.push(...flattenIndexless(child));
+    }
+  }
+  for (const [key, page] of current.leaves.entries()) {
+    childItems.push({ key, page });
+  }
+  const items = childItems
     .sort((a, b) => {
-      const left = navOrder(a);
-      const right = navOrder(b);
+      const left = explicitOrder(a.page ?? a.child?.page);
+      const right = explicitOrder(b.page ?? b.child?.page);
       if (left !== null && right !== null) {
         return left !== right ? left - right : compareText(a.key, b.key);
       }
@@ -63,21 +68,21 @@ function sidebarItems(current) {
       return compareText(a.key, b.key);
     })
     .flatMap(({ key, child, page }) => {
-      const items = page
+      const childItems = page
         ? [{ text: page.data.title, link: page.route }]
         : sidebarItems(child);
-      return items.length ? items : [{ text: key, items: [] }];
+      return childItems.length ? childItems : [{ text: key, items: [] }];
     });
   const result = [];
   if (current.page) {
     result.push({
       text: current.page.data.title,
       link: current.page.route,
-      ...(childItems.length ? { items: childItems } : {})
+      ...(items.length ? { items } : {})
     });
     return result;
   }
-  return childItems;
+  return items;
 }
 
 function sectionTree(pages, section) {

--- a/agents/docs/skills/docs-site-bootstrap/assets/docs/site/scripts/lib/sidebar.mjs
+++ b/agents/docs/skills/docs-site-bootstrap/assets/docs/site/scripts/lib/sidebar.mjs
@@ -19,12 +19,13 @@ function compareText(left, right) {
   return left < right ? -1 : left > right ? 1 : 0;
 }
 
-// Section 内排序：优先按 frontmatter `nav_order`（非负整数升序），
-// 缺省、非整数或负值一律回退路径 slug 字典序。
+// Section 内排序：显式声明 `nav_order`（非负整数）的页面按值升序、
+// 始终排在无 `nav_order` 的页面之前；无序页面之间回退路径 slug 字典序。
+// 存在性优先，因此任意合法 `nav_order` 取值都不会与「无序」混淆。
 function navOrder(item) {
   const page = item.page ?? item.child?.page;
   const value = page?.data?.nav_order;
-  return Number.isInteger(value) && value >= 0 ? value : Number.MAX_SAFE_INTEGER;
+  return Number.isInteger(value) && value >= 0 ? value : null;
 }
 
 function sidebarItems(current) {
@@ -33,8 +34,14 @@ function sidebarItems(current) {
     ...[...current.leaves.entries()].map(([key, page]) => ({ key, page }))
   ]
     .sort((a, b) => {
-      const order = navOrder(a) - navOrder(b);
-      return order !== 0 ? order : compareText(a.key, b.key);
+      const left = navOrder(a);
+      const right = navOrder(b);
+      if (left !== null && right !== null) {
+        return left !== right ? left - right : compareText(a.key, b.key);
+      }
+      if (left !== null) return -1;
+      if (right !== null) return 1;
+      return compareText(a.key, b.key);
     })
     .flatMap(({ key, child, page }) => {
       const items = page

--- a/agents/docs/skills/formal-docs-sync/_internal/INSTRUCTIONS.md
+++ b/agents/docs/skills/formal-docs-sync/_internal/INSTRUCTIONS.md
@@ -223,6 +223,14 @@ Apply that contract to every created or updated formal page. Set
 must not stamp a release version, redefine frontmatter fields, or add a dynamic
 host schema.
 
+Write `nav_order` (a non-negative integer, per the contract's Optional Fields)
+only when a section's pages need a business-logic order that path slugs cannot
+express — for example, overview pages first or related feature pages grouped
+together. Number the pages within the section so the sidebar renders the
+intended sequence, and update existing `nav_order` values only when the page
+set or its intended order actually changes. When a section reads naturally in
+slug order, do not invent `nav_order`; keep the page set and metadata minimal.
+
 ### 7. Run host documentation checks
 
 Read required commands from the host `docs/site/package.json`, repository

--- a/agents/docs/skills/formal-docs-sync/_internal/INSTRUCTIONS.md
+++ b/agents/docs/skills/formal-docs-sync/_internal/INSTRUCTIONS.md
@@ -223,7 +223,7 @@ Apply that contract to every created or updated formal page. Set
 must not stamp a release version, redefine frontmatter fields, or add a dynamic
 host schema.
 
-Write `nav_order` (a non-negative integer, per the contract's Optional Fields)
+Write `nav_order` (a non-negative safe integer `≤ 9007199254740991`, per the contract's Optional Fields)
 only when a section's pages need a business-logic order that path slugs cannot
 express — for example, overview pages first or related feature pages grouped
 together. Number the pages within the section so the sidebar renders the

--- a/agents/docs/skills/formal-docs-sync/_internal/INSTRUCTIONS.md
+++ b/agents/docs/skills/formal-docs-sync/_internal/INSTRUCTIONS.md
@@ -231,6 +231,15 @@ intended sequence, and update existing `nav_order` values only when the page
 set or its intended order actually changes. When a section reads naturally in
 slug order, do not invent `nav_order`; keep the page set and metadata minimal.
 
+Before emitting `nav_order`, confirm the host's delivered navigation generator
+supports it: the host `docs/site/scripts/lib/sidebar.mjs` must reference
+`nav_order` in its ordering logic. Delivered bootstrap assets are not upgraded
+automatically — a host bootstrapped before the `nav_order` capability shipped
+would ignore the field while the sync reports an intended sequence. If host
+support is missing, do not write `nav_order`; report in the batch summary that
+the host must rerun `docs-site-bootstrap` (or merge a confirmed bootstrap
+upgrade) before the field can take effect.
+
 ### 7. Run host documentation checks
 
 Read required commands from the host `docs/site/package.json`, repository

--- a/agents/docs/skills/manual-gen/_internal/INSTRUCTIONS.md
+++ b/agents/docs/skills/manual-gen/_internal/INSTRUCTIONS.md
@@ -15,6 +15,17 @@ If the foundation, standards entry, or change map is absent, stop with zero
 site writes and return a bounded `docs-site-bootstrap` handoff. Do not create a
 partial site or initialize missing foundations.
 
+Consume the shared frontmatter contract
+(`agents/docs/skills/docs-agent/_internal/_shared/frontmatter-contract.md`)
+for every created or updated manual page. When a section's pages need a
+business-logic order that path slugs cannot express, `nav_order` may be written
+per the contract's Optional Fields — but only after confirming the host's
+delivered `docs/site/scripts/lib/sidebar.mjs` references `nav_order` in its
+ordering logic. Delivered bootstrap assets are not upgraded automatically; on a
+pre-upgrade host that ignores the field, do not write `nav_order` and report
+in the batch summary that the host must rerun `docs-site-bootstrap` (or merge a
+confirmed bootstrap upgrade) before the field can take effect.
+
 ## 2. Read the unique manual template and existing structure
 
 Follow the host standards entry to the manual template under

--- a/agents/docs/test/formal-docs-sync/evals/evals.json
+++ b/agents/docs/test/formal-docs-sync/evals/evals.json
@@ -40,6 +40,11 @@
           "id": "keeps_unconfirmed_batch_read_only",
           "description": "候选批次未确认时零写入且不提前 handoff",
           "text": "明确指出 `backfill-request.md` 和本轮请求都不是 candidate-scope confirmation；不创建或修改页面、change-map、index 或导航，不开始下一批，不运行写后 host checks，也不输出 `docs-agent:docs-audit` handoff；停在维护者对完整候选树与映射的一次明确确认。"
+        },
+        {
+          "id": "defaults_new_pages_to_internal_visibility",
+          "description": "新页面 visibility 默认收紧为 internal",
+          "text": "候选与映射中的新增页面 visibility 收紧为 `internal`（宿主未明确要求 `both` 或 `public` 时），不为满足导航或链接检查而放宽为 `both`；解释收紧依据与例外。"
         }
       ]
     },
@@ -496,9 +501,21 @@
       "expected_output": "完整场景保持 integrated 且不重放 DevOps；部分场景因仅 Public 被覆盖而为 partial，并返回 PM 确认。",
       "workspace": "workspace/eval-014-existing-site-deployment-recheck",
       "assertions": [
-        {"id": "reports_existing_site_integrated", "description": "老站仍完整", "text": "内容更新后重新核对 Public/Internal 构建和启动链路，证据未漂移时报告 integrated、列出证据并不重复执行 DevOps。"},
-        {"id": "detects_partial_variant_coverage", "description": "识别仅 Public 覆盖", "text": "Public 有镜像/CI/编排而 Internal 缺少 CI 与启动入口时必须枚举两者并判为 partial，不能宣称完整。"},
-        {"id": "returns_gap_to_pm_read_only", "description": "只读返回 PM", "text": "询问是否由 pm-agent 生成 repo-wide deployment handoff；formal-docs-sync 不修改 Dockerfile、workflow、Compose、Helm 或执行部署。"}
+        {
+          "id": "reports_existing_site_integrated",
+          "description": "老站仍完整",
+          "text": "内容更新后重新核对 Public/Internal 构建和启动链路，证据未漂移时报告 integrated、列出证据并不重复执行 DevOps。"
+        },
+        {
+          "id": "detects_partial_variant_coverage",
+          "description": "识别仅 Public 覆盖",
+          "text": "Public 有镜像/CI/编排而 Internal 缺少 CI 与启动入口时必须枚举两者并判为 partial，不能宣称完整。"
+        },
+        {
+          "id": "returns_gap_to_pm_read_only",
+          "description": "只读返回 PM",
+          "text": "询问是否由 pm-agent 生成 repo-wide deployment handoff；formal-docs-sync 不修改 Dockerfile、workflow、Compose、Helm 或执行部署。"
+        }
       ]
     },
     {

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-001-sync-feature-api/comparison.md
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-001-sync-feature-api/comparison.md
@@ -16,7 +16,8 @@
 
 ## Latest Result
 
-- Overall result: PASS
+- Overall result: BLOCKED
+- 注：PASS 结论基于旧断言（6 条）评测记录保留；断言已按 #239 增强（新增 internal 收紧断言，共 7 条），待 fresh eval 重跑验证新断言。
 - Discrimination note: 修复后隔离重跑（2026-08-05，fresh 会话、workspace 仓库外拷贝）with/without 均满足全部断言。成因：宿主 handoff 材料（pm-handoff.md 的 required_output、change-map.yaml 模板、feature-catalog）天然承载候选树/change-map/零写入结构，按 AGENTS.md 泄漏判定表属「规则天然存在于 skill 交付物」，非泄漏缺陷，如实记录。skill 特有行为差异（新增页面 internal 收紧、change-map exclude 完整性）未落入断言粒度，建议后续增强断言。
 
 **PASS (with skill 6/6; without skill 3/6)** — the skill lane satisfied the full unconfirmed-batch protocol, while the fresh baseline retained only generic tree derivation, scope protection, and read-only behavior. Comparative discrimination is restored.

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-001-sync-feature-api/comparison.md
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-001-sync-feature-api/comparison.md
@@ -18,9 +18,9 @@
 
 - Overall result: BLOCKED
 - 注：PASS 结论基于旧断言（6 条）评测记录保留；断言已按 #239 增强（新增 internal 收紧断言，共 7 条），待 fresh eval 重跑验证新断言。
-- Discrimination note: 修复后隔离重跑（2026-08-05，fresh 会话、workspace 仓库外拷贝）with/without 均满足全部断言。成因：宿主 handoff 材料（pm-handoff.md 的 required_output、change-map.yaml 模板、feature-catalog）天然承载候选树/change-map/零写入结构，按 AGENTS.md 泄漏判定表属「规则天然存在于 skill 交付物」，非泄漏缺陷，如实记录。skill 特有行为差异（新增页面 internal 收紧、change-map exclude 完整性）未落入断言粒度，建议后续增强断言。
+- Discrimination note: 修复后隔离重跑（2026-08-05，fresh 会话、workspace 仓库外拷贝）with/without 均满足旧断言（6 条，增强前）。成因：宿主 handoff 材料（pm-handoff.md 的 required_output、change-map.yaml 模板、feature-catalog）天然承载候选树/change-map/零写入结构，按 AGENTS.md 泄漏判定表属「规则天然存在于 skill 交付物」，非泄漏缺陷，如实记录。skill 特有行为差异（新增页面 internal 收紧、change-map exclude 完整性）未落入断言粒度，建议后续增强断言。
 
-**PASS (with skill 6/6; without skill 3/6)** — the skill lane satisfied the full unconfirmed-batch protocol, while the fresh baseline retained only generic tree derivation, scope protection, and read-only behavior. Comparative discrimination is restored.
+**PASS (with skill 6/6; without skill 3/6, 旧断言)** — the skill lane satisfied the full unconfirmed-batch protocol, while the fresh baseline retained only generic tree derivation, scope protection, and read-only behavior. Comparative discrimination is restored.
 
 ## Assertions
 

--- a/agents/product_manager/test/github-release-gen/evals/evals.json
+++ b/agents/product_manager/test/github-release-gen/evals/evals.json
@@ -70,6 +70,11 @@
           "id": "keeps_preview_or_draft",
           "description": "阻塞时只保留非发布态",
           "text": "任一发布门禁缺失时只展示预览或保持既有 draft，不调用发布操作。"
+        },
+        {
+          "id": "inline_preview_body_and_version_normalization",
+          "description": "preview 含内联完整正文且版本标准化",
+          "text": "preview 或 draft 展示内联完整 Release 正文（标题、升级说明、变更明细），版本号按仓库约定标准化（识别 SemVer prerelease、按规则剥离或保留前缀），PRERELEASE_FLAG 由版本推导并在 draft create/update 命令中显式声明。"
         }
       ]
     },

--- a/agents/product_manager/test/github-release-gen/evals/workspace/eval-002-enforce-release-sequence-gates/comparison.md
+++ b/agents/product_manager/test/github-release-gen/evals/workspace/eval-002-enforce-release-sequence-gates/comparison.md
@@ -7,6 +7,7 @@
 - Latest result: **PASS**（Behavior: PASS / Coverage: FULL）
 - Overall result: BLOCKED
 - 注：PASS 结论基于改名前的 `github-release-generator` 评测记录保留；改名后待 fresh eval 重跑验证新入口。
+- 注：断言已按 #239 增强（新增内联预览正文/版本标准化断言），待 fresh eval 重跑验证。
 - Discrimination note: 修复后隔离重跑（2026-08-05）with/without 均满足全部断言。成因：宿主 release-package.md 天然承载门禁字段（ready_for_tag/release_verified/预览语义），baseline 可从中推断；skill 特有差异（内联完整预览正文、版本标准化、PRERELEASE_FLAG 推导）未落入断言粒度，建议后续增强断言。按 AGENTS.md 泄漏判定表属「规则天然存在于 skill 交付物」。
 
 ## Review Context

--- a/agents/product_manager/test/github-release-gen/evals/workspace/eval-002-enforce-release-sequence-gates/comparison.md
+++ b/agents/product_manager/test/github-release-gen/evals/workspace/eval-002-enforce-release-sequence-gates/comparison.md
@@ -8,7 +8,7 @@
 - Overall result: BLOCKED
 - 注：PASS 结论基于改名前的 `github-release-generator` 评测记录保留；改名后待 fresh eval 重跑验证新入口。
 - 注：断言已按 #239 增强（新增内联预览正文/版本标准化断言），待 fresh eval 重跑验证。
-- Discrimination note: 修复后隔离重跑（2026-08-05）with/without 均满足全部断言。成因：宿主 release-package.md 天然承载门禁字段（ready_for_tag/release_verified/预览语义），baseline 可从中推断；skill 特有差异（内联完整预览正文、版本标准化、PRERELEASE_FLAG 推导）未落入断言粒度，建议后续增强断言。按 AGENTS.md 泄漏判定表属「规则天然存在于 skill 交付物」。
+- Discrimination note: 修复后隔离重跑（2026-08-05）with/without 均满足旧断言（6 条，增强前）。成因：宿主 release-package.md 天然承载门禁字段（ready_for_tag/release_verified/预览语义），baseline 可从中推断；skill 特有差异（内联完整预览正文、版本标准化、PRERELEASE_FLAG 推导）未落入断言粒度，建议后续增强断言。按 AGENTS.md 泄漏判定表属「规则天然存在于 skill 交付物」。
 
 ## Review Context
 

--- a/agents/product_manager/test/github-release-gen/evals/workspace/eval-002-enforce-release-sequence-gates/release-package.md
+++ b/agents/product_manager/test/github-release-gen/evals/workspace/eval-002-enforce-release-sequence-gates/release-package.md
@@ -26,10 +26,6 @@
 - repository_standard_tag_prefix: `v`
 - current_latest_release: `v0.9.0`
 - current_latest_url: https://github.com/example/ai-hub/releases/tag/v0.9.0
-- target_after_single_prefix_removal: `1.0.0-rc.1`
-- expected_classification: SemVer prerelease
-- expected_prerelease_flag: `--prerelease`
-- expected_latest_flag: `--latest=false`
 
 ## Requested output
 

--- a/agents/security/test/appsec-checklist/evals/evals.json
+++ b/agents/security/test/appsec-checklist/evals/evals.json
@@ -32,9 +32,9 @@
           "text": "提供具体、可执行的修复建议或验证步骤"
         },
         {
-          "id": "writes_security_report",
-          "description": "产出 docs/security 下的落盘报告",
-          "text": "创建 `docs/security/{feature_path}/appsec-checklist.md` 报告，包含发现、严重度与修复建议，作为 Security-owned 过程证据；不修改 PM/设计/实现等其他角色拥有的文档。"
+          "id": "writes_protocol_shaped_security_report",
+          "description": "报告按 SKILL.md 协议结构落盘（frontmatter + Executive Summary 分区）",
+          "text": "创建 `docs/security/user-search/appsec-checklist.md` 并按协议结构组织：frontmatter 含 feature/feature_path/version/date 等字段，报告含 Executive Summary 分区（问题总数、风险等级分布、总体态势）与逐问题说明（位置 file:line、风险解释、修复建议）；不修改 PM/设计/实现等其他角色拥有的文档。"
         }
       ]
     },

--- a/agents/security/test/appsec-checklist/evals/evals.json
+++ b/agents/security/test/appsec-checklist/evals/evals.json
@@ -30,6 +30,11 @@
           "id": "remediation",
           "description": "提供具体、可执行的修复建议或验证步骤",
           "text": "提供具体、可执行的修复建议或验证步骤"
+        },
+        {
+          "id": "writes_security_report",
+          "description": "产出 docs/security 下的落盘报告",
+          "text": "创建 `docs/security/{feature_path}/appsec-checklist.md` 报告，包含发现、严重度与修复建议，作为 Security-owned 过程证据；不修改 PM/设计/实现等其他角色拥有的文档。"
         }
       ]
     },
@@ -116,16 +121,16 @@
           "description": "报告 frontmatter 包含 feature path 字段",
           "text": "报告 frontmatter 必须包含 `feature_path: chat-interface/messages/history/search`、`parent_feature: chat-interface/messages/history` 和 `feature_level: 4`。"
         },
-    {
-      "id": "does_not_invent_feature_directory",
-      "description": "路径不清时回 PM/Engineer",
-      "text": "如果 feature_path 不清或同路径 PRD/TRD/实施计划缺失，必须回 PM/Engineer 对齐，而不是自建同义顶层目录。"
-    },
-    {
-      "id": "escalates_fact_changing_conclusion_to_pm",
-      "description": "改变正式文档事实的结论升级",
-      "text": "确认结论改变正式文档事实时，必须把结论与证据回交 `pm-agent` 分类并创建 issue，不直接交给 `docs-agent`、不由 Security 自行创建 issue；Security 自有的 `docs/security/` 过程报告除外，仍必须作为升级证据产出。"
-    }
+        {
+          "id": "does_not_invent_feature_directory",
+          "description": "路径不清时回 PM/Engineer",
+          "text": "如果 feature_path 不清或同路径 PRD/TRD/实施计划缺失，必须回 PM/Engineer 对齐，而不是自建同义顶层目录。"
+        },
+        {
+          "id": "escalates_fact_changing_conclusion_to_pm",
+          "description": "改变正式文档事实的结论升级",
+          "text": "确认结论改变正式文档事实时，必须把结论与证据回交 `pm-agent` 分类并创建 issue，不直接交给 `docs-agent`、不由 Security 自行创建 issue；Security 自有的 `docs/security/` 过程报告除外，仍必须作为升级证据产出。"
+        }
       ]
     },
     {
@@ -146,16 +151,16 @@
           "description": "以处理器代码核对查询参数安全声明",
           "text": "关键安全结论回到 src/api/search-handler.js；识别文档声称使用参数化查询、代码实际直接插值 query 的不一致，并以代码事实评估风险。"
         },
-    {
-      "id": "treats_unverified_as_low_trust",
-      "description": "将 unverified 搜索文档按最低信任处理",
-      "text": "识别 required_docs 的 last_verified_version 为 unverified，对所有关键安全判断扩大代码核证，而不是直接采信文档或拒绝读取。"
-    },
-    {
-      "id": "escalates_fact_changing_conclusion_to_pm",
-      "description": "改变正式文档事实的结论升级",
-      "text": "确认结论改变正式文档事实时，必须把结论与证据回交 `pm-agent` 分类并创建 issue，不直接交给 `docs-agent`、不由 Security 自行创建 issue；Security 自有的 `docs/security/` 过程报告除外，仍必须作为升级证据产出。"
-    }
+        {
+          "id": "treats_unverified_as_low_trust",
+          "description": "将 unverified 搜索文档按最低信任处理",
+          "text": "识别 required_docs 的 last_verified_version 为 unverified，对所有关键安全判断扩大代码核证，而不是直接采信文档或拒绝读取。"
+        },
+        {
+          "id": "escalates_fact_changing_conclusion_to_pm",
+          "description": "改变正式文档事实的结论升级",
+          "text": "确认结论改变正式文档事实时，必须把结论与证据回交 `pm-agent` 分类并创建 issue，不直接交给 `docs-agent`、不由 Security 自行创建 issue；Security 自有的 `docs/security/` 过程报告除外，仍必须作为升级证据产出。"
+        }
       ]
     }
   ]

--- a/agents/security/test/appsec-checklist/evals/workspace/eval-001-sql-injection/comparison.md
+++ b/agents/security/test/appsec-checklist/evals/workspace/eval-001-sql-injection/comparison.md
@@ -8,10 +8,10 @@
 - Test case: SQL Injection Vulnerability
 - Workspace: `workspace/eval-001-sql-injection`
 - Review context: issue #143 thin fixture 补齐后的 Fresh Codex 复验
-- Latest result: PASS（4/4 assertions）- fresh Codex paired validation completed on 2026-07-21
+- Latest result: PASS（4/4 assertions，旧断言）- fresh Codex paired validation completed on 2026-07-21
 - Overall result: BLOCKED
 - 注：PASS 结论基于旧断言（4 条）评测记录保留；断言已按 #239 增强（新增报告落盘断言，共 5 条），待 fresh eval 重跑验证。
-- Discrimination note: 修复后隔离重跑（2026-08-05）with/without 均满足全部断言。成因：模型基线能力已覆盖通用安全审查（识别注入/严重度/修复建议），按 AGENTS.md 泄漏判定表属「模型基线能力覆盖」，记为 skill 生命周期信号交 issue 审查，不硬修。
+- Discrimination note: 修复后隔离重跑（2026-08-05）with/without 均满足旧断言（4 条，增强前）。成因：模型基线能力已覆盖通用安全审查（识别注入/严重度/修复建议），按 AGENTS.md 泄漏判定表属「模型基线能力覆盖」，记为 skill 生命周期信号交 issue 审查，不硬修。
 
 
 ## Test Set / Fixture Version

--- a/agents/security/test/appsec-checklist/evals/workspace/eval-001-sql-injection/comparison.md
+++ b/agents/security/test/appsec-checklist/evals/workspace/eval-001-sql-injection/comparison.md
@@ -9,7 +9,8 @@
 - Workspace: `workspace/eval-001-sql-injection`
 - Review context: issue #143 thin fixture 补齐后的 Fresh Codex 复验
 - Latest result: PASS（4/4 assertions）- fresh Codex paired validation completed on 2026-07-21
-- Overall result: PASS
+- Overall result: BLOCKED
+- 注：PASS 结论基于旧断言（4 条）评测记录保留；断言已按 #239 增强（新增报告落盘断言，共 5 条），待 fresh eval 重跑验证。
 - Discrimination note: 修复后隔离重跑（2026-08-05）with/without 均满足全部断言。成因：模型基线能力已覆盖通用安全审查（识别注入/严重度/修复建议），按 AGENTS.md 泄漏判定表属「模型基线能力覆盖」，记为 skill 生命周期信号交 issue 审查，不硬修。
 
 

--- a/agents/security/test/appsec-checklist/evals/workspace/eval-001-sql-injection/eval_metadata.json
+++ b/agents/security/test/appsec-checklist/evals/workspace/eval-001-sql-injection/eval_metadata.json
@@ -7,5 +7,16 @@
     "PM_HANDOFF.md",
     "docs/pm/user-search/PRD.md",
     "src/api/user-search.js"
+  ],
+  "execution_cleanup": [
+    "docs/security/user-search/appsec-checklist.md",
+    "with_skill",
+    "without_skill",
+    "outputs",
+    "diagnostics",
+    "transcript.md",
+    "subagent-verdict.md",
+    "run_status.json",
+    "timing.json"
   ]
 }

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -179,7 +179,7 @@
     "docs-site-bootstrap": {
       "source": "agents/docs/skills/docs-site-bootstrap",
       "sourceType": "local",
-      "computedHash": "641bb6d4d0e9bdbed2bb3281a4da0f5fe6c130f15d92f07549e430e504ab1eb2"
+      "computedHash": "f87338f7045ff3e4486b185496139bc85510cf67b8edcc6caf02cf060b2a32ee"
     },
     "formal-docs-sync": {
       "source": "agents/docs/skills/formal-docs-sync",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -174,7 +174,7 @@
     "docs-agent": {
       "source": "agents/docs/skills/docs-agent",
       "sourceType": "local",
-      "computedHash": "97226c95b67ca9e20b7cfc80227a5125ca9d689427d75c38d2e66a8f91212df9"
+      "computedHash": "b5246af7772383ed241d169d3de3b03d230477e90b9aec81fbc4fc785a865290"
     },
     "docs-site-bootstrap": {
       "source": "agents/docs/skills/docs-site-bootstrap",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -194,7 +194,7 @@
     "docs-audit": {
       "source": "agents/docs/skills/docs-audit",
       "sourceType": "local",
-      "computedHash": "6466488828b54f752ea7ec97810dd36b8168d147e2a34b04d7642a82d74d50d2"
+      "computedHash": "90546b5c433b8524dd75217bd1a0be6db6a013f65db007a62a633aa1ab8d548b"
     }
   }
 }

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -189,12 +189,12 @@
     "manual-gen": {
       "source": "agents/docs/skills/manual-gen",
       "sourceType": "local",
-      "computedHash": "80660b5716969d16709d1b0703ab72feba3f5bf20dafc6784e148df3f85d7bfc"
+      "computedHash": "de0e85c388e3f74db16defea12ef9a62cacb9b09fa4309e8533f41b2a5dffdd4"
     },
     "docs-audit": {
       "source": "agents/docs/skills/docs-audit",
       "sourceType": "local",
-      "computedHash": "90546b5c433b8524dd75217bd1a0be6db6a013f65db007a62a633aa1ab8d548b"
+      "computedHash": "8651110cfa750340ebcac1965532fc26dbac3bbbcc3807157d99842dfb0fbb7e"
     }
   }
 }

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -179,12 +179,12 @@
     "docs-site-bootstrap": {
       "source": "agents/docs/skills/docs-site-bootstrap",
       "sourceType": "local",
-      "computedHash": "5102d5e4cda4267e9c3703ba1f44aa3091448f5ed5ce1091dbebb65f51fb449a"
+      "computedHash": "8cd1d3a8fd035c8e4c0a06e2a74ade5cf2e0deec5b5e30a4d11fd639c17685a4"
     },
     "formal-docs-sync": {
       "source": "agents/docs/skills/formal-docs-sync",
       "sourceType": "local",
-      "computedHash": "8f743026d0a88f5f652e3cce2fa3e645298171f0526b3b178ca2adc2643814b4"
+      "computedHash": "ecddd7f2ccca1e19b020beac134e71837f2212d886ad1efb9a7f0d9a420783b7"
     },
     "manual-gen": {
       "source": "agents/docs/skills/manual-gen",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -174,7 +174,7 @@
     "docs-agent": {
       "source": "agents/docs/skills/docs-agent",
       "sourceType": "local",
-      "computedHash": "0d90abf938de8992105ad991a4520023c1f826a6c8c00acf816b8b9396e248cb"
+      "computedHash": "0f2f1349d715ed84790c51d978e0fc0bfc61c266b74c9769d882902c7100076c"
     },
     "docs-site-bootstrap": {
       "source": "agents/docs/skills/docs-site-bootstrap",
@@ -184,7 +184,7 @@
     "formal-docs-sync": {
       "source": "agents/docs/skills/formal-docs-sync",
       "sourceType": "local",
-      "computedHash": "ecddd7f2ccca1e19b020beac134e71837f2212d886ad1efb9a7f0d9a420783b7"
+      "computedHash": "909fab6d03124c89b35cf7ccea8e75c2ed4770fc4ebde32cdba42b7d2f407dd6"
     },
     "manual-gen": {
       "source": "agents/docs/skills/manual-gen",
@@ -194,7 +194,7 @@
     "docs-audit": {
       "source": "agents/docs/skills/docs-audit",
       "sourceType": "local",
-      "computedHash": "8ab1e21a59eef95f3a615bcea033457c931dde326853367a4ffa86a9854a09a5"
+      "computedHash": "6466488828b54f752ea7ec97810dd36b8168d147e2a34b04d7642a82d74d50d2"
     }
   }
 }

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -179,7 +179,7 @@
     "docs-site-bootstrap": {
       "source": "agents/docs/skills/docs-site-bootstrap",
       "sourceType": "local",
-      "computedHash": "f87338f7045ff3e4486b185496139bc85510cf67b8edcc6caf02cf060b2a32ee"
+      "computedHash": "af6c8d45ab52a4b6ee4043f7fe9c23748ef6ead5db81fc972e138c1adb61c212"
     },
     "formal-docs-sync": {
       "source": "agents/docs/skills/formal-docs-sync",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -174,17 +174,17 @@
     "docs-agent": {
       "source": "agents/docs/skills/docs-agent",
       "sourceType": "local",
-      "computedHash": "0faa188f00fdbdc609c1bd5b7318626d41d9337cbe648fceaeee8dac39aada67"
+      "computedHash": "0d90abf938de8992105ad991a4520023c1f826a6c8c00acf816b8b9396e248cb"
     },
     "docs-site-bootstrap": {
       "source": "agents/docs/skills/docs-site-bootstrap",
       "sourceType": "local",
-      "computedHash": "aff522dbdb2bc2a39f4a193371083548a691277dbaa3b07c56b9a275ee08ae6a"
+      "computedHash": "5102d5e4cda4267e9c3703ba1f44aa3091448f5ed5ce1091dbebb65f51fb449a"
     },
     "formal-docs-sync": {
       "source": "agents/docs/skills/formal-docs-sync",
       "sourceType": "local",
-      "computedHash": "b128bdc8ec318be15976fadc13ed84b684f2412e24c7ff3d4e5f71baf7f02574"
+      "computedHash": "8f743026d0a88f5f652e3cce2fa3e645298171f0526b3b178ca2adc2643814b4"
     },
     "manual-gen": {
       "source": "agents/docs/skills/manual-gen",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -179,7 +179,7 @@
     "docs-site-bootstrap": {
       "source": "agents/docs/skills/docs-site-bootstrap",
       "sourceType": "local",
-      "computedHash": "8cd1d3a8fd035c8e4c0a06e2a74ade5cf2e0deec5b5e30a4d11fd639c17685a4"
+      "computedHash": "71e6e2af22202823f18045b6571c1893c87ec024faf4c9d05b81154afa3163dc"
     },
     "formal-docs-sync": {
       "source": "agents/docs/skills/formal-docs-sync",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -179,7 +179,7 @@
     "docs-site-bootstrap": {
       "source": "agents/docs/skills/docs-site-bootstrap",
       "sourceType": "local",
-      "computedHash": "71e6e2af22202823f18045b6571c1893c87ec024faf4c9d05b81154afa3163dc"
+      "computedHash": "641bb6d4d0e9bdbed2bb3281a4da0f5fe6c130f15d92f07549e430e504ab1eb2"
     },
     "formal-docs-sync": {
       "source": "agents/docs/skills/formal-docs-sync",
@@ -194,7 +194,7 @@
     "docs-audit": {
       "source": "agents/docs/skills/docs-audit",
       "sourceType": "local",
-      "computedHash": "caccc5c900a8b751bfffd3cb6de5b2b3498d03e274b9cd3ee4f357fefd4611ad"
+      "computedHash": "8ab1e21a59eef95f3a615bcea033457c931dde326853367a4ffa86a9854a09a5"
     }
   }
 }

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -174,7 +174,7 @@
     "docs-agent": {
       "source": "agents/docs/skills/docs-agent",
       "sourceType": "local",
-      "computedHash": "0f2f1349d715ed84790c51d978e0fc0bfc61c266b74c9769d882902c7100076c"
+      "computedHash": "97226c95b67ca9e20b7cfc80227a5125ca9d689427d75c38d2e66a8f91212df9"
     },
     "docs-site-bootstrap": {
       "source": "agents/docs/skills/docs-site-bootstrap",


### PR DESCRIPTION
## 背景

docs-agent 生成的文档站侧栏在 section 内部按路径 slug 字典序排序，与中文展示文案无对应关系，同一功能域条目被拆散（issue #231）。同时 #239 要求为 formal-docs-sync / github-release-gen 的 eval 补充 skill 特有行为断言。

## 改动

**#231 侧栏排序机制**

- `sidebar.mjs`：section 内排序优先按 frontmatter `nav_order`（非负整数升序），缺省或相等时回退路径 slug 字典序；section 之间仍按固定 `SECTION_ORDER`
- `frontmatter-contract.md`：新增 Optional Fields 节定义 `nav_order`（类型、语义、缺省行为）
- `formal-docs-sync` INSTRUCTIONS.md：生成/迁移文档时按功能逻辑写入 `nav_order` 的规则（仅当 slug 序无法表达业务顺序时写，页集合不变时不改已有值）

**#239 断言增强**

- `formal-docs-sync` eval-001：新增 `defaults_new_pages_to_internal_visibility` 断言（新页面 visibility 默认收紧为 internal，不为导航检查放宽为 both）
- `github-release-gen` eval-002：新增 `inline_preview_body_and_version_normalization` 断言（内联完整预览正文、版本标准化、PRERELEASE_FLAG 推导）

**配套**

- `skills-lock.json`：docs-agent / docs-site-bootstrap / formal-docs-sync 三个 skill 的 computedHash 刷新
- 两个 eval 的 `comparison.md` 标注旧断言结论：formal-docs-sync eval-001 PASS 重标 BLOCKED 待重跑（断言 6→7 条），github-release-gen eval-002 BLOCKED 原因补充断言因素（#238 重跑时统一验证）

## 验证

- 排序行为实测：`nav_order` 优先、缺省回退字典序，PASS
- 5 项契约/测试全绿：repository / eval-contract / eval-artifacts / doc-contract / pytest（103 passed）
