### PR TITLE
docs(governance): 约定合并后清理本地分支

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,7 @@ PM / Engineer / QA / DevOps（条件式）→ Docs Agent（正式文档生产 / 
 - 维护变更不得直接在 `main` 上进行；开始修改前先创建工作分支，完成后通过 PR 合入。
 - PR 创建后的更新默认追加新 commit 并普通 push；除非用户明确要求整理提交历史，否则不要 amend、rebase 或 force push。
 - 创建 PR 后不要直接合并；必须等待维护者明确确认“可以合并”后再执行 merge / squash / rebase 合并操作。
+- PR 合并并复核成功后，切回默认分支，使用 `git pull --ff-only` 同步远端，再删除已合并的本地工作分支；squash merge 导致普通删除无法识别合并关系时，仅在已确认对应 PR 为 `MERGED` 且默认分支包含其 merge commit 后，允许强制删除该精确本地分支。除非用户明确要求，不自动删除远端分支。
 - 当前仓库仍处于早期维护阶段，暂不新增 Release CI；发布前使用手动 release checklist：按「市场注册」节的版本规则核对 `metadata.version` 与 `.kimi-plugin/plugin.json` 的 `version`，确认对应 `docs/changelog/changelog-v{version}.md` 存在并被根 `CHANGELOG.md` 索引，tag 使用 `v` 前缀 SemVer，PR 必跑 CI 全部通过，必要时手动触发 eval workflow 并记录结果；每次使用 tag 发版时，按 skill 维度汇总 skill eval 后的 `comparison.md` 最新结论。每次 tag 发版后，由 `pm-agent → github-release-gen` 使用 skill 流程自动创建 GitHub Release draft，并直接交维护者审批；draft 的发布（publish）仍必须等待维护者显式批准。不要自动上传 marketplace package，也不要配置 release bot bypass tag ruleset。
 
 ### 变更分级契约


### PR DESCRIPTION
## 变更内容

- 约定 PR 合并并复核后切回默认分支并同步远端
- 要求删除已合并的本地工作分支
- 明确 squash merge 场景下强制删除本地分支的安全前提
- 默认不自动删除远端分支

## 原因

避免已合并的本地工作分支持续残留，并为 squash merge 后的安全清理提供统一流程。

## 验证

- repository contract PASS
- documentation contract PASS
- git diff --check PASS