### PR TITLE
docs(collab): 对齐 PM 协作拓扑并补齐中文依赖安全网

### DIFF
--- a/agents/designer/README_zh.md
+++ b/agents/designer/README_zh.md
@@ -91,7 +91,7 @@ agents/designer/skills/visual-design/references/
 
 ## 协作依赖
 
-Designer Agent 依赖可能作为独立插件打包的同级能力：
+Designer Agent 将工作交接给作为独立插件打包并安装的同级 Agent：
 
 - `pm-agent` 用于范围与 feature-path 澄清
 - `engineer-agent` 用于设计 handoff 后的实现

--- a/agents/designer/README_zh.md
+++ b/agents/designer/README_zh.md
@@ -89,6 +89,15 @@ agents/designer/skills/visual-design/references/
 - Engineer 是唯一负责把 PM/Designer 文档转化为代码、测试和交付产物的角色。
 - 来自 Engineer 的 UI 维护请求在 Designer 内仍然只做设计；设计 handoff 后由 Engineer 继续实现。
 
+## 协作依赖
+
+Designer Agent 依赖可能作为独立插件打包的同级能力：
+
+- `pm-agent` 用于范围与 feature-path 澄清
+- `engineer-agent` 用于设计 handoff 后的实现
+
+如果所需目标不可用，Designer Agent 会识别缺失的阶段和插件，将该阶段标记为 blocked，并且不会执行缺失角色的工作。
+
 ## 本地维护
 
 ```bash

--- a/agents/devops/README_zh.md
+++ b/agents/devops/README_zh.md
@@ -76,6 +76,15 @@ flowchart LR
   `docs/engineer/{feature_path}/TRD.md` 和
   `docs/engineer/{feature_path}/IMPLEMENTATION_PLAN.md`。
 
+## 协作依赖
+
+DevOps Agent 依赖可能作为独立插件打包的同级能力：
+
+- `pm-agent` 用于 PRD 与 feature-path 澄清
+- `engineer-agent` 用于缺失或过时的 TRD / 实施计划
+
+如果所需目标不可用，DevOps Agent 会识别缺失的阶段和插件，将该阶段标记为 blocked，并且不会执行缺失角色的工作。
+
 ## 本地维护
 
 ```bash

--- a/agents/devops/README_zh.md
+++ b/agents/devops/README_zh.md
@@ -78,7 +78,7 @@ flowchart LR
 
 ## 协作依赖
 
-DevOps Agent 依赖可能作为独立插件打包的同级能力：
+DevOps Agent 将工作交接给作为独立插件打包并安装的同级 Agent：
 
 - `pm-agent` 用于 PRD 与 feature-path 澄清
 - `engineer-agent` 用于缺失或过时的 TRD / 实施计划

--- a/agents/docs/README_zh.md
+++ b/agents/docs/README_zh.md
@@ -79,7 +79,7 @@ Docs Agent 拥有宿主项目在 `docs/site/` 下的正式文档层。它消费�
 
 ## 协作依赖
 
-Docs Agent 依赖可能作为独立插件打包的同级能力：
+Docs Agent 将工作交接给作为独立插件打包并安装的同级 Agent：
 
 - `pm-agent` 用于请求分类、已批准的发布范围、功能目录和共享 handoff 契约；站内 Release Notes 由 Docs Agent 自身的 `release-notes-gen` 所有，而受 gate 约束的 GitHub Release 工作流由 PM `github-release-gen` 所有
 - `engineer-agent` 用于已确认的 TRD、实施计划、代码证据和未解决的技术影响范围

--- a/agents/docs/README_zh.md
+++ b/agents/docs/README_zh.md
@@ -79,7 +79,7 @@ Docs Agent 拥有宿主项目在 `docs/site/` 下的正式文档层。它消费�
 
 ## 协作依赖
 
-Docs Agent 将工作交接给作为独立插件打包并安装的同级 Agent：
+Docs Agent 依赖可能作为独立插件打包的同级能力：
 
 - `pm-agent` 用于请求分类、已批准的发布范围、功能目录和共享 handoff 契约；站内 Release Notes 由 Docs Agent 自身的 `release-notes-gen` 所有，而受 gate 约束的 GitHub Release 工作流由 PM `github-release-gen` 所有
 - `engineer-agent` 用于已确认的 TRD、实施计划、代码证据和未解决的技术影响范围

--- a/agents/engineer/README_zh.md
+++ b/agents/engineer/README_zh.md
@@ -106,7 +106,7 @@ Engineer 的主产物包括技术计划、API / ADR 文档、实现计划、代�
 
 ## 协作依赖
 
-Engineer Agent 依赖可能作为独立插件打包的同级能力：
+Engineer Agent 将工作交接给作为独立插件打包并安装的同级 Agent：
 
 - `pm-agent` 用于需求定义、范围对齐和 PRD 更新
 - `designer-agent` 用于缺失或过时的 UI/UX 与视觉设计交付物

--- a/agents/engineer/README_zh.md
+++ b/agents/engineer/README_zh.md
@@ -104,6 +104,16 @@ Engineer 的主产物包括技术计划、API / ADR 文档、实现计划、代�
 - QA 发现实现缺陷时回到 Engineer；发现需求缺口时回到 PM。
 - DevOps 和 Security 只在部署、运行、安全审查成为当前目标时介入。
 
