### PR TITLE
docs(eval): 对齐贡献指南与角色 README 的统一 eval 入口

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,9 @@ uv run --with pytest pytest \
   agents/docs/test/test_docs_run_eval.py \
   agents/test_doc_contract.py \
   agents/test_eval_contract.py \
+  scripts/test_eval_runtime.py \
+  scripts/test_run_skill_eval.py \
+  scripts/test_check_eval_artifacts.py \
   scripts/test_install_codex_skills.py \
   scripts/test_summarize_eval_results.py \
   scripts/test_check_repository_contract.py
@@ -45,20 +48,17 @@ uv run python -m json.tool skills-lock.json >/tmp/skills-lock.json.out
 
 ## Manual Eval
 
-Local model evals are quality checks and are not part of the first-round required PR status checks:
+Local model evals are quality checks and are not part of the first-round required PR status checks. Designing, writing, running, rerunning, summarizing, or diagnosing evals must go through the project-level skill `.agents/skills/skill-eval-runner/SKILL.md`:
 
 ```bash
-# Designer eval diagnostics
-uv run agents/designer/test/run_all_evals.py
+# One role (e.g. designer)
+uv run scripts/run_skill_eval.py --agent designer --jobs 10
 
-# Docs eval diagnostics
-uv run agents/docs/test/run_all_evals.py
-
-# QA model eval
-uv run agents/qa/test/run_all_evals.py
+# All regular evals
+uv run scripts/run_skill_eval.py --jobs 10
 ```
 
