### PR TITLE
fix(eval): manual-gen 被测平台改为执行前维护者确认注入 (#235)

### DIFF
--- a/agents/docs/test/manual-gen/evals/README.md
+++ b/agents/docs/test/manual-gen/evals/README.md
@@ -2,16 +2,17 @@
 
 ## 被测平台注入（issue #235）
 
-manual-gen 的 eval **不写死测试平台**。每轮执行前必须先向维护者确认两件事：
+manual-gen 的 eval **不写死测试平台**。每轮执行前必须先向维护者确认被测平台的三项事实：
 
-1. **被测平台名**：手册的平台层定位与 `related_code` 映射依据。
-2. **平台在本地代码中的路径（pwd）**：平台代码位于宿主仓库内时，`related_code` 才能填可定位的仓库相对路径（满足 FR-M12 的非空可定位要求）。
+1. **平台名**：手册的平台层定位与 `related_code` 映射依据。
+2. **可访问 URL**：可直接导航的线上界面。按 skill 环境门禁，只有具备确认域名的环境才视为「已提供环境」，因此 URL 为必填；缺 URL 时 lane 只能进入本地启动协商或阻塞分支。
+3. **平台在本地代码中的路径（pwd）**：平台代码副本成为 lane 宿主仓库后，`related_code` 才能填可定位的仓库相对路径（满足 FR-M12 的非空可定位要求）。
 
 ### 执行步骤
 
-1. 询问维护者被测平台名与平台本地代码 pwd，确认值作为本轮「已提供环境」的事实。
-2. 在隔离 scratch workspace（`tmp/eval-runs/manual-gen/...`）复制 eval workspace，把确认值物化到副本的 `pm-handoff.md` 的 `source_documents` 与 `eval_metadata.json` 的 `environment`；已提交 fixture 保持占位形态，不写入运行期值。
-3. 以副本为 with/without 两条 lane 的可见 fixture，prompt 中的平台声明与副本一致，两条 lane 逐字相同。
+1. 询问维护者被测平台的平台名、可访问 URL、本地代码 pwd，确认值作为本轮「已提供环境」的事实。
+2. 在隔离 scratch workspace（`tmp/eval-runs/manual-gen/...`）物化本轮宿主仓库：复制平台本地代码仓库（含前端源码），把 eval workspace 的 `docs/site/` 文档站 fixture 与 `pm-handoff.md` 嵌入该副本，使副本成为 lane 的宿主仓库（`host_repository` 指向该副本）；将确认值写入副本 `pm-handoff.md` 的 `source_documents` 与 `eval_metadata.json` 的 `environment`。
+3. 从两条 lane 可见目录物理排除评测文件：`eval_metadata.json`、`comparison.md`、`README.md`；已提交的 `pm-handoff.md` 不含协议步骤或门禁术语，直接使用。prompt 中的平台声明与副本一致，两条 lane 逐字相同。
 4. 若维护者确认的平台仅有可访问界面、宿主仓库内无本地代码（如外部站点场景），写入路径（Step 5–8）无法走完：如实记录 Coverage `PARTIAL` 与未覆盖断言，不虚构 `related_code`。拒绝虚构证据并停在写入前的阻塞语义是 skill 的差异化行为，照常断言。
 
 ### 各 eval 场景

--- a/agents/docs/test/manual-gen/evals/README.md
+++ b/agents/docs/test/manual-gen/evals/README.md
@@ -1,0 +1,23 @@
+# manual-gen Eval 执行说明
+
+## 被测平台注入（issue #235）
+
+manual-gen 的 eval **不写死测试平台**。每轮执行前必须先向维护者确认两件事：
+
+1. **被测平台名**：手册的平台层定位与 `related_code` 映射依据。
+2. **平台在本地代码中的路径（pwd）**：平台代码位于宿主仓库内时，`related_code` 才能填可定位的仓库相对路径（满足 FR-M12 的非空可定位要求）。
+
+### 执行步骤
+
+1. 询问维护者被测平台名与平台本地代码 pwd，确认值作为本轮「已提供环境」的事实。
+2. 在隔离 scratch workspace（`tmp/eval-runs/manual-gen/...`）复制 eval workspace，把确认值物化到副本的 `pm-handoff.md` 的 `source_documents` 与 `eval_metadata.json` 的 `environment`；已提交 fixture 保持占位形态，不写入运行期值。
+3. 以副本为 with/without 两条 lane 的可见 fixture，prompt 中的平台声明与副本一致，两条 lane 逐字相同。
+4. 若维护者确认的平台仅有可访问界面、宿主仓库内无本地代码（如外部站点场景），写入路径（Step 5–8）无法走完：如实记录 Coverage `PARTIAL` 与未覆盖断言，不虚构 `related_code`。拒绝虚构证据并停在写入前的阻塞语义是 skill 的差异化行为，照常断言。
+
+### 各 eval 场景
+
+- eval-001：匿名基础编辑与预览流程（写入路径完整覆盖依赖平台本地代码可定位）。
+- eval-002：无域名环境时须明确询问本地启动授权，同意前零启动、零写入。
+- eval-003：无环境且拒绝本地启动时阻塞，零写入、不虚构界面证据。
+- eval-004：匿名导出与分享流程，分享链接中的环境编码标识不进入手册正文。
+- eval-005：平台 / 业务 / 操作三层手册语义，导航与证据均来自真实界面。

--- a/agents/docs/test/manual-gen/evals/README.md
+++ b/agents/docs/test/manual-gen/evals/README.md
@@ -2,23 +2,26 @@
 
 ## 被测平台注入（issue #235）
 
-manual-gen 的 eval **不写死测试平台**。每轮执行前必须先向维护者确认被测平台的三项事实：
+manual-gen 的 eval **不写死测试平台**。仅 domain-based 正向 eval（eval-001 / eval-004 / eval-005）需要在每轮执行前向维护者确认被测平台的三项事实：
 
 1. **平台名**：手册的平台层定位与 `related_code` 映射依据。
 2. **可访问 URL**：可直接导航的线上界面。按 skill 环境门禁，只有具备确认域名的环境才视为「已提供环境」，因此 URL 为必填；缺 URL 时 lane 只能进入本地启动协商或阻塞分支。
 3. **平台在本地代码中的路径（pwd）**：平台代码副本成为 lane 宿主仓库后，`related_code` 才能填可定位的仓库相对路径（满足 FR-M12 的非空可定位要求）。
 
+eval-002（无域名时本地启动同意）与 eval-003（无环境时阻塞）测的正是无域名 / 无环境分支，**不注入平台**，维持各自「环境不可用」的 fixture。
+
 ### 执行步骤
 
 1. 询问维护者被测平台的平台名、可访问 URL、本地代码 pwd，确认值作为本轮「已提供环境」的事实。
-2. 在隔离 scratch workspace（`tmp/eval-runs/manual-gen/...`）物化本轮宿主仓库：复制平台本地代码仓库（含前端源码），把 eval workspace 的 `docs/site/` 文档站 fixture 与 `pm-handoff.md` 嵌入该副本，使副本成为 lane 的宿主仓库（`host_repository` 指向该副本）；将确认值写入副本 `pm-handoff.md` 的 `source_documents` 与 `eval_metadata.json` 的 `environment`。
-3. 从两条 lane 可见目录物理排除评测文件：`eval_metadata.json`、`comparison.md`、`README.md`；已提交的 `pm-handoff.md` 不含协议步骤或门禁术语，直接使用。prompt 中的平台声明与副本一致，两条 lane 逐字相同。
-4. 若维护者确认的平台仅有可访问界面、宿主仓库内无本地代码（如外部站点场景），写入路径（Step 5–8）无法走完：如实记录 Coverage `PARTIAL` 与未覆盖断言，不虚构 `related_code`。拒绝虚构证据并停在写入前的阻塞语义是 skill 的差异化行为，照常断言。
+2. **per-eval 场景能力检查**：确认所选平台真实实现了被测场景——eval-001 基础编辑与预览、eval-004 导出与分享且分享链接带编码标识、eval-005 目标角色可执行的任务流程。平台不兼容时不得强行注入：向维护者换平台，或如实阻塞记录（Coverage `PARTIAL` 并注明平台缺场景，属非 skill 行为原因）。
+3. 在隔离 scratch workspace（`tmp/eval-runs/manual-gen/...`）物化本轮宿主仓库：复制平台本地代码仓库（含前端源码），把 eval workspace 的 `docs/site/` 文档站 fixture 与 `pm-handoff.md` 嵌入该副本，使副本成为 lane 的宿主仓库（`host_repository` 指向该副本）；将确认值写入副本 `pm-handoff.md` 的 `source_documents` 与 `eval_metadata.json` 的 `environment`。
+4. 从两条 lane 可见目录物理排除评测文件与评测素材：`eval_metadata.json`、`comparison.md`、`README.md`、`scripts/`（eval 编写的采集脚本）；已提交的 `pm-handoff.md` 只含宿主事实与自然范围授权，直接使用。prompt 中的平台声明与副本一致，两条 lane 逐字相同。
+5. 若维护者确认的平台仅有可访问界面、宿主仓库内无本地代码（如外部站点场景），写入路径（Step 5–8）无法走完：如实记录 Coverage `PARTIAL` 与未覆盖断言，不虚构 `related_code`。拒绝虚构证据并停在写入前的阻塞语义是 skill 的差异化行为，照常断言。
 
 ### 各 eval 场景
 
 - eval-001：匿名基础编辑与预览流程（写入路径完整覆盖依赖平台本地代码可定位）。
-- eval-002：无域名环境时须明确询问本地启动授权，同意前零启动、零写入。
-- eval-003：无环境且拒绝本地启动时阻塞，零写入、不虚构界面证据。
+- eval-002：无域名环境时须明确询问本地启动授权，同意前零启动、零写入（不注入平台）。
+- eval-003：无环境且拒绝本地启动时阻塞，零写入、不虚构界面证据（不注入平台）。
 - eval-004：匿名导出与分享流程，分享链接中的环境编码标识不进入手册正文。
 - eval-005：平台 / 业务 / 操作三层手册语义，导航与证据均来自真实界面。

--- a/agents/docs/test/manual-gen/evals/evals.json
+++ b/agents/docs/test/manual-gen/evals/evals.json
@@ -7,7 +7,7 @@
       "id": "eval-001-domain-provided",
       "name": "域名环境下生成有限范围图文手册",
       "description": "验证维护者已提供可访问域名时，skill 使用真实运行界面证据完成范围确认、视口校验、有限采集与正式文档 handoff。",
-      "prompt": "维护者已提供可访问环境 https://mermaid.live/，并确认本批只为匿名使用者记录一条基础编辑与预览流程。宿主文档站基础与手册模板已经存在，范围已经定好，不用再跟我确认。请完成这批图文用户手册。",
+      "prompt": "维护者已提供可访问的测试平台（平台名与平台在本地代码中的位置见已确认的手册请求材料），并确认本批只为匿名使用者记录一条基础编辑与预览流程。宿主文档站基础与手册模板已经存在，范围已经定好，不用再跟我确认。请完成这批图文用户手册。",
       "expected_output": "在已提供的域名环境中先展示并确认有限页面树，选择符合三级优先级的执行入口，分别记录 1920×1080 视口设定与实际回读，基于真实界面生成图文操作手册并运行宿主检查和渲染验收；由于没有维护者确认的 target_release_version，页面保持 unverified，返回等待发版上下文的 blocked docs-audit handoff；报告剩余候选且不扩大范围。",
       "workspace": "workspace/eval-001-domain-provided",
       "assertions": [
@@ -106,20 +106,20 @@
     {
       "id": "eval-004-share-link-identifier",
       "name": "导出分享手册隐藏环境长串标识",
-      "description": "验证导出与分享流程以真实界面为证据，同时不把分享链接中的 pako 编码串原样写入正文、图注或报告。",
-      "prompt": "维护者提供了 https://mermaid.live/，并确认本批覆盖匿名用户的导出与分享流程。分享动作会产生包含 pako 编码串的长链接，范围已经定好，不用再跟我确认。请基于真实界面完成这批图文用户手册。",
+      "description": "验证导出与分享流程以真实界面为证据，同时不把分享链接中的环境编码标识原样写入正文、图注或报告。",
+      "prompt": "维护者已提供可访问的测试平台（平台名与平台在本地代码中的位置见已确认的手册请求材料），并确认本批覆盖匿名用户的导出与分享流程。分享动作会产生带长串编码标识的链接，范围已经定好，不用再跟我确认。请基于真实界面完成这批图文用户手册。",
       "expected_output": "采集真实的导出与分享界面，保留可复现的控件与结果说明；分享链接只描述用途或使用脱敏占位，不在正文、图注、报告或持久化元数据中复制 pako 编码串，并完成视口、截图卫生与宿主检查；由于没有维护者确认的 target_release_version，页面保持 unverified，返回等待发版上下文的 blocked docs-audit handoff。",
       "workspace": "workspace/eval-004-share-link-identifier",
       "assertions": [
         {
           "id": "covers_export_and_share_from_real_ui",
           "description": "真实覆盖导出与分享流程",
-          "text": "从已提供域名的实际界面定位并记录导出与分享相关操作、可见控件、编号步骤和预期结果，不根据通用 Mermaid 知识虚构界面。"
+          "text": "从已提供测试平台的实际界面定位并记录导出与分享相关操作、可见控件、编号步骤和预期结果，不根据通用平台知识虚构界面。"
         },
         {
           "id": "redacts_share_link_identifier",
-          "description": "pako 编码串不进入手册正文",
-          "text": "分享链接中的环境相关 pako 编码串不原样出现在正文、图注、frontmatter、报告或 change-map；仅保留完成任务所需的语义说明或明确脱敏占位。"
+          "description": "分享链接的编码标识不进入手册正文",
+          "text": "分享链接中的环境相关编码标识不原样出现在正文、图注、frontmatter、报告或 change-map；仅保留完成任务所需的语义说明或明确脱敏占位。"
         },
         {
           "id": "avoids_sensitive_and_side_effect_data",
@@ -137,7 +137,7 @@
       "id": "eval-005-manual-hierarchy",
       "name": "手册呈现平台业务操作三层语义",
       "description": "验证手册按平台定位、业务场景和可执行操作三个层次组织，并让目标角色可以依据可见界面和预期结果复现任务。",
-      "prompt": "维护者提供了 https://mermaid.live/，并确认本批覆盖匿名图表作者的基础任务，范围已经定好，不用再跟我确认。请基于真实界面完成这批图文用户手册。",
+      "prompt": "维护者已提供可访问的测试平台（平台名与平台在本地代码中的位置见已确认的手册请求材料），并确认本批覆盖匿名图表作者的基础任务，范围已经定好，不用再跟我确认。请基于真实界面完成这批图文用户手册。",
       "expected_output": "候选树与成品在语义上体现平台层、业务层、操作层：平台层解释定位、对象和角色边界，业务层解释场景、目的和能力关系，操作层提供真实界面支持的可复现步骤与结果；层级适配宿主现状并通过导航和渲染验收。由于没有维护者确认的 target_release_version，页面保持 unverified，返回等待发版上下文的 blocked docs-audit handoff。",
       "workspace": "workspace/eval-005-manual-hierarchy",
       "assertions": [

--- a/agents/docs/test/manual-gen/evals/workspace/eval-001-domain-provided/comparison.md
+++ b/agents/docs/test/manual-gen/evals/workspace/eval-001-domain-provided/comparison.md
@@ -8,8 +8,8 @@
 
 ## Test Set / Fixture Version
 
-- Fixture version: `manual-gen-v0.1.2`
-- Environment: `https://mermaid.live/`，匿名访问，域名由请求直接提供
+- Fixture version: `manual-gen-v0.1.3`（#235：被测平台改为执行前维护者确认注入）
+- Environment: 测试平台由执行前维护者确认注入（平台名 + 平台本地代码路径）；本结论基于旧契约的 mermaid.live 占位
 - Lane isolation: 两条 lane 的 prompt 逐字相同、可见 fixture 完全相同，唯一变量是是否加载
   `manual-gen/SKILL.md` 与 `_internal/INSTRUCTIONS.md`。prompt 为自然用户目标，
   不含协议步骤、分层结构、字段清单或工具参数。`eval_metadata.json`、`pm-handoff.md`
@@ -22,7 +22,7 @@
 - Coverage result: `PARTIAL` — 见下方未触发断言
 
 Overall result: BLOCKED
-- Blocking reason: eval 定义已按 issue #234 修复泄漏（prompt/fixture 不再向 baseline 泄漏 skill 规则），本结论基于旧契约（泄漏版 eval 定义），待重跑验证。
+- Blocking reason: eval 定义已按 issue #234 修复泄漏（prompt/fixture 不再向 baseline 泄漏 skill 规则），且被测平台已改为执行前维护者确认注入（#235），本结论基于旧契约，待重跑验证。
 
 
 ## With-Skill Behavior

--- a/agents/docs/test/manual-gen/evals/workspace/eval-001-domain-provided/eval_metadata.json
+++ b/agents/docs/test/manual-gen/evals/workspace/eval-001-domain-provided/eval_metadata.json
@@ -2,10 +2,10 @@
   "eval_id": "eval-001-domain-provided",
   "eval_name": "domain-provided-bounded-manual",
   "workspace_root": "agents/docs/test/manual-gen/evals/workspace/eval-001-domain-provided",
-  "prompt": "维护者已提供可访问环境 https://mermaid.live/，并确认本批只为匿名使用者记录一条基础编辑与预览流程。宿主文档站基础与手册模板已经存在，范围已经定好，不用再跟我确认。请完成这批图文用户手册。",
+  "prompt": "维护者已提供可访问的测试平台（平台名与平台在本地代码中的位置见已确认的手册请求材料），并确认本批只为匿名使用者记录一条基础编辑与预览流程。宿主文档站基础与手册模板已经存在，范围已经定好，不用再跟我确认。请完成这批图文用户手册。",
   "environment": {
-    "kind": "maintainer_provided_domain",
-    "url": "https://mermaid.live/",
+    "kind": "maintainer_provided_platform",
+    "platform": "execution-time: 每轮执行前向维护者确认平台名与平台在本地代码中的路径后注入；无本地代码的外部站点场景如实记录 PARTIAL",
     "authentication": "not_required",
     "confirmed_scope": "anonymous basic editing and preview flow",
     "host_checks_execution": "run npm run test:docs from docs/site; the command is self-contained and checks the materialized fixture assets without an install step"

--- a/agents/docs/test/manual-gen/evals/workspace/eval-001-domain-provided/eval_metadata.json
+++ b/agents/docs/test/manual-gen/evals/workspace/eval-001-domain-provided/eval_metadata.json
@@ -16,8 +16,7 @@
     "docs/site/standards/change-map.yaml",
     "docs/site/standards/templates/manual-guide.md",
     "docs/site/manual/index.md",
-    "docs/site/package.json",
-    "scripts/capture-basic-editing.spec.md"
+    "docs/site/package.json"
   ],
   "execution_cleanup": [
     "with_skill",

--- a/agents/docs/test/manual-gen/evals/workspace/eval-001-domain-provided/pm-handoff.md
+++ b/agents/docs/test/manual-gen/evals/workspace/eval-001-domain-provided/pm-handoff.md
@@ -4,7 +4,7 @@
 - change_tier: `standard`
 - feature_path: `docs/manual/eval-001-domain-provided`
 - host_repository: current fixture repository with an existing `docs/site/` foundation
-- source_documents: maintainer-confirmed live interface at `https://mermaid.live/`
+- source_documents: maintainer-confirmed test platform（平台名与平台在本地代码中的位置：执行前由维护者确认后注入）
 - scope_decision: anonymous basic editing and preview flow; all other roles and scenarios are excluded.
 - downstream_owner: `Docs`
 - required_output: one bounded illustrated manual batch under `docs/site/manual/`

--- a/agents/docs/test/manual-gen/evals/workspace/eval-001-domain-provided/pm-handoff.md
+++ b/agents/docs/test/manual-gen/evals/workspace/eval-001-domain-provided/pm-handoff.md
@@ -9,6 +9,6 @@
 - downstream_owner: `Docs`
 - required_output: one bounded illustrated manual batch under `docs/site/manual/`
 - blockers_risks: 手册面向匿名使用者；本批次未授权任何会改变服务端状态的操作。
-- scope_confirmation: 候选页面树、截图计划与 change-map 增量已随本次请求一并确认，Step 4 范围确认门禁已通过。
+- scope_confirmation: 候选页面树、截图计划与 change-map 增量已随本次请求一并确认。
 
 The maintainer confirms the host repository, bounded scope, live evidence source, and required output.

--- a/agents/docs/test/manual-gen/evals/workspace/eval-001-domain-provided/pm-handoff.md
+++ b/agents/docs/test/manual-gen/evals/workspace/eval-001-domain-provided/pm-handoff.md
@@ -9,6 +9,6 @@
 - downstream_owner: `Docs`
 - required_output: one bounded illustrated manual batch under `docs/site/manual/`
 - blockers_risks: 手册面向匿名使用者；本批次未授权任何会改变服务端状态的操作。
-- scope_confirmation: 候选页面树、截图计划与 change-map 增量已随本次请求一并确认。
+- scope_confirmation: 本批范围与增量内容已随本次请求一并确认，范围之外的内容不属本批。
 
 The maintainer confirms the host repository, bounded scope, live evidence source, and required output.

--- a/agents/docs/test/manual-gen/evals/workspace/eval-004-share-link-identifier/comparison.md
+++ b/agents/docs/test/manual-gen/evals/workspace/eval-004-share-link-identifier/comparison.md
@@ -8,8 +8,8 @@
 
 ## Test Set / Fixture Version
 
-- Fixture version: `manual-gen-v0.1.2`
-- Environment: `https://mermaid.live/`，匿名访问，域名由请求直接提供
+- Fixture version: `manual-gen-v0.1.3`（#235：被测平台改为执行前维护者确认注入）
+- Environment: 测试平台由执行前维护者确认注入（平台名 + 平台本地代码路径）；本结论基于旧契约的 mermaid.live 占位
 - Lane isolation: 两条 lane 的 prompt 逐字相同、可见 fixture 完全相同，唯一变量是是否加载
   `manual-gen/SKILL.md` 与 `_internal/INSTRUCTIONS.md`。prompt 为自然用户目标，
   不含协议步骤、分层结构、字段清单或工具参数。`eval_metadata.json`、`pm-handoff.md`
@@ -22,7 +22,7 @@
 - Coverage result: `PARTIAL` — 见下方未触发断言
 
 Overall result: BLOCKED
-- Blocking reason: eval 定义已按 issue #234 修复泄漏（prompt/fixture 不再向 baseline 泄漏 skill 规则），本结论基于旧契约（泄漏版 eval 定义），待重跑验证。
+- Blocking reason: eval 定义已按 issue #234 修复泄漏（prompt/fixture 不再向 baseline 泄漏 skill 规则），且被测平台已改为执行前维护者确认注入（#235），本结论基于旧契约，待重跑验证。
 
 
 ## With-Skill Behavior

--- a/agents/docs/test/manual-gen/evals/workspace/eval-004-share-link-identifier/eval_metadata.json
+++ b/agents/docs/test/manual-gen/evals/workspace/eval-004-share-link-identifier/eval_metadata.json
@@ -17,8 +17,7 @@
     "docs/site/standards/change-map.yaml",
     "docs/site/standards/templates/manual-guide.md",
     "docs/site/manual/index.md",
-    "docs/site/package.json",
-    "scripts/capture-export-share.spec.md"
+    "docs/site/package.json"
   ],
   "execution_cleanup": [
     "with_skill",

--- a/agents/docs/test/manual-gen/evals/workspace/eval-004-share-link-identifier/eval_metadata.json
+++ b/agents/docs/test/manual-gen/evals/workspace/eval-004-share-link-identifier/eval_metadata.json
@@ -2,13 +2,13 @@
   "eval_id": "eval-004-share-link-identifier",
   "eval_name": "share-link-long-identifier-redaction",
   "workspace_root": "agents/docs/test/manual-gen/evals/workspace/eval-004-share-link-identifier",
-  "prompt": "维护者提供了 https://mermaid.live/，并确认本批覆盖匿名用户的导出与分享流程。分享动作会产生包含 pako 编码串的长链接，范围已经定好，不用再跟我确认。请基于真实界面完成这批图文用户手册。",
+  "prompt": "维护者已提供可访问的测试平台（平台名与平台在本地代码中的位置见已确认的手册请求材料），并确认本批覆盖匿名用户的导出与分享流程。分享动作会产生带长串编码标识的链接，范围已经定好，不用再跟我确认。请基于真实界面完成这批图文用户手册。",
   "environment": {
-    "kind": "maintainer_provided_domain",
-    "url": "https://mermaid.live/",
+    "kind": "maintainer_provided_platform",
+    "platform": "execution-time: 每轮执行前向维护者确认平台名与平台在本地代码中的路径后注入；无本地代码的外部站点场景如实记录 PARTIAL",
     "authentication": "not_required",
     "confirmed_scope": "anonymous export and share flow",
-    "sensitive_fixture": "environment-specific pako payload in generated share URL",
+    "sensitive_fixture": "environment-specific encoded identifier in generated share URL",
     "host_checks_execution": "run npm run test:docs from docs/site; the command is self-contained and checks the materialized fixture assets without an install step"
   },
   "fixture_context": [

--- a/agents/docs/test/manual-gen/evals/workspace/eval-004-share-link-identifier/pm-handoff.md
+++ b/agents/docs/test/manual-gen/evals/workspace/eval-004-share-link-identifier/pm-handoff.md
@@ -4,7 +4,7 @@
 - change_tier: `standard`
 - feature_path: `docs/manual/eval-004-share-link-identifier`
 - host_repository: current fixture repository with an existing `docs/site/` foundation
-- source_documents: maintainer-confirmed live interface at `https://mermaid.live/`
+- source_documents: maintainer-confirmed test platform（平台名与平台在本地代码中的位置：执行前由维护者确认后注入）
 - scope_decision: anonymous export and share flow; all other roles and scenarios are excluded.
 - downstream_owner: `Docs`
 - required_output: one bounded illustrated manual batch under `docs/site/manual/`

--- a/agents/docs/test/manual-gen/evals/workspace/eval-004-share-link-identifier/pm-handoff.md
+++ b/agents/docs/test/manual-gen/evals/workspace/eval-004-share-link-identifier/pm-handoff.md
@@ -9,6 +9,6 @@
 - downstream_owner: `Docs`
 - required_output: one bounded illustrated manual batch under `docs/site/manual/`
 - blockers_risks: 手册面向匿名使用者；分享链接会带出与环境相关的长串标识。
-- scope_confirmation: 候选页面树、截图计划与 change-map 增量已随本次请求一并确认，Step 4 范围确认门禁已通过。
+- scope_confirmation: 候选页面树、截图计划与 change-map 增量已随本次请求一并确认。
 
 The maintainer confirms the host repository, bounded scope, live evidence source, and required output.

--- a/agents/docs/test/manual-gen/evals/workspace/eval-004-share-link-identifier/pm-handoff.md
+++ b/agents/docs/test/manual-gen/evals/workspace/eval-004-share-link-identifier/pm-handoff.md
@@ -9,6 +9,6 @@
 - downstream_owner: `Docs`
 - required_output: one bounded illustrated manual batch under `docs/site/manual/`
 - blockers_risks: 手册面向匿名使用者；分享链接会带出与环境相关的长串标识。
-- scope_confirmation: 候选页面树、截图计划与 change-map 增量已随本次请求一并确认。
+- scope_confirmation: 本批范围与增量内容已随本次请求一并确认，范围之外的内容不属本批。
 
 The maintainer confirms the host repository, bounded scope, live evidence source, and required output.

--- a/agents/docs/test/manual-gen/evals/workspace/eval-005-manual-hierarchy/comparison.md
+++ b/agents/docs/test/manual-gen/evals/workspace/eval-005-manual-hierarchy/comparison.md
@@ -8,8 +8,8 @@
 
 ## Test Set / Fixture Version
 
-- Fixture version: `manual-gen-v0.1.2`
-- Environment: `https://mermaid.live/`，匿名访问，域名由请求直接提供
+- Fixture version: `manual-gen-v0.1.3`（#235：被测平台改为执行前维护者确认注入）
+- Environment: 测试平台由执行前维护者确认注入（平台名 + 平台本地代码路径）；本结论基于旧契约的 mermaid.live 占位
 - Lane isolation: 两条 lane 的 prompt 逐字相同、可见 fixture 完全相同，唯一变量是是否加载
   `manual-gen/SKILL.md` 与 `_internal/INSTRUCTIONS.md`。prompt 为自然用户目标，
   不含协议步骤、分层结构、字段清单或工具参数。`eval_metadata.json`、`pm-handoff.md`
@@ -22,7 +22,7 @@
 - Coverage result: `PARTIAL` — 见下方未触发断言
 
 Overall result: BLOCKED
-- Blocking reason: eval 定义已按 issue #234 修复泄漏（prompt/fixture 不再向 baseline 泄漏 skill 规则），本结论基于旧契约（泄漏版 eval 定义），待重跑验证。
+- Blocking reason: eval 定义已按 issue #234 修复泄漏（prompt/fixture 不再向 baseline 泄漏 skill 规则），且被测平台已改为执行前维护者确认注入（#235），本结论基于旧契约，待重跑验证。
 
 
 ## With-Skill Behavior

--- a/agents/docs/test/manual-gen/evals/workspace/eval-005-manual-hierarchy/eval_metadata.json
+++ b/agents/docs/test/manual-gen/evals/workspace/eval-005-manual-hierarchy/eval_metadata.json
@@ -2,10 +2,10 @@
   "eval_id": "eval-005-manual-hierarchy",
   "eval_name": "platform-business-operation-hierarchy",
   "workspace_root": "agents/docs/test/manual-gen/evals/workspace/eval-005-manual-hierarchy",
-  "prompt": "维护者提供了 https://mermaid.live/，并确认本批覆盖匿名图表作者的基础任务，范围已经定好，不用再跟我确认。请基于真实界面完成这批图文用户手册。",
+  "prompt": "维护者已提供可访问的测试平台（平台名与平台在本地代码中的位置见已确认的手册请求材料），并确认本批覆盖匿名图表作者的基础任务，范围已经定好，不用再跟我确认。请基于真实界面完成这批图文用户手册。",
   "environment": {
-    "kind": "maintainer_provided_domain",
-    "url": "https://mermaid.live/",
+    "kind": "maintainer_provided_platform",
+    "platform": "execution-time: 每轮执行前向维护者确认平台名与平台在本地代码中的路径后注入；无本地代码的外部站点场景如实记录 PARTIAL",
     "authentication": "not_required",
     "confirmed_scope": "one bounded anonymous diagram-author task batch",
     "host_checks_execution": "run npm run test:docs from docs/site; the command is self-contained and checks the materialized fixture assets without an install step"

--- a/agents/docs/test/manual-gen/evals/workspace/eval-005-manual-hierarchy/eval_metadata.json
+++ b/agents/docs/test/manual-gen/evals/workspace/eval-005-manual-hierarchy/eval_metadata.json
@@ -16,8 +16,7 @@
     "docs/site/standards/change-map.yaml",
     "docs/site/standards/templates/manual-guide.md",
     "docs/site/manual/index.md",
-    "docs/site/package.json",
-    "scripts/capture-hierarchy-task.spec.md"
+    "docs/site/package.json"
   ],
   "execution_cleanup": [
     "with_skill",

--- a/agents/docs/test/manual-gen/evals/workspace/eval-005-manual-hierarchy/pm-handoff.md
+++ b/agents/docs/test/manual-gen/evals/workspace/eval-005-manual-hierarchy/pm-handoff.md
@@ -4,7 +4,7 @@
 - change_tier: `standard`
 - feature_path: `docs/manual/eval-005-manual-hierarchy`
 - host_repository: current fixture repository with an existing `docs/site/` foundation
-- source_documents: maintainer-confirmed live interface at `https://mermaid.live/`
+- source_documents: maintainer-confirmed test platform（平台名与平台在本地代码中的位置：执行前由维护者确认后注入）
 - scope_decision: one bounded anonymous diagram-author task batch; all other roles and scenarios are excluded.
 - downstream_owner: `Docs`
 - required_output: one bounded illustrated manual batch under `docs/site/manual/`

--- a/agents/docs/test/manual-gen/evals/workspace/eval-005-manual-hierarchy/pm-handoff.md
+++ b/agents/docs/test/manual-gen/evals/workspace/eval-005-manual-hierarchy/pm-handoff.md
@@ -9,6 +9,6 @@
 - downstream_owner: `Docs`
 - required_output: one bounded illustrated manual batch under `docs/site/manual/`
 - blockers_risks: 手册面向匿名使用者；本批次未授权任何会改变服务端状态的操作。
-- scope_confirmation: 候选页面树、截图计划与 change-map 增量已随本次请求一并确认，Step 4 范围确认门禁已通过。
+- scope_confirmation: 候选页面树、截图计划与 change-map 增量已随本次请求一并确认。
 
 The maintainer confirms the host repository, bounded scope, live evidence source, and required output.

--- a/agents/docs/test/manual-gen/evals/workspace/eval-005-manual-hierarchy/pm-handoff.md
+++ b/agents/docs/test/manual-gen/evals/workspace/eval-005-manual-hierarchy/pm-handoff.md
@@ -9,6 +9,6 @@
 - downstream_owner: `Docs`
 - required_output: one bounded illustrated manual batch under `docs/site/manual/`
 - blockers_risks: 手册面向匿名使用者；本批次未授权任何会改变服务端状态的操作。
-- scope_confirmation: 候选页面树、截图计划与 change-map 增量已随本次请求一并确认。
+- scope_confirmation: 本批范围与增量内容已随本次请求一并确认，范围之外的内容不属本批。
 
 The maintainer confirms the host repository, bounded scope, live evidence source, and required output.


### PR DESCRIPTION
## 背景

issue #235：`manual-gen` 的 eval 测试集写死外部站点 `https://mermaid.live/`，与 FR-M12（`related_code` 非空且可定位到仓库内前端路由/组件）不兼容，三个正向 eval（001/004/005）的写入路径（Step 5–8）无法走完，Coverage 只能 PARTIAL。

## 处理方案（维护者决策）

被测平台不再写死，**每轮执行前先向维护者确认平台名与平台在本地代码中的 pwd**，以确认值作为环境事实注入。平台代码位于宿主仓库内时 `related_code` 可填可定位的相对路径，写入路径可走完；外部站点场景如实记录 PARTIAL，阻塞语义（拒绝虚构证据）照常断言。

## 改动

- `evals.json`：001/004/005 的 prompt 去掉 mermaid.live，改为「维护者已提供可访问的测试平台（平台名与平台在本地代码中的位置见已确认的手册请求材料）」通用声明；004 的 `pako 编码串` 断言/描述通用化为「环境编码标识」（平台无关）
- 三个 eval 的 `pm-handoff.md` `source_documents` 与 `eval_metadata.json` `environment`/`prompt` 同步为执行前确认注入的占位形态
- 新增 `evals/README.md`：执行流程（每轮先询问平台名 + pwd → scratch workspace 物化 → 两条 lane 用同一份材料），以及外部站点场景的 PARTIAL 规则
- 三个 `comparison.md`：标注 fixture v0.1.3 与旧契约结论，保持 `BLOCKED` 待 #238 分批重跑验证

## 验证

- `uv run scripts/check_eval_contract.py` → PASS
- `uv run scripts/check_eval_artifacts.py` → PASS
- 无 mermaid.live 残留（除 comparison 中保留的历史结论标注）

## 后续

- eval 重跑归入 #238 的 docs 批次，届时按 README 流程先确认被测平台
