### PR TITLE
docs(eval): 统一项目级评测工作流

### DIFF
--- a/.agents/skills/skill-eval-runner/SKILL.md
+++ b/.agents/skills/skill-eval-runner/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: skill-eval-runner
+description: Author, review, run, batch, inspect, and diagnose this repository's skill evaluations. Use when Codex needs to create or change evals.json, scenarios, prompts, assertions, eval_metadata.json, fixtures, or comparison.md; select and run fresh paired eval targets with up to 10 workers; inspect summaries; distinguish eval defects from skill defects or infrastructure blockers; or verify eval contracts without model execution. Do not use for ordinary unit tests or QA E2E product testing.
+---
+
+# Skill Eval Runner
+
+Operate the repository's skill-eval lifecycle without reimplementing its validation,
+isolation, judging, persistence, or cleanup logic. Treat this skill as the operator
+workflow, `scripts/check_eval_contract.py` as the definition contract, and
+`scripts/run_skill_eval.py` plus `scripts/eval_runtime.py` as the executable contract.
+
+Read [references/eval-authoring.md](references/eval-authoring.md) before creating,
+changing, or reviewing an eval definition, metadata file, or candidate-visible fixture.
+Read [references/eval-runbook.md](references/eval-runbook.md) before launching model
+evals or diagnosing a non-passing result. For a static contract-only request, the
+commands in this file are sufficient.
+
+## Classify the Request
+
+- Treat “检查 eval 定义、comparison 或 CI” as static verification. Do not launch
+  `codex exec`.
+- Treat “新增、修改或评审 eval” as authoring. Validate scenario truthfulness, prompt
+  naturalness, assertion semantics, metadata, and candidate-visible materials before
+  considering a model run.
+- Treat “运行、重跑、批量跑 eval” as model execution. Require explicit user
+  authorization because it consumes model time and rewrites durable results.
+- Treat “分析 FAIL/BLOCKED/PARTIAL” as diagnosis. Inspect current evidence before
+  proposing changes; do not rerun first.
+- Exclude `manual-gen`; it is the repository's only manual-only skill.
+
+## Establish the Target
+
+Resolve targets from `agents/{agent}/test/{skill}/evals/evals.json`. Prefer the
+narrowest selector that satisfies the request:
+
+```bash
+# One eval
+uv run scripts/run_skill_eval.py \
+  --agent docs --skill docs-audit --eval eval-001-audit-mismatch --jobs 1
+
+# One skill
+uv run scripts/run_skill_eval.py --agent docs --skill docs-audit --jobs 10
+
+# One role
+uv run scripts/run_skill_eval.py --agent docs --jobs 10
+
+# Exact targets across roles; repeat --select
+uv run scripts/run_skill_eval.py --jobs 10 \
+  --select docs/docs-audit/eval-001-audit-mismatch \
+  --select qa/bug-analyzer/eval-001-analyze-test-failure
+
+# All regular evals
+uv run scripts/run_skill_eval.py --jobs 10
+```
+
+Use `--metadata <path>` only for one exact metadata file. Do not combine it with
+filters or `--select`. Use `uv run scripts/run_skill_eval.py --help` rather than
+guessing a flag.
+
+## Run Static Gates First
+
+Run these checks before any model eval:
+
+```bash
+uv run scripts/check_repository_contract.py
+uv run scripts/check_eval_contract.py
+uv run scripts/check_eval_artifacts.py
+uv run scripts/check_doc_contract.py
+```
+
+Stop and repair a static contract failure before spending model calls. Do not convert a
+static failure into `BLOCKED` by manually editing `comparison.md`.
+
+## Preserve the Execution Boundary
+
+- Launch one `run_skill_eval.py` process. Let its `--jobs` pool provide concurrency.
+  Never shell-parallelize multiple runner processes against the same checkout.
+- Use at most `--jobs 10`. Parallelism is across eval targets only.
+- Preserve each target's serial order: fresh `without_skill`, destroy it; fresh
+  `with_skill`, destroy it; then create the read-only fresh judge.
+- Keep the candidate prompt and canonical fixture identical across both lanes. The
+  only variable is whether the target skill and its declared dependencies are loaded.
+- Keep `gpt-5.6-luna` with `model_reasoning_effort="medium"` for both candidates and
+  the judge. If unavailable, report `BLOCKED`; do not substitute a model.
+- Do not edit eval inputs while a batch is running. The runner locks inputs and rejects
+  source drift, but concurrent edits waste completed model work.
+- Do not reuse an older baseline, a candidate self-assessment, or a transcript as the
+  verdict.
+
+## Interpret and Persist Results
+
+- Accept `PASS`, `PASS (partial coverage)`, or `FAIL` only from the fresh independent
+  judge after both lane outputs and raw evidence are locked.
+- Treat preflight, candidate, dependency, schema, or judge completion failures as
+  `BLOCKED`. Do not fabricate a durable result to make the contract green.
+- Let the runner transactionally update the target `comparison.md` and migration
+  inventory. Do not hand-copy results between evals.
+- Keep only the latest result in `comparison.md`; use Git history for superseded runs.
+- Expect any non-passing target to make the batch command exit nonzero. Classify each
+  target from its printed `Overall result` and blockers instead of treating the whole
+  process as one undifferentiated failure.
+- Confirm the runner removes `tmp/eval-runs/` and all candidate, snapshot, judge,
+  transcript, timing, and diagnostic artifacts on every exit path.
+
+Summarize durable results with:
+
+```bash
+uv run scripts/summarize_eval_results.py
+```
+
+## Diagnose Before Changing Anything
+
+- If preflight or model execution is `BLOCKED`, diagnose infrastructure or isolation;
+  do not score the skill.
+- If the prompt, scenario, fixture, or assertions leak protocol details or contradict
+  available materials, fix the eval definition or fixture.
+- If the eval is valid and with-skill behavior violates the skill contract, record a
+  skill defect. Do not weaken assertions to turn it green.
+- If both lanes pass, check for fixture leakage, behavior already supplied by a shipped
+  template, or baseline capability. Treat zero differentiation as lifecycle evidence,
+  not a reason to forge a difference.
+- If behavior passes with partial coverage, list unexercised assertions and decide
+  whether another realistic eval is needed. Do not relabel it as a behavior failure.
+- Create or update GitHub issues only when the user authorizes external writes. Keep
+  eval defects, skill defects, and runner/infrastructure defects as separate issues.
+
+## Verify the Final State
+
+After a model run or eval-related edit, run:
+
+```bash
+uv run scripts/check_eval_contract.py
+uv run scripts/check_eval_artifacts.py
+uv run scripts/summarize_eval_results.py
+git status --short
+git diff --check
+```
+
+Report the exact selected targets, worker count, result counts, blockers, files changed,
+and whether runtime artifacts remain. Never claim that required CI ran model evals;
+`.github/workflows/ci.yml` runs deterministic contracts and tests, while model evals are
+manual through `.github/workflows/evals.yml`.