+## 协作依赖
+
+Engineer Agent 依赖可能作为独立插件打包的同级能力：
+
+- `pm-agent` 用于需求定义、范围对齐和 PRD 更新
+- `designer-agent` 用于缺失或过时的 UI/UX 与视觉设计交付物
+- `qa-agent` 用于验证，`devops-agent` 用于部署，`security-agent` 用于安全审查
+
+如果所需目标不可用，Engineer Agent 会识别缺失的阶段和插件，将该阶段标记为 blocked，并且不会执行缺失角色的工作。
+
 ## 本地维护
 
 ```bash

--- a/agents/product_manager/README.md
+++ b/agents/product_manager/README.md
@@ -16,7 +16,7 @@
 | Specialist skills | 7 |
 | Main inputs | User ideas, local `docs/`, repository state, GitHub Issues / PRs / Milestones / Releases |
 | Main outputs | `docs/pm/{feature_path}/`, `docs/roadmap.md`, `docs/changelog/changelog-v{version}.md` |
-| Downstream agents | `designer-agent`, `engineer-agent` |
+| Downstream agents | `designer-agent`, `engineer-agent`, `qa-agent`, `devops-agent`, `security-agent`, `docs-agent` |
 
 ## Skills
 
@@ -94,8 +94,12 @@ host site's `docs/site/release-notes/`; PM only produces GitHub Releases via
 
 PM Agent hands off to peer agents that are packaged and installed as separate plugins:
 
-- `engineer-agent` for TRD and technical planning after PM scope is stable
-- `designer-agent` for UI/UX deliverables
+- `designer-agent` for confirmed UX, UI structure, visual-system, or design handoff work
+- `engineer-agent` for confirmed TRD, implementation, tests, debugging, delivery, or codebase work
+- `qa-agent` for confirmed acceptance, exploratory, bug analysis, or regression validation work
+- `devops-agent` for confirmed deployment, CI/CD, environment, release readiness, rollback, or runbook work
+- `security-agent` for confirmed AppSec, auth/authz, dependency, privacy, or data-flow review work
+- `docs-agent` for confirmed formal documentation site bootstrap, synchronization, backfill, or release documentation audit work
 
 If a target agent is not installed, the corresponding handoff stage is unavailable; PM Agent reports the missing stage and the recommended plugin and marks that stage blocked instead of doing the work itself.
 

--- a/agents/product_manager/README.md
+++ b/agents/product_manager/README.md
@@ -99,7 +99,7 @@ PM Agent hands off to peer agents that are packaged and installed as separate pl
 - `qa-agent` for confirmed acceptance, exploratory, bug analysis, or regression validation work
 - `devops-agent` for confirmed deployment, CI/CD, environment, release readiness, rollback, or runbook work
 - `security-agent` for confirmed AppSec, auth/authz, dependency, privacy, or data-flow review work
-- `docs-agent` for confirmed formal documentation site bootstrap, synchronization, backfill, or release documentation audit work
+- `docs-agent` for confirmed formal documentation site bootstrap, synchronization, backfill, illustrated user operation manuals from real running interfaces, or release documentation audit work
 
 If a target agent is not installed, the corresponding handoff stage is unavailable; PM Agent reports the missing stage and the recommended plugin and marks that stage blocked instead of doing the work itself.
 

--- a/agents/product_manager/README_zh.md
+++ b/agents/product_manager/README_zh.md
@@ -16,7 +16,7 @@
 | Specialist skills | 7 个 |
 | 主要输入 | 用户想法、本地 `docs/`、代码库现状、GitHub Issues / PRs / Milestones / Releases |
 | 主要输出 | `docs/pm/{feature_path}/`、`docs/roadmap.md`、`docs/changelog/changelog-v{version}.md` |
-| 下游协作 | `designer-agent`、`engineer-agent` |
+| 下游协作 | `designer-agent`、`engineer-agent`、`qa-agent`、`devops-agent`、`security-agent`、`docs-agent` |
 
 ## Skill 清单
 
@@ -88,6 +88,19 @@ Repo 级 PM 产物可以放在：
 - PM Agent 不直接实现代码、测试、部署配置或安全修复。
 - Designer 主要消费 `PRD.md`、`DECISIONS.md`。
 - Engineer 消费 PM 文档后，通过 `engineer-agent:trd-gen` 负责 `docs/engineer/{feature_path}/TRD.md`。
+
+## 协作依赖
+
+PM Agent 依赖可能作为独立插件打包的同级能力：
+
+- `designer-agent` 用于已确认的 UX、UI 结构、视觉系统或设计 handoff 工作
+- `engineer-agent` 用于已确认的 TRD、实现、测试、调试、交付或代码库工作
+- `qa-agent` 用于已确认的验收、探索、缺陷分析或回归验证工作
+- `devops-agent` 用于已确认的部署、CI/CD、环境、发版就绪、回滚或 runbook 工作
+- `security-agent` 用于已确认的 AppSec、认证授权、依赖、隐私或数据流审查工作
+- `docs-agent` 用于已确认的正式文档站 bootstrap、同步、回填或发版文档审计工作
+
+如果所需目标不可用，PM Agent 会识别缺失的阶段和插件，将该阶段标记为 blocked，并且不会执行缺失角色的工作。
 
 ## 本地维护
 

--- a/agents/product_manager/README_zh.md
+++ b/agents/product_manager/README_zh.md
@@ -98,7 +98,7 @@ PM Agent 依赖可能作为独立插件打包的同级能力：
 - `qa-agent` 用于已确认的验收、探索、缺陷分析或回归验证工作
 - `devops-agent` 用于已确认的部署、CI/CD、环境、发版就绪、回滚或 runbook 工作
 - `security-agent` 用于已确认的 AppSec、认证授权、依赖、隐私或数据流审查工作
-- `docs-agent` 用于已确认的正式文档站 bootstrap、同步、回填或发版文档审计工作
+- `docs-agent` 用于已确认的正式文档站 bootstrap、同步、回填、基于真实运行界面的图文用户操作手册或发版文档审计工作
 
 如果所需目标不可用，PM Agent 会识别缺失的阶段和插件，将该阶段标记为 blocked，并且不会执行缺失角色的工作。
 

--- a/agents/product_manager/README_zh.md
+++ b/agents/product_manager/README_zh.md
@@ -91,7 +91,7 @@ Repo 级 PM 产物可以放在：
 
 ## 协作依赖
 
-PM Agent 依赖可能作为独立插件打包的同级能力：
+PM Agent 将工作交接给作为独立插件打包并安装的同级 Agent：
 
 - `designer-agent` 用于已确认的 UX、UI 结构、视觉系统或设计 handoff 工作
 - `engineer-agent` 用于已确认的 TRD、实现、测试、调试、交付或代码库工作

--- a/agents/qa/README_zh.md
+++ b/agents/qa/README_zh.md
@@ -98,7 +98,7 @@ flowchart LR
 
 ## 协作依赖
 
-QA Agent 依赖可能作为独立插件打包的同级能力：
+QA Agent 将工作交接给作为独立插件打包并安装的同级 Agent：
 
 - `pm-agent` 用于需求缺口与 feature-path 澄清
 - `engineer-agent` 用于 TRD 缺口、缺失的实施计划和代码修复

--- a/agents/qa/README_zh.md
+++ b/agents/qa/README_zh.md
@@ -96,6 +96,15 @@ flowchart LR
 - 实现问题交给 Engineer；需求或验收标准问题交给 PM。
 - QA 报告应明确区分已验证、未覆盖、被阻塞和残余风险。
 
+## 协作依赖
+
+QA Agent 依赖可能作为独立插件打包的同级能力：
+
+- `pm-agent` 用于需求缺口与 feature-path 澄清
+- `engineer-agent` 用于 TRD 缺口、缺失的实施计划和代码修复
+
+如果所需目标不可用，QA Agent 会识别缺失的阶段和插件，将该阶段标记为 blocked，并且不会执行缺失角色的工作。
+
 ## 本地维护
 
 ```bash

--- a/agents/security/README_zh.md
+++ b/agents/security/README_zh.md
@@ -78,7 +78,7 @@ flowchart LR
 
 ## 协作依赖
 
-Security Agent 依赖可能作为独立插件打包的同级能力：
+Security Agent 将工作交接给作为独立插件打包并安装的同级 Agent：
 
 - `engineer-agent` 和 `devops-agent` 用于已确认发现项的修复
 - `pm-agent` 用于需求驱动的风险与 feature-path 澄清

--- a/agents/security/README_zh.md
+++ b/agents/security/README_zh.md
@@ -76,6 +76,15 @@ flowchart LR
 - Security 不判断父功能归属；需要功能范围时读取
   `docs/pm/{feature_path}/PRD.md` 和匹配的 Engineer TRD/实施计划。
 