-Changes involving skill behavior, routing, eval fixtures, or release readiness follow the eval strategy in [AGENTS.md](./AGENTS.md#skill-测试). The GitHub Actions `Manual Evals` workflow accepts `all`, `designer`, `docs`, or `qa`; the QA eval requires the repository `OPENAI_API_KEY` secret.
+Changes involving skill behavior, routing, eval fixtures, or release readiness follow the eval strategy in [AGENTS.md](./AGENTS.md#skill-测试). The GitHub Actions `Manual Evals` workflow accepts `all`, `designer`, `devops`, `docs`, `engineer`, `product_manager`, `qa`, or `security`; every target requires the repository `OPENAI_API_KEY` secret.
 
 ## Eval Maintenance Checklist
 

--- a/CONTRIBUTING_zh.md
+++ b/CONTRIBUTING_zh.md
@@ -31,6 +31,9 @@ uv run --with pytest pytest \
   agents/docs/test/test_docs_run_eval.py \
   agents/test_doc_contract.py \
   agents/test_eval_contract.py \
+  scripts/test_eval_runtime.py \
+  scripts/test_run_skill_eval.py \
+  scripts/test_check_eval_artifacts.py \
   scripts/test_install_codex_skills.py \
   scripts/test_summarize_eval_results.py \
   scripts/test_check_repository_contract.py
@@ -45,20 +48,17 @@ uv run python -m json.tool skills-lock.json >/tmp/skills-lock.json.out
 
 ## 手动 Eval
 
-本地模型 eval 是质量检查，不属于第一版 PR 必跑 status check：
+本地模型 eval 是质量检查，不属于第一版 PR 必跑 status check。eval 的设计、编写、运行、重跑、汇总或诊断必须经由项目级 skill `.agents/skills/skill-eval-runner/SKILL.md`：
 
 ```bash
-# Designer eval diagnostics
-uv run agents/designer/test/run_all_evals.py
+# 单个角色（例如 designer）
+uv run scripts/run_skill_eval.py --agent designer --jobs 10
 
-# Docs eval diagnostics
-uv run agents/docs/test/run_all_evals.py
-
-# QA model eval
-uv run agents/qa/test/run_all_evals.py
+# 全部常规 eval
+uv run scripts/run_skill_eval.py --jobs 10
 ```
 
-涉及 skill 行为、routing、eval fixture 或 release readiness 的变更，按 [AGENTS.md](./AGENTS.md#skill-测试) 的 eval 策略执行。GitHub Actions 的 `Manual Evals` workflow 可选择 `all`、`designer`、`docs` 或 `qa`；QA eval 需要仓库 `OPENAI_API_KEY` secret。
+涉及 skill 行为、routing、eval fixture 或 release readiness 的变更，按 [AGENTS.md](./AGENTS.md#skill-测试) 的 eval 策略执行。GitHub Actions 的 `Manual Evals` workflow 可选择 `all`、`designer`、`devops`、`docs`、`engineer`、`product_manager`、`qa` 或 `security`；所有角色目标都需要仓库 `OPENAI_API_KEY` secret。
 
 ## Eval 维护清单
 

--- a/agents/designer/README.md
+++ b/agents/designer/README.md
@@ -107,5 +107,5 @@ If a target agent is not installed, the corresponding handoff stage is unavailab
 npx skills add ./agents/designer/skills/visual-design
 
 # Run Designer eval
-uv run agents/designer/test/run_all_evals.py
+uv run scripts/run_skill_eval.py --agent designer --jobs 10
 ```

--- a/agents/designer/README_zh.md
+++ b/agents/designer/README_zh.md
@@ -96,5 +96,5 @@ agents/designer/skills/visual-design/references/
 npx skills add ./agents/designer/skills/visual-design
 
 # 运行 Designer eval
-uv run agents/designer/test/run_all_evals.py
+uv run scripts/run_skill_eval.py --agent designer --jobs 10
 ```

--- a/agents/devops/README.md
+++ b/agents/devops/README.md
@@ -96,7 +96,6 @@ If a target agent is not installed, the corresponding handoff stage is unavailab
 # Install one DevOps skill into the current project runtime
 npx skills add ./agents/devops/skills/deployment-planner
 
-# Run one DevOps eval
-uv run agents/devops/test/run_eval.py \
-  agents/devops/test/env-config-auditor/workspace/iteration-1/eval-1-missing-variables/eval_metadata.json
+# Run DevOps eval
+uv run scripts/run_skill_eval.py --agent devops --jobs 10
 ```

--- a/agents/devops/README_zh.md
+++ b/agents/devops/README_zh.md
@@ -82,7 +82,6 @@ flowchart LR
 # 安装某个 DevOps skill 到当前项目运行时
 npx skills add ./agents/devops/skills/deployment-planner
 
-# 运行单个 DevOps eval
-uv run agents/devops/test/run_eval.py \
-  agents/devops/test/env-config-auditor/workspace/iteration-1/eval-1-missing-variables/eval_metadata.json
+# 运行 DevOps eval
+uv run scripts/run_skill_eval.py --agent devops --jobs 10
 ```

--- a/agents/qa/README.md
+++ b/agents/qa/README.md
@@ -112,5 +112,5 @@ If a target agent is not installed, the corresponding handoff stage is unavailab
 npx skills add ./agents/qa/skills/spec-based-tester
 
 # Run QA eval
-uv run agents/qa/test/run_all_evals.py
+uv run scripts/run_skill_eval.py --agent qa --jobs 10
 ```

--- a/agents/qa/README_zh.md
+++ b/agents/qa/README_zh.md
@@ -103,5 +103,5 @@ flowchart LR
 npx skills add ./agents/qa/skills/spec-based-tester
 
 # 运行 QA eval
-uv run agents/qa/test/run_all_evals.py
+uv run scripts/run_skill_eval.py --agent qa --jobs 10
 ```


### PR DESCRIPTION
## 背景

Issue #258：PR #256/#257 将 fresh paired eval 收敛到统一 runtime 与项目级 `skill-eval-runner` 后，公开贡献文档与角色 Agent README 仍保留旧的角色级 eval runner 命令、过时的 Manual Evals 角色范围与凭据要求，以及缺失的本地 pytest 清单。

## 改动

- `CONTRIBUTING.md` / `CONTRIBUTING_zh.md`：
  - python-tests 清单补齐 `scripts/test_eval_runtime.py`、`scripts/test_run_skill_eval.py`、`scripts/test_check_eval_artifacts.py`，与 CI `python-tests` job 一致
  - 手动 Eval 入口改为项目级 `.agents/skills/skill-eval-runner/SKILL.md` 与 `uv run scripts/run_skill_eval.py`（角色级与全量示例）
  - `Manual Evals` workflow 角色范围更新为 7 个角色（`all`、`designer`、`devops`、`docs`、`engineer`、`product_manager`、`qa`、`security`）；所有目标都需要仓库 `OPENAI_API_KEY` secret
- Designer / QA / DevOps 中英文 Agent README 的 Local Maintenance eval 命令改为统一入口 `uv run scripts/run_skill_eval.py --agent <role> --jobs 10`

## 验证

- `check_doc_contract.py`、`check_repository_contract.py`、`check_eval_contract.py`、`check_eval_artifacts.py` 全部 PASS
- 修改文件中无残留旧 runner 命令

## 说明

以下位置的旧入口引用不在本 issue 范围，未改动：

- `agents/{designer,docs,qa}/test/README.md`：描述仍存在的 `run_all_evals.py` 脚本机制，且脚本仍被 CI 测试引用
- `docs/pm/repository-ci-governance/CI_PLAN.md`、`docs/engineer/agents/docs-agent/IMPLEMENTATION_PLAN.md`：历史规划与实施记录，非当前事实文档

Closes #258