--- a/.agents/skills/skill-eval-runner/agents/openai.yaml
+++ b/.agents/skills/skill-eval-runner/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Skill Eval Runner"
+  short_description: "编写、运行并诊断本仓库的隔离 paired skill eval"
+  default_prompt: "使用 $skill-eval-runner 编写、运行或诊断本仓库的 fresh paired skill eval。"

--- a/.agents/skills/skill-eval-runner/references/eval-authoring.md
+++ b/.agents/skills/skill-eval-runner/references/eval-authoring.md
@@ -1,0 +1,97 @@
+# Eval Authoring Contract
+
+## Scope and Purpose
+
+Create a regular eval for every marketplace skill except `docs/manual-gen`, the only
+manual-only exception. Do not infer new exceptions. Require maintainer approval and a
+checker update before adding another manual-only skill.
+
+Use skill evals to test skill-specific usability: activation, protocol execution,
+context use, evidence handling, blocking discipline, handoff boundaries, and expected
+role output. Do not score generic writing quality or require one exact phrasing when
+several equivalent answers are valid.
+
+## Definition and Metadata
+
+Use schema version `1.0` under
+`agents/{agent}/test/{skill}/evals/evals.json`. Treat
+`scripts/check_eval_contract.py` as the exact field and path authority rather than
+copying its schema into prose.
+
+For each eval:
+
+- use a unique `eval-NNN-short-slug` ID and a real `workspace/...` directory;
+- provide non-empty name, description, prompt, expected output, scenario, and semantic
+  assertion objects;
+- define scenario persona, situation, trigger, goal, materials, constraints, and
+  success criteria from facts that exist in the user request or candidate workspace;
+- keep assertion IDs lower snake case and assertion text outcome-oriented;
+- keep the prompt only in `evals.json`, never duplicated in metadata;
+- declare all explicit cross-skill dependencies and all six runtime-isolation surfaces;
+- use output declarations only for deterministic candidate outputs; baseline outputs
+  are diagnostic and never a passing gate;
+- omit `validation_method` and runtime diagnostic artifact paths from committed
+  metadata.
+
+Run `uv run scripts/check_eval_contract.py` after every authoring change.
+
+## Scenario and Prompt Integrity
+
+Write the prompt as a request a real user would make outside this test repository.
+Describe the problem and desired outcome, not the test protocol.
+
+Reject prompt text that names or explains internal skills, agents, gates, steps,
+`feature_path`, `change_tier`, assertions, expected output, runner modes, model choice,
+or judging. Express required authorization naturally, such as “范围已经确认，可以直接
+处理”, instead of declaring an internal gate passed.
+
+Apply this leakage test to every sentence:
+
+> If deleting the sentence leaves the real user goal complete but prevents an agent
+> unfamiliar with the skill from guessing a scoring item, delete it.
+
+Do not derive the scenario backward from the skill rules. Verify that every claimed
+material, Git ref, dependency, runtime, and authorization actually exists in both
+candidate lanes before loading the target skill.
+
+## Assertions
+
+Derive assertions from the documented skill obligations and observable user outcome.
+Use semantic evidence rather than exact strings when localization, formatting, or
+equivalent wording may vary.
+
+Do not copy assertions into prompts, required-output lists, handoff blockers, README
+instructions, evidence summaries, or fixture comments. Keep authorization, safety, and
+workflow assertions testable through natural facts and actual candidate behavior.
+
+## Candidate-Visible Fixture
+
+Include only host-native facts that both candidate lanes should see. Remove
+`eval_metadata.json`, `evals.json`, old comparisons, assertions, expected output, judge
+instructions, transcripts, diagnostics, mode labels, and answer-bearing scripts or
+summaries from the materialized fixture.
+
+Use `required_output` in a handoff only for the user's desired deliverable shape. Use
+`blockers_risks` only for objective risks. Do not place skill rules or scoring
+prohibitions in either field.
+
+Treat templates, standards, source code, configurations, raw diffs, logs, and
+maintainer-approved scope as legitimate host material. Reject synthetic `.rules`,
+`evidence.md`, README text, comments, fake object IDs, or renamed setup scripts created
+only to reveal an answer. Confirm that referenced files and Git topology are executable,
+not merely described in prose.
+
+## Persistence and Review
+
+Commit the eval definition, metadata, host fixture, and latest durable `comparison.md`.
+Never commit lane workspaces, outputs, snapshots, judge packages, verdicts, transcripts,
+timing, diagnostics, or run-status files.
+
+After changing a skill, internal instruction, assertion dependency, or behavioral
+fixture, identify the affected evals and ask whether to run them. Launch model evals
+only after explicit authorization. If a fresh run occurs, let the shared runner update
+the latest comparison; never handcraft a PASS or reuse an earlier baseline.
+
+If both lanes satisfy an assertion, check for prompt or fixture leakage, behavior
+shipped inside a template, or baseline model capability. Record the cause instead of
+weakening the assertion or fabricating differentiation.