+## 协作依赖
+
+Security Agent 依赖可能作为独立插件打包的同级能力：
+
+- `engineer-agent` 和 `devops-agent` 用于已确认发现项的修复
+- `pm-agent` 用于需求驱动的风险与 feature-path 澄清
+
+如果所需目标不可用，Security Agent 会识别缺失的阶段和插件，将该阶段标记为 blocked，并且不会执行缺失角色的工作。
+
 ## 本地维护
 
 ```bash

--- a/docs/engineer/repository-governance/pm-single-entry/TRD.md
+++ b/docs/engineer/repository-governance/pm-single-entry/TRD.md
@@ -236,8 +236,8 @@ Agent 依赖）、#67（feature-catalog）、#68（change_tier 契约）全部�
 | 批次 | 内容 | 依赖 | 验证 |
 | --- | --- | --- | --- |
 | Batch 1: 发现面收口 | marketplace.json plugin description、README / README_zh / `.codex/INSTALL.md` / `docs/README.codex.md`、6 个 role router SKILL.md frontmatter description 弱化、specialist frontmatter description 弱化 + `visibility: internal`（与 #60 的 description 压缩合并执行）。router description 与 marketplace / specialist description 同批收口，因为三者同属 Claude/Codex 的直接 discovery 输入，任何一层单独遗留都会保持公开触发面；弱化语义按第 5 节契约执行：保留角色能力枚举与「invoked after pm-agent handoff / PM 编排下使用」的内部编排定位，删除用户侧触发短语，并指向 `pm-agent` 作为用户入口。 | 在途 PR 全部合并。 | 三个契约脚本 + pytest；description 分工静态审查。 |
-| Batch 2: PM router 重写 | pm-agent SKILL.md 高召回 description、请求分类协议、change_tier 判级、handoff packet 组装；PM `_internal` handoff contract 权威定义。 | Batch 1；#68 已合入（change_tier 定义来源）。 | 契约脚本 + PM 入口 eval（FR-006 场景 1-7）。 |
-| Batch 3: 下游 gate 统一与 #59 去重 | 6 个 role router gate 指针化（description 弱化已在 Batch 1 完成，本批只动 gate 正文）、specialist gate 按 6.2 改写为唯一副本、AGENTS.md 契约声明；与 #59 gate 归位同一批执行。 | Batch 2。 | 契约脚本 + 防绕过 eval（FR-006 场景 8-9）。 |
+| Batch 2: PM router 重写 | pm-agent SKILL.md 高召回 description、请求分类协议、change_tier 判级、handoff packet 组装；PM `_internal` handoff contract 权威定义。 | Batch 1；#68 已合入（change_tier 定义来源）。 | 契约脚本 + PM 入口 eval（FR-006 场景 1-6、9）。 |
+| Batch 3: 下游 gate 统一与 #59 去重 | 6 个 role router gate 指针化（description 弱化已在 Batch 1 完成，本批只动 gate 正文）、specialist gate 按 6.2 改写为唯一副本、AGENTS.md 契约声明；与 #59 gate 归位同一批执行。 | Batch 2。 | 契约脚本 + 防绕过 eval（FR-006 场景 7-8）。 |
 | Batch 4: eval 与 contract 收尾 | PM-only 入口 eval 全量、`check_repository_contract.py` 新校验、durable `comparison.md` 更新。 | Batch 1-3。 | 三个契约脚本 + pytest + fresh subagent validation。 |
 
 与相关 issue 的执行顺序：#59（gate 去重）在 Batch 3 内协同完成；#60（SKILL.md 瘦身）

--- a/docs/engineer/repository-governance/pm-single-entry/TRD.md
+++ b/docs/engineer/repository-governance/pm-single-entry/TRD.md
@@ -236,7 +236,7 @@ Agent 依赖）、#67（feature-catalog）、#68（change_tier 契约）全部�
 | 批次 | 内容 | 依赖 | 验证 |
 | --- | --- | --- | --- |
 | Batch 1: 发现面收口 | marketplace.json plugin description、README / README_zh / `.codex/INSTALL.md` / `docs/README.codex.md`、6 个 role router SKILL.md frontmatter description 弱化、specialist frontmatter description 弱化 + `visibility: internal`（与 #60 的 description 压缩合并执行）。router description 与 marketplace / specialist description 同批收口，因为三者同属 Claude/Codex 的直接 discovery 输入，任何一层单独遗留都会保持公开触发面；弱化语义按第 5 节契约执行：保留角色能力枚举与「invoked after pm-agent handoff / PM 编排下使用」的内部编排定位，删除用户侧触发短语，并指向 `pm-agent` 作为用户入口。 | 在途 PR 全部合并。 | 三个契约脚本 + pytest；description 分工静态审查。 |
-| Batch 2: PM router 重写 | pm-agent SKILL.md 高召回 description、请求分类协议、change_tier 判级、handoff packet 组装；PM `_internal` handoff contract 权威定义。 | Batch 1；#68 已合入（change_tier 定义来源）。 | 契约脚本 + PM 入口 eval（FR-006 场景 1-6、9）。 |
+| Batch 2: PM router 重写 | pm-agent SKILL.md 高召回 description、请求分类协议、change_tier 判级、handoff packet 组装；PM `_internal` handoff contract 权威定义。 | Batch 1；#68 已合入（change_tier 定义来源）。 | 契约脚本 + PM 入口 eval（FR-006 场景 1-6；正式文档路由见 eval-014~016）。 |
 | Batch 3: 下游 gate 统一与 #59 去重 | 6 个 role router gate 指针化（description 弱化已在 Batch 1 完成，本批只动 gate 正文）、specialist gate 按 6.2 改写为唯一副本、AGENTS.md 契约声明；与 #59 gate 归位同一批执行。 | Batch 2。 | 契约脚本 + 防绕过 eval（FR-006 场景 7-8）。 |
 | Batch 4: eval 与 contract 收尾 | PM-only 入口 eval 全量、`check_repository_contract.py` 新校验、durable `comparison.md` 更新。 | Batch 1-3。 | 三个契约脚本 + pytest + fresh subagent validation。 |
 

--- a/docs/engineer/repository-governance/pm-single-entry/TRD.md
+++ b/docs/engineer/repository-governance/pm-single-entry/TRD.md
@@ -114,7 +114,7 @@ flowchart TD
 **采用「PM 收口 + specialist description 弱化（#61 方案 B 语义）+ specialist 内 gate 保留
 作为纵深防御」的组合策略。**
 
-- 对外入口层面按 #52 收口：`pm-agent` 是默认入口，5 个 role router 与 28 个
+- 对外入口层面按 #52 收口：`pm-agent` 是默认入口，6 个 role router 与 32 个
   specialist 标记为非默认入口，用户显式直达下游仍是受支持路径。
 - description 分工按方案 B 语义执行于 specialist 与 role router 两层：用户侧起点短语
   全部收敛到 `pm-agent` description（高召回）；role router description 收敛为「PM handoff
@@ -165,18 +165,18 @@ flowchart TD
   入口文件内**，不得下沉到 `_internal` 按需加载——gate 必须在 skill 被触发的第一时间
   生效，而 `_internal` 模块只有模型主动读取才生效。
 - description 弱化改写与 #60 的 description 压缩合并为同一次编辑，避免两轮 PR 都动
-  34 个 frontmatter。
+  39 个 frontmatter。
 
 ## 5. Description 分工契约
 
 | 层 | Description 职责 | 允许内容 | 禁止内容 |
 | --- | --- | --- | --- |
 | `pm-agent` | 唯一用户入口，高召回。 | PRD FR-002 九类用户侧起点的代表性短语（新需求、变更、bug、工程诉求、设计、测试、部署、安全、GitHub 状态）；「意图模糊、需要分流」的宽泛表述。 | 无（上限受 harness description 长度与上下文成本约束，实现时控制总长）。 |
-| Role router（5 个） | PM handoff 后的角色内分流。 | 角色能力枚举 + 「invoked after pm-agent handoff / PM 编排下使用」定位；目标约 300 字符。 | 用户侧第一人称起点短语（「帮我实现」「修一下」「测一下」等）。 |
-| Specialist（28 个） | 编排下的执行模块，弱触发。 | 单一职责描述 + 上游入口声明（由哪个 router/PM 场景进入）。 | 与 PM / router 重叠的 trigger phrases；「Use when the user asks...」类用户起点表述（改为「Use when routed from ...」语义）。 |
+| Role router（6 个） | PM handoff 后的角色内分流。 | 角色能力枚举 + 「invoked after pm-agent handoff / PM 编排下使用」定位；目标约 300 字符。 | 用户侧第一人称起点短语（「帮我实现」「修一下」「测一下」等）。 |
+| Specialist（32 个） | 编排下的执行模块，弱触发。 | 单一职责描述 + 上游入口声明（由哪个 router/PM 场景进入）。 | 与 PM / router 重叠的 trigger phrases；「Use when the user asks...」类用户起点表述（改为「Use when routed from ...」语义）。 |
 
-marketplace.json 的 6 个 plugin description 同步改写：`pm-agent` plugin 描述为 entry
-dispatcher，其余 5 个 plugin 描述为 downstream role capability。
+marketplace.json 的 7 个 plugin description 同步改写：`pm-agent` plugin 描述为 entry
+dispatcher，其余 6 个 plugin 描述为 downstream role capability。
 
 ## 6. Handoff packet 与下游入口校验
 
@@ -216,11 +216,11 @@ specialist（及 role router）入口 gate 的统一判定顺序：
 | 优先级 | 路径 | 预期改动 |
 | --- | --- | --- |
 | P0 | `README.md`、`README_zh.md`、`.codex/INSTALL.md`、`docs/README.codex.md` | 推荐 `pm-agent` 为默认入口；下游定位为 PM 编排能力，同时保留显式直达路径。 |
-| P0 | `.claude-plugin/marketplace.json` | 6 个 plugin description 收口；skill 列表保持不变。 |
+| P0 | `.claude-plugin/marketplace.json` | 7 个 plugin description 收口；skill 列表保持不变。 |
 | P0 | `agents/product_manager/skills/pm-agent/SKILL.md` | description 高召回扩写；路由协议增加请求分类表、change_tier 判级、handoff packet 组装。 |
 | P0 | PM `_internal` 共享模块（skill-map / handoff contract） | packet 字段唯一权威定义；下游 owner 映射。 |
-| P0 | 5 个 role router SKILL.md | description 弱化为 handoff 后使用；gate 全文改指针。 |
-| P0 | 28 个 specialist SKILL.md frontmatter | description 弱触发改写 + `visibility: internal` 声明字段。 |
+| P0 | 6 个 role router SKILL.md | description 弱化为 handoff 后使用；gate 全文改指针。 |
+| P0 | 32 个 specialist SKILL.md frontmatter | description 弱触发改写 + `visibility: internal` 声明字段。 |
 | P0 | `agents/engineer/skills/feature-implementor/SKILL.md`、`debugger/SKILL.md`、`agents/qa/skills/qa-agent/SKILL.md` 等 | 入口 gate 按 6.2 判定顺序统一改写（gate 唯一副本，#59 协同）。 |
 | P0 | `AGENTS.md` | PM 唯一入口契约声明 + gate 指针化（#59 协同）。 |
 | P0 | `skills-lock.json` | 随每个修改 skill 目录的批次在同一 PR 内重算受影响 `computedHash`（见第 8 节）。 |
@@ -235,9 +235,9 @@ Agent 依赖）、#67（feature-catalog）、#68（change_tier 契约）全部�
 
 | 批次 | 内容 | 依赖 | 验证 |
 | --- | --- | --- | --- |
-| Batch 1: 发现面收口 | marketplace.json plugin description、README / README_zh / `.codex/INSTALL.md` / `docs/README.codex.md`、5 个 role router SKILL.md frontmatter description 弱化、specialist frontmatter description 弱化 + `visibility: internal`（与 #60 的 description 压缩合并执行）。router description 与 marketplace / specialist description 同批收口，因为三者同属 Claude/Codex 的直接 discovery 输入，任何一层单独遗留都会保持公开触发面；弱化语义按第 5 节契约执行：保留角色能力枚举与「invoked after pm-agent handoff / PM 编排下使用」的内部编排定位，删除用户侧触发短语，并指向 `pm-agent` 作为用户入口。 | 在途 PR 全部合并。 | 三个契约脚本 + pytest；description 分工静态审查。 |
+| Batch 1: 发现面收口 | marketplace.json plugin description、README / README_zh / `.codex/INSTALL.md` / `docs/README.codex.md`、6 个 role router SKILL.md frontmatter description 弱化、specialist frontmatter description 弱化 + `visibility: internal`（与 #60 的 description 压缩合并执行）。router description 与 marketplace / specialist description 同批收口，因为三者同属 Claude/Codex 的直接 discovery 输入，任何一层单独遗留都会保持公开触发面；弱化语义按第 5 节契约执行：保留角色能力枚举与「invoked after pm-agent handoff / PM 编排下使用」的内部编排定位，删除用户侧触发短语，并指向 `pm-agent` 作为用户入口。 | 在途 PR 全部合并。 | 三个契约脚本 + pytest；description 分工静态审查。 |
 | Batch 2: PM router 重写 | pm-agent SKILL.md 高召回 description、请求分类协议、change_tier 判级、handoff packet 组装；PM `_internal` handoff contract 权威定义。 | Batch 1；#68 已合入（change_tier 定义来源）。 | 契约脚本 + PM 入口 eval（FR-006 场景 1-6）。 |
-| Batch 3: 下游 gate 统一与 #59 去重 | 5 个 role router gate 指针化（description 弱化已在 Batch 1 完成，本批只动 gate 正文）、specialist gate 按 6.2 改写为唯一副本、AGENTS.md 契约声明；与 #59 gate 归位同一批执行。 | Batch 2。 | 契约脚本 + 防绕过 eval（FR-006 场景 7-8）。 |
+| Batch 3: 下游 gate 统一与 #59 去重 | 6 个 role router gate 指针化（description 弱化已在 Batch 1 完成，本批只动 gate 正文）、specialist gate 按 6.2 改写为唯一副本、AGENTS.md 契约声明；与 #59 gate 归位同一批执行。 | Batch 2。 | 契约脚本 + 防绕过 eval（FR-006 场景 8-9）。 |
 | Batch 4: eval 与 contract 收尾 | PM-only 入口 eval 全量、`check_repository_contract.py` 新校验、durable `comparison.md` 更新。 | Batch 1-3。 | 三个契约脚本 + pytest + fresh subagent validation。 |
 
 与相关 issue 的执行顺序：#59（gate 去重）在 Batch 3 内协同完成；#60（SKILL.md 瘦身）

--- a/docs/engineer/repository-governance/pm-single-entry/TRD.md
+++ b/docs/engineer/repository-governance/pm-single-entry/TRD.md
@@ -5,6 +5,7 @@ version: "1.0.1"
 status: Draft
 author: "Neplich Codex"
 date: "2026-07-05"
+last_updated: "2026-08-11"
 generated_by: "trd-gen"
 feature: "pm-single-entry"
 feature_path: "repository-governance/pm-single-entry"
@@ -43,8 +44,8 @@ changelog:
 ## 1. 来源上下文
 
 本 TRD 承接 `docs/pm/repository-governance/pm-single-entry/PRD.md`、GitHub issue #52 和
-issue #61。PM 范围已明确：`pm-agent` 收口为唯一对外公开入口，5 个下游 role agent 和
-28 个 specialist skills 内部化为 PM 编排下的下游能力，并对平台无法完全阻止的直接触发
+issue #61。PM 范围已明确：`pm-agent` 收口为唯一对外公开入口，6 个下游 role agent 和
+32 个 specialist skills 内部化为 PM 编排下的下游能力，并对平台无法完全阻止的直接触发
 路径建立防绕过机制。
 
 本 TRD 只定义技术契约、平台约束分析、架构决策、影响范围和验证策略，**不进入实现**。
@@ -62,8 +63,8 @@ flowchart TD
         PM["pm-agent（唯一推荐入口，高召回 description）"]
     end
     subgraph Internal["内部/下游能力（description 弱化）"]
-        R1["engineer-agent / designer-agent / qa-agent / devops-agent / security-agent（router）"]
-        S1["28 个 specialist skills"]
+        R1["engineer-agent / designer-agent / qa-agent / devops-agent / security-agent / docs-agent（router）"]
+        S1["32 个 specialist skills"]
     end
     U["用户请求"] --> PM
     PM -->|"分类 + change_tier + handoff packet"| R1

--- a/docs/engineer/repository-governance/pm-single-entry/TRD.md
+++ b/docs/engineer/repository-governance/pm-single-entry/TRD.md
@@ -171,7 +171,7 @@ flowchart TD
 
 | 层 | Description 职责 | 允许内容 | 禁止内容 |
 | --- | --- | --- | --- |
-| `pm-agent` | 唯一用户入口，高召回。 | PRD FR-002 九类用户侧起点的代表性短语（新需求、变更、bug、工程诉求、设计、测试、部署、安全、GitHub 状态）；「意图模糊、需要分流」的宽泛表述。 | 无（上限受 harness description 长度与上下文成本约束，实现时控制总长）。 |
+| `pm-agent` | 唯一用户入口，高召回。 | PRD FR-002 十类用户侧起点的代表性短语（新需求、变更、bug、工程诉求、设计、测试、部署、安全、GitHub 状态、正式文档）；「意图模糊、需要分流」的宽泛表述。 | 无（上限受 harness description 长度与上下文成本约束，实现时控制总长）。 |
 | Role router（6 个） | PM handoff 后的角色内分流。 | 角色能力枚举 + 「invoked after pm-agent handoff / PM 编排下使用」定位；目标约 300 字符。 | 用户侧第一人称起点短语（「帮我实现」「修一下」「测一下」等）。 |
 | Specialist（32 个） | 编排下的执行模块，弱触发。 | 单一职责描述 + 上游入口声明（由哪个 router/PM 场景进入）。 | 与 PM / router 重叠的 trigger phrases；「Use when the user asks...」类用户起点表述（改为「Use when routed from ...」语义）。 |
 
@@ -224,7 +224,7 @@ specialist（及 role router）入口 gate 的统一判定顺序：
 | P0 | `agents/engineer/skills/feature-implementor/SKILL.md`、`debugger/SKILL.md`、`agents/qa/skills/qa-agent/SKILL.md` 等 | 入口 gate 按 6.2 判定顺序统一改写（gate 唯一副本，#59 协同）。 |
 | P0 | `AGENTS.md` | PM 唯一入口契约声明 + gate 指针化（#59 协同）。 |
 | P0 | `skills-lock.json` | 随每个修改 skill 目录的批次在同一 PR 内重算受影响 `computedHash`（见第 8 节）。 |
-| P1 | `agents/**/test/**/evals/`（PM 入口与防绕过 eval） | 新增/改造 FR-006 的 8 类场景，含「绕过 router 直接触发」用例。 |
+| P1 | `agents/**/test/**/evals/`（PM 入口与防绕过 eval） | 新增/改造 FR-006 的 9 类场景，含「绕过 router 直接触发」用例。 |
 | P1 | `scripts/check_repository_contract.py` | 校验 description 分工（specialist 无用户侧触发短语）、`visibility` 字段、packet 字段定义唯一性（可行范围内的静态检查）。 |
 
 ## 8. 实施拆分（后续 PR 分批计划)
@@ -236,7 +236,7 @@ Agent 依赖）、#67（feature-catalog）、#68（change_tier 契约）全部�
 | 批次 | 内容 | 依赖 | 验证 |
 | --- | --- | --- | --- |
 | Batch 1: 发现面收口 | marketplace.json plugin description、README / README_zh / `.codex/INSTALL.md` / `docs/README.codex.md`、6 个 role router SKILL.md frontmatter description 弱化、specialist frontmatter description 弱化 + `visibility: internal`（与 #60 的 description 压缩合并执行）。router description 与 marketplace / specialist description 同批收口，因为三者同属 Claude/Codex 的直接 discovery 输入，任何一层单独遗留都会保持公开触发面；弱化语义按第 5 节契约执行：保留角色能力枚举与「invoked after pm-agent handoff / PM 编排下使用」的内部编排定位，删除用户侧触发短语，并指向 `pm-agent` 作为用户入口。 | 在途 PR 全部合并。 | 三个契约脚本 + pytest；description 分工静态审查。 |
-| Batch 2: PM router 重写 | pm-agent SKILL.md 高召回 description、请求分类协议、change_tier 判级、handoff packet 组装；PM `_internal` handoff contract 权威定义。 | Batch 1；#68 已合入（change_tier 定义来源）。 | 契约脚本 + PM 入口 eval（FR-006 场景 1-6）。 |
+| Batch 2: PM router 重写 | pm-agent SKILL.md 高召回 description、请求分类协议、change_tier 判级、handoff packet 组装；PM `_internal` handoff contract 权威定义。 | Batch 1；#68 已合入（change_tier 定义来源）。 | 契约脚本 + PM 入口 eval（FR-006 场景 1-7）。 |
 | Batch 3: 下游 gate 统一与 #59 去重 | 6 个 role router gate 指针化（description 弱化已在 Batch 1 完成，本批只动 gate 正文）、specialist gate 按 6.2 改写为唯一副本、AGENTS.md 契约声明；与 #59 gate 归位同一批执行。 | Batch 2。 | 契约脚本 + 防绕过 eval（FR-006 场景 8-9）。 |
 | Batch 4: eval 与 contract 收尾 | PM-only 入口 eval 全量、`check_repository_contract.py` 新校验、durable `comparison.md` 更新。 | Batch 1-3。 | 三个契约脚本 + pytest + fresh subagent validation。 |
 

--- a/docs/engineer/repository-governance/pm-single-entry/TRD.md
+++ b/docs/engineer/repository-governance/pm-single-entry/TRD.md
@@ -11,7 +11,6 @@ feature: "pm-single-entry"
 feature_path: "repository-governance/pm-single-entry"
 parent_feature: "repository-governance"
 feature_level: "2"
-last_updated: "2026-07-06"
 related_prd: "docs/pm/repository-governance/pm-single-entry/PRD.md"
 related_issue: "https://github.com/Neplich/dev-agent-skills/issues/52"
 related_docs:

--- a/docs/engineer/repository-governance/pm-single-entry/TRD.md
+++ b/docs/engineer/repository-governance/pm-single-entry/TRD.md
@@ -236,7 +236,7 @@ Agent 依赖）、#67（feature-catalog）、#68（change_tier 契约）全部�
 | 批次 | 内容 | 依赖 | 验证 |
 | --- | --- | --- | --- |
 | Batch 1: 发现面收口 | marketplace.json plugin description、README / README_zh / `.codex/INSTALL.md` / `docs/README.codex.md`、6 个 role router SKILL.md frontmatter description 弱化、specialist frontmatter description 弱化 + `visibility: internal`（与 #60 的 description 压缩合并执行）。router description 与 marketplace / specialist description 同批收口，因为三者同属 Claude/Codex 的直接 discovery 输入，任何一层单独遗留都会保持公开触发面；弱化语义按第 5 节契约执行：保留角色能力枚举与「invoked after pm-agent handoff / PM 编排下使用」的内部编排定位，删除用户侧触发短语，并指向 `pm-agent` 作为用户入口。 | 在途 PR 全部合并。 | 三个契约脚本 + pytest；description 分工静态审查。 |
-| Batch 2: PM router 重写 | pm-agent SKILL.md 高召回 description、请求分类协议、change_tier 判级、handoff packet 组装；PM `_internal` handoff contract 权威定义。 | Batch 1；#68 已合入（change_tier 定义来源）。 | 契约脚本 + PM 入口 eval（FR-006 场景 1-6；正式文档路由见 eval-014~016）。 |
+| Batch 2: PM router 重写 | pm-agent SKILL.md 高召回 description、请求分类协议、change_tier 判级、handoff packet 组装；PM `_internal` handoff contract 权威定义。 | Batch 1；#68 已合入（change_tier 定义来源）。 | 契约脚本 + PM 入口 eval（FR-006 场景 1-6、9；交付 fast lane 见 eval-010）。 |
 | Batch 3: 下游 gate 统一与 #59 去重 | 6 个 role router gate 指针化（description 弱化已在 Batch 1 完成，本批只动 gate 正文）、specialist gate 按 6.2 改写为唯一副本、AGENTS.md 契约声明；与 #59 gate 归位同一批执行。 | Batch 2。 | 契约脚本 + 防绕过 eval（FR-006 场景 7-8）。 |
 | Batch 4: eval 与 contract 收尾 | PM-only 入口 eval 全量、`check_repository_contract.py` 新校验、durable `comparison.md` 更新。 | Batch 1-3。 | 三个契约脚本 + pytest + fresh subagent validation。 |
 

--- a/docs/pm/agent-collaboration/readme-collaboration-guardrails/PRD.md
+++ b/docs/pm/agent-collaboration/readme-collaboration-guardrails/PRD.md
@@ -26,7 +26,7 @@ GitHub issue #28 要求 README 层面准确表达 Agent 协作门禁，避免用
 
 ## 范围
 
-- 主 README 保留 6 个 Agent 的协作关系，并补充现有功能变更、bug fix 和用户可见实现的关键门禁。
+- 主 README 保留 7 个 Agent 的协作关系，并补充现有功能变更、bug fix 和用户可见实现的关键门禁。
 - Engineer README 展示 TRD 确认、实施计划确认、实现或 debug、测试与 QA E2E handoff 的关系。
 - 中英文 README 保持语义一致。
 

--- a/docs/pm/agent-collaboration/readme-collaboration-guardrails/PRD.md
+++ b/docs/pm/agent-collaboration/readme-collaboration-guardrails/PRD.md
@@ -5,7 +5,7 @@ version: "0.1.0"
 status: Draft
 author: "Neplich Codex"
 date: "2026-06-25"
-last_updated: "2026-06-25"
+last_updated: "2026-08-11"
 generated_by: "idea-to-spec"
 feature: "readme-collaboration-guardrails"
 feature_path: "agent-collaboration/readme-collaboration-guardrails"

--- a/docs/pm/agent-collaboration/readme-collaboration-guardrails/review-fix/PRD.md
+++ b/docs/pm/agent-collaboration/readme-collaboration-guardrails/review-fix/PRD.md
@@ -5,7 +5,7 @@ version: "0.1.0"
 status: Draft
 author: "Neplich Codex"
 date: "2026-06-25"
-last_updated: "2026-06-25"
+last_updated: "2026-08-11"
 generated_by: "idea-to-spec"
 feature: "review-fix"
 feature_path: "agent-collaboration/readme-collaboration-guardrails/review-fix"

--- a/docs/pm/agent-collaboration/readme-collaboration-guardrails/review-fix/PRD.md
+++ b/docs/pm/agent-collaboration/readme-collaboration-guardrails/review-fix/PRD.md
@@ -27,7 +27,7 @@ PR #34 review 指出，README 协作门禁主链路需要调整展示层级，�
 
 ## 范围
 
-- 主 README / README_zh 保留 6 个 Agent 的主交互图。
+- 主 README / README_zh 保留 7 个 Agent 的主交互图。
 - 门禁关系作为主图后的补充信息呈现。
 - Engineer README / README_zh 中 debugger 分支连接到 QA E2E handoff。
 - 原主链路实施计划保持历史完成状态。
@@ -36,7 +36,7 @@ PR #34 review 指出，README 协作门禁主链路需要调整展示层级，�
 
 | ID | 标准 |
 | --- | --- |
-| AC-01 | 主 README 的主图仍表达 6 个 Agent 的交互关系。 |
+| AC-01 | 主 README 的主图仍表达 7 个 Agent 的交互关系。 |
 | AC-02 | 门禁关系不抢占主协作图语义。 |
 | AC-03 | Engineer README 的 implementation 和 debugger 路径都进入 QA E2E handoff。 |
 

--- a/docs/pm/repository-governance/pm-single-entry/PRD.md
+++ b/docs/pm/repository-governance/pm-single-entry/PRD.md
@@ -5,6 +5,7 @@ version: "1.0.0"
 status: Draft
 author: "Neplich Codex"
 date: "2026-07-05"
+last_updated: "2026-08-11"
 generated_by: "prd-gen"
 feature: "pm-single-entry"
 feature_path: "repository-governance/pm-single-entry"
@@ -48,7 +49,7 @@ changelog:
 部署诉求或安全诉求，都应先从 PM 侧进入，由 PM 判断它是新需求、现有功能变更、缺陷、
 验证、部署、安全审查，还是需要继续澄清，再编排到下游角色。
 
-issue #61 为「防绕过」需求提供了直接证据：34 个 skill 的 frontmatter description 全部常驻
+issue #61 为「防绕过」需求提供了直接证据：39 个 skill 的 frontmatter description 全部常驻
 harness 上下文（router 类普遍 500-670 字符，合计约 10KB），且 router 与 specialist 的触发
 短语大量重叠。例如「实现这个功能」同时出现在 `engineer-agent`（router）和
 `feature-implementor`（specialist）的 description 中。harness 层由模型基于 description 自主

--- a/docs/pm/repository-governance/pm-single-entry/PRD.md
+++ b/docs/pm/repository-governance/pm-single-entry/PRD.md
@@ -256,7 +256,7 @@ flowchart TD
 | --- | --- | --- |
 | AC-001 | 用户文档只把 `pm-agent` 描述为公开入口。 | 审查 README / README_zh / `.codex/INSTALL.md` / `docs/README.codex.md`。 |
 | AC-002 | 新需求、功能变更、bug、测试、部署、安全、交付、正式文档请求默认先进入 PM 分类和编排。 | PM 入口 eval（FR-006 场景 1-7）。 |
-| AC-003 | 无 PM handoff packet 时，下游 role agent / specialist 不直接承接用户原始请求。 | 防绕过 eval（FR-006 场景 7-8）。 |
+| AC-003 | 无 PM handoff packet 时，下游 role agent / specialist 不直接承接用户原始请求。 | 防绕过 eval（FR-006 场景 8-9）。 |
 | AC-004 | `feature-implementor` 不直接响应用户新需求并进入实现。 | `feature-implementor` eval 与 gate 审查。 |
 | AC-005 | PM handoff packet 字段被文档化，并被下游 agent 作为入口校验依据。 | 审查 PM skill-map / handoff contract 与下游 SKILL.md。 |
 | AC-006 | PM-only 入口 eval 覆盖主要用户侧起点和防绕过场景。 | `check_eval_contract.py` + fresh subagent validation + `comparison.md`。 |

--- a/docs/pm/repository-governance/pm-single-entry/PRD.md
+++ b/docs/pm/repository-governance/pm-single-entry/PRD.md
@@ -255,7 +255,7 @@ flowchart TD
 | ID | 验收标准 | 验证方式 |
 | --- | --- | --- |
 | AC-001 | 用户文档只把 `pm-agent` 描述为公开入口。 | 审查 README / README_zh / `.codex/INSTALL.md` / `docs/README.codex.md`。 |
-| AC-002 | 新需求、功能变更、bug、测试、部署、安全、交付、正式文档请求默认先进入 PM 分类和编排。 | PM 入口 eval（FR-006 场景 1-6；正式文档路由见 eval-014~016；交付 fast lane 见 eval-010）。 |
+| AC-002 | 新需求、功能变更、bug、测试、部署、安全、交付、正式文档请求默认先进入 PM 分类和编排。 | PM 入口 eval（FR-006 场景 1-6；交付 fast lane 见 eval-010；正式文档场景 9 对应 eval 待补充）。 |
 | AC-003 | 无 PM handoff packet 时，下游 role agent / specialist 不直接承接用户原始请求。 | 防绕过 eval（FR-006 场景 7-8）。 |
 | AC-004 | `feature-implementor` 不直接响应用户新需求并进入实现。 | `feature-implementor` eval 与 gate 审查。 |
 | AC-005 | PM handoff packet 字段被文档化，并被下游 agent 作为入口校验依据。 | 审查 PM skill-map / handoff contract 与下游 SKILL.md。 |

--- a/docs/pm/repository-governance/pm-single-entry/PRD.md
+++ b/docs/pm/repository-governance/pm-single-entry/PRD.md
@@ -218,8 +218,7 @@ PM handoff 到下游角色时必须携带结构化输入：
 6. 用户说「看下权限 / 依赖漏洞 / secrets 风险」，命中 `pm-agent`，再 handoff Security。
 7. 用户直接调用下游 agent 或 specialist 时，如果没有 PM handoff packet，应被拉回 PM 分类。
 8. 绕过 router 直接触发 specialist 时（#61 场景），specialist 内 gate 仍然执行。
-9. 用户说「搭个文档站 / 同步正式文档 / 写用户手册」，命中 `pm-agent`，再 handoff Docs
-   （正式文档路由已由 eval-014 / eval-015 / eval-016 覆盖）。
+9. 用户说「搭个文档站 / 同步正式文档 / 写用户手册」，命中 `pm-agent`，再 handoff Docs。
 
 验收标准：eval 使用 schema `1.0` 与语义断言；实际执行后更新 durable `comparison.md`。
 
@@ -256,7 +255,7 @@ flowchart TD
 | ID | 验收标准 | 验证方式 |
 | --- | --- | --- |
 | AC-001 | 用户文档只把 `pm-agent` 描述为公开入口。 | 审查 README / README_zh / `.codex/INSTALL.md` / `docs/README.codex.md`。 |
-| AC-002 | 新需求、功能变更、bug、测试、部署、安全、交付、正式文档请求默认先进入 PM 分类和编排。 | PM 入口 eval（FR-006 场景 1-6、9；交付 fast lane 见 eval-010）。 |
+| AC-002 | 新需求、功能变更、bug、测试、部署、安全、交付、正式文档请求默认先进入 PM 分类和编排。 | PM 入口 eval（FR-006 场景 1-6；正式文档路由见 eval-014~016；交付 fast lane 见 eval-010）。 |
 | AC-003 | 无 PM handoff packet 时，下游 role agent / specialist 不直接承接用户原始请求。 | 防绕过 eval（FR-006 场景 7-8）。 |
 | AC-004 | `feature-implementor` 不直接响应用户新需求并进入实现。 | `feature-implementor` eval 与 gate 审查。 |
 | AC-005 | PM handoff packet 字段被文档化，并被下游 agent 作为入口校验依据。 | 审查 PM skill-map / handoff contract 与下游 SKILL.md。 |

--- a/docs/pm/repository-governance/pm-single-entry/PRD.md
+++ b/docs/pm/repository-governance/pm-single-entry/PRD.md
@@ -140,8 +140,10 @@ harness 上下文（router 类普遍 500-670 字符，合计约 10KB），且 ro
 - 部署、CI/CD、环境变量、Docker/Helm、发布、回滚、runbook 诉求。
 - 安全、权限、登录、依赖、secrets、隐私、数据流、webhook/upload 等风险诉求。
 - GitHub issue / PR / milestone / release / changelog / roadmap / repo status 诉求。
+- 正式文档站 bootstrap、功能/部署/发版后的同步、存量回填、图文用户操作手册、站内
+  Release Notes、发版审计诉求。
 
-验收标准：`pm-agent` description 覆盖上述九类起点的代表性短语；FR-006 的 eval 场景全部
+验收标准：`pm-agent` description 覆盖上述十类起点的代表性短语；FR-006 的 eval 场景全部
 命中 `pm-agent`。
 
 ### FR-003: PM 先分类，再 handoff（P0）
@@ -156,6 +158,7 @@ harness 上下文（router 类普遍 500-670 字符，合计约 10KB），且 ro
 | 设计诉求 | 先确认是设计产物需求还是前端实现需求。 | 设计产物 handoff Designer；前端实现需 PM/TRD/设计对齐后 handoff Engineer。 |
 | 测试诉求 | 先确认测试依据（PRD/TRD/已确认实施计划）。 | 预期未确认不得让 QA 或 test-writer 固化新预期。 |
 | 部署/运维/安全诉求 | PM 记录目标、范围和风险。 | 记录完成后 handoff DevOps/Security。 |
+| 正式文档诉求 | PM 确认范围（bootstrap / sync / 手册 / Release Notes / audit）。 | 确认后 handoff Docs（docs-agent）。 |
 | 已完成工作交付 | 确认变更范围和验证状态。 | 确认后 handoff Engineer/delivery，不得绕过状态确认。 |
 
 分类时同步判定变更等级（`change_tier`，衔接 issue #55 / PR #68 的变更分级契约）：
@@ -190,12 +193,12 @@ PM handoff 到下游角色时必须携带结构化输入：
 
 | 字段 | 说明 |
 | --- | --- |
-| `request_type` | new_feature / existing_update / bug_report / validation / deployment / security / delivery / status 等。 |
+| `request_type` | new_feature / existing_update / bug_report / validation / deployment / security / delivery / status / formal_docs 等。 |
 | `change_tier` | hotfix / standard / major（衔接 issue #55 / PR #68 的变更分级契约；契约未合入前由 PM 按同一定义判级）。 |
 | `feature_path` / `feature` / `parent_feature` / `feature_level` / `feature_path_evidence` | 功能归属主键与证据，遵循 feature-path-contract。 |
 | `source_documents` | PRD / DECISIONS / TRD / design docs / issue / PR / release context。 |
 | `scope_decision` | 本次范围、非目标、是否改变已批准预期。 |
-| `downstream_owner` | Designer / Engineer / QA / DevOps / Security / delivery 等。 |
+| `downstream_owner` | Designer / Engineer / QA / DevOps / Security / Docs / delivery 等。 |
 | `required_output` | 下游需要产出的文档、计划、实现、报告或验证证据。 |
 | `blockers_risks` | 缺失文档、未确认决策、平台限制、验证风险。 |
 
@@ -213,8 +216,9 @@ PM handoff 到下游角色时必须携带结构化输入：
 4. 用户说「更新前端 UI」，命中 `pm-agent`，再判断 PM / Designer / Engineer 路径。
 5. 用户说「部署一下 / 配 CI / 上线前检查」，命中 `pm-agent`，再 handoff DevOps。
 6. 用户说「看下权限 / 依赖漏洞 / secrets 风险」，命中 `pm-agent`，再 handoff Security。
-7. 用户直接调用下游 agent 或 specialist 时，如果没有 PM handoff packet，应被拉回 PM 分类。
-8. 绕过 router 直接触发 specialist 时（#61 场景），specialist 内 gate 仍然执行。
+7. 用户说「搭个文档站 / 同步正式文档 / 写用户手册」，命中 `pm-agent`，再 handoff Docs。
+8. 用户直接调用下游 agent 或 specialist 时，如果没有 PM handoff packet，应被拉回 PM 分类。
+9. 绕过 router 直接触发 specialist 时（#61 场景），specialist 内 gate 仍然执行。
 
 验收标准：eval 使用 schema `1.0` 与语义断言；实际执行后更新 durable `comparison.md`。
 
@@ -251,7 +255,7 @@ flowchart TD
 | ID | 验收标准 | 验证方式 |
 | --- | --- | --- |
 | AC-001 | 用户文档只把 `pm-agent` 描述为公开入口。 | 审查 README / README_zh / `.codex/INSTALL.md` / `docs/README.codex.md`。 |
-| AC-002 | 新需求、功能变更、bug、测试、部署、安全、交付、正式文档请求默认先进入 PM 分类和编排。 | PM 入口 eval（FR-006 场景 1-6）。 |
+| AC-002 | 新需求、功能变更、bug、测试、部署、安全、交付、正式文档请求默认先进入 PM 分类和编排。 | PM 入口 eval（FR-006 场景 1-7）。 |
 | AC-003 | 无 PM handoff packet 时，下游 role agent / specialist 不直接承接用户原始请求。 | 防绕过 eval（FR-006 场景 7-8）。 |
 | AC-004 | `feature-implementor` 不直接响应用户新需求并进入实现。 | `feature-implementor` eval 与 gate 审查。 |
 | AC-005 | PM handoff packet 字段被文档化，并被下游 agent 作为入口校验依据。 | 审查 PM skill-map / handoff contract 与下游 SKILL.md。 |

--- a/docs/pm/repository-governance/pm-single-entry/PRD.md
+++ b/docs/pm/repository-governance/pm-single-entry/PRD.md
@@ -38,7 +38,7 @@ changelog:
 
 ## 1. 背景与动机
 
-本仓库当前将 6 个入口 dispatcher skills 和 28 个 specialist skills 一起暴露在
+本仓库当前将 7 个入口 dispatcher skills 和 32 个 specialist skills 一起暴露在
 `.claude-plugin/marketplace.json` 和 Codex skill discovery 中。即使 README 建议优先调用
 入口 agent，用户的新需求、问题反馈、修复诉求或上线准备仍可能直接命中
 `engineer-agent`、`feature-implementor`、`debugger`、`qa-agent` 等下游能力，绕过 PM 侧的
@@ -68,9 +68,9 @@ harness 上下文（router 类普遍 500-670 字符，合计约 10KB），且 ro
 2. `pm-agent` 扩大触发范围，能捕获近似、模糊、不完整的需求和问题表达（高召回）。
 3. `pm-agent` 负责统一路由和编排：需求澄清、范围判断、feature_path 解析、PM 文档更新、
    下游角色 handoff、执行状态追踪。
-4. `engineer-agent`、`designer-agent`、`qa-agent`、`devops-agent`、`security-agent` 不再作为
-   用户公开入口，而是 PM handoff 后的下游 role capability。
-5. 28 个 specialist skills 保留目录和协议能力，但定位为 role agent 或 PM 编排下的内部
+4. `engineer-agent`、`designer-agent`、`qa-agent`、`devops-agent`、`security-agent`、
+   `docs-agent` 不再作为用户公开入口，而是 PM handoff 后的下游 role capability。
+5. 32 个 specialist skills 保留目录和协议能力，但定位为 role agent 或 PM 编排下的内部
    执行模块，不再面向用户直接触发。
 6. 防止「用户提了一个新需求，直接被 `engineer-agent` / `feature-implementor` 响应并进入
    实现」的路径；承认平台无法完全阻止直接触发时，提供明确的纵深防御与降级策略。

--- a/docs/pm/repository-governance/pm-single-entry/PRD.md
+++ b/docs/pm/repository-governance/pm-single-entry/PRD.md
@@ -216,9 +216,10 @@ PM handoff 到下游角色时必须携带结构化输入：
 4. 用户说「更新前端 UI」，命中 `pm-agent`，再判断 PM / Designer / Engineer 路径。
 5. 用户说「部署一下 / 配 CI / 上线前检查」，命中 `pm-agent`，再 handoff DevOps。
 6. 用户说「看下权限 / 依赖漏洞 / secrets 风险」，命中 `pm-agent`，再 handoff Security。
-7. 用户说「搭个文档站 / 同步正式文档 / 写用户手册」，命中 `pm-agent`，再 handoff Docs。
-8. 用户直接调用下游 agent 或 specialist 时，如果没有 PM handoff packet，应被拉回 PM 分类。
-9. 绕过 router 直接触发 specialist 时（#61 场景），specialist 内 gate 仍然执行。
+7. 用户直接调用下游 agent 或 specialist 时，如果没有 PM handoff packet，应被拉回 PM 分类。
+8. 绕过 router 直接触发 specialist 时（#61 场景），specialist 内 gate 仍然执行。
+9. 用户说「搭个文档站 / 同步正式文档 / 写用户手册」，命中 `pm-agent`，再 handoff Docs
+   （正式文档路由已由 eval-014 / eval-015 / eval-016 覆盖）。
 
 验收标准：eval 使用 schema `1.0` 与语义断言；实际执行后更新 durable `comparison.md`。
 
@@ -255,8 +256,8 @@ flowchart TD
 | ID | 验收标准 | 验证方式 |
 | --- | --- | --- |
 | AC-001 | 用户文档只把 `pm-agent` 描述为公开入口。 | 审查 README / README_zh / `.codex/INSTALL.md` / `docs/README.codex.md`。 |
-| AC-002 | 新需求、功能变更、bug、测试、部署、安全、交付、正式文档请求默认先进入 PM 分类和编排。 | PM 入口 eval（FR-006 场景 1-7）。 |
-| AC-003 | 无 PM handoff packet 时，下游 role agent / specialist 不直接承接用户原始请求。 | 防绕过 eval（FR-006 场景 8-9）。 |
+| AC-002 | 新需求、功能变更、bug、测试、部署、安全、交付、正式文档请求默认先进入 PM 分类和编排。 | PM 入口 eval（FR-006 场景 1-6、9；交付 fast lane 见 eval-010）。 |
+| AC-003 | 无 PM handoff packet 时，下游 role agent / specialist 不直接承接用户原始请求。 | 防绕过 eval（FR-006 场景 7-8）。 |
 | AC-004 | `feature-implementor` 不直接响应用户新需求并进入实现。 | `feature-implementor` eval 与 gate 审查。 |
 | AC-005 | PM handoff packet 字段被文档化，并被下游 agent 作为入口校验依据。 | 审查 PM skill-map / handoff contract 与下游 SKILL.md。 |
 | AC-006 | PM-only 入口 eval 覆盖主要用户侧起点和防绕过场景。 | `check_eval_contract.py` + fresh subagent validation + `comparison.md`。 |

--- a/docs/pm/repository-governance/pm-single-entry/PRD.md
+++ b/docs/pm/repository-governance/pm-single-entry/PRD.md
@@ -11,7 +11,6 @@ feature: "pm-single-entry"
 feature_path: "repository-governance/pm-single-entry"
 parent_feature: "repository-governance"
 feature_level: "2"
-last_updated: "2026-07-05"
 related_issue: "https://github.com/Neplich/dev-agent-skills/issues/52"
 related_docs:
   - "AGENTS.md"
@@ -92,7 +91,7 @@ harness 上下文（router 类普遍 500-670 字符，合计约 10KB），且 ro
 
 | 用户画像 | 描述 | 核心诉求 | 痛点 |
 | --- | --- | --- | --- |
-| 终端用户 | 在自己项目里安装本 marketplace 的开发者。 | 说一句需求就能被正确编排，不需要先学 34 个 skill 的分工。 | 直接命中下游 skill 后跳过范围确认，产出与预期不符。 |
+| 终端用户 | 在自己项目里安装本 marketplace 的开发者。 | 说一句需求就能被正确编排，不需要先学 39 个 skill 的分工。 | 直接命中下游 skill 后跳过范围确认，产出与预期不符。 |
 | 仓库维护者 | 维护 Agent skill 行为、文档契约和 eval 的人。 | 路由竞争行为可预期，治理规则不因入口不同而失效。 | router/specialist 描述重叠，gate 被绕过时只能靠三层复制兜底。 |
 | Skill 作者 | 维护单个 agent 或 specialist skill 的人。 | description 分工清晰，改一处不用同步多处。 | 触发短语互相抄写，改任意一条要检查多个文件。 |
 | 下游 Agent 使用者 | 已有明确 PM handoff、需要执行下游能力的用户。 | 携带 handoff packet 时下游直接承接，不被反复拉回 PM。 | 收口过严会让明确的执行请求也被强制绕路。 |
@@ -167,9 +166,9 @@ harness 上下文（router 类普遍 500-670 字符，合计约 10KB），且 ro
 
 ### FR-004: 下游 agent 不直接响应用户入口（P0）
 
-- 5 个下游 role agent（Engineer、Designer、QA、DevOps、Security）的公开触发描述调整为
-  「PM handoff 后使用」；specialist 的 description 移除与用户侧起点重叠的触发短语，改为
-  弱触发表述（#61 方案 B 语义应用于 specialist 层）。
+- 6 个下游 role agent（Engineer、Designer、QA、DevOps、Security、Docs）的公开触发描述
+  调整为「PM handoff 后使用」；specialist 的 description 移除与用户侧起点重叠的触发短语，
+  改为弱触发表述（#61 方案 B 语义应用于 specialist 层）。
 - 用户直接点名下游 agent 或 specialist 时，默认先回到 `pm-agent` 做入口分类，除非该请求
   已携带明确、已确认的 PM handoff packet（或等效的已确认 PRD/TRD/实施计划文档链）。
 - `feature-implementor` 不得直接响应「新需求 / 改功能 / 做个功能 / 帮我实现」等用户原始
@@ -237,6 +236,7 @@ flowchart TD
     TQ -->|否| Spec
     TQ -->|是| HQ["handoff QA / test-writer"]
     C -->|部署 / 安全| HO["记录目标范围风险 -> handoff DevOps / Security"]
+    C -->|正式文档| HF["handoff Docs（bootstrap / sync / 手册 / release notes / audit）"]
     C -->|交付 / 状态 (fast lane)| HL["确认范围与验证状态 -> handoff delivery / github-reader"]
     Spec --> Packet["PM handoff packet"]
     Update --> Packet
@@ -251,7 +251,7 @@ flowchart TD
 | ID | 验收标准 | 验证方式 |
 | --- | --- | --- |
 | AC-001 | 用户文档只把 `pm-agent` 描述为公开入口。 | 审查 README / README_zh / `.codex/INSTALL.md` / `docs/README.codex.md`。 |
-| AC-002 | 新需求、功能变更、bug、测试、部署、安全、交付请求默认先进入 PM 分类和编排。 | PM 入口 eval（FR-006 场景 1-6）。 |
+| AC-002 | 新需求、功能变更、bug、测试、部署、安全、交付、正式文档请求默认先进入 PM 分类和编排。 | PM 入口 eval（FR-006 场景 1-6）。 |
 | AC-003 | 无 PM handoff packet 时，下游 role agent / specialist 不直接承接用户原始请求。 | 防绕过 eval（FR-006 场景 7-8）。 |
 | AC-004 | `feature-implementor` 不直接响应用户新需求并进入实现。 | `feature-implementor` eval 与 gate 审查。 |
 | AC-005 | PM handoff packet 字段被文档化，并被下游 agent 作为入口校验依据。 | 审查 PM skill-map / handoff contract 与下游 SKILL.md。 |


### PR DESCRIPTION
## 背景

同一 PR 处理两个 Codex Review 文档漂移 issue：

- **#259**：marketplace 已进入 7-Agent / 6-downstream-role 状态，但 PM Agent 指南与协作治理 PRD 仍保留 Docs Agent 加入前的数量与角色集合。
- **#260**：英文 Agent README 均含 `Collaboration Dependencies`（目标插件不可用 → blocked → 不代行职责），对应六份中文 README_zh 缺等价契约。

## 改动

### #259 PM 协作拓扑

- `agents/product_manager/README.md`：
  - Quick Facts `Downstream agents` 从 2 个补全为 6 个下游角色
  - `Collaboration Dependencies` 按 `pm-agent` SKILL.md 的 Downstream Role Handoff Targets 补全 6 个下游（designer / engineer / qa / devops / security / docs）
- `agents/product_manager/README_zh.md`：快速信息「下游协作」同步补全 6 个
- `docs/pm/repository-governance/pm-single-entry/PRD.md`：
  - 背景数字 6 dispatcher / 28 specialist → 7 / 32
  - 目标 4 下游角色枚举补 `docs-agent`
  - 目标 5 specialist 数量 28 → 32
- `docs/pm/agent-collaboration/readme-collaboration-guardrails/PRD.md` 与 `review-fix/PRD.md`：主 README 协作图 Agent 数量 6 → 7

### #260 中文依赖安全网

PM / Designer / Engineer / QA / DevOps / Security 六份 `README_zh.md` 在「协作边界」后新增「协作依赖」章节，与英文 `Collaboration Dependencies` 语义一致，包含同级插件未安装时报告缺失阶段与插件、标记 blocked、不代行缺失角色职责的契约。PM 版本按 6 个下游角色撰写。

## 验证

- `check_doc_contract.py`、`check_repository_contract.py`、`check_eval_contract.py` 全部 PASS

## 说明

`docs/pm/agents/docs-agent/PRD.md` 中的「现有 6 个 Agent」表述描述的是 docs-agent 加入前的历史基线（该 PRD 即「定义第 7 个角色」的决策记录），不改写。

Closes #259
Closes #260