--- a/.agents/skills/skill-eval-runner/references/eval-runbook.md
+++ b/.agents/skills/skill-eval-runner/references/eval-runbook.md
@@ -1,0 +1,203 @@
+# Skill Eval Runbook
+
+## Purpose
+
+Use this runbook to operate the shared paired evaluator introduced by Issue #246. It
+describes the current repository behavior; the Python implementation remains the
+authority when commands or fields change.
+
+## Contents
+
+- [End-to-End Flow](#end-to-end-flow)
+- [Parallelism Model](#parallelism-model)
+- [Inputs Locked at Start](#inputs-locked-at-start)
+- [Isolation Preflight](#isolation-preflight)
+- [Candidate and Judge Evidence](#candidate-and-judge-evidence)
+- [Durable and Ephemeral Outputs](#durable-and-ephemeral-outputs)
+- [Result Triage](#result-triage)
+- [Command Reference](#command-reference)
+
+## End-to-End Flow
+
+```mermaid
+flowchart TD
+    A["Select exact eval targets"] --> B["Run repository, eval, artifact, and doc contracts"]
+    B -->|"failure"| C["Repair static contract; do not call models"]
+    B -->|"pass"| D["Lock eval definition, metadata, fixture, skill overlay, and judge schema"]
+    D --> E["Materialize canonical fixture and runtime dependencies"]
+    E --> F["Open without-skill context"]
+    F --> G["Run isolation preflight"]
+    G -->|"blocked"| H["Return BLOCKED and clean runtime"]
+    G -->|"pass"| I["Run fresh baseline and lock raw evidence"]
+    I --> J["Destroy without-skill context"]
+    J --> K["Open with-skill context with locked target skill and dependencies"]
+    K --> L["Run isolation preflight"]
+    L -->|"blocked"| H
+    L -->|"pass"| M["Run fresh candidate and lock raw evidence"]
+    M --> N["Destroy with-skill context"]
+    N --> O["Open third fresh read-only judge"]
+    O --> P["Validate judge preflight and structured verdict"]
+    P -->|"blocked"| H
+    P -->|"valid"| Q["Executor recomputes Behavior, Coverage, and Overall"]
+    Q --> R["Recheck source identity"]
+    R -->|"drift"| H
+    R -->|"stable"| S["Transactionally replace latest comparison and inventory state"]
+    S --> T["Always delete all runtime artifacts"]
+    H --> T
+```
+
+## Parallelism Model
+
+Use one runner process with `--jobs 1..10`.
+
+```text
+runner process
+├── worker 1: eval A = without → with → judge
+├── worker 2: eval B = without → with → judge
+├── ...
+└── worker 10: eval J = without → with → judge
+```
+
+The worker pool parallelizes independent eval targets. It never parallelizes the three
+contexts inside one eval. The in-process durable write lock protects the inventory and
+comparison transaction. Starting several runner processes removes that protection and
+is unsupported.
+
+Use `--jobs 1` for one target or when reproducing a timing-sensitive infrastructure
+failure. Use `--jobs 10` for role, skill, cross-role, or full batches unless resource
+pressure makes a lower value necessary.
+
+## Inputs Locked at Start
+
+The runner locks or hashes these inputs before candidate execution:
+
+- the selected eval item and its assertions;
+- its `eval_metadata.json` bytes;
+- the canonical candidate-visible fixture;
+- the target skill plus declared `skill_dependencies` overlay;
+- the judge result schema;
+- the shared executor and runtime implementations.
+
+Only the locked overlay is installed into the with-skill lane. The runner rechecks
+source identity before durable persistence. A drift or mismatch is `BLOCKED`.
+
+## Isolation Preflight
+
+Each candidate context must prove:
+
+- the workspace is readable and writable;
+- its isolated `HOME` is writable;
+- repository source, sibling context, and isolated `CODEX_HOME` authentication bytes
+  are unreadable;
+- the two canonical fixtures have the same manifest and prompt hash;
+- without-skill cannot see the target overlay and with-skill sees only the locked
+  target plus declared dependencies;
+- Git topology and runtime dependencies match the declared metadata;
+- declared process, port, database, browser, login, and download state is isolated,
+  reset, or explicitly `not_used`;
+- the judge context is a fresh third context and is read-only.
+
+Unknown or unprovable isolation is `BLOCKED`, never a degraded run.
+
+## Candidate and Judge Evidence
+
+Both candidate lanes receive the same natural user prompt. Neither receives mode
+labels, assertions, expected output, historical comparison, judge instructions, or
+other eval scaffolding.
+
+The executor locks candidate final output, delivery snapshot, initial and final Git
+state, ref changes, committed diffs, relevant blobs, dependency hashes, return code,
+timeout state, prompt hash, and fixture hash. The independent judge receives only the
+assertions, both locked outputs, and the raw evidence needed to verify them. Candidate
+self-assessment is not evidence.
+
+The executor validates the judge JSON schema and enforces the result combination:
+
+| Behavior | Coverage | Overall |
+| --- | --- | --- |
+| FAIL | FULL or PARTIAL | FAIL |
+| PASS | FULL | PASS |
+| PASS | PARTIAL | PASS (partial coverage) |
+
+External data that does not exercise an assertion affects Coverage, not Behavior.
+
+## Durable and Ephemeral Outputs
+
+A completed fresh judge writes the latest `comparison.md` and the matching inventory
+record in one transaction. A fresh `FAIL` is valid durable evidence and is persisted;
+it must not be disguised as `BLOCKED` or `PASS`.
+
+The durable comparison records the target, source identity, preflight, assertion
+evidence, both lane summaries, Behavior, Coverage, Overall, failures, next steps, and
+runtime artifact policy. It contains only the latest result; previous results remain in
+Git history.
+
+The runner deletes all ephemeral state in `finally`, including workspaces, skill and
+dependency copies, outputs, snapshots, judge package and verdict, transcripts, timing,
+diagnostics, and run status. Do not commit or upload `tmp/eval-runs/`.
+
+## Result Triage
+
+| Observation | Primary classification | Next action |
+| --- | --- | --- |
+| Preflight, dependency, candidate process, model, or judge cannot complete | Runner/infrastructure blocker | Reproduce with one target and `--jobs 1`; fix isolation or execution without scoring the skill. |
+| Prompt or fixture tells the baseline the protocol, gate, answer, or expected behavior | Eval defect | Rewrite the scenario or host material; keep the skill unchanged. |
+| Scenario claims materials, refs, runtime, or dependencies that the lane does not contain | Eval defect | Repair the fixture or narrow the assertion to real evidence. |
+| Valid with-skill lane violates a documented skill obligation | Skill defect | Open a skill issue with assertion and raw behavior evidence. |
+| Both lanes pass the same assertion | Leakage, shipped-template behavior, or baseline capability | Identify the cause; do not manufacture differentiation. |
+| Behavior passes but an assertion is not exercised | Coverage gap | Keep partial coverage and add a realistic scenario only if the missing path matters. |
+| Several evals fail on the same routing or evidence rule | Shared contract or skill-family defect | Cluster by root cause before editing individual evals. |
+
+Keep issue scopes separate so later remediation can answer whether the eval drifted from
+the skill design, the skill has an execution defect, or the runner could not produce
+trustworthy evidence.
+
+## Command Reference
+
+Static validation, without model calls:
+
+```bash
+uv run scripts/check_repository_contract.py
+uv run scripts/check_eval_contract.py
+uv run scripts/check_eval_artifacts.py
+uv run scripts/check_doc_contract.py
+uv run --with pytest pytest \
+  scripts/test_eval_runtime.py \
+  scripts/test_run_skill_eval.py \
+  agents/test_eval_contract.py \
+  scripts/test_check_eval_artifacts.py \
+  scripts/test_summarize_eval_results.py
+```
+
+Fresh model execution:
+
+```bash
+# Exact eval
+uv run scripts/run_skill_eval.py \
+  --agent <agent> --skill <skill> --eval <eval-id> --jobs 1
+
+# Exact mixed set
+uv run scripts/run_skill_eval.py --jobs 10 \
+  --select <agent>/<skill>/<eval-id> \
+  --select <agent>/<skill>/<eval-id>
+
+# Filtered or full batch
+uv run scripts/run_skill_eval.py --agent <agent> --jobs 10
+uv run scripts/run_skill_eval.py --agent <agent> --skill <skill> --jobs 10
+uv run scripts/run_skill_eval.py --jobs 10
+```
+
+Post-run verification:
+
+```bash
+uv run scripts/check_eval_contract.py
+uv run scripts/check_eval_artifacts.py
+uv run scripts/summarize_eval_results.py
+git status --short
+git diff --check
+```
+
+The manual GitHub Actions workflow exposes `target`, optional `skill`, and optional
+`eval_id`, then invokes the same runner with `--jobs 10`. Required CI intentionally
+runs only deterministic contract checks and Python tests; it does not spend model eval
+capacity.

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
-.agents/
+.agents/*
+!.agents/skills/
+.agents/skills/*
+!.agents/skills/skill-eval-runner/
+!.agents/skills/skill-eval-runner/**
 .claude/
 .kiro/
 .windsurf/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,7 +122,7 @@ skill eval 的 Fresh Sub-Agent 门禁作用于 skill 自身的测试流程，不
 
 2. 按现有 Agent 模式创建 `agents/{agent-name}/README.md`
 
-3. 为每个 skill 创建 `skills/{skill-name}/SKILL.md`；除下文登记的 manual-only 例外外，同时创建 `test/{skill-name}/evals/evals.json`，仅在需要渐进加载时创建 `skills/{skill-name}/_internal/`
+3. 为每个 skill 创建 `skills/{skill-name}/SKILL.md`；除项目级 `skill-eval-runner` 登记的 manual-only 例外外，同时创建 `test/{skill-name}/evals/evals.json`，仅在需要渐进加载时创建 `skills/{skill-name}/_internal/`
 
 4. 在 `.claude-plugin/marketplace.json` 注册 Agent：
    ```json
@@ -134,7 +134,7 @@ skill eval 的 Fresh Sub-Agent 门禁作用于 skill 自身的测试流程，不
    ```
    随后用新 skill 元数据更新 `skills-lock.json`
 
-5. 为可常规评测的 skill 添加 eval 并对比使用与不使用 skill 的结果；manual-only skill 记录真实使用反馈与当前结论，再按下节「新增或重命名 Skill 的同步面」逐面核对遗漏项
+5. 为可常规评测的 skill 添加 eval 并对比使用与不使用 skill 的结果；manual-only skill 按项目级 `skill-eval-runner` 记录真实使用反馈与当前结论，再按下节「新增或重命名 Skill 的同步面」逐面核对遗漏项
 
 ### 新增或重命名 Skill 的同步面
 
@@ -155,7 +155,7 @@ skill eval 的 Fresh Sub-Agent 门禁作用于 skill 自身的测试流程，不
 - **发现层**决定客户端在读正文之前是否会选中这个 skill。计数和正文改全了、描述没改，等于新能力在元数据层不存在。
 - **router 路由 eval** 缺失时，路由分支写错也能全绿通过。
 - **PM 入口分类**：`pm-agent` 是默认用户入口，用户不点名 skill 时全部经它分类。下游 router 认识新 specialist，但 PM 的分类词典里没有对应说法时，该能力对普通用户不可达。
-- **既有 skill 的 eval 与 comparison**：本次改动若扩展了它们断言依赖的契约（例如资产数量、类型枚举），旧断言会 stale，旧 `comparison.md` 会让发版评审读到过时结论。此时保留历史结论并标注其适用的旧契约，`Overall result` 记为 `BLOCKED` 待重跑，不要伪造成新的 PASS。
+- **既有 skill 的 eval 与 comparison**：改动若影响断言依赖的契约，必须通过项目级 `skill-eval-runner` 识别受影响范围并处理 fresh 证据；不得沿用或手工伪造旧结论。
 - **过程文档与实际 diff 的一致性**：计划里写成禁止区、实际却改了的文件，会让后续维护者按文档回退掉必要修改。
 
 扩展共享契约（如 `doc_type` 枚举）时，还要同步其全部副本：权威定义、消费方 skill 中的复制表、以及 `docs-site-bootstrap` 交付给宿主的脚本资产与模板。交付给宿主的脚本副本不会随 marketplace 更新自动升级，存量宿主需重跑 bootstrap，PR 中要说明这一点。
@@ -188,101 +188,17 @@ skill eval 的 Fresh Sub-Agent 门禁作用于 skill 自身的测试流程，不
 
 ### Skill 测试
 
-除明确登记的 manual-only 例外外，每个 skill 包含 `test/{skill-name}/evals/evals.json`、eval workspace，以及每个 eval 的 `comparison.md`（使用与不使用 skill 的最新持久化对比结果）。
-
-Skill eval 是可用性测试：验证 skill 能被触发、协议可执行、能产出该角色预期的结构化产物。断言检查 skill 特有行为——上下文读取、执行路径选择、证据处理、阻塞假设、handoff 边界，而不是泛化回答质量。
-
-`manual-gen` 是当前唯一 manual-only 例外：它依赖用户真实的已登录运行环境、对应源码仓库、实际界面状态、截图结果与用户对手册可用性的判断，常规合成 fixture 和 with/without lane 无法提供可信结论。该 skill 不保留 `evals.json` 或 eval workspace，只在 `agents/docs/test/manual-gen/comparison.md` 维护真实使用结论，并根据用户实际使用反馈迭代。其他 skill 不得类推此例外；新增 manual-only skill 必须先获得维护者确认并同步契约检查器。
-
-更新 skill 文档、内部指令或影响 skill 行为的 fixture 后，主动询问是否运行对应 eval。实际执行过 eval 就必须在同一轮变更中更新 durable `comparison.md`；无法生成 baseline、没有可更新文件或不适用时，写明 blocked 或不适用原因。缺少 runner、凭据或外部服务导致无法执行时明确记 blocked，不得静默降级成只读静态验证。
-
-**Eval 定义契约**
-
-- 所有常规 eval 使用共享 `evals.json` schema version `1.0`，不允许 Agent 专属 schema 例外；文件位于 `agents/{agent}/test/{skill-name}/evals/evals.json`，顶层含 `schema_version`、`agent`、`skill_name`、非空 `evals`，`skill_name` 与对应 `SKILL.md` 对齐
-- 每个 eval item 含 `id`（格式 `eval-NNN-short-slug`）、非空 `name`/`description`/`prompt`/`expected_output`、显式 `workspace`（值为 `workspace/...`）、非空对象形式 assertions；每个 assertion 含 lower snake_case `id`、非空 `description` 和非空语义化 `text`，不允许纯字符串 assertion
-- 优先语义断言，避免脆弱的精确字符串检查。语言或格式可合理变化时（如本地化、等价的 lane label），保持预期语义即可
-- 提交前运行 `uv run scripts/check_eval_contract.py`
-
-**Eval 执行契约**
-
-- 最终验证必须在与被测会话隔离的全新上下文中执行。各 eval 独立启动 `codex exec` 会话提供干净上下文。
-- 所有 eval 执行中的 lane（`with_skill` / `without_skill` / 独立 judge）必须在实际执行命令或会话中显式使用 `gpt-5.6-luna` 模型并传入 `model_reasoning_effort="medium"`；不以编排 subagent 或当前会话自身的模型代替。模型不可用时 blocked 并询问维护者，不得静默更换模型。
-- 每轮必须重新生成 `without_skill` baseline，**不得复用历史 baseline**，也不得为掩盖执行失败把 baseline 弱化成可选项。
-- 判定由独立评审方（fresh subagent 或独立 judge）对照 assertions 得出。**被测 lane 的自评不算判定**，评审方须独立核对零写入等关键事实。批量 transcript 生成脚本的输出只是诊断产物，不是 pass/fail 事实来源。
-- 运行期文件写隔离 scratch workspace（如 `tmp/eval-runs/...`），不得写入已提交 fixture——历史输出会污染 empty-workspace 这类上下文敏感用例。每轮运行前需清理的路径用 `eval_metadata.json` 的 `execution_cleanup` 声明。
-- 每条 eval 在成功、FAIL、BLOCKED 或异常退出后，都必须在 runner 结束前删除该轮全部过程产物，包括 lane workspace、依赖副本、candidate 输出、snapshot、judge package/verdict、transcript、timing、diagnostics 与 `run_status.json`；批量执行也必须逐条执行同一 `finally` 清理。仓库和 CI 只保留 durable `comparison.md` 结论，不保留或上传 `tmp/eval-runs/`。
-- 只在实际存在 deterministic runner 时声明 run diagnostics（command、cwd、timeout、return code 等），便于区分基础设施失败与 assertion 失败。
-
-**Eval prompt 与 lane 隔离契约**
-
-`with_skill` 与 `without_skill` 的**唯一变量是「是否加载被测 skill 文档」**：prompt 逐字相同，可见 fixture 完全相同。任何把 skill 规则提前透给 baseline 的做法都会让两条 lane 拉不开差距，eval 失去判别力。
-
-每条 eval 先设计真实用户场景，再写 prompt 和 assertions。场景至少说明一个可信的用户角色、触发原因、要完成的结果、用户当时确实掌握的材料与约束，以及用户如何判断事情办成；优先来自真实项目、历史请求或可验证工作流，不从某条 skill 规则反向拼装一个只为触发断言的场景。assertions 从 skill 契约与用户结果中提取，但不得回填到 prompt 或 lane fixture。
-
-prompt 必须有“活人感”：直接写成用户会在真实工作中发出的自然请求，以要解决的问题和结果为中心。不要加「用户说：」外壳，不要由测试编排者替用户讲解 PM 路由、skill 名、gate、`feature_path`、`change_tier`、assertion、runner 或判分方式，也不要要求 agent「判断应该怎么分类/交给谁」来命中内部路由断言；确有交接前提时，把它作为宿主原生 handoff 文档放进 fixture，prompt 只引用用户自然会看到的业务材料。
-
-prompt 泄漏判据：*删掉某句话后，一个不知道被测 skill 协议的 agent 就无法猜到评判项，但真实用户目标仍完整——这句话就是测试提示，应删除。* 每条新建或重设计的 eval 在评审时必须能肯定回答：这句话会由真实用户说出吗；离开测试仓库仍能独立成立吗；baseline 是否无法从措辞反推出评分清单。
-
-| 不得写进 prompt | 应当写进 prompt |
-| --- | --- |
-| 协议名与步骤名：「按八步契约执行」 | 自然目标：「写一份用户操作手册，要有操作步骤和对应截图」 |
-| 行为规则与禁令：「不要替维护者确认」「保持零启动命令」 | 环境客观事实：「当前没有可通过域名访问的部署环境」 |
-| 测试编排与分类术语：「pm-agent 已路由」「这是 feature-update 场景」 | 用户事实：「这次登录页只改了错误提示，我想确认上线前没有影响原来的登录流程」 |
-| 产物字段清单、目录分层、命名规范、工具与参数 | 自然授权：「范围我已经定好了，不用再跟我确认」 |
-
-最后一行是测试**需要用户确认的门禁**的正确方式：用真实用户会说的话表达授权，而不是「Step N 门禁视为已通过」这类协议术语——后者直接把门禁的存在告诉了 baseline。
-
-lane 可见素材只给宿主环境事实，评测脚手架一律不给：`eval_metadata.json`、`evals.json`、assertions、`expected_output`、旧 `comparison.md`、judge prompt/verdict、transcript、diagnostics 与专为 eval 造的答案脚本必须从 lane 目录中物理移除。`pm-handoff.md` 的 `required_output` 只写用户所需产出形态，`blockers_risks` 只写客观风险，不复制 skill 禁令。宿主本来就该有的模板、standards、已有配置不算泄漏；专为命中断言而伪造的 `.rules`、`evidence.md` 或同义答案文件不算宿主事实。
-
-每轮在 scratch 下分别物化 `with_skill` 与 `without_skill` 两个独立工作目录并创建各自的 Git 根，禁止共享可写 cwd、复用 Codex 会话或让 agent 向上读取测试仓库的 `AGENTS.md`、skill、comparison 和历史运行目录。两份可见 fixture 在加载 skill 前做内容一致性检查；with lane 只在自然用户 prompt 之外加载被测 skill 及其明确引用，without lane 必须确认无法访问该 skill 的安装副本、仓库副本或被宿主文档转述的规则。runner 发给 candidate 的用户消息不得包含 mode/label、skill 路径、expected output、assertions 或评测说明。
-
-进程、端口、数据库、浏览器标签页、登录态、下载目录等运行时状态也属于 lane 隔离面。优先为两条 lane 创建独立且可重置的运行时；只能共用外部环境时，必须串行执行、保证核心流程只读或在每条 lane 后恢复同一初始状态，否则该轮记 `BLOCKED`。后一条 lane 不得读取前一条 lane 的文件、页面改动、截图、终端输出或浏览器状态。
-
-独立 judge 使用第三个全新、只读上下文；只在两条 lane 输出锁定后向 judge 提供 assertions、最终输出和必要的原始证据，不提供 lane 自评或预设结论。执行前记录隔离 preflight：两个工作目录、fixture 一致性、被排除的脚手架、skill 可见性、运行时重置状态和 judge 上下文，任一项无法证明就不得把结果写成 PASS。
-
-零区分度先判成因，不得为制造区分度而伪造结果或弱化断言：
-
-| 成因 | 动作 |
-| --- | --- |
-| prompt 或 fixture 规则泄漏 | 修 eval，按上表改成自然表述 |
-| 规则天然存在于 skill 交付物（模板、脚手架本就承载字段与命名） | 不是缺陷。如实记录，观测重心移到门禁与纪律类断言 |
-| 模型基线能力已覆盖该行为 | 记为 skill 生命周期信号交 issue 审查，不硬修 |
-
-**Eval 产物策略**
-
-- 提交 eval 定义、metadata、fixtures、README 与最新 `comparison.md`。不提交运行期产物：`with_skill/`、`without_skill/`、`baseline/`、`outputs/`、`comparison.auto.md`、`transcript.md`、`candidate-output.md`、`subagent-verdict.md`、`timing.json`、`run_status.json`、diagnostics 目录
-- metadata 中的 `with_skill_outputs` / `without_skill_outputs` 只是 deterministic runner 的运行期产物预期，不要求存在于已提交 workspace。`with_skill_outputs` 可作 runner 门禁；baseline 类输出只报告，不作失败条件。无 deterministic 产物的 eval 不声明 runner output
-- `eval_metadata.json` 不声明 `validation_method`；skill eval 默认执行 fresh subagent validation
-- 模型 transcript、verdict、timing、diagnostics 只允许在单条 eval 运行期间供 judge 使用，结论写入 `comparison.md` 后立即删除，不入 git、不上传 CI artifact
-- PR 评论或对话中的 eval 结论必须与已提交或拟提交的 `comparison.md` 一致
-- Python eval 测试不得依赖上次运行的输出；用临时目录或最小 fixture，避免跨测试根目录重名模块。提交前运行 `uv run scripts/check_eval_artifacts.py`
-
-**Eval 结果模型**
-
-`comparison.md` 含 evaluation target、fixture version、latest result、with-skill 行为、`without_skill` baseline 的运行来源与行为摘要、failures、next steps、runtime artifact policy。
-
-`Latest result` 分两维，结果区必须含一行 `Overall result: <PASS | PASS (partial coverage) | FAIL | BLOCKED>` 供 `scripts/summarize_eval_results.py` 解析：
-
-| 维度 | 含义 | 取值 |
-| --- | --- | --- |
-| Behavior result | 本轮实际触发的路径上是否满足 assertions、有无回归 | `PASS` / `FAIL` |
-| Coverage result | 本轮实际覆盖了多少 assertion 场景 | `FULL` / `PARTIAL`（取 `PARTIAL` 须列出未覆盖项及原因） |
-
-组合规则：Behavior `FAIL` → `FAIL`；Behavior `PASS` + Coverage `FULL` → `PASS`；Behavior `PASS` + Coverage `PARTIAL` → `PASS (partial coverage)`。
-
-依赖实时外部数据的 eval，若外部当时缺少特定实体（open milestone、eligible PR、breaking marker 等）导致 assertion 未触发，记 `NOT EXERCISED`，只计入 Coverage，不得计入 Behavior 的 `FAIL`。发版或 review 汇总引用结论时，必须能仅从两维区分 skill 回归与实时样本缺口。
-
-Baseline 是 comparison 的对照输入，不是独立的机器判定对象。两维结果由 subagent、fresh judge 或人工 reviewer 基于 with_skill、without_skill、assertions 与上下文得出；deterministic contract checker 只校验 eval 定义、workspace、durable `comparison.md` 与产物策略，不根据 baseline 自由文本判断结果。
-
-**校验与 CI**
-
-- PR 必跑顺序：`repository-contract` → `eval-contract` → `doc-contract` → `python-tests`，即 `check_repository_contract.py` → `check_eval_contract.py` 与 `check_eval_artifacts.py` → `check_doc_contract.py` → 确定性 pytest
-- 模型 eval 不作 required status check。涉及 skill 行为、routing、eval fixture 或发版前变更时，管理员应在合并前手动触发 eval workflow，把 transcript 与 subagent validation 结果一并作为 merge 依据
+本仓库 skill eval 的设计、编写、静态校验、fresh paired 执行、并发、judge、
+durable `comparison.md`、运行期清理与失败分诊，统一由项目级
+`.agents/skills/skill-eval-runner/SKILL.md` 负责。任何创建、修改、运行、重跑、
+汇总或诊断 eval 的任务都必须使用该 skill；具体字段约束以
+`scripts/check_eval_contract.py`，具体执行语义以 `scripts/run_skill_eval.py` 与
+`scripts/eval_runtime.py` 为准。`AGENTS.md` 不再复制第二份 eval 流程。
 
 ## 重要文件
 
 - `.claude-plugin/marketplace.json` - Agent 和 skill registry
 - `scripts/install_codex_skills.py` - Codex 复制式 skill 安装脚本，避免祖先 plugin manifest 造成 namespace 前缀
 - `skills-lock.json` - 已安装 skill metadata
-- `AGENTS.md` - 仓库指导的唯一来源
+- `AGENTS.md` - 通用仓库指导的唯一来源；专项 eval 工作流只保留上方项目 skill 指针
 - `agents/{agent}/README.md` - Agent 级文档


### PR DESCRIPTION
## 变更内容

- 新增仓库级 `skill-eval-runner`，统一 eval 编写、运行、10 worker 并发、结果分诊与收尾验证流程
- 将场景、prompt、防泄漏、metadata、fixture 和 assertion 规范迁入项目 skill reference
- 将 `AGENTS.md` 中重复的 eval 专章收敛为项目 skill 指针
- 精确放行 `.agents/skills/skill-eval-runner`，其余本地安装副本继续忽略

## 原因

`AGENTS.md` 与 eval skill 同时保存运行细节会形成两份事实源，且旧文案可能落后于 checker 和 runner。此次把项目 skill 作为唯一操作入口，字段与执行语义分别以 checker 和共享 runner 为准。

## 影响

- 不修改 eval runner、fixture、assertion 或 comparison
- 不运行模型 eval
- Required CI 仍只执行静态 contract 与确定性测试

## 验证

- `quick_validate.py .agents/skills/skill-eval-runner`
- `uv run scripts/check_repository_contract.py`
- `uv run scripts/check_eval_contract.py`
- `uv run scripts/check_eval_artifacts.py`
- `uv run scripts/check_doc_contract.py`
- 相关确定性 pytest
- `git diff --check`