### PR TITLE
feat(pm-agent): 精简用户可见的路由决策输出

### DIFF
--- a/agents/product_manager/skills/pm-agent/SKILL.md
+++ b/agents/product_manager/skills/pm-agent/SKILL.md
@@ -5,19 +5,20 @@ description: "Default entry point for any new user request. Use this when the us
 
 # PM Agent Dispatcher
 
-Every response starts with the complete `Routing decision` block before any
-repository inspection or clarification question — except when the Scope Guard
-below stops the request (one-line out-of-scope notice, nothing else), or when
-the Scope Guard lets a general request through and it fits no PM category or
-downstream role (one-line honest notice, no Routing decision). The Scope
-Guard's enable-marker check runs before the Routing decision. In particular,
-a requested
-business-rule or approved-expectation change must render the literal values
-`change_tier: standard` (or `major`) and `hotfix_disposition: rejected`; an
-empty repository or missing implementation context never suppresses them.
-For example, a request to change a membership trial duration and merge quickly
-starts with `change_tier: standard` and `hotfix_disposition: rejected` before
-asking which users are affected or reporting that source is unavailable.
+Every response starts with a one-line routing statement before any repository
+inspection or clarification question — except when the Scope Guard below stops
+the request (one-line out-of-scope notice, nothing else), or when the Scope
+Guard lets a general request through and it fits no PM category or downstream
+role (one-line honest notice, no routing statement). The Scope Guard's
+enable-marker check runs before the routing statement; the classification
+protocol itself always runs in full, only its user-visible rendering varies.
+In particular, a requested business-rule or approved-expectation change must
+render the literal values `change_tier: standard` (or `major`) and
+`hotfix_disposition: rejected`; an empty repository or missing implementation
+context never suppresses them. For example, a request to change a membership
+trial duration and merge quickly starts with a one-line statement that carries
+`change_tier: standard` and `hotfix_disposition: rejected` before asking which
+users are affected or reporting that source is unavailable.
 
 `pm-agent` is the public entry point for user requests in this marketplace. It
 classifies the user's goal first, routes to the narrowest downstream PM skill
@@ -77,7 +78,26 @@ content.
 
 Do not begin by inspecting or implementing the requested work. First apply the
 classification protocol below, even when the workspace is empty or a requested
-file is missing. The first response must make these decisions observable:
+file is missing. Classification always runs in full; what the user sees varies
+by scenario:
+
+- **默认**：输出一行简短路由说明，格式为 `已路由到 <skill>：<一句话原因>`。
+  例如 `已路由到 idea-to-spec：收敛需求范围并产出 PRD`。
+- **必须显式呈现关键值**（安全网，不可省略）：业务规则或已批准预期变更、
+  以及 hotfix 判定场景，一行说明内必须呈现 `change_tier` 与
+  `hotfix_disposition` 的字面值（如 `change_tier: standard`、
+  `hotfix_disposition: rejected`），以紧凑形式表达即可，不需要完整 YAML 块；
+  空仓库或缺失实现上下文不抑制这些值。
+- **完整结构化信息**（`Routing decision` 块或等价的关键字段组合）仅在以下
+  情况补充：
+  - 用户明确要求查看完整路由依据；
+  - 入口缺失或 blocked，需要说明具体缺口和禁止执行边界；
+  - 跨角色 handoff，需要输出下游可消费的完整 handoff packet；
+  - 调试或 eval 场景需要验证结构化路由结果。
+- **连续追问**：同一任务的追问和状态更新不重复输出路由说明，除非 owner、
+  scope 或 route 发生变化。
+
+The classification itself must make these decisions:
 
 - name the `request_type` and `change_tier`, with the evidence that supports
   them
@@ -90,8 +110,8 @@ file is missing. The first response must make these decisions observable:
 - if a direct role or specialist request lacks its entry basis, stop execution,
   return it to `pm-agent`, and name the missing handoff fields or documents
 
-Start with this compact block and keep every field visible; use `N/A`, `[]`, or
-`missing` instead of dropping a key:
+When a full structured block is required, use this schema and keep every field
+visible; use `N/A`, `[]`, or `missing` instead of dropping a key:
 
 ```yaml
 Routing decision:
@@ -134,13 +154,16 @@ Greenfield discovery starts with the highest-information question; later
 context collection and PRD/DECISIONS delivery remain pending until the user
 answers, and engineering/TRD work remains downstream of confirmed scope.
 
-Before returning any response, validate its first non-whitespace line and
-required keys. It must start with `Routing decision:` and contain every field
-in the schema above; a `greenfield-discovery`, checkpoint, or specialist block
-may follow it but never substitute for it. If this validation fails, prepend
-the complete routing block before returning — unless the Scope Guard stopped
-the request or let an unroutable general request through, in which case no
-routing block is emitted.
+Before returning any response, validate the routing statement and required
+values. The default one-line statement must name the routed skill and, when the
+classification signal requires it, carry the literal `change_tier` /
+`hotfix_disposition` values; whenever a full `Routing decision:` block is
+emitted, it must contain every field in the schema above, and a
+`greenfield-discovery`, checkpoint, or specialist block may follow it but never
+substitute for it. If this validation fails, prepend the missing routing
+information before returning — unless the Scope Guard stopped the request or
+let an unroutable general request through, in which case no routing statement
+is emitted.
 
 Repository inspection may supply evidence after classification, but a missing
 README, source tree, or command is not a substitute for the routing decision.
@@ -414,6 +437,11 @@ do not perform the missing agent's responsibilities yourself.
 
 When routing is complete:
 
+- the user-facing output defaults to the one-line routing statement defined in
+  the Mandatory Entry Decision; do not repeat it on follow-up turns of the same
+  task, and do not re-emit a full `Routing decision` block unless the user asks
+  for it, the entry basis or route changes, or the block is required for a
+  handoff / blocked / debug-eval scenario
 - briefly anchor which PM skill was selected when that context is useful
 - immediately continue with the routed skill's protocol instead of asking for
   permission to proceed

--- a/agents/product_manager/skills/pm-agent/SKILL.md
+++ b/agents/product_manager/skills/pm-agent/SKILL.md
@@ -5,11 +5,14 @@ description: "Default entry point for any new user request. Use this when the us
 
 # PM Agent Dispatcher
 
-Every response starts with a one-line routing statement before any repository
-inspection or clarification question — except when the Scope Guard below stops
-the request (one-line out-of-scope notice, nothing else), or when the Scope
-Guard lets a general request through and it fits no PM category or downstream
-role (one-line honest notice, no routing statement). The Scope Guard's
+Every new request starts with a one-line routing statement before any
+repository inspection or clarification question — except when the Scope Guard
+below stops the request (one-line out-of-scope notice, nothing else), when the
+Scope Guard lets a general request through and it fits no PM category or
+downstream role (one-line honest notice, no routing statement), or when the
+request is a follow-up on an already-routed task whose owner, scope, or route
+has not changed (no routing statement; continue the settled lane directly).
+The Scope Guard's
 enable-marker check runs before the routing statement; the classification
 protocol itself always runs in full, only its user-visible rendering varies.
 In particular, a requested business-rule or approved-expectation change must
@@ -81,8 +84,11 @@ classification protocol below, even when the workspace is empty or a requested
 file is missing. Classification always runs in full; what the user sees varies
 by scenario:
 
-- **默认**：输出一行简短路由说明，格式为 `已路由到 <skill>：<一句话原因>`。
-  例如 `已路由到 idea-to-spec：收敛需求范围并产出 PRD`。
+- **默认**：输出一行简短路由说明。入口就绪时格式为
+  `已路由到 <skill>：<一句话原因>`，例如
+  `已路由到 idea-to-spec：收敛需求范围并产出 PRD`；entry basis 缺失或
+  blocked 时用就绪感知措辞（如 `拟路由到 <skill>` 或直接说明缺口），不得
+  把未来路由表述成已完成 handoff。
 - **必须显式呈现关键值**（安全网，不可省略）：业务规则或已批准预期变更、
   以及 hotfix 判定场景，一行说明内必须呈现 `change_tier` 与
   `hotfix_disposition` 的字面值（如 `change_tier: standard`、
@@ -149,7 +155,9 @@ specialist requests, the block must also say whether its own entry gate passed;
 if not, explicitly reject downstream execution, planning, implementation, and
 testing and return the request to `pm-agent`. For a PM-owned route, name the
 owner exactly as listed under Available PM Skills before any internal lane,
-then emit this block before continuing into the specialist's first step.
+then output the routing statement (default one line; the full block only when
+one of the exceptional scenarios above applies) before continuing into the
+specialist's first step.
 Greenfield discovery starts with the highest-information question; later
 context collection and PRD/DECISIONS delivery remain pending until the user
 answers, and engineering/TRD work remains downstream of confirmed scope.

--- a/agents/product_manager/test/pm-agent/evals/evals.json
+++ b/agents/product_manager/test/pm-agent/evals/evals.json
@@ -304,13 +304,13 @@
         ]
       },
       "prompt": "直接帮我实现设置页布局调整；目前没有准备产品或设计材料，希望先开始改代码。",
-      "expected_output": "先给出 PM Routing decision；将范围和 feature_path 标为未确认，继续由 PM 完成需求与设计依据对齐，不把未来的 Engineer 路由表述成已完成 handoff，也不开始工程实现。",
+      "expected_output": "先给出简短路由说明（默认一行），将范围和 feature_path 标为未确认，继续由 PM 完成需求与设计依据对齐，不把未来的 Engineer 路由表述成已完成 handoff，也不开始工程实现。",
       "workspace": "workspace/eval-7-direct-downstream-without-handoff",
       "assertions": [
         {
           "id": "routing_decision_present",
           "description": "先给出 PM 路由决策",
-          "text": "输出先给出明确的 Routing decision，包含 request_type、selected owner、entry basis、feature_path 和 execution boundary；不得只进入需求讨论而省略入口分类。"
+          "text": "输出路由说明（默认一行简短形式即可），分类结果可审计：请求留在 PM 范围对齐路径，selected_owner 为 PM specialist（如 `idea-to-spec`）或语义等价表述，entry basis、feature_path 和 execution boundary 的状态可核对；不得只进入需求讨论而省略入口分类，不要求完整 Routing decision YAML 块作为首行。"
         },
         {
           "id": "stay_in_pm_alignment",
@@ -349,13 +349,13 @@
         ]
       },
       "prompt": "账号中心要做一个新功能。目前只有这句话，还没有需求文档或技术设计；请先直接给我实施计划并开始写代码。",
-      "expected_output": "先给出 PM Routing decision，将该请求留在新功能范围确认；说明一句需求不足以形成实施依据，需求范围与 PRD 确认后还需技术设计和已确认实施范围，当前不创建实施计划、不写代码或测试。",
+      "expected_output": "先给出简短路由说明（默认一行），将该请求留在新功能范围确认；说明一句需求不足以形成实施依据，需求范围与 PRD 确认后还需技术设计和已确认实施范围，当前不创建实施计划、不写代码或测试。",
       "workspace": "workspace/eval-8-direct-specialist-bypass-gate",
       "assertions": [
         {
           "id": "routing_decision_present",
           "description": "先给出 PM 路由决策",
-          "text": "输出先给出明确的 Routing decision，识别这是范围未确认的新功能或等价 PM 请求，并标明 entry basis 和 execution boundary；Direct invocation 不得绕过 PM handoff entry gate，仍由 `pm-agent` 承接。"
+          "text": "输出路由说明（默认一行简短形式即可），识别这是范围未确认的新功能或等价 PM 请求，请求留在 PM 入口分类（selected_owner 为 PM specialist 如 `idea-to-spec` 或语义等价表述），并标明 entry basis 和 execution boundary（显式值或语义等价形式均可）；Direct invocation 不得绕过 PM handoff entry gate，入口分类仍由 `pm-agent` 承接（语义等价表述亦可），不得创建实施计划或开始编码。"
         },
         {
           "id": "requires_product_and_engineering_basis",

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-015-route-docs-site-deployment-gap/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-015-route-docs-site-deployment-gap/comparison.md
@@ -14,10 +14,10 @@
 - Fixture version/source: canonical manifest `16e3b6cbbbae6769ac6b5ead7bae34214b3dd90e3e6c4d5fad97cfd7d3784013` from `agents/product_manager/test/pm-agent/evals/workspace/eval-015-route-docs-site-deployment-gap`.
 - Fixture SHA-256: `16e3b6cbbbae6769ac6b5ead7bae34214b3dd90e3e6c4d5fad97cfd7d3784013`
 - Prompt SHA-256: `f6c9996daf9a7bdf78228fb674eccb457f386d1e74abf9925ac4646e4da1c9d4`
-- Repository HEAD: `715bd6b76fcd6f14f475aeabe141543063d431ba`
+- Repository HEAD: `8813f864e743f7c83dc2e51e0b5add79f312e870`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `be11ec63823b148323fef6c35d27c0861bd093b24d683f705e846234e98b7baa`
-- Skill overlay SHA-256: `961e7aacbdec2d154ad578bc7bf54d5d734f34031af1384fb20aa67a8e2d392a`
+- Target skill tree SHA-256: `0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7`
+- Skill overlay SHA-256: `4d4a580c5e7c36b9199abb80221829f90c900c96463581d7f87c6d7ccc538bd7`
 - Judge schema SHA-256: `69f2798cad12b0dd0ca3c224e3cfd6cf611a315695684db1b07a23452b52a60e`
 - Eval definition SHA-256: `8bc69d85fc3ff063d885b8a2c4d7a9ea83b6dca3de23a034dba15fb34f1ba98e`
 - Metadata SHA-256: `e7a743e88e4c53094e4afe2903a87ebcc467ace2dc58c61ccb0a0dcf64ebf2fd`
@@ -31,26 +31,26 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `blocks_unknown_evidence` | PASS | PASS：with_skill 将状态判定为 partial，明确 CI/Helm 未覆盖全部变体、授权仅限规划与交接，并未声称 integrated 或 ready handoff。 |
-| `builds_repo_wide_deployment_packet` | NOT_EXERCISED | NOT_EXERCISED：未出现用户确认正式纳入部署后的 deployment handoff；候选输出仍是 repo_status 规划包。 |
-| `routes_devops_ordered_chain` | NOT_EXERCISED | NOT_EXERCISED：候选仅建议后续交给 DevOps，未执行需要确认及下游运行时证据的完整有序链路。 |
+| `blocks_unknown_evidence` | PASS | with_skill 明确使用 entry_basis: blocked，列出 devops-agent 不可用、未确认 internal 变体及禁止提交/发布/部署等阻塞，没有将状态表述为 ready 或 integrated handoff。 |
+| `builds_repo_wide_deployment_packet` | PASS | with_skill 输出包含 request_type: deployment、feature/parent_feature/feature_level/feature_path 为 N/A、feature_path_evidence: []，并在 source_documents 列出四份真实材料、在 blockers_risks 列出环境不可用、授权边界和 internal 变体未确认等证据。 |
+| `routes_devops_ordered_chain` | NOT_EXERCISED | with_skill 仅完成了向 devops-agent 的下一步路由，并明确 devops-agent 当前不可用；没有可证明后续 devops-agent:deployment-planner → devops-agent:cicd-bootstrap → devops-agent:env-config-auditor → docs-agent:formal-docs-sync 已执行或完成的锁定证据。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f6c9996daf9a7bdf78228fb674eccb457f386d1e74abf9925ac4646e4da1c9d4; fixture_sha256=16e3b6cbbbae6769ac6b5ead7bae34214b3dd90e3e6c4d5fad97cfd7d3784013; output_sha256=9ab40ebc4be499b50c6f6c8732cd584f24789223c9ac2d6b0b33ca751c63d071; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 准确识别当前为 partial，保留源证据与阻塞项，并提出受授权边界约束的下一步 DevOps 规划。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f6c9996daf9a7bdf78228fb674eccb457f386d1e74abf9925ac4646e4da1c9d4; fixture_sha256=16e3b6cbbbae6769ac6b5ead7bae34214b3dd90e3e6c4d5fad97cfd7d3784013; output_sha256=fa32d5b3b29e90ebfbc36a77af39181348c9e9d3c2712eddc98e7391f26456e4; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 正确识别受限状态并生成 deployment handoff packet，完成首个 DevOps 路由；后续有序链未执行。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f6c9996daf9a7bdf78228fb674eccb457f386d1e74abf9925ac4646e4da1c9d4; fixture_sha256=16e3b6cbbbae6769ac6b5ead7bae34214b3dd90e3e6c4d5fad97cfd7d3784013; output_sha256=e8556489c8cfa358e1b1478bcb27bed59734191d488bdd0c89d95f0525a07fae; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 识别 public/internal 覆盖缺口并建议变体确认与责任交接，但未形成结构化路由包。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f6c9996daf9a7bdf78228fb674eccb457f386d1e74abf9925ac4646e4da1c9d4; fixture_sha256=16e3b6cbbbae6769ac6b5ead7bae34214b3dd90e3e6c4d5fad97cfd7d3784013; output_sha256=1f43be5befe6e77636122d2a67734006eedf7bae3d6a120fac343acfaf98daaa; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 给出有依据的部署前建议并识别 CI/Helm 不完整，但未生成标准 deployment packet，也未执行规定的角色路由链。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: 获得用户确认后生成 deployment handoff，并按依赖顺序继续路由。
+- Next: 在 devops-agent 可用且获得后续确认后，继续执行规定的 DevOps 顺序链；仅在运维事实落地并验证后进行 Docs 同步。
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-015-route-docs-site-deployment-gap/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-015-route-docs-site-deployment-gap/comparison.md
@@ -14,10 +14,10 @@
 - Fixture version/source: canonical manifest `16e3b6cbbbae6769ac6b5ead7bae34214b3dd90e3e6c4d5fad97cfd7d3784013` from `agents/product_manager/test/pm-agent/evals/workspace/eval-015-route-docs-site-deployment-gap`.
 - Fixture SHA-256: `16e3b6cbbbae6769ac6b5ead7bae34214b3dd90e3e6c4d5fad97cfd7d3784013`
 - Prompt SHA-256: `f6c9996daf9a7bdf78228fb674eccb457f386d1e74abf9925ac4646e4da1c9d4`
-- Repository HEAD: `33a503192c752d6227de1bc0d8d8a2e78e31cdf5`
+- Repository HEAD: `715bd6b76fcd6f14f475aeabe141543063d431ba`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `8b87fb93cdb85ecb0436a61b1aedfcf9c8b41c4cd8f9eff41c412a3196c1d245`
-- Skill overlay SHA-256: `56390e18f057b654978938889dac7daf0263eaaf39d741419b573d12bff2c198`
+- Target skill tree SHA-256: `be11ec63823b148323fef6c35d27c0861bd093b24d683f705e846234e98b7baa`
+- Skill overlay SHA-256: `961e7aacbdec2d154ad578bc7bf54d5d734f34031af1384fb20aa67a8e2d392a`
 - Judge schema SHA-256: `69f2798cad12b0dd0ca3c224e3cfd6cf611a315695684db1b07a23452b52a60e`
 - Eval definition SHA-256: `8bc69d85fc3ff063d885b8a2c4d7a9ea83b6dca3de23a034dba15fb34f1ba98e`
 - Metadata SHA-256: `e7a743e88e4c53094e4afe2903a87ebcc467ace2dc58c61ccb0a0dcf64ebf2fd`
@@ -31,26 +31,26 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `blocks_unknown_evidence` | PASS | with_skill 输出将状态标为 blocked，列出 CI、Helm、DevOps 能力和授权缺口，并明确不是可直接发布。 |
-| `builds_repo_wide_deployment_packet` | PASS | with_skill 输出包含 request_type: deployment、feature_path/feature/parent_feature/feature_level: N/A、feature_path_evidence: []，并在 source_documents 与 blockers_risks 中保留了 fixture 文件和真实检查证据。 |
-| `routes_devops_ordered_chain` | NOT_EXERCISED | with_skill 已将下一步交给 DevOps，但 devops-agent 不可用，未执行后续下游链路；因此完整的有序 DevOps→Docs 链未被行使。 |
+| `blocks_unknown_evidence` | PASS | PASS：with_skill 将状态判定为 partial，明确 CI/Helm 未覆盖全部变体、授权仅限规划与交接，并未声称 integrated 或 ready handoff。 |
+| `builds_repo_wide_deployment_packet` | NOT_EXERCISED | NOT_EXERCISED：未出现用户确认正式纳入部署后的 deployment handoff；候选输出仍是 repo_status 规划包。 |
+| `routes_devops_ordered_chain` | NOT_EXERCISED | NOT_EXERCISED：候选仅建议后续交给 DevOps，未执行需要确认及下游运行时证据的完整有序链路。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f6c9996daf9a7bdf78228fb674eccb457f386d1e74abf9925ac4646e4da1c9d4; fixture_sha256=16e3b6cbbbae6769ac6b5ead7bae34214b3dd90e3e6c4d5fad97cfd7d3784013; output_sha256=0c1d4b0d599a7d8be8bb28733f47072a1a597775a48e2ce1a72550d52cc1f488; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 识别部署状态为 blocked/partial，构建了部署交接包，并指出当前只允许只读判断和交接。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f6c9996daf9a7bdf78228fb674eccb457f386d1e74abf9925ac4646e4da1c9d4; fixture_sha256=16e3b6cbbbae6769ac6b5ead7bae34214b3dd90e3e6c4d5fad97cfd7d3784013; output_sha256=9ab40ebc4be499b50c6f6c8732cd584f24789223c9ac2d6b0b33ca751c63d071; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 准确识别当前为 partial，保留源证据与阻塞项，并提出受授权边界约束的下一步 DevOps 规划。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f6c9996daf9a7bdf78228fb674eccb457f386d1e74abf9925ac4646e4da1c9d4; fixture_sha256=16e3b6cbbbae6769ac6b5ead7bae34214b3dd90e3e6c4d5fad97cfd7d3784013; output_sha256=12dfeac8dac594b67abb611243547e30772081fc9e676de9e949ff51713dfa79; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 仅基于初始可见材料指出 CI 证据缺失并建议先核验，未生成部署交接包。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f6c9996daf9a7bdf78228fb674eccb457f386d1e74abf9925ac4646e4da1c9d4; fixture_sha256=16e3b6cbbbae6769ac6b5ead7bae34214b3dd90e3e6c4d5fad97cfd7d3784013; output_sha256=e8556489c8cfa358e1b1478bcb27bed59734191d488bdd0c89d95f0525a07fae; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 识别 public/internal 覆盖缺口并建议变体确认与责任交接，但未形成结构化路由包。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: 在 devops-agent 可用并获得继续执行确认后，行使 deployment-planner → cicd-bootstrap → env-config-auditor → formal-docs-sync 链路。
+- Next: 获得用户确认后生成 deployment handoff，并按依赖顺序继续路由。
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-016-route-document-structure-governance/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-016-route-document-structure-governance/comparison.md
@@ -14,39 +14,39 @@
 - Fixture version/source: canonical manifest `1a6d7fa4c22a394f3c854eef7a25f4d0cf2e6b4ecd7c7a3d3bf15d295d6e43f8` from `agents/product_manager/test/pm-agent/evals/workspace/eval-016-route-document-structure-governance`.
 - Fixture SHA-256: `1a6d7fa4c22a394f3c854eef7a25f4d0cf2e6b4ecd7c7a3d3bf15d295d6e43f8`
 - Prompt SHA-256: `78a9ed4a2ff6af194b93c81277958547f5a87533a70b2aa14e43822f139e54d3`
-- Repository HEAD: `33a503192c752d6227de1bc0d8d8a2e78e31cdf5`
+- Repository HEAD: `715bd6b76fcd6f14f475aeabe141543063d431ba`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `8b87fb93cdb85ecb0436a61b1aedfcf9c8b41c4cd8f9eff41c412a3196c1d245`
-- Skill overlay SHA-256: `56390e18f057b654978938889dac7daf0263eaaf39d741419b573d12bff2c198`
+- Target skill tree SHA-256: `be11ec63823b148323fef6c35d27c0861bd093b24d683f705e846234e98b7baa`
+- Skill overlay SHA-256: `961e7aacbdec2d154ad578bc7bf54d5d734f34031af1384fb20aa67a8e2d392a`
 - Judge schema SHA-256: `c8400122a967de4e5b8b409bbe920fe16ec946724a3aa7d4b3077b3582a3f2f0`
 - Eval definition SHA-256: `ba37454a106688e9f5f2e2586231a60f2093e364612eb14bfa53540c9e2d1589`
 - Metadata SHA-256: `fe53b448dd4fd2693ceb179d875dd617b7b717601fc7d9d3214cab940b4cdef7`
 - Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
 - Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
-- Coverage result: **PARTIAL**
-Overall result: PASS (partial coverage)
+- Coverage result: **FULL**
+Overall result: PASS
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `routes_to_structure_governance` | NOT_EXERCISED | With-skill raw evidence does not independently prove the selected route; the route statement appears only in an agent-message event. |
-| `read_only_audit` | PASS | The candidate explicitly states the repository was not modified; git evidence shows unchanged HEAD, branch, status, index, and worktree. |
-| `report_form` | PASS | Raw command evidence shows an HTML report created in a runtime temporary directory, moved out of the workspace, validated as non-empty, and accompanied by an in-conversation summary. |
-| `scope_six_role_dirs` | PASS | Raw command evidence explicitly checks docs/pm, docs/engineer, docs/design, docs/qa, docs/devops, and docs/security; the candidate records missing role roots as coverage gaps. |
-| `structural_change_requires_confirmation` | PASS | The candidate performed no structural document changes and explicitly states that structural adjustment requires confirmation before proceeding. |
+| `routes_to_structure_governance` | PASS | With-skill output explicitly states route `idea-to-spec / structure-governance`; trace also records routing to `idea-to-spec` and the `structure-governance` lane. |
+| `read_only_audit` | PASS | With-skill output states the audit was read-only and no repository files were modified; git evidence shows no changes. |
+| `report_form` | PASS | Trace records creation of `structure-governance-report.html` under a runtime tmp directory, validates its sections and size, and the final output links the report while providing a conclusion summary. |
+| `scope_six_role_dirs` | PASS | Trace explicitly checks docs/pm, docs/engineer, docs/design, docs/qa, docs/devops, and docs/security; the generated report lists all six scan roots and records missing roots as limitations. |
+| `structural_change_requires_confirmation` | PASS | The report states no merge/split/move is executed, advises no structural action, requires future approval, and identifies approved structural implementation as `change_tier: major`. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=78a9ed4a2ff6af194b93c81277958547f5a87533a70b2aa14e43822f139e54d3; fixture_sha256=1a6d7fa4c22a394f3c854eef7a25f4d0cf2e6b4ecd7c7a3d3bf15d295d6e43f8; output_sha256=7c45d72ececd88b9973d29d5b2ee270667e0a5c9932ec279ce56790eff5dc77b; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Completed a read-only six-role structure audit, produced a runtime HTML report and summary, preserved the workspace, and gated future structural changes on confirmation.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=78a9ed4a2ff6af194b93c81277958547f5a87533a70b2aa14e43822f139e54d3; fixture_sha256=1a6d7fa4c22a394f3c854eef7a25f4d0cf2e6b4ecd7c7a3d3bf15d295d6e43f8; output_sha256=47f17b4caae8a72e7b92b586c8ee2e463c932e33c1b265c856e9a03f3d98dea7; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly routed the request, performed a read-only six-role structure audit, generated the required temporary HTML report, summarized findings, and preserved the confirmation gate for major structural changes.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=78a9ed4a2ff6af194b93c81277958547f5a87533a70b2aa14e43822f139e54d3; fixture_sha256=1a6d7fa4c22a394f3c854eef7a25f4d0cf2e6b4ecd7c7a3d3bf15d295d6e43f8; output_sha256=195fcc4031d5a392ef4a0303a1264d41166ac38e474653337016ed0bd69ba1ee; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Produced a useful read-only report covering only the PM and Engineer trees, without the required six-role coverage or runtime HTML delivery.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=78a9ed4a2ff6af194b93c81277958547f5a87533a70b2aa14e43822f139e54d3; fixture_sha256=1a6d7fa4c22a394f3c854eef7a25f4d0cf2e6b4ecd7c7a3d3bf15d295d6e43f8; output_sha256=72d78c0425ef5276a5ecae16c88e9a8e1dc71bb91d44e38397d85c396aef7990; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Provided a basic read-only Markdown inspection of only the existing PM and Engineer directories; it did not demonstrate the governed route, six-role scope, temporary HTML report, or structural-change confirmation policy.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-016-route-document-structure-governance/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-016-route-document-structure-governance/comparison.md
@@ -14,10 +14,10 @@
 - Fixture version/source: canonical manifest `1a6d7fa4c22a394f3c854eef7a25f4d0cf2e6b4ecd7c7a3d3bf15d295d6e43f8` from `agents/product_manager/test/pm-agent/evals/workspace/eval-016-route-document-structure-governance`.
 - Fixture SHA-256: `1a6d7fa4c22a394f3c854eef7a25f4d0cf2e6b4ecd7c7a3d3bf15d295d6e43f8`
 - Prompt SHA-256: `78a9ed4a2ff6af194b93c81277958547f5a87533a70b2aa14e43822f139e54d3`
-- Repository HEAD: `715bd6b76fcd6f14f475aeabe141543063d431ba`
+- Repository HEAD: `8813f864e743f7c83dc2e51e0b5add79f312e870`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `be11ec63823b148323fef6c35d27c0861bd093b24d683f705e846234e98b7baa`
-- Skill overlay SHA-256: `961e7aacbdec2d154ad578bc7bf54d5d734f34031af1384fb20aa67a8e2d392a`
+- Target skill tree SHA-256: `0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7`
+- Skill overlay SHA-256: `4d4a580c5e7c36b9199abb80221829f90c900c96463581d7f87c6d7ccc538bd7`
 - Judge schema SHA-256: `c8400122a967de4e5b8b409bbe920fe16ec946724a3aa7d4b3077b3582a3f2f0`
 - Eval definition SHA-256: `ba37454a106688e9f5f2e2586231a60f2093e364612eb14bfa53540c9e2d1589`
 - Metadata SHA-256: `fe53b448dd4fd2693ceb179d875dd617b7b717601fc7d9d3214cab940b4cdef7`
@@ -31,22 +31,22 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `routes_to_structure_governance` | PASS | With-skill output explicitly states route `idea-to-spec / structure-governance`; trace also records routing to `idea-to-spec` and the `structure-governance` lane. |
-| `read_only_audit` | PASS | With-skill output states the audit was read-only and no repository files were modified; git evidence shows no changes. |
-| `report_form` | PASS | Trace records creation of `structure-governance-report.html` under a runtime tmp directory, validates its sections and size, and the final output links the report while providing a conclusion summary. |
-| `scope_six_role_dirs` | PASS | Trace explicitly checks docs/pm, docs/engineer, docs/design, docs/qa, docs/devops, and docs/security; the generated report lists all six scan roots and records missing roots as limitations. |
-| `structural_change_requires_confirmation` | PASS | The report states no merge/split/move is executed, advises no structural action, requires future approval, and identifies approved structural implementation as `change_tier: major`. |
+| `routes_to_structure_governance` | PASS | 原始 trace 明确路由至 `pm-agent:idea-to-spec:structure-governance`。 |
+| `read_only_audit` | PASS | 候选输出明确声明只读审计；git evidence 显示 HEAD、分支和工作区均未改变。 |
+| `report_form` | PASS | 原始 trace 证明报告写入 `/tmp/structure-governance.8tcJjR/structure-governance-report.html`，并在对话中提供结论摘要。 |
+| `scope_six_role_dirs` | PASS | 原始 trace 检查了 `docs/pm`、`docs/engineer`、`docs/design`、`docs/qa`、`docs/devops`、`docs/security` 六个目录；HTML 报告也覆盖六角色。 |
+| `structural_change_requires_confirmation` | PASS | 报告明确表示当前不执行 merge/split/move，并规定未来结构实施须用户确认且使用 `change_tier: major`；git evidence 显示未执行结构变更。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=78a9ed4a2ff6af194b93c81277958547f5a87533a70b2aa14e43822f139e54d3; fixture_sha256=1a6d7fa4c22a394f3c854eef7a25f4d0cf2e6b4ecd7c7a3d3bf15d295d6e43f8; output_sha256=47f17b4caae8a72e7b92b586c8ee2e463c932e33c1b265c856e9a03f3d98dea7; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly routed the request, performed a read-only six-role structure audit, generated the required temporary HTML report, summarized findings, and preserved the confirmation gate for major structural changes.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=78a9ed4a2ff6af194b93c81277958547f5a87533a70b2aa14e43822f139e54d3; fixture_sha256=1a6d7fa4c22a394f3c854eef7a25f4d0cf2e6b4ecd7c7a3d3bf15d295d6e43f8; output_sha256=3d544c1b2ad47aa0a8b336fdf31f4190b64038a9d2c37fa456526c08bd86f149; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 完成结构治理路由、六角色只读审计、临时 HTML 报告交付和结构变更确认约束；未修改仓库。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=78a9ed4a2ff6af194b93c81277958547f5a87533a70b2aa14e43822f139e54d3; fixture_sha256=1a6d7fa4c22a394f3c854eef7a25f4d0cf2e6b4ecd7c7a3d3bf15d295d6e43f8; output_sha256=72d78c0425ef5276a5ecae16c88e9a8e1dc71bb91d44e38397d85c396aef7990; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Provided a basic read-only Markdown inspection of only the existing PM and Engineer directories; it did not demonstrate the governed route, six-role scope, temporary HTML report, or structural-change confirmation policy.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=78a9ed4a2ff6af194b93c81277958547f5a87533a70b2aa14e43822f139e54d3; fixture_sha256=1a6d7fa4c22a394f3c854eef7a25f4d0cf2e6b4ecd7c7a3d3bf15d295d6e43f8; output_sha256=f36b8b3c8690c8569966b24cb7f30babb2f33780274861d5359ce121321b4804; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 完成基础只读文档检查并给出摘要，但仅覆盖 PM 和 Engineer，未交付 HTML 报告，也未证明结构治理路由或变更确认约束。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-1-route-greenfield-product-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-1-route-greenfield-product-request/comparison.md
@@ -14,10 +14,10 @@
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-1-route-greenfield-product-request`.
 - Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
 - Prompt SHA-256: `acfb6edf3aff0b94988c5e9a7ff435967801458a79c851afd902400163536b81`
-- Repository HEAD: `715bd6b76fcd6f14f475aeabe141543063d431ba`
+- Repository HEAD: `8813f864e743f7c83dc2e51e0b5add79f312e870`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `be11ec63823b148323fef6c35d27c0861bd093b24d683f705e846234e98b7baa`
-- Skill overlay SHA-256: `961e7aacbdec2d154ad578bc7bf54d5d734f34031af1384fb20aa67a8e2d392a`
+- Target skill tree SHA-256: `0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7`
+- Skill overlay SHA-256: `4d4a580c5e7c36b9199abb80221829f90c900c96463581d7f87c6d7ccc538bd7`
 - Judge schema SHA-256: `8e99b873e976898a8a9714405f69dce2d81e6c553f7d4c2b0a99b8b832eee831`
 - Eval definition SHA-256: `4e776e14ac2c8d3f3aa33718b92238355ee2d15eab3267a50cdada6bb3d4a1de`
 - Metadata SHA-256: `98a5616a9f22e4ba7d6ed10c98a36b572ccd9f5c0bfcfaf868ea982ef672635f`
@@ -31,28 +31,28 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `route_to_idea_to_spec` | PASS | With-skill output explicitly selects `idea-to-spec`, identifies `greenfield-discovery`, and keeps responsibility in product discovery without engineering execution. |
-| `pm_first_guardrail` | PASS | With-skill output identifies an empty project, marks scope and tech stack pending, requires confirmation, and states it will not write formal documents or enter implementation yet; git evidence shows no changes. |
-| `context_to_collect` | PASS | With-skill output asks the highest-information first discovery question about the primary target user and requests a reply before proceeding. |
-| `expected_pm_artifacts` | NOT_EXERCISED | The output is explicitly waiting for the user's answer and marks PRD/DECISIONS as pending, so this assertion is not yet exercised. |
-| `handoff_boundary` | NOT_EXERCISED | Only the initial discovery question has been asked; no handoff has occurred. |
+| `route_to_idea_to_spec` | PASS | With-skill output identifies the work as greenfield product discovery and the locked trace records routing to idea-to-spec; it remains in PM discovery. |
+| `pm_first_guardrail` | PASS | With-skill output explicitly confirms an empty project, keeps technology pending, requires product-position confirmation, and states that no code will be written. |
+| `context_to_collect` | PASS | With-skill output asks the user to identify the primary audience and scenario, offering focused options. |
+| `expected_pm_artifacts` | NOT_EXERCISED | The candidate is still waiting for the user's answer and explicitly marks PRD and DECISIONS.md as pending, so this assertion is not exercised. |
+| `handoff_boundary` | NOT_EXERCISED | No handoff occurs while the candidate waits for product-position confirmation, so this assertion is not exercised. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=acfb6edf3aff0b94988c5e9a7ff435967801458a79c851afd902400163536b81; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=480b3b908106630afa0e4b5974a4e658dd73b0d6673437bca3a05996c5bb5359; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly routes the empty-directory product idea through PM-first greenfield discovery, asks one focused user question, and makes no workspace changes.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=acfb6edf3aff0b94988c5e9a7ff435967801458a79c851afd902400163536b81; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=af660b402b7ed70efd901044495c4d633ea2a7062e5583ece40650b35d2d56e1; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Stayed in PM-first greenfield discovery, identified the empty project, deferred implementation, and asked a focused product-discovery question.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=acfb6edf3aff0b94988c5e9a7ff435967801458a79c851afd902400163536b81; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=781017dc3e41abb4cb634c447ef9c29c72f8b34562c60ebd76ea10248c454a70; snapshot_sha256=7034f2b3505bf6f75c216e16b6213a311413e969cb9e2bdc1367dfdce06a93fe
-- Behavior: Fresh baseline produced a PRODUCT_BRIEF and proposed defaults before user discovery was resolved, while still avoiding code and asking several follow-up questions.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=acfb6edf3aff0b94988c5e9a7ff435967801458a79c851afd902400163536b81; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=b286246d470a9dabf8fd385f3c535911c47344aa9caf4e79d07ab4d0ea2f3084; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Did not mutate the empty workspace and offered a broad MVP and technical direction, but did not establish the focused PM discovery route as clearly.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Wait for the user's target-user answer, then produce the PM PRD and decision record before any handoff.
+- Next: Await the user's answer about the primary audience and core scenario before producing PM artifacts or considering handoff.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-1-route-greenfield-product-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-1-route-greenfield-product-request/comparison.md
@@ -14,10 +14,10 @@
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-1-route-greenfield-product-request`.
 - Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
 - Prompt SHA-256: `acfb6edf3aff0b94988c5e9a7ff435967801458a79c851afd902400163536b81`
-- Repository HEAD: `33a503192c752d6227de1bc0d8d8a2e78e31cdf5`
+- Repository HEAD: `715bd6b76fcd6f14f475aeabe141543063d431ba`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `8b87fb93cdb85ecb0436a61b1aedfcf9c8b41c4cd8f9eff41c412a3196c1d245`
-- Skill overlay SHA-256: `56390e18f057b654978938889dac7daf0263eaaf39d741419b573d12bff2c198`
+- Target skill tree SHA-256: `be11ec63823b148323fef6c35d27c0861bd093b24d683f705e846234e98b7baa`
+- Skill overlay SHA-256: `961e7aacbdec2d154ad578bc7bf54d5d734f34031af1384fb20aa67a8e2d392a`
 - Judge schema SHA-256: `8e99b873e976898a8a9714405f69dce2d81e6c553f7d4c2b0a99b8b832eee831`
 - Eval definition SHA-256: `4e776e14ac2c8d3f3aa33718b92238355ee2d15eab3267a50cdada6bb3d4a1de`
 - Metadata SHA-256: `98a5616a9f22e4ba7d6ed10c98a36b572ccd9f5c0bfcfaf868ea982ef672635f`
@@ -31,28 +31,28 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `route_to_idea_to_spec` | PASS | With-skill output explicitly selects `pm-agent:idea-to-spec`, identifies `greenfield-discovery`, and keeps the request in product discovery. |
-| `pm_first_guardrail` | PASS | With-skill output identifies `project_status: empty`, requires confirmation, and explicitly limits execution to product discovery without code or technical implementation. |
-| `context_to_collect` | PASS | With-skill output asks one high-information question about the target user and problem, with three concrete options and trade-offs. |
-| `expected_pm_artifacts` | NOT_EXERCISED | The with-skill output is still awaiting the first discovery answer; `delivery_snapshot` is empty and no PM completion or handoff is claimed. |
-| `handoff_boundary` | NOT_EXERCISED | No handoff occurs; the output remains at the first discovery question and explicitly keeps engineering work for a later stage. |
+| `route_to_idea_to_spec` | PASS | With-skill output explicitly selects `idea-to-spec`, identifies `greenfield-discovery`, and keeps responsibility in product discovery without engineering execution. |
+| `pm_first_guardrail` | PASS | With-skill output identifies an empty project, marks scope and tech stack pending, requires confirmation, and states it will not write formal documents or enter implementation yet; git evidence shows no changes. |
+| `context_to_collect` | PASS | With-skill output asks the highest-information first discovery question about the primary target user and requests a reply before proceeding. |
+| `expected_pm_artifacts` | NOT_EXERCISED | The output is explicitly waiting for the user's answer and marks PRD/DECISIONS as pending, so this assertion is not yet exercised. |
+| `handoff_boundary` | NOT_EXERCISED | Only the initial discovery question has been asked; no handoff has occurred. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=acfb6edf3aff0b94988c5e9a7ff435967801458a79c851afd902400163536b81; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=c9c45e64d7e4422194457bf56a20500614625df851c86017274dd60b66664a80; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly routes the empty-directory idea into PM greenfield discovery, asks the next product question, and avoids implementation.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=acfb6edf3aff0b94988c5e9a7ff435967801458a79c851afd902400163536b81; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=480b3b908106630afa0e4b5974a4e658dd73b0d6673437bca3a05996c5bb5359; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly routes the empty-directory product idea through PM-first greenfield discovery, asks one focused user question, and makes no workspace changes.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=acfb6edf3aff0b94988c5e9a7ff435967801458a79c851afd902400163536b81; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=2b4af7db6f65fef950a714543984faac797cbd3b88ad4ae2c0e046fe474322a5; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Provides a plausible MVP proposal and several implementation-oriented questions, but lacks explicit PM routing and focused first-step discovery control.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=acfb6edf3aff0b94988c5e9a7ff435967801458a79c851afd902400163536b81; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=781017dc3e41abb4cb634c447ef9c29c72f8b34562c60ebd76ea10248c454a70; snapshot_sha256=7034f2b3505bf6f75c216e16b6213a311413e969cb9e2bdc1367dfdce06a93fe
+- Behavior: Fresh baseline produced a PRODUCT_BRIEF and proposed defaults before user discovery was resolved, while still avoiding code and asking several follow-up questions.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Obtain the user's answer to the target-user/core-problem question before producing PRD/DECISIONS or considering handoff.
+- Next: Wait for the user's target-user answer, then produce the PM PRD and decision record before any handoff.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-10-change-tier-hotfix-fast-lane/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-10-change-tier-hotfix-fast-lane/comparison.md
@@ -14,10 +14,10 @@
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-10-change-tier-hotfix-fast-lane`.
 - Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
 - Prompt SHA-256: `c8036aad85835ee733e12f58737233d7e9bc1a90da347bec50e7094cf58797ad`
-- Repository HEAD: `33a503192c752d6227de1bc0d8d8a2e78e31cdf5`
+- Repository HEAD: `715bd6b76fcd6f14f475aeabe141543063d431ba`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `8b87fb93cdb85ecb0436a61b1aedfcf9c8b41c4cd8f9eff41c412a3196c1d245`
-- Skill overlay SHA-256: `56390e18f057b654978938889dac7daf0263eaaf39d741419b573d12bff2c198`
+- Target skill tree SHA-256: `be11ec63823b148323fef6c35d27c0861bd093b24d683f705e846234e98b7baa`
+- Skill overlay SHA-256: `961e7aacbdec2d154ad578bc7bf54d5d734f34031af1384fb20aa67a8e2d392a`
 - Judge schema SHA-256: `bb0ee0282945f3d4f9dce339b9d8538e36a23ce40cb0cf92b33dc2be95234be0`
 - Eval definition SHA-256: `47a19a6c15b443fba6827b5bff8e5f73b3367c26176898038b1822e6a445e0c6`
 - Metadata SHA-256: `dd7edb355d66e4505d2039e9fe3eb4eb203c3d8b2cfcc299410f099efef7e166`
@@ -31,26 +31,26 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `classify_hotfix` | PASS | With-skill output explicitly sets `change_tier: hotfix` and explains that the README-only change does not alter functional expectations and is covered by the user's verification evidence. |
-| `allow_fast_lane` | PASS | With-skill output explicitly sets `fast_lane: allowed_after_classification`, establishing that fast lane is allowed only after hotfix classification. |
-| `preserve_evidence` | PASS | With-skill output records confirmed scope, source documents, user/local verification basis, and required verification output; it does not waive verification despite the hotfix classification. |
+| `classify_hotfix` | PASS | The with_skill output explicitly sets change_tier to hotfix and explains that the README-only correction leaves functionality and expectations unchanged, with local verification evidence. |
+| `allow_fast_lane` | PASS | It explicitly sets fast_lane to allowed_after_classification for the delivery request, preserving the required ordering after classification. |
+| `preserve_evidence` | PASS | It records confirmed_scope, source_documents including local-link verification, and required verification of the diff; hotfix handling does not waive verification. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c8036aad85835ee733e12f58737233d7e9bc1a90da347bec50e7094cf58797ad; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=7acfb037d424e3d1e8000001b69632ebdbda02146156b6e6930964c96921fe5f; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly classified the request as a hotfix, allowed fast lane only after classification, preserved scope and verification evidence, and reported the execution blockers without mutation.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c8036aad85835ee733e12f58737233d7e9bc1a90da347bec50e7094cf58797ad; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=e27654698638234e1f004a65309d0c5bb54739095543f891d3322ae39dfa49e6; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly classifies the request as an allowed hotfix, permits fast lane after classification, preserves scope and evidence requirements, and transparently blocks delivery on missing workspace inputs.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c8036aad85835ee733e12f58737233d7e9bc1a90da347bec50e7094cf58797ad; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=9769d7f3c0bc2cb08ae3ac0eac69f0e5e21eda38493519b3b4d285860e16175a; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Could not complete delivery and reported the empty workspace; it did not provide the required hotfix routing and evidence-preservation decisions.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c8036aad85835ee733e12f58737233d7e9bc1a90da347bec50e7094cf58797ad; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=938ee222867d02b1c453a8a3ed968006fa5d381ef5836340f3407687e381f402; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Reports the empty repository and stops without making the routing classification or evidence-preservation decision.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Provide a workspace containing the target README/PR and make the engineer agent available, then perform and verify the delivery.
+- Next: Restore or attach the PR workspace/diff, then rerun delivery.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-10-change-tier-hotfix-fast-lane/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-10-change-tier-hotfix-fast-lane/comparison.md
@@ -14,10 +14,10 @@
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-10-change-tier-hotfix-fast-lane`.
 - Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
 - Prompt SHA-256: `c8036aad85835ee733e12f58737233d7e9bc1a90da347bec50e7094cf58797ad`
-- Repository HEAD: `715bd6b76fcd6f14f475aeabe141543063d431ba`
+- Repository HEAD: `8813f864e743f7c83dc2e51e0b5add79f312e870`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `be11ec63823b148323fef6c35d27c0861bd093b24d683f705e846234e98b7baa`
-- Skill overlay SHA-256: `961e7aacbdec2d154ad578bc7bf54d5d734f34031af1384fb20aa67a8e2d392a`
+- Target skill tree SHA-256: `0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7`
+- Skill overlay SHA-256: `4d4a580c5e7c36b9199abb80221829f90c900c96463581d7f87c6d7ccc538bd7`
 - Judge schema SHA-256: `bb0ee0282945f3d4f9dce339b9d8538e36a23ce40cb0cf92b33dc2be95234be0`
 - Eval definition SHA-256: `47a19a6c15b443fba6827b5bff8e5f73b3367c26176898038b1822e6a445e0c6`
 - Metadata SHA-256: `dd7edb355d66e4505d2039e9fe3eb4eb203c3d8b2cfcc299410f099efef7e166`
@@ -31,26 +31,26 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `classify_hotfix` | PASS | The with_skill output explicitly sets change_tier to hotfix and explains that the README-only correction leaves functionality and expectations unchanged, with local verification evidence. |
-| `allow_fast_lane` | PASS | It explicitly sets fast_lane to allowed_after_classification for the delivery request, preserving the required ordering after classification. |
-| `preserve_evidence` | PASS | It records confirmed_scope, source_documents including local-link verification, and required verification of the diff; hotfix handling does not waive verification. |
+| `classify_hotfix` | PASS | with_skill explicitly sets `change_tier: hotfix` and explains the README-only, no-functional-change scope plus one-link verification basis. |
+| `allow_fast_lane` | PASS | with_skill explicitly sets `fast_lane: allowed_after_classification`, establishing that fast lane is allowed for this classified hotfix delivery. |
+| `preserve_evidence` | PASS | with_skill preserves confirmed scope, source documents, and verification evidence stating the new link was locally verified; it does not omit verification because this is a hotfix. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c8036aad85835ee733e12f58737233d7e9bc1a90da347bec50e7094cf58797ad; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=e27654698638234e1f004a65309d0c5bb54739095543f891d3322ae39dfa49e6; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly classifies the request as an allowed hotfix, permits fast lane after classification, preserves scope and evidence requirements, and transparently blocks delivery on missing workspace inputs.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c8036aad85835ee733e12f58737233d7e9bc1a90da347bec50e7094cf58797ad; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=5c4fdaf574f62984e70a778eee6b9161261fd51bb0ec01bbb21b2021243e8029; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly classified the request as an allowed hotfix fast-lane delivery and preserved scope/source/verification evidence, while accurately reporting the workspace and agent blockers.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c8036aad85835ee733e12f58737233d7e9bc1a90da347bec50e7094cf58797ad; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=938ee222867d02b1c453a8a3ed968006fa5d381ef5836340f3407687e381f402; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Reports the empty repository and stops without making the routing classification or evidence-preservation decision.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c8036aad85835ee733e12f58737233d7e9bc1a90da347bec50e7094cf58797ad; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=889d18a4c6e3da06d4666e144a45393dc9f3a33912800503460034add40e98a9; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline found an empty repository and stopped without making a routing classification or delivery handoff.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Restore or attach the PR workspace/diff, then rerun delivery.
+- Next: Provide a workspace containing the README and enable engineer-agent to perform the requested delivery.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-11-change-tier-standard-full-gate/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-11-change-tier-standard-full-gate/comparison.md
@@ -14,10 +14,10 @@
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-11-change-tier-standard-full-gate`.
 - Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
 - Prompt SHA-256: `2c9f63eba393d7546f89112ce3f1659145dc2f6ca60bdba6ba71df10258a35a4`
-- Repository HEAD: `715bd6b76fcd6f14f475aeabe141543063d431ba`
+- Repository HEAD: `8813f864e743f7c83dc2e51e0b5add79f312e870`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `be11ec63823b148323fef6c35d27c0861bd093b24d683f705e846234e98b7baa`
-- Skill overlay SHA-256: `961e7aacbdec2d154ad578bc7bf54d5d734f34031af1384fb20aa67a8e2d392a`
+- Target skill tree SHA-256: `0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7`
+- Skill overlay SHA-256: `4d4a580c5e7c36b9199abb80221829f90c900c96463581d7f87c6d7ccc538bd7`
 - Judge schema SHA-256: `e0fce32f646911cc00fe0709c7d0e934a3657054c9fc5a2efda7653a3ac97ea6`
 - Eval definition SHA-256: `da85ba336c757be6c6ca84ef12c1d1a20655adb3e82559a2c2234b5462387973`
 - Metadata SHA-256: `6652dce9ab8a85ed09b58d853b1bdac1fd0f6f3e5ccd74f38c1d4aa6171a8cf4`
@@ -31,20 +31,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `classify_standard` | PASS | With-skill output explicitly sets `change_tier: standard` and `hotfix_disposition: rejected`. |
-| `require_prd_trd_alignment` | PASS | With-skill output requires scope and process confirmation, calls for PRD/DECISIONS update, recommends change-impact analysis before downstream mirroring, and explicitly prohibits handing off to Engineer before alignment. |
-| `request_type_existing_update` | PASS | With-skill output explicitly sets `request_type: existing_update` and identifies the approved behavior change from automatic approval to administrator confirmation. |
+| `classify_standard` | PASS | With_skill output explicitly states `change_tier: standard` and `hotfix_disposition: rejected`. |
+| `require_prd_trd_alignment` | PASS | With_skill output identifies PRD/TRD and related product/test expectations as pending, requests the missing context and confirmation, and sets `execution_boundary` to prohibit direct planning, implementation, or testing before alignment. |
+| `request_type_existing_update` | PASS | With_skill output explicitly sets `request_type: existing_update` and explains that the request changes an existing refund-approval business rule. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2c9f63eba393d7546f89112ce3f1659145dc2f6ca60bdba6ba71df10258a35a4; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=b9d15125b5c1d95f159154981655f8cfeefe48cf992003b06e521c38c615b047; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly classified the request as an existing standard update, rejected hotfix treatment, preserved the product-alignment gate, and paused for required scope confirmation before downstream implementation.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2c9f63eba393d7546f89112ce3f1659145dc2f6ca60bdba6ba71df10258a35a4; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=8fd0af405e240b4cd1092713a10e10f7d2c6275b40c4ba7d35cae7fd9c0c3d2a; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly classified the request as an existing update with standard change tier, rejected hotfix handling, and gated downstream work on missing product and technical context.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2c9f63eba393d7546f89112ce3f1659145dc2f6ca60bdba6ba71df10258a35a4; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=e5cfcff8325c190b6f50023bf7cbc327d8813f0d9c3bddaf4afb7da7916300ea; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Fresh baseline reported only that the workspace lacked project files and did not provide the required request classification or governance handling.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2c9f63eba393d7546f89112ce3f1659145dc2f6ca60bdba6ba71df10258a35a4; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=bd6375fa04132cecdd9ad7f7520c89831a5f10feb0094cd0d61ba395d5fdfcb5; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline treated the empty workspace as the primary issue and did not classify the request or establish the required product-alignment gate.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-11-change-tier-standard-full-gate/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-11-change-tier-standard-full-gate/comparison.md
@@ -14,10 +14,10 @@
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-11-change-tier-standard-full-gate`.
 - Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
 - Prompt SHA-256: `2c9f63eba393d7546f89112ce3f1659145dc2f6ca60bdba6ba71df10258a35a4`
-- Repository HEAD: `33a503192c752d6227de1bc0d8d8a2e78e31cdf5`
+- Repository HEAD: `715bd6b76fcd6f14f475aeabe141543063d431ba`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `8b87fb93cdb85ecb0436a61b1aedfcf9c8b41c4cd8f9eff41c412a3196c1d245`
-- Skill overlay SHA-256: `56390e18f057b654978938889dac7daf0263eaaf39d741419b573d12bff2c198`
+- Target skill tree SHA-256: `be11ec63823b148323fef6c35d27c0861bd093b24d683f705e846234e98b7baa`
+- Skill overlay SHA-256: `961e7aacbdec2d154ad578bc7bf54d5d734f34031af1384fb20aa67a8e2d392a`
 - Judge schema SHA-256: `e0fce32f646911cc00fe0709c7d0e934a3657054c9fc5a2efda7653a3ac97ea6`
 - Eval definition SHA-256: `da85ba336c757be6c6ca84ef12c1d1a20655adb3e82559a2c2234b5462387973`
 - Metadata SHA-256: `6652dce9ab8a85ed09b58d853b1bdac1fd0f6f3e5ccd74f38c1d4aa6171a8cf4`
@@ -32,19 +32,19 @@ Overall result: PASS
 | Assertion | Result | Evidence |
 | --- | --- | --- |
 | `classify_standard` | PASS | With-skill output explicitly sets `change_tier: standard` and `hotfix_disposition: rejected`. |
-| `require_prd_trd_alignment` | PASS | With-skill output requires PM scope alignment and updated PRD/DECISIONS before downstream implementation, and explicitly forbids modifying implementation, tests, or deployment at this stage. |
-| `request_type_existing_update` | PASS | With-skill output explicitly sets `request_type: existing_update` and identifies the approved business-rule change. |
+| `require_prd_trd_alignment` | PASS | With-skill output requires scope and process confirmation, calls for PRD/DECISIONS update, recommends change-impact analysis before downstream mirroring, and explicitly prohibits handing off to Engineer before alignment. |
+| `request_type_existing_update` | PASS | With-skill output explicitly sets `request_type: existing_update` and identifies the approved behavior change from automatic approval to administrator confirmation. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2c9f63eba393d7546f89112ce3f1659145dc2f6ca60bdba6ba71df10258a35a4; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=60a288e03db7017747a24a75e404b9af1a55dcf2b7762efdbcc1a35fc7108b29; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly classified the request as an existing standard update, rejected hotfix treatment, and preserved the requirements-alignment gate before implementation handoff.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2c9f63eba393d7546f89112ce3f1659145dc2f6ca60bdba6ba71df10258a35a4; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=b9d15125b5c1d95f159154981655f8cfeefe48cf992003b06e521c38c615b047; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly classified the request as an existing standard update, rejected hotfix treatment, preserved the product-alignment gate, and paused for required scope confirmation before downstream implementation.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2c9f63eba393d7546f89112ce3f1659145dc2f6ca60bdba6ba71df10258a35a4; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=1c8b4187d11d35f0e7a6c680c2043ba668d57ad06b75b07a8d5a1dc62281c317; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Reported the empty workspace and requested project context without classifying or routing the request.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2c9f63eba393d7546f89112ce3f1659145dc2f6ca60bdba6ba71df10258a35a4; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=e5cfcff8325c190b6f50023bf7cbc327d8813f0d9c3bddaf4afb7da7916300ea; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline reported only that the workspace lacked project files and did not provide the required request classification or governance handling.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-12-change-tier-hotfix-abuse-blocked/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-12-change-tier-hotfix-abuse-blocked/comparison.md
@@ -14,10 +14,10 @@
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-12-change-tier-hotfix-abuse-blocked`.
 - Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
 - Prompt SHA-256: `fd21822d29f9f59daea200bd14c26fadf30442cbe2bd48489976827d9b597907`
-- Repository HEAD: `33a503192c752d6227de1bc0d8d8a2e78e31cdf5`
+- Repository HEAD: `715bd6b76fcd6f14f475aeabe141543063d431ba`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `8b87fb93cdb85ecb0436a61b1aedfcf9c8b41c4cd8f9eff41c412a3196c1d245`
-- Skill overlay SHA-256: `56390e18f057b654978938889dac7daf0263eaaf39d741419b573d12bff2c198`
+- Target skill tree SHA-256: `be11ec63823b148323fef6c35d27c0861bd093b24d683f705e846234e98b7baa`
+- Skill overlay SHA-256: `961e7aacbdec2d154ad578bc7bf54d5d734f34031af1384fb20aa67a8e2d392a`
 - Judge schema SHA-256: `05754bc7141a9de585a1127391112d0da97f3c7138eba96f4377a8a50be63d7c`
 - Eval definition SHA-256: `757872d7dabcbeb5f63781cd39c51a0fbd55c644aaecd2a814401a4e784d4603`
 - Metadata SHA-256: `5be95630fc657c3ddfcd1eee211fb45bdc7cc20a37cf20c50f58a72635d4712c`
@@ -31,20 +31,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `reject_hotfix_abuse` | PASS | With_skill output explicitly sets `hotfix_disposition: rejected` and states the 7-to-30-day rule change is not eligible for hotfix handling. |
-| `expectation_change_standard` | PASS | With_skill output explicitly sets `change_tier: standard` and identifies the request as a membership business-rule/expectation change. |
-| `block_or_return_pm` | PASS | With_skill output routes to PM, requires scope confirmation, and explicitly blocks implementation, testing, commit, and merge pending PM alignment. |
+| `reject_hotfix_abuse` | PASS | with_skill 明确写出 `hotfix_disposition: rejected`，并说明禁止直接改代码、测试或合并。 |
+| `expectation_change_standard` | PASS | with_skill 明确写出 `change_tier: standard`，并将其说明为业务规则变更。 |
+| `block_or_return_pm` | PASS | with_skill 将下一步设为 PM 确认适用范围并补齐产品依据，标记 `confirmation_required: true`，且明确 Engineer/直接合并暂不可开始。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=fd21822d29f9f59daea200bd14c26fadf30442cbe2bd48489976827d9b597907; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=3930c45e76fc10b0182e799694fea1ca854759735721f7616d090e7b3aa97814; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly classified the request as a standard expectation change, rejected hotfix handling, and blocked implementation pending PM scope confirmation.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=fd21822d29f9f59daea200bd14c26fadf30442cbe2bd48489976827d9b597907; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=e243bdb685aa1befd94d41f3856e72888b7e87479ba0f4be45c54612f7f7facf; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 拒绝 hotfix，按 standard 处理业务规则变化，并阻止直接实现或合并，要求 PM 确认范围。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=fd21822d29f9f59daea200bd14c26fadf30442cbe2bd48489976827d9b597907; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=3d4215d95b3a75edbd85c82eec20bc2af88f6e7df2030f3fea190bb2d84e00b3; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Fresh baseline only reported that the empty repository prevented modification or merge, without providing the requested change classification or PM routing.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=fd21822d29f9f59daea200bd14c26fadf30442cbe2bd48489976827d9b597907; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=48d6f5ef17b686782a5ed3577aa0632b015012196ec177e76522ba8f226513b6; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 仅因空工作区而无法操作，未处理 hotfix、standard 或 PM 范围确认要求。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-12-change-tier-hotfix-abuse-blocked/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-12-change-tier-hotfix-abuse-blocked/comparison.md
@@ -14,10 +14,10 @@
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-12-change-tier-hotfix-abuse-blocked`.
 - Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
 - Prompt SHA-256: `fd21822d29f9f59daea200bd14c26fadf30442cbe2bd48489976827d9b597907`
-- Repository HEAD: `715bd6b76fcd6f14f475aeabe141543063d431ba`
+- Repository HEAD: `8813f864e743f7c83dc2e51e0b5add79f312e870`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `be11ec63823b148323fef6c35d27c0861bd093b24d683f705e846234e98b7baa`
-- Skill overlay SHA-256: `961e7aacbdec2d154ad578bc7bf54d5d734f34031af1384fb20aa67a8e2d392a`
+- Target skill tree SHA-256: `0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7`
+- Skill overlay SHA-256: `4d4a580c5e7c36b9199abb80221829f90c900c96463581d7f87c6d7ccc538bd7`
 - Judge schema SHA-256: `05754bc7141a9de585a1127391112d0da97f3c7138eba96f4377a8a50be63d7c`
 - Eval definition SHA-256: `757872d7dabcbeb5f63781cd39c51a0fbd55c644aaecd2a814401a4e784d4603`
 - Metadata SHA-256: `5be95630fc657c3ddfcd1eee211fb45bdc7cc20a37cf20c50f58a72635d4712c`
@@ -31,20 +31,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `reject_hotfix_abuse` | PASS | with_skill 明确写出 `hotfix_disposition: rejected`，并说明禁止直接改代码、测试或合并。 |
-| `expectation_change_standard` | PASS | with_skill 明确写出 `change_tier: standard`，并将其说明为业务规则变更。 |
-| `block_or_return_pm` | PASS | with_skill 将下一步设为 PM 确认适用范围并补齐产品依据，标记 `confirmation_required: true`，且明确 Engineer/直接合并暂不可开始。 |
+| `reject_hotfix_abuse` | PASS | with_skill 输出明确包含 `hotfix_disposition: rejected`，并说明禁止直接改代码、测试、提交或合并。 |
+| `expectation_change_standard` | PASS | with_skill 输出明确包含 `change_tier: standard`，并将其描述为业务预期变更。 |
+| `block_or_return_pm` | PASS | with_skill 输出将下一步设为 PM 对齐，并明确 `execution_boundary` 禁止直接实现，要求补齐产品与工程依据。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=fd21822d29f9f59daea200bd14c26fadf30442cbe2bd48489976827d9b597907; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=e243bdb685aa1befd94d41f3856e72888b7e87479ba0f4be45c54612f7f7facf; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 拒绝 hotfix，按 standard 处理业务规则变化，并阻止直接实现或合并，要求 PM 确认范围。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=fd21822d29f9f59daea200bd14c26fadf30442cbe2bd48489976827d9b597907; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=c779153a6142ee151aa57f5f9e6eb775d4146f7f5eb2c0700bb554ddef662139; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 正确拒绝 hotfix 滥用，按 standard 处理业务规则变化，并阻止直接进入实现，返回 PM 范围确认。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=fd21822d29f9f59daea200bd14c26fadf30442cbe2bd48489976827d9b597907; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=48d6f5ef17b686782a5ed3577aa0632b015012196ec177e76522ba8f226513b6; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 仅因空工作区而无法操作，未处理 hotfix、standard 或 PM 范围确认要求。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=fd21822d29f9f59daea200bd14c26fadf30442cbe2bd48489976827d9b597907; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=40ef85412278167e9e59de44ddd2503dc1a23999430a15c8230b88ac32a0018f; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 仅报告工作区为空并请求重新挂载，未处理 hotfix、standard 或 PM 流程要求。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-13-change-tier-hotfix-e2e-direct-path/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-13-change-tier-hotfix-e2e-direct-path/comparison.md
@@ -14,45 +14,43 @@
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-13-change-tier-hotfix-e2e-direct-path`.
 - Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
 - Prompt SHA-256: `4b716f413649b163f4dd5dcd45dc5b4214bafbb5cb059afb757fef3a77b94653`
-- Repository HEAD: `33a503192c752d6227de1bc0d8d8a2e78e31cdf5`
+- Repository HEAD: `715bd6b76fcd6f14f475aeabe141543063d431ba`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `8b87fb93cdb85ecb0436a61b1aedfcf9c8b41c4cd8f9eff41c412a3196c1d245`
-- Skill overlay SHA-256: `56390e18f057b654978938889dac7daf0263eaaf39d741419b573d12bff2c198`
+- Target skill tree SHA-256: `be11ec63823b148323fef6c35d27c0861bd093b24d683f705e846234e98b7baa`
+- Skill overlay SHA-256: `961e7aacbdec2d154ad578bc7bf54d5d734f34031af1384fb20aa67a8e2d392a`
 - Judge schema SHA-256: `6a4c53f4d8ac913c9f4214c0dc35c3bf4c2a1bd9745f539a3879966e5d7f9011`
 - Eval definition SHA-256: `0e4e9687500855bbb8cac580183d47bafa14e53a69d5477185a5ceacddfe1857`
 - Metadata SHA-256: `385a2edb2c46d9f3ce571c34b812bf357f9247b71af061faebaf0764c87334a2`
 - Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
 - Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
-- Behavior result: **FAIL**
-- Coverage result: **FULL**
-Overall result: FAIL
+- Behavior result: **PASS**
+- Coverage result: **PARTIAL**
+Overall result: PASS (partial coverage)
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `hotfix_direct_path_only` | FAIL | with_skill 标注 hotfix_disposition 为 rejected，但未说明 hotfix 的 QA/E2E 可限制到 directly affected path。 |
-| `evidence_still_required` | FAIL | with_skill 仅要求后续“修改并验证”，未要求记录 verification evidence、结果及 blocked checks。 |
-| `no_full_suite_required` | FAIL | with_skill 标注 change_tier 为 standard，但未说明不需要完整 E2E suite，或给出 standard/major 风险升级例外。 |
+| `hotfix_direct_path_only` | NOT_EXERCISED | with_skill 明确将 hotfix_disposition 设为 rejected、change_tier 设为 standard，且工作流因缺少业务源码而停止；未进入 hotfix QA 覆盖决策。 |
+| `evidence_still_required` | NOT_EXERCISED | with_skill 要求验证结果并明确无法执行验证、禁止伪造验证结果，但由于缺少源码未进入记录 verification evidence、结果及 blocked checks 的验证步骤。 |
+| `no_full_suite_required` | NOT_EXERCISED | with_skill 将变更判定为 standard 且 hotfix 被拒绝；工作流在源码缺失处阻断，未进入 E2E 套件范围决策。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4b716f413649b163f4dd5dcd45dc5b4214bafbb5cb059afb757fef3a77b94653; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=a9d7295fedfe1ea114cfaaa6b54950e6109b76b76a4303d4c9f48b47412d11ff; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 正确识别工作区缺少目标文案和项目文件，拒绝臆造并请求补充信息；但未提供断言要求的 hotfix QA 范围、验证证据记录和 E2E 套件策略。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4b716f413649b163f4dd5dcd45dc5b4214bafbb5cb059afb757fef3a77b94653; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=fcc072f94b45257f5e67663f0db7af4b8723be7920d6df3c77c2c6ad8711bbcf; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 诚实识别空工作区和缺失文案，未修改文件或伪造验证，并输出了 standard/rejected 的路由与阻断边界。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4b716f413649b163f4dd5dcd45dc5b4214bafbb5cb059afb757fef3a77b94653; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=07c558686f49a5712929aea5c4660f1105272d9bae676c3b921a2000b79c61e9; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 识别为空仓库并停止，未进行修改或验证；同样未提供断言要求的 QA 策略说明。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4b716f413649b163f4dd5dcd45dc5b4214bafbb5cb059afb757fef3a77b94653; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=ec062499e6be5fefcbce169334e139932c4ae23bb1446700af242a8c455cd9af; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 识别到空 Git 仓库后直接阻断，未提供结构化路由或验证要求。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- with_skill 未满足三项用户可见的 QA/验证策略要求。
-- Next: 补充说明 hotfix QA/E2E 可限制到 directly affected path。
-- Next: 明确记录 verification evidence、验证结果和 blocked checks。
-- Next: 明确 standard/major 风险升级前不需要完整 E2E suite。
+- None.
+- Next: 提供正确的项目工作区和目标新文案后，再执行最小范围修改与验证。
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-13-change-tier-hotfix-e2e-direct-path/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-13-change-tier-hotfix-e2e-direct-path/comparison.md
@@ -14,43 +14,44 @@
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-13-change-tier-hotfix-e2e-direct-path`.
 - Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
 - Prompt SHA-256: `4b716f413649b163f4dd5dcd45dc5b4214bafbb5cb059afb757fef3a77b94653`
-- Repository HEAD: `715bd6b76fcd6f14f475aeabe141543063d431ba`
+- Repository HEAD: `8813f864e743f7c83dc2e51e0b5add79f312e870`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `be11ec63823b148323fef6c35d27c0861bd093b24d683f705e846234e98b7baa`
-- Skill overlay SHA-256: `961e7aacbdec2d154ad578bc7bf54d5d734f34031af1384fb20aa67a8e2d392a`
+- Target skill tree SHA-256: `0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7`
+- Skill overlay SHA-256: `4d4a580c5e7c36b9199abb80221829f90c900c96463581d7f87c6d7ccc538bd7`
 - Judge schema SHA-256: `6a4c53f4d8ac913c9f4214c0dc35c3bf4c2a1bd9745f539a3879966e5d7f9011`
 - Eval definition SHA-256: `0e4e9687500855bbb8cac580183d47bafa14e53a69d5477185a5ceacddfe1857`
 - Metadata SHA-256: `385a2edb2c46d9f3ce571c34b812bf357f9247b71af061faebaf0764c87334a2`
 - Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
 - Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
-- Behavior result: **PASS**
-- Coverage result: **PARTIAL**
-Overall result: PASS (partial coverage)
+- Behavior result: **FAIL**
+- Coverage result: **FULL**
+Overall result: FAIL
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `hotfix_direct_path_only` | NOT_EXERCISED | with_skill 明确将 hotfix_disposition 设为 rejected、change_tier 设为 standard，且工作流因缺少业务源码而停止；未进入 hotfix QA 覆盖决策。 |
-| `evidence_still_required` | NOT_EXERCISED | with_skill 要求验证结果并明确无法执行验证、禁止伪造验证结果，但由于缺少源码未进入记录 verification evidence、结果及 blocked checks 的验证步骤。 |
-| `no_full_suite_required` | NOT_EXERCISED | with_skill 将变更判定为 standard 且 hotfix 被拒绝；工作流在源码缺失处阻断，未进入 E2E 套件范围决策。 |
+| `hotfix_direct_path_only` | FAIL | with_skill 输出只包含 `change_tier: standard` 和 `hotfix_disposition: rejected`，未说明 hotfix QA/E2E 可限制到 directly affected path。 |
+| `evidence_still_required` | FAIL | with_skill 输出列出了 blockers_risks，但未要求记录 verification evidence、验证结果及 blocked checks。 |
+| `no_full_suite_required` | FAIL | with_skill 输出未说明无需完整 E2E suite，或仅在升级到 `standard` / `major` 时例外。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4b716f413649b163f4dd5dcd45dc5b4214bafbb5cb059afb757fef3a77b94653; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=fcc072f94b45257f5e67663f0db7af4b8723be7920d6df3c77c2c6ad8711bbcf; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 诚实识别空工作区和缺失文案，未修改文件或伪造验证，并输出了 standard/rejected 的路由与阻断边界。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4b716f413649b163f4dd5dcd45dc5b4214bafbb5cb059afb757fef3a77b94653; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=f2d1a8bc68d88ebf5dbd6ebdb7139515de40fbdffac81beefb8a2832878bb637; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 诚实识别空仓库并停止修改，记录了路由与阻塞项，但遗漏断言要求的 hotfix QA 范围和验证证据政策。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4b716f413649b163f4dd5dcd45dc5b4214bafbb5cb059afb757fef3a77b94653; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=ec062499e6be5fefcbce169334e139932c4ae23bb1446700af242a8c455cd9af; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 识别到空 Git 仓库后直接阻断，未提供结构化路由或验证要求。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4b716f413649b163f4dd5dcd45dc5b4214bafbb5cb059afb757fef3a77b94653; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=d2c6e5abf62abcb3af02d58e983e0a1a594514edab0386c9a1736d583fedc869; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 识别为空仓库后直接报告无法修改或验证，未提供断言相关策略说明。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- None.
-- Next: 提供正确的项目工作区和目标新文案后，再执行最小范围修改与验证。
+- with_skill 未交付三个断言要求的用户可见 QA/验证策略说明。
+- Next: 补充应用源码、预期文案和测试上下文后重新执行。
+- Next: 在交付说明中明确直接影响路径 QA/E2E 范围、verification evidence/结果/blocked checks，以及完整 E2E suite 的适用条件。
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-14-route-site-notes-and-github-release/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-14-route-site-notes-and-github-release/comparison.md
@@ -14,10 +14,10 @@
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-14-route-site-notes-and-github-release`.
 - Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
 - Prompt SHA-256: `aeb9d94911e2f21a05aec636eb7871f30e1f918271687f3e921766aab4cdc3f2`
-- Repository HEAD: `33a503192c752d6227de1bc0d8d8a2e78e31cdf5`
+- Repository HEAD: `715bd6b76fcd6f14f475aeabe141543063d431ba`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `8b87fb93cdb85ecb0436a61b1aedfcf9c8b41c4cd8f9eff41c412a3196c1d245`
-- Skill overlay SHA-256: `56390e18f057b654978938889dac7daf0263eaaf39d741419b573d12bff2c198`
+- Target skill tree SHA-256: `be11ec63823b148323fef6c35d27c0861bd093b24d683f705e846234e98b7baa`
+- Skill overlay SHA-256: `961e7aacbdec2d154ad578bc7bf54d5d734f34031af1384fb20aa67a8e2d392a`
 - Judge schema SHA-256: `0e6be21ab02e72aa076a9b774d5cc60139434feba550f781574340027908427d`
 - Eval definition SHA-256: `ae4335c3ea7ab2052d5988d1cbe329b872d3570826da6174d95ecdee75a8f11e`
 - Metadata SHA-256: `7b48bd11ada861ee54366c474d903263630fabf2c5e0d3a66c9f38056e80908e`
@@ -31,27 +31,27 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `routes_site_notes_to_docs_specialist` | PASS | With-skill routing explicitly selects docs-agent:release-notes-gen for the site-facing release notes request. |
-| `routes_github_release_to_pm_specialist` | NOT_EXERCISED | The workflow is blocked before the downstream GitHub Release step because release evidence and the required specialist are unavailable; no contrary PM route is exercised. |
-| `preserves_release_sequence` | PASS | The candidate explicitly preserves the site Release Notes → Docs audit/gates → GitHub Release sequence. |
-| `does_not_use_old_pm_skill_name` | PASS | The PM owner is not named release-notes-gen; that name is used only for docs-agent. |
+| `routes_site_notes_to_docs_specialist` | PASS | With_skill output explicitly routes the request to `docs-agent:release-notes-gen`. |
+| `routes_github_release_to_pm_specialist` | PASS | With_skill output explicitly routes the GitHub Release stage to `pm-agent:github-release-gen`. |
+| `preserves_release_sequence` | NOT_EXERCISED | The candidate identifies the intended Docs-to-PM order, but downstream Docs confirmation, ready handoff, and release audit evidence cannot occur because the required specialists and source evidence are unavailable. |
+| `does_not_use_old_pm_skill_name` | PASS | The PM owner is named `github-release-gen`; `release-notes-gen` is used only under `docs-agent`, not as the PM owner. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=aeb9d94911e2f21a05aec636eb7871f30e1f918271687f3e921766aab4cdc3f2; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=63fb3119d7d2a49dd0eedeb7a4f754407375218ed8c724e6279398413fa87f88; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly routes site notes to docs-agent:release-notes-gen and preserves the Docs-gated release sequence, but stops before downstream GitHub Release routing.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=aeb9d94911e2f21a05aec636eb7871f30e1f918271687f3e921766aab4cdc3f2; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=b9664edccd97be4ce845ce97bd88fe55172a34ecca034db437d0e59baefdef95; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly routes the two-stage workflow and stops at the blocked PM entry without generating or publishing release artifacts.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=aeb9d94911e2f21a05aec636eb7871f30e1f918271687f3e921766aab4cdc3f2; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=844685d34e14f53e1db03ed71d47e6204c5ccafd908acd88d1d1f0df50a4ed68; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Fresh baseline requests missing repository and release evidence and does not exercise the workflow.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=aeb9d94911e2f21a05aec636eb7871f30e1f918271687f3e921766aab4cdc3f2; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=1bd52ec39ee7a56e2a9e651b6318c10bdd27c31b214a490190006f8343756c7e; snapshot_sha256=573bb8fe25dc4669e69b48ed8e6f6e43eca7a7cc78edce18355823928cf4d242
+- Behavior: Creates release-note and GitHub preview files from the empty snapshot without demonstrating the required specialist routing.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Provide confirmed v1.0.0 release evidence and make the downstream GitHub Release specialist available to exercise the remaining assertion.
+- Next: Enable the Docs and PM specialists and provide confirmed v1.0.0 release evidence before executing the downstream stages.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-14-route-site-notes-and-github-release/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-14-route-site-notes-and-github-release/comparison.md
@@ -14,10 +14,10 @@
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-14-route-site-notes-and-github-release`.
 - Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
 - Prompt SHA-256: `aeb9d94911e2f21a05aec636eb7871f30e1f918271687f3e921766aab4cdc3f2`
-- Repository HEAD: `715bd6b76fcd6f14f475aeabe141543063d431ba`
+- Repository HEAD: `8813f864e743f7c83dc2e51e0b5add79f312e870`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `be11ec63823b148323fef6c35d27c0861bd093b24d683f705e846234e98b7baa`
-- Skill overlay SHA-256: `961e7aacbdec2d154ad578bc7bf54d5d734f34031af1384fb20aa67a8e2d392a`
+- Target skill tree SHA-256: `0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7`
+- Skill overlay SHA-256: `4d4a580c5e7c36b9199abb80221829f90c900c96463581d7f87c6d7ccc538bd7`
 - Judge schema SHA-256: `0e6be21ab02e72aa076a9b774d5cc60139434feba550f781574340027908427d`
 - Eval definition SHA-256: `ae4335c3ea7ab2052d5988d1cbe329b872d3570826da6174d95ecdee75a8f11e`
 - Metadata SHA-256: `7b48bd11ada861ee54366c474d903263630fabf2c5e0d3a66c9f38056e80908e`
@@ -31,27 +31,27 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `routes_site_notes_to_docs_specialist` | PASS | With_skill output explicitly routes the request to `docs-agent:release-notes-gen`. |
-| `routes_github_release_to_pm_specialist` | PASS | With_skill output explicitly routes the GitHub Release stage to `pm-agent:github-release-gen`. |
-| `preserves_release_sequence` | NOT_EXERCISED | The candidate identifies the intended Docs-to-PM order, but downstream Docs confirmation, ready handoff, and release audit evidence cannot occur because the required specialists and source evidence are unavailable. |
-| `does_not_use_old_pm_skill_name` | PASS | The PM owner is named `github-release-gen`; `release-notes-gen` is used only under `docs-agent`, not as the PM owner. |
+| `routes_site_notes_to_docs_specialist` | PASS | With-skill routing decision explicitly selects `docs-agent:release-notes-gen` for the requested site release notes. |
+| `routes_github_release_to_pm_specialist` | NOT_EXERCISED | The PM GitHub Release stage is blocked by missing runtime capability, so this later routing step is not exercised. |
+| `preserves_release_sequence` | NOT_EXERCISED | The output records site-first sequencing as required, but no ready handoff, Docs gates, or release audit evidence is produced because execution is blocked. |
+| `does_not_use_old_pm_skill_name` | PASS | The PM owner is not named `release-notes-gen`; the output names `docs-agent:release-notes-gen` as the downstream Docs specialist. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=aeb9d94911e2f21a05aec636eb7871f30e1f918271687f3e921766aab4cdc3f2; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=b9664edccd97be4ce845ce97bd88fe55172a34ecca034db437d0e59baefdef95; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly routes the two-stage workflow and stops at the blocked PM entry without generating or publishing release artifacts.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=aeb9d94911e2f21a05aec636eb7871f30e1f918271687f3e921766aab4cdc3f2; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=58d552206fb5af95533dd73acf539a6765f12dc72957ab878e1ffdd43b4ebb6b; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly selects the Docs specialist and preserves the site-first boundary, but stops before the PM Release stage because required capabilities and source evidence are unavailable.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=aeb9d94911e2f21a05aec636eb7871f30e1f918271687f3e921766aab4cdc3f2; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=1bd52ec39ee7a56e2a9e651b6318c10bdd27c31b214a490190006f8343756c7e; snapshot_sha256=573bb8fe25dc4669e69b48ed8e6f6e43eca7a7cc78edce18355823928cf4d242
-- Behavior: Creates release-note and GitHub preview files from the empty snapshot without demonstrating the required specialist routing.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=aeb9d94911e2f21a05aec636eb7871f30e1f918271687f3e921766aab4cdc3f2; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=8bb3305a2db29083491536bf68c3ebe1ea686642c60ccbcdd74acd58a27d25fa; snapshot_sha256=ec43c795f403cdaedc59295e8d12ec4da8d823d501a4ed41186e262cf97a5fa1
+- Behavior: Creates site notes and a GitHub Release preview without routing or specialist handoff, using unconfirmed placeholders.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Enable the Docs and PM specialists and provide confirmed v1.0.0 release evidence before executing the downstream stages.
+- Next: Provide the missing release-source evidence and enable the Docs and PM GitHub Release capabilities to exercise the remaining stages.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-2-route-bugfix-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-2-route-bugfix-request/comparison.md
@@ -14,10 +14,10 @@
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-2-route-bugfix-request`.
 - Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
 - Prompt SHA-256: `3622b3dfdb9bef50766ff22e70a5639483865b84fa39f8a64f027bc492debda1`
-- Repository HEAD: `33a503192c752d6227de1bc0d8d8a2e78e31cdf5`
+- Repository HEAD: `715bd6b76fcd6f14f475aeabe141543063d431ba`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `8b87fb93cdb85ecb0436a61b1aedfcf9c8b41c4cd8f9eff41c412a3196c1d245`
-- Skill overlay SHA-256: `56390e18f057b654978938889dac7daf0263eaaf39d741419b573d12bff2c198`
+- Target skill tree SHA-256: `be11ec63823b148323fef6c35d27c0861bd093b24d683f705e846234e98b7baa`
+- Skill overlay SHA-256: `961e7aacbdec2d154ad578bc7bf54d5d734f34031af1384fb20aa67a8e2d392a`
 - Judge schema SHA-256: `00a01c5f9432a18e723abe9a7b1a555e5a2a41dc2c36a101ed91497434d1c7f4`
 - Eval definition SHA-256: `fe6d213ce4edb254dae39c5fefca87002824c8356e6ca05dfa6b8b92c57d378d`
 - Metadata SHA-256: `163386e80d321ea48ddfd244853e278bc70ea13a08cdc68ac01f85bf3ba7240f`
@@ -31,27 +31,26 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `request_type_bug_report` | PASS | with_skill 输出明确将 request_type 设为 bug_report。 |
-| `expectation_first` | NOT_EXERCISED | 候选先检查并报告缺少 PRD/TRD/DECISIONS 或等价预期文档，因此无法完成预期确认；该后续步骤受缺失运行时证据阻塞。 |
-| `debugger_handoff_after_confirmation` | NOT_EXERCISED | 由于预期行为未能确认，候选明确拒绝下游工程执行，未实际 handoff 给 debugger/Engineer；确认偏差后的后续步骤未发生。 |
+| `request_type_bug_report` | PASS | With-skill output explicitly classifies the request as `request_type: bug_report`. |
+| `expectation_first` | PASS | With-skill output routes to PM/idea-to-spec, requires comparison with approved expectations, and asks for the expected token-expiry behavior before repair; no approved PRD/TRD or equivalent evidence is available in the fixture, so the confirmation step is only partially exercised. |
+| `debugger_handoff_after_confirmation` | NOT_EXERCISED | The output explicitly requires confirmation before generating an Engineer debugging package and does not hand off yet; confirmation is unavailable, so this later assertion is not exercised. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3622b3dfdb9bef50766ff22e70a5639483865b84fa39f8a64f027bc492debda1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=13a609baa257d21723150bc2818ca85a1f020c363ad33453af4a69c2ed8d946d; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 正确识别为 bug report，先进行只读证据盘点；因缺少预期文档和工程代理而安全阻塞，未修改文件。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3622b3dfdb9bef50766ff22e70a5639483865b84fa39f8a64f027bc492debda1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=3a358f898be11bdc7d82d403429bec68a9657dcde0dd06f222e33cf681bc5b09; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly classified the report, routed it through PM expectation-first discovery, and stopped before implementation or debugger handoff pending confirmation and missing evidence.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3622b3dfdb9bef50766ff22e70a5639483865b84fa39f8a64f027bc492debda1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=f94de000284b9d4648b15e2597ace31bf0dfacae715137a4a358c1ddc87a5d19; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 仅发现空仓库并请求提供源码，未执行分类或预期确认流程。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3622b3dfdb9bef50766ff22e70a5639483865b84fa39f8a64f027bc492debda1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=1efc8e96a59aab20b6a74d23021e4801b0a07a81f5926960222bccf955cd1370; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Reported the empty repository and requested source, but did not classify the request or establish an expectation-first handoff gate.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: 提供批准的 PRD/TRD 或等价预期行为文档及应用源码。
-- Next: 安装或提供 engineer-agent 后再继续确认偏差并进行工程调试。
+- Next: Provide the application source, approved expected behavior, and relevant logs; then confirm the implementation deviation before Engineer/debugger handoff.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-2-route-bugfix-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-2-route-bugfix-request/comparison.md
@@ -14,10 +14,10 @@
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-2-route-bugfix-request`.
 - Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
 - Prompt SHA-256: `3622b3dfdb9bef50766ff22e70a5639483865b84fa39f8a64f027bc492debda1`
-- Repository HEAD: `715bd6b76fcd6f14f475aeabe141543063d431ba`
+- Repository HEAD: `8813f864e743f7c83dc2e51e0b5add79f312e870`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `be11ec63823b148323fef6c35d27c0861bd093b24d683f705e846234e98b7baa`
-- Skill overlay SHA-256: `961e7aacbdec2d154ad578bc7bf54d5d734f34031af1384fb20aa67a8e2d392a`
+- Target skill tree SHA-256: `0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7`
+- Skill overlay SHA-256: `4d4a580c5e7c36b9199abb80221829f90c900c96463581d7f87c6d7ccc538bd7`
 - Judge schema SHA-256: `00a01c5f9432a18e723abe9a7b1a555e5a2a41dc2c36a101ed91497434d1c7f4`
 - Eval definition SHA-256: `fe6d213ce4edb254dae39c5fefca87002824c8356e6ca05dfa6b8b92c57d378d`
 - Metadata SHA-256: `163386e80d321ea48ddfd244853e278bc70ea13a08cdc68ac01f85bf3ba7240f`
@@ -31,26 +31,26 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `request_type_bug_report` | PASS | With-skill output explicitly classifies the request as `request_type: bug_report`. |
-| `expectation_first` | PASS | With-skill output routes to PM/idea-to-spec, requires comparison with approved expectations, and asks for the expected token-expiry behavior before repair; no approved PRD/TRD or equivalent evidence is available in the fixture, so the confirmation step is only partially exercised. |
-| `debugger_handoff_after_confirmation` | NOT_EXERCISED | The output explicitly requires confirmation before generating an Engineer debugging package and does not hand off yet; confirmation is unavailable, so this later assertion is not exercised. |
+| `request_type_bug_report` | PASS | with_skill 输出明确包含 `request_type: bug_report`。 |
+| `expectation_first` | NOT_EXERCISED | 工作区没有 PRD/TRD 或等价预期文档；候选输出的 `source_documents` 为空，并将补充已批准预期行为列为后续缺口。 |
+| `debugger_handoff_after_confirmation` | NOT_EXERCISED | 未提供实际 debugger/Engineer handoff；且因预期文档缺失，入口被标记为 blocked/failed，执行边界禁止工程执行。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3622b3dfdb9bef50766ff22e70a5639483865b84fa39f8a64f027bc492debda1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=3a358f898be11bdc7d82d403429bec68a9657dcde0dd06f222e33cf681bc5b09; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly classified the report, routed it through PM expectation-first discovery, and stopped before implementation or debugger handoff pending confirmation and missing evidence.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3622b3dfdb9bef50766ff22e70a5639483865b84fa39f8a64f027bc492debda1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=692f05e9dcd45ff16e6d292af33d5b58995e552ae7ba4bbf6bc30b03616ea4cc; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 正确识别为 bug report，并在缺少项目与预期证据时阻止工程执行。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3622b3dfdb9bef50766ff22e70a5639483865b84fa39f8a64f027bc492debda1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=1efc8e96a59aab20b6a74d23021e4801b0a07a81f5926960222bccf955cd1370; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Reported the empty repository and requested source, but did not classify the request or establish an expectation-first handoff gate.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3622b3dfdb9bef50766ff22e70a5639483865b84fa39f8a64f027bc492debda1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=a4a226af3fc3ee5f66ee6128730b0ff561c0c5c0d8c85f652fa944a1a328720b; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 仅识别为空仓库并停止，未进行请求分类或预期确认流程。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Provide the application source, approved expected behavior, and relevant logs; then confirm the implementation deviation before Engineer/debugger handoff.
+- Next: 补充项目源码及已批准的 PRD/TRD 或等价产品预期后，再确认实现偏差并决定是否 handoff。
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-3-route-test-writing-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-3-route-test-writing-request/comparison.md
@@ -14,10 +14,10 @@
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-3-route-test-writing-request`.
 - Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
 - Prompt SHA-256: `3f7994fdecfb94451400a56972388597b7ae51d2d37508524058139c5273a4e3`
-- Repository HEAD: `715bd6b76fcd6f14f475aeabe141543063d431ba`
+- Repository HEAD: `8813f864e743f7c83dc2e51e0b5add79f312e870`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `be11ec63823b148323fef6c35d27c0861bd093b24d683f705e846234e98b7baa`
-- Skill overlay SHA-256: `961e7aacbdec2d154ad578bc7bf54d5d734f34031af1384fb20aa67a8e2d392a`
+- Target skill tree SHA-256: `0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7`
+- Skill overlay SHA-256: `4d4a580c5e7c36b9199abb80221829f90c900c96463581d7f87c6d7ccc538bd7`
 - Judge schema SHA-256: `4bea92cb3e04f7ad6bcf4e0dcdb3aa7c06af7bec325a6bea731363f44bd4e944`
 - Eval definition SHA-256: `4c0ee7c09752627d6057c1ccc0d45cb292b19c1428b51ca9513725150029cf5a`
 - Metadata SHA-256: `48e1e31078cfd6a23e5c1bdb5481d8f4c6428eb757f9b42750f6377a78297239`
@@ -31,26 +31,26 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `request_type_validation` | PASS | With_skill output explicitly classifies the request as `request_type: validation`. |
-| `test_basis_first` | NOT_EXERCISED | The lane reports `entry_basis: blocked` and `source_documents: []`; no PRD, TRD, implementation plan, or acceptance record was available to confirm as the test basis. |
-| `qa_or_test_writer_handoff` | NOT_EXERCISED | The lane correctly stops pending confirmed expectations and source documents, so a QA/test-writer handoff cannot yet occur. |
+| `request_type_validation` | PASS | With-skill output explicitly classifies the request as `validation` and routes it toward QA validation. |
+| `test_basis_first` | PASS | With-skill output records `entry_basis: missing`, lists no source documents, identifies the missing PRD/TRD/acceptance basis, and blocks downstream test work until the basis is provided. |
+| `qa_or_test_writer_handoff` | NOT_EXERCISED | No downstream handoff occurred because the required behavior basis was missing; the later handoff step therefore could not yet be exercised. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3f7994fdecfb94451400a56972388597b7ae51d2d37508524058139c5273a4e3; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=d33cce63167d48af6832c1200e64fb0a82aff393210d915fc2e27934e78607f7; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly routes the request as validation, identifies missing project and test-basis evidence, and stops without making unsupported changes or handoff.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3f7994fdecfb94451400a56972388597b7ae51d2d37508524058139c5273a4e3; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=4bd30343171c1f0aa74cb7413f84b26c3a7960397d1507fda68f87840a1e33a0; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly classifies the request, verifies that the required test basis is absent, and blocks downstream execution pending documentation and project code.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3f7994fdecfb94451400a56972388597b7ae51d2d37508524058139c5273a4e3; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=b953bfddd6e51c1963465b4c6fe67a5fea47ae8e9f423c50a05329a17e42d723; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Fresh baseline only reports an empty repository and cannot proceed; it does not classify the request or establish the validation workflow.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3f7994fdecfb94451400a56972388597b7ae51d2d37508524058139c5273a4e3; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=376e61527b2a34a5473b42945f94774826f681202e0fb21dec24067f9b4377d8; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Detects the empty repository and stops, but does not provide the structured validation classification or basis-gated routing behavior.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Provide the correct project workspace and a confirmed PRD, TRD, implementation plan, or acceptance record, then resume QA/test-writer handoff.
+- Next: Provide the order/refund code and an approved PRD, TRD, implementation plan, or acceptance record, then perform the QA handoff.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-3-route-test-writing-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-3-route-test-writing-request/comparison.md
@@ -14,10 +14,10 @@
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-3-route-test-writing-request`.
 - Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
 - Prompt SHA-256: `3f7994fdecfb94451400a56972388597b7ae51d2d37508524058139c5273a4e3`
-- Repository HEAD: `33a503192c752d6227de1bc0d8d8a2e78e31cdf5`
+- Repository HEAD: `715bd6b76fcd6f14f475aeabe141543063d431ba`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `8b87fb93cdb85ecb0436a61b1aedfcf9c8b41c4cd8f9eff41c412a3196c1d245`
-- Skill overlay SHA-256: `56390e18f057b654978938889dac7daf0263eaaf39d741419b573d12bff2c198`
+- Target skill tree SHA-256: `be11ec63823b148323fef6c35d27c0861bd093b24d683f705e846234e98b7baa`
+- Skill overlay SHA-256: `961e7aacbdec2d154ad578bc7bf54d5d734f34031af1384fb20aa67a8e2d392a`
 - Judge schema SHA-256: `4bea92cb3e04f7ad6bcf4e0dcdb3aa7c06af7bec325a6bea731363f44bd4e944`
 - Eval definition SHA-256: `4c0ee7c09752627d6057c1ccc0d45cb292b19c1428b51ca9513725150029cf5a`
 - Metadata SHA-256: `48e1e31078cfd6a23e5c1bdb5481d8f4c6428eb757f9b42750f6377a78297239`
@@ -31,27 +31,26 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `request_type_validation` | PASS | with_skill 明确将请求分类为 `request_type: validation`。 |
-| `test_basis_first` | NOT_EXERCISED | 工作区缺少 PRD、TRD、实现和验收记录；with_skill 明确将 `source_documents` 置空并要求补齐测试依据，因此该后续步骤未被执行。 |
-| `qa_or_test_writer_handoff` | NOT_EXERCISED | 由于测试依据和预期行为均缺失，with_skill 将入口标记为 blocked，并拒绝下游 QA 交接；该步骤尚无法执行。 |
+| `request_type_validation` | PASS | With_skill output explicitly classifies the request as `request_type: validation`. |
+| `test_basis_first` | NOT_EXERCISED | The lane reports `entry_basis: blocked` and `source_documents: []`; no PRD, TRD, implementation plan, or acceptance record was available to confirm as the test basis. |
+| `qa_or_test_writer_handoff` | NOT_EXERCISED | The lane correctly stops pending confirmed expectations and source documents, so a QA/test-writer handoff cannot yet occur. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3f7994fdecfb94451400a56972388597b7ae51d2d37508524058139c5273a4e3; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=9a9aca1b3438b98f7317114d77202a071b076a16d0136918aef95214cab81c32; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 正确完成 validation 分类，识别测试依据缺失并阻止未经依据的测试规划、实现和 QA 交接。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3f7994fdecfb94451400a56972388597b7ae51d2d37508524058139c5273a4e3; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=d33cce63167d48af6832c1200e64fb0a82aff393210d915fc2e27934e78607f7; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly routes the request as validation, identifies missing project and test-basis evidence, and stops without making unsupported changes or handoff.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3f7994fdecfb94451400a56972388597b7ae51d2d37508524058139c5273a4e3; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=6221d665bbc354152a42aab4a24a7ab2f98488dd8b62f4f6018cd86792804f95; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 仅报告空仓库并请求补充项目代码，未进行请求类型分类或测试依据/交接路由。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3f7994fdecfb94451400a56972388597b7ae51d2d37508524058139c5273a4e3; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=b953bfddd6e51c1963465b4c6fe67a5fea47ae8e9f423c50a05329a17e42d723; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline only reports an empty repository and cannot proceed; it does not classify the request or establish the validation workflow.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: 提供订单退款源码、测试目录及批准的 PRD、TRD 或既有验收记录。
-- Next: 补齐并确认稳定预期后，再交接 QA 或 test-writer。
+- Next: Provide the correct project workspace and a confirmed PRD, TRD, implementation plan, or acceptance record, then resume QA/test-writer handoff.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-4-route-ui-update-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-4-route-ui-update-request/comparison.md
@@ -14,10 +14,10 @@
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-4-route-ui-update-request`.
 - Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
 - Prompt SHA-256: `cc5c00e0814501d7ed50a7f0170322a995f768ddcee0b14ac461aa95868c10b8`
-- Repository HEAD: `715bd6b76fcd6f14f475aeabe141543063d431ba`
+- Repository HEAD: `8813f864e743f7c83dc2e51e0b5add79f312e870`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `be11ec63823b148323fef6c35d27c0861bd093b24d683f705e846234e98b7baa`
-- Skill overlay SHA-256: `961e7aacbdec2d154ad578bc7bf54d5d734f34031af1384fb20aa67a8e2d392a`
+- Target skill tree SHA-256: `0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7`
+- Skill overlay SHA-256: `4d4a580c5e7c36b9199abb80221829f90c900c96463581d7f87c6d7ccc538bd7`
 - Judge schema SHA-256: `afcbd1cd02daddf2a5de8000a17edb44c8f3338aa4214be0e836d3a78f54f541`
 - Eval definition SHA-256: `601243bb221e4073b25a6eba61d2cbbc1d243cb0d11ebc88b60ef8187a2e86e1`
 - Metadata SHA-256: `aa0eca0938ef56711257694af52b821c5be5dbedc9b5982d77710814288d3115`
@@ -31,28 +31,26 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `request_type_design_or_update` | PASS | With-skill output explicitly classifies the request as `existing_update` and sets execution boundary to PM-only, with no code or frontend execution. |
-| `pm_designer_engineer_decision` | PASS | With-skill output selects `pm-agent:idea-to-spec`, explains the PM ownership rationale, and explicitly excludes Designer and Engineer execution until scope is confirmed. |
-| `implementation_waits_for_alignment` | NOT_EXERCISED | The output states `confirmation_required: true`, limits work to PM requirement convergence, and says not to perform Designer, Engineer, code, or test execution; implementation handoff is therefore not yet exercised. |
+| `request_type_design_or_update` | PASS | With_skill explicitly classifies the request as `request_type: existing_update`, routes it through `pm-agent` and `idea-to-spec`, and does not implement code. |
+| `pm_designer_engineer_decision` | PASS | With_skill explicitly uses the PM route, identifies design and engineering impacts as pending, and keeps the work in discovery pending confirmation rather than handing off implementation. |
+| `implementation_waits_for_alignment` | NOT_EXERCISED | No Engineer handoff or implementation occurred. The workflow correctly pauses for user confirmation, so the later alignment gate is not exercised. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cc5c00e0814501d7ed50a7f0170322a995f768ddcee0b14ac461aa95868c10b8; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=be71157f11fef47a6a65522f88f2feede0abf5c02a43953f62a0c70ac80cbbf7; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly routes the request through PM discovery, distinguishes PM from Designer and Engineer work, and pauses before implementation pending confirmation and alignment.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cc5c00e0814501d7ed50a7f0170322a995f768ddcee0b14ac461aa95868c10b8; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=aec9ff445a1a3d33daa44fc84e3315f05bc4208b868f1053675503a13636d1d5; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly classified the UI request as an existing update, routed it through PM and idea-to-spec discovery, and paused for confirmation before downstream work.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cc5c00e0814501d7ed50a7f0170322a995f768ddcee0b14ac461aa95868c10b8; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=5b11dba6873d33c47021b8203c7384366063f4e28a9aed40ac31e7808d6fd4d5; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Provides an immediate speculative settings-page design without classifying the request or routing through PM, Designer, and Engineer decision gates.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cc5c00e0814501d7ed50a7f0170322a995f768ddcee0b14ac461aa95868c10b8; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=99bc864a02bf778897890f2c80c945b8fc4a72312222783f784082eaafdabe5a; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Provided a generic UI proposal without explicit request classification or PM/Designer/Engineer routing, while making no code changes.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Confirm the settings-page scenario and scope.
-- Next: Complete PM alignment and durable requirements/decision artifacts.
-- Next: Obtain design alignment before handing off frontend implementation to Engineer.
+- Next: Confirm the preferred left-navigation pattern, then complete the applicable PM/design alignment before any Engineer implementation handoff.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-4-route-ui-update-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-4-route-ui-update-request/comparison.md
@@ -14,10 +14,10 @@
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-4-route-ui-update-request`.
 - Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
 - Prompt SHA-256: `cc5c00e0814501d7ed50a7f0170322a995f768ddcee0b14ac461aa95868c10b8`
-- Repository HEAD: `33a503192c752d6227de1bc0d8d8a2e78e31cdf5`
+- Repository HEAD: `715bd6b76fcd6f14f475aeabe141543063d431ba`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `8b87fb93cdb85ecb0436a61b1aedfcf9c8b41c4cd8f9eff41c412a3196c1d245`
-- Skill overlay SHA-256: `56390e18f057b654978938889dac7daf0263eaaf39d741419b573d12bff2c198`
+- Target skill tree SHA-256: `be11ec63823b148323fef6c35d27c0861bd093b24d683f705e846234e98b7baa`
+- Skill overlay SHA-256: `961e7aacbdec2d154ad578bc7bf54d5d734f34031af1384fb20aa67a8e2d392a`
 - Judge schema SHA-256: `afcbd1cd02daddf2a5de8000a17edb44c8f3338aa4214be0e836d3a78f54f541`
 - Eval definition SHA-256: `601243bb221e4073b25a6eba61d2cbbc1d243cb0d11ebc88b60ef8187a2e86e1`
 - Metadata SHA-256: `aa0eca0938ef56711257694af52b821c5be5dbedc9b5982d77710814288d3115`
@@ -31,26 +31,28 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `request_type_design_or_update` | PASS | with_skill 的 Routing decision 明确将 request_type 设为 existing_update。 |
-| `pm_designer_engineer_decision` | PASS | with_skill 明确选择 PM idea-to-spec，指出 Designer 需要产出新版页面结构与交互方案，并标明 Engineer 暂不进入。 |
-| `implementation_waits_for_alignment` | NOT_EXERCISED | 候选正确停留在 PM 需求收敛阶段；由于尚未获得用户确认及完整基线，Engineer handoff 的后续门禁尚未实际发生。 |
+| `request_type_design_or_update` | PASS | With-skill output explicitly classifies the request as `existing_update` and sets execution boundary to PM-only, with no code or frontend execution. |
+| `pm_designer_engineer_decision` | PASS | With-skill output selects `pm-agent:idea-to-spec`, explains the PM ownership rationale, and explicitly excludes Designer and Engineer execution until scope is confirmed. |
+| `implementation_waits_for_alignment` | NOT_EXERCISED | The output states `confirmation_required: true`, limits work to PM requirement convergence, and says not to perform Designer, Engineer, code, or test execution; implementation handoff is therefore not yet exercised. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cc5c00e0814501d7ed50a7f0170322a995f768ddcee0b14ac461aa95868c10b8; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=2c0b397fe2be820df41dd1b4aa4cf69380765bc6f37cae018b47a817489f1757; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 先进行 existing_update 路由和 PM 需求收敛，识别 Designer 与 Engineer 的后续路径，并明确暂不实现。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cc5c00e0814501d7ed50a7f0170322a995f768ddcee0b14ac461aa95868c10b8; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=be71157f11fef47a6a65522f88f2feede0abf5c02a43953f62a0c70ac80cbbf7; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly routes the request through PM discovery, distinguishes PM from Designer and Engineer work, and pauses before implementation pending confirmation and alignment.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cc5c00e0814501d7ed50a7f0170322a995f768ddcee0b14ac461aa95868c10b8; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=842ce9d883c543a6ca702326689716a22f2c2079050bfab410e7418623ab0ea0; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 直接给出设置页左右分栏和交互方案，未先进行 PM/Designer/Engineer 路由判断。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cc5c00e0814501d7ed50a7f0170322a995f768ddcee0b14ac461aa95868c10b8; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=5b11dba6873d33c47021b8203c7384366063f4e28a9aed40ac31e7808d6fd4d5; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Provides an immediate speculative settings-page design without classifying the request or routing through PM, Designer, and Engineer decision gates.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: None.
+- Next: Confirm the settings-page scenario and scope.
+- Next: Complete PM alignment and durable requirements/decision artifacts.
+- Next: Obtain design alignment before handing off frontend implementation to Engineer.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-5-route-deployment-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-5-route-deployment-request/comparison.md
@@ -14,43 +14,43 @@
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-5-route-deployment-request`.
 - Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
 - Prompt SHA-256: `df8dd8d18e0b79f0114ea9e750efb47af7d21bc05b6ea3666cff7d6bae4802fe`
-- Repository HEAD: `33a503192c752d6227de1bc0d8d8a2e78e31cdf5`
+- Repository HEAD: `715bd6b76fcd6f14f475aeabe141543063d431ba`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `8b87fb93cdb85ecb0436a61b1aedfcf9c8b41c4cd8f9eff41c412a3196c1d245`
-- Skill overlay SHA-256: `56390e18f057b654978938889dac7daf0263eaaf39d741419b573d12bff2c198`
+- Target skill tree SHA-256: `be11ec63823b148323fef6c35d27c0861bd093b24d683f705e846234e98b7baa`
+- Skill overlay SHA-256: `961e7aacbdec2d154ad578bc7bf54d5d734f34031af1384fb20aa67a8e2d392a`
 - Judge schema SHA-256: `42fd42dc7a350eab589db47b48a132e9f478c8e119c1fdbd30b4875075f9f0b5`
 - Eval definition SHA-256: `73a2b58c1c65bf56a5f6d6f35f003c86e432caed7b530c34cf851322050e2633`
 - Metadata SHA-256: `d17a05b229136107ac1e50142856979a9ae9f563cdb19b940e4810dadda79e1c`
 - Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
 - Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
-- Coverage result: **PARTIAL**
-Overall result: PASS (partial coverage)
+- Coverage result: **FULL**
+Overall result: PASS
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
 | `request_type_deployment` | PASS | with_skill 输出明确写出 `request_type: deployment`。 |
-| `repo_wide_scope_allowed` | PASS | with_skill 输出明确使用 `feature_path: N/A`、`feature: N/A`，且 `feature_path_evidence: []`。 |
-| `devops_handoff_packet` | NOT_EXERCISED | with_skill 已识别并列出缺失的环境、发布范围、回滚方案及风险，但因这些上下文尚未确认且 DevOps agent 未安装，未实际完成 handoff；后续 handoff 未被行使。 |
+| `repo_wide_scope_allowed` | PASS | with_skill 输出将仓库级 CI 配置与上线前检查作为非 feature 工作，并使用 `feature_path: N/A`、`feature: N/A`、`parent_feature: N/A`、`feature_level: N/A` 和 `feature_path_evidence: []`。 |
+| `devops_handoff_packet` | PASS | with_skill 的 handoff packet 记录了 CI/上线前检查目标、仓库级范围、环境/发布目标与回滚策略尚未确认的状态，以及源码、构建入口、部署环境、发布目标和回滚要求等风险，随后指定 `downstream_owner: DevOps`。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=df8dd8d18e0b79f0114ea9e750efb47af7d21bc05b6ea3666cff7d6bae4802fe; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=8d40d480f4b9d8d8e8368bdb8303549119fa75a47140a85e2f90e6da2f8ebb99; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 正确完成 deployment 路由和仓库级 N/A scope 处理，并在缺少必要上线上下文时只读阻塞，未虚构完成 DevOps handoff。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=df8dd8d18e0b79f0114ea9e750efb47af7d21bc05b6ea3666cff7d6bae4802fe; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=5eaa8d02a425eca63703fe2316902dddccbc943f14ffffba93d6795a9ef335b9; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 正确识别 deployment，允许仓库级 N/A scope，并提供带上下文、风险和执行边界的 DevOps 交接包；未修改文件。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=df8dd8d18e0b79f0114ea9e750efb47af7d21bc05b6ea3666cff7d6bae4802fe; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=957bff5f2536fe7f61686b9e1fb6b8bec9b55d176d20f6076f40c92d4f3a6be0; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 识别仓库为空并停止配置，但未提供 deployment 路由、N/A scope 或 DevOps handoff 上下文。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=df8dd8d18e0b79f0114ea9e750efb47af7d21bc05b6ea3666cff7d6bae4802fe; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=3d73e2d5c6d5f8857c01216036a5103b0888125cab44479cc13f769d54772399; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 识别到仓库为空并请求补充信息，但未完成 deployment 分类、N/A scope 或 DevOps 交接。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: 补充目标 CI 平台、目标环境、发布范围、触发条件、凭据策略和回滚方案后，再执行 DevOps handoff。
+- Next: None.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-5-route-deployment-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-5-route-deployment-request/comparison.md
@@ -14,43 +14,43 @@
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-5-route-deployment-request`.
 - Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
 - Prompt SHA-256: `df8dd8d18e0b79f0114ea9e750efb47af7d21bc05b6ea3666cff7d6bae4802fe`
-- Repository HEAD: `715bd6b76fcd6f14f475aeabe141543063d431ba`
+- Repository HEAD: `8813f864e743f7c83dc2e51e0b5add79f312e870`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `be11ec63823b148323fef6c35d27c0861bd093b24d683f705e846234e98b7baa`
-- Skill overlay SHA-256: `961e7aacbdec2d154ad578bc7bf54d5d734f34031af1384fb20aa67a8e2d392a`
+- Target skill tree SHA-256: `0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7`
+- Skill overlay SHA-256: `4d4a580c5e7c36b9199abb80221829f90c900c96463581d7f87c6d7ccc538bd7`
 - Judge schema SHA-256: `42fd42dc7a350eab589db47b48a132e9f478c8e119c1fdbd30b4875075f9f0b5`
 - Eval definition SHA-256: `73a2b58c1c65bf56a5f6d6f35f003c86e432caed7b530c34cf851322050e2633`
 - Metadata SHA-256: `d17a05b229136107ac1e50142856979a9ae9f563cdb19b940e4810dadda79e1c`
 - Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
 - Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
-- Coverage result: **FULL**
-Overall result: PASS
+- Coverage result: **PARTIAL**
+Overall result: PASS (partial coverage)
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `request_type_deployment` | PASS | with_skill 输出明确写出 `request_type: deployment`。 |
-| `repo_wide_scope_allowed` | PASS | with_skill 输出将仓库级 CI 配置与上线前检查作为非 feature 工作，并使用 `feature_path: N/A`、`feature: N/A`、`parent_feature: N/A`、`feature_level: N/A` 和 `feature_path_evidence: []`。 |
-| `devops_handoff_packet` | PASS | with_skill 的 handoff packet 记录了 CI/上线前检查目标、仓库级范围、环境/发布目标与回滚策略尚未确认的状态，以及源码、构建入口、部署环境、发布目标和回滚要求等风险，随后指定 `downstream_owner: DevOps`。 |
+| `request_type_deployment` | PASS | With_skill explicitly states `request_type: deployment` in its Routing decision. |
+| `repo_wide_scope_allowed` | PASS | With_skill uses `feature_path: N/A`, `feature: N/A`, `parent_feature: N/A`, and `feature_path_evidence: []` for repository-wide work. |
+| `devops_handoff_packet` | NOT_EXERCISED | The DevOps handoff is explicitly blocked because the target agent and required release context are unavailable; the actual handoff cannot yet occur. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=df8dd8d18e0b79f0114ea9e750efb47af7d21bc05b6ea3666cff7d6bae4802fe; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=5eaa8d02a425eca63703fe2316902dddccbc943f14ffffba93d6795a9ef335b9; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 正确识别 deployment，允许仓库级 N/A scope，并提供带上下文、风险和执行边界的 DevOps 交接包；未修改文件。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=df8dd8d18e0b79f0114ea9e750efb47af7d21bc05b6ea3666cff7d6bae4802fe; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=259042ca0672c7b0cc9ca01dcd11fa18d6918cce2344e47e60d0cdb8db780016; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly classifies the request as deployment, permits repository-wide N/A scope, and stops before an unsupported DevOps handoff.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=df8dd8d18e0b79f0114ea9e750efb47af7d21bc05b6ea3666cff7d6bae4802fe; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=3d73e2d5c6d5f8857c01216036a5103b0888125cab44479cc13f769d54772399; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 识别到仓库为空并请求补充信息，但未完成 deployment 分类、N/A scope 或 DevOps 交接。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=df8dd8d18e0b79f0114ea9e750efb47af7d21bc05b6ea3666cff7d6bae4802fe; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=3ea9ec3f666f17ed064514f2fafa4c925fc8f737b7904e6aa6d9c97d2b17679d; snapshot_sha256=df9e7182eb760cabfbd10b7e99ad05abcb8ad7436780a669611ff080265c733b
+- Behavior: Implemented repository-level CI artifacts but did not provide the required deployment classification or structured handoff context.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: None.
+- Next: Confirm environment, release scope, rollback needs, and risks, then hand off to DevOps when the target is available.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-6-route-security-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-6-route-security-request/comparison.md
@@ -14,10 +14,10 @@
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-6-route-security-request`.
 - Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
 - Prompt SHA-256: `36e2dc52efc02bd4a536346d8f3cd5d27459a1a97e6287cf5969afca708442f1`
-- Repository HEAD: `33a503192c752d6227de1bc0d8d8a2e78e31cdf5`
+- Repository HEAD: `715bd6b76fcd6f14f475aeabe141543063d431ba`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `8b87fb93cdb85ecb0436a61b1aedfcf9c8b41c4cd8f9eff41c412a3196c1d245`
-- Skill overlay SHA-256: `56390e18f057b654978938889dac7daf0263eaaf39d741419b573d12bff2c198`
+- Target skill tree SHA-256: `be11ec63823b148323fef6c35d27c0861bd093b24d683f705e846234e98b7baa`
+- Skill overlay SHA-256: `961e7aacbdec2d154ad578bc7bf54d5d734f34031af1384fb20aa67a8e2d392a`
 - Judge schema SHA-256: `356a8438fe026d0b1352a3ef7467cbb1d1fa3bb6c089f0c3e64b4d4c5d3741fc`
 - Eval definition SHA-256: `33054d35eb6adb9b2259eedec7e911d8545eb305cd711e4206483eea10d13a8f`
 - Metadata SHA-256: `b68604b9408ecd1ae4f680e8b6bea0f1c221e273dc6389c6b8150eff4b36f0d2`
@@ -31,26 +31,26 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `request_type_security` | PASS | With-skill output explicitly classifies the request as `request_type: security`. |
-| `security_scope_first` | PASS | The initial routing block records `risk_surface`, `assets`, `permissions`, `data_flow`, and `remediation_expectations` before the recorded inspection steps. |
-| `security_handoff` | NOT_EXERCISED | The candidate identifies `selected_owner: security-agent` and supplies scope plus `required_output`, but states the actual Security handoff is blocked because `security-agent` is unavailable. |
+| `request_type_security` | PASS | With-skill output identifies the work as a security review and names `security-agent`. |
+| `security_scope_first` | NOT_EXERCISED | The locked final output does not independently prove the required first-recorded scope fields or ordering. |
+| `security_handoff` | NOT_EXERCISED | The output says handoff is required, but no completed handoff is evidenced and the stated security-agent runtime is unavailable. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=36e2dc52efc02bd4a536346d8f3cd5d27459a1a97e6287cf5969afca708442f1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=bbfd35cfac94950680718164abf278d36eb84e48715a2c77ecdb4bbd0f046a49; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Classifies the request as security and records the required scope fields first; downstream handoff is explicitly blocked pending security-agent availability.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=36e2dc52efc02bd4a536346d8f3cd5d27459a1a97e6287cf5969afca708442f1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=81c6725827911515ff1423bbac9dfd9b72604fa7ff99e606f7131653f4a336f2; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly identifies and routes the request as security-related, but does not provide independently verifiable scope-first or completed-handoff evidence.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=36e2dc52efc02bd4a536346d8f3cd5d27459a1a97e6287cf5969afca708442f1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=4c9c8412e3b3bcd669399692ce9d4a56a3ffd26c4b8a9161e4d2c0f096c1eaa0; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Provides a substantive audit-style response about the empty repository but does not classify, scope, or hand off the request through the required security workflow.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=36e2dc52efc02bd4a536346d8f3cd5d27459a1a97e6287cf5969afca708442f1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=e2a8d2e122d68fc35c3bd4c3931bc7ded9cd65db6b7187e6ff66b85b06f40abc; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Provides a substantive security checklist but does not classify or route the request through a security handoff.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Install or make `security-agent` available, then perform the Security handoff with the recorded scope and required output.
+- Next: Provide runtime evidence of the recorded security scope and completed Security handoff.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-6-route-security-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-6-route-security-request/comparison.md
@@ -14,10 +14,10 @@
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-6-route-security-request`.
 - Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
 - Prompt SHA-256: `36e2dc52efc02bd4a536346d8f3cd5d27459a1a97e6287cf5969afca708442f1`
-- Repository HEAD: `715bd6b76fcd6f14f475aeabe141543063d431ba`
+- Repository HEAD: `8813f864e743f7c83dc2e51e0b5add79f312e870`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `be11ec63823b148323fef6c35d27c0861bd093b24d683f705e846234e98b7baa`
-- Skill overlay SHA-256: `961e7aacbdec2d154ad578bc7bf54d5d734f34031af1384fb20aa67a8e2d392a`
+- Target skill tree SHA-256: `0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7`
+- Skill overlay SHA-256: `4d4a580c5e7c36b9199abb80221829f90c900c96463581d7f87c6d7ccc538bd7`
 - Judge schema SHA-256: `356a8438fe026d0b1352a3ef7467cbb1d1fa3bb6c089f0c3e64b4d4c5d3741fc`
 - Eval definition SHA-256: `33054d35eb6adb9b2259eedec7e911d8545eb305cd711e4206483eea10d13a8f`
 - Metadata SHA-256: `b68604b9408ecd1ae4f680e8b6bea0f1c221e273dc6389c6b8150eff4b36f0d2`
@@ -31,26 +31,26 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `request_type_security` | PASS | With-skill output identifies the work as a security review and names `security-agent`. |
-| `security_scope_first` | NOT_EXERCISED | The locked final output does not independently prove the required first-recorded scope fields or ordering. |
-| `security_handoff` | NOT_EXERCISED | The output says handoff is required, but no completed handoff is evidenced and the stated security-agent runtime is unavailable. |
+| `request_type_security` | PASS | With-skill output explicitly sets `request_type: security`. |
+| `security_scope_first` | PASS | With-skill output records `risk_surface`, `assets`, `permissions`, `data_flow`, and `remediation_expectations` in its routing scope. |
+| `security_handoff` | NOT_EXERCISED | The output selects `security-agent` and includes scope plus `required_output`, but states the agent is unavailable; an actual handoff is not exercised or independently evidenced. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=36e2dc52efc02bd4a536346d8f3cd5d27459a1a97e6287cf5969afca708442f1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=81c6725827911515ff1423bbac9dfd9b72604fa7ff99e606f7131653f4a336f2; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly identifies and routes the request as security-related, but does not provide independently verifiable scope-first or completed-handoff evidence.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=36e2dc52efc02bd4a536346d8f3cd5d27459a1a97e6287cf5969afca708442f1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=02a5a0aea5339b63b966b6448904636c0b9200213b610ed5d5483739fb4175a6; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly classified the request and recorded the required security scope and output contract; handoff was blocked by the unavailable Security agent.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=36e2dc52efc02bd4a536346d8f3cd5d27459a1a97e6287cf5969afca708442f1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=e2a8d2e122d68fc35c3bd4c3931bc7ded9cd65db6b7187e6ff66b85b06f40abc; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Provides a substantive security checklist but does not classify or route the request through a security handoff.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=36e2dc52efc02bd4a536346d8f3cd5d27459a1a97e6287cf5969afca708442f1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=63cc93a8319ca7ed3365902c952b8349f24a71ebe3e3950b98ac649c6d0f457a; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Performed a factual empty-repository assessment but did not classify, scope, or route the request through a Security handoff.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Provide runtime evidence of the recorded security scope and completed Security handoff.
+- Next: Enable or install security-agent and perform the Security handoff using the recorded scope and required output.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-7-direct-downstream-without-handoff/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-7-direct-downstream-without-handoff/comparison.md
@@ -14,10 +14,10 @@
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-7-direct-downstream-without-handoff`.
 - Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
 - Prompt SHA-256: `57e82609f413c88720ec90ed64877ede694585115e55bf0256d08e8274436d4f`
-- Repository HEAD: `715bd6b76fcd6f14f475aeabe141543063d431ba`
+- Repository HEAD: `8813f864e743f7c83dc2e51e0b5add79f312e870`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `be11ec63823b148323fef6c35d27c0861bd093b24d683f705e846234e98b7baa`
-- Skill overlay SHA-256: `961e7aacbdec2d154ad578bc7bf54d5d734f34031af1384fb20aa67a8e2d392a`
+- Target skill tree SHA-256: `0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7`
+- Skill overlay SHA-256: `4d4a580c5e7c36b9199abb80221829f90c900c96463581d7f87c6d7ccc538bd7`
 - Judge schema SHA-256: `6f1f540339fe5c4c310ca6aaedc38adff3d61e4268399a40149f44e3770ac25c`
 - Eval definition SHA-256: `13771c6d0b126a3ca1ee1723ee43dcbca8cef0bbfd3ed1a8c42651bbd42a7c19`
 - Metadata SHA-256: `70b36659756bbd4d7fc0e09d0fabc7ee5ba1a168323c148fa735110fb59ec768`
@@ -31,20 +31,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `routing_decision_present` | PASS | With_skill output provides a routing decision with request type, selected_owner `idea-to-spec`, entry_basis, feature_path, source documents, and execution boundary. |
-| `stay_in_pm_alignment` | PASS | With_skill keeps the work in the PM/idea-to-spec path, marks the entry blocked, and explicitly says no downstream execution or Engineer handoff has occurred. |
-| `blocks_engineering_without_basis` | PASS | With_skill identifies missing product/design basis, unresolved scope and acceptance criteria, missing implementation context, requires confirmation, and states that code modification is not allowed; locked git evidence shows no changes. |
+| `routing_decision_present` | PASS | With-skill output provides an auditable routing decision with selected_owner `idea-to-spec`, blocked entry_basis, unresolved feature_path, and an explicit execution boundary. |
+| `stay_in_pm_alignment` | PASS | With-skill output keeps the request in PM/idea-to-spec discovery, states the project is empty and blocked, and does not claim an Engineer handoff or downstream execution. |
+| `blocks_engineering_without_basis` | PASS | With-skill output requires product scope, design materials, and existing implementation/code or layout basis before proceeding, and explicitly prohibits writing code. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=57e82609f413c88720ec90ed64877ede694585115e55bf0256d08e8274436d4f; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=999d14f336cf0f8d7653d1b8918c08b1970186af864a746479880406ea6081fb; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly routed the request to PM scope alignment, blocked downstream implementation, and preserved the read-only boundary.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=57e82609f413c88720ec90ed64877ede694585115e55bf0256d08e8274436d4f; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=a9b3dbe3e3cdc4bde676128a1cebfa75f23e59859424ed8dba8daae1037e0dc0; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly routed the request to PM discovery, identified missing basis, and blocked implementation without modifying code.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=57e82609f413c88720ec90ed64877ede694585115e55bf0256d08e8274436d4f; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=a61e159bfab77c22fcaf14b3184217c41205fa0610d3753eab9bab9cd0b737ae; snapshot_sha256=64c2d9a61ca4f7c80ec2811854a5fa9eed4bbdb28f39cfa28c6b781afe741f6d
-- Behavior: Implemented a new settings page despite missing product/design basis and created untracked files.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=57e82609f413c88720ec90ed64877ede694585115e55bf0256d08e8274436d4f; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=2b400a645dfce3cae65dfe0f7a27ab340cfa6f225a071ff27642c41f0cfd065a; snapshot_sha256=df30d332dc7c1cb669534c43b47f952e575933dc964041c74ce5db24956ada0f
+- Behavior: Fresh baseline directly implemented a static settings page despite missing product/design basis.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-7-direct-downstream-without-handoff/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-7-direct-downstream-without-handoff/comparison.md
@@ -14,12 +14,12 @@
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-7-direct-downstream-without-handoff`.
 - Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
 - Prompt SHA-256: `57e82609f413c88720ec90ed64877ede694585115e55bf0256d08e8274436d4f`
-- Repository HEAD: `33a503192c752d6227de1bc0d8d8a2e78e31cdf5`
+- Repository HEAD: `715bd6b76fcd6f14f475aeabe141543063d431ba`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `8b87fb93cdb85ecb0436a61b1aedfcf9c8b41c4cd8f9eff41c412a3196c1d245`
-- Skill overlay SHA-256: `56390e18f057b654978938889dac7daf0263eaaf39d741419b573d12bff2c198`
+- Target skill tree SHA-256: `be11ec63823b148323fef6c35d27c0861bd093b24d683f705e846234e98b7baa`
+- Skill overlay SHA-256: `961e7aacbdec2d154ad578bc7bf54d5d734f34031af1384fb20aa67a8e2d392a`
 - Judge schema SHA-256: `6f1f540339fe5c4c310ca6aaedc38adff3d61e4268399a40149f44e3770ac25c`
-- Eval definition SHA-256: `700336d4b7193b70e468b0c4438658b25a2ebad8ec77c1b4f8af7b856ebd1494`
+- Eval definition SHA-256: `13771c6d0b126a3ca1ee1723ee43dcbca8cef0bbfd3ed1a8c42651bbd42a7c19`
 - Metadata SHA-256: `70b36659756bbd4d7fc0e09d0fabc7ee5ba1a168323c148fa735110fb59ec768`
 - Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
 - Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
@@ -31,20 +31,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `routing_decision_present` | PASS | With-skill output begins with a labeled Routing decision and includes request_type, selected_owner, entry_basis, feature_path, and execution_boundary. |
-| `stay_in_pm_alignment` | PASS | With-skill output keeps the work in the idea-to-spec path, marks feature_path unresolved, provides no handoff packet, and does not claim Engineer handoff or downstream execution. |
-| `blocks_engineering_without_basis` | PASS | With-skill output identifies missing product, design, and implementation basis, requires further scope/context confirmation, and locked git evidence shows no changes or commits. |
+| `routing_decision_present` | PASS | With_skill output provides a routing decision with request type, selected_owner `idea-to-spec`, entry_basis, feature_path, source documents, and execution boundary. |
+| `stay_in_pm_alignment` | PASS | With_skill keeps the work in the PM/idea-to-spec path, marks the entry blocked, and explicitly says no downstream execution or Engineer handoff has occurred. |
+| `blocks_engineering_without_basis` | PASS | With_skill identifies missing product/design basis, unresolved scope and acceptance criteria, missing implementation context, requires confirmation, and states that code modification is not allowed; locked git evidence shows no changes. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=57e82609f413c88720ec90ed64877ede694585115e55bf0256d08e8274436d4f; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=b7d110ed82c94c517491ee072fd0a7baf9064fcf24b6f435a66ee7937d867e0a; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Provided the required PM routing decision, stayed in idea-to-spec alignment, and blocked implementation pending missing evidence.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=57e82609f413c88720ec90ed64877ede694585115e55bf0256d08e8274436d4f; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=999d14f336cf0f8d7653d1b8918c08b1970186af864a746479880406ea6081fb; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly routed the request to PM scope alignment, blocked downstream implementation, and preserved the read-only boundary.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=57e82609f413c88720ec90ed64877ede694585115e55bf0256d08e8274436d4f; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=b17b2d23697eac6a8a90976c53ca85456f56195834b24e19221450d565b4570f; snapshot_sha256=a1273a0cddd53bcd621b3c17848d1c796777a81199bd74268225d1a3af40236e
-- Behavior: Implemented and delivered new settings-page files without the required routing or evidence gates.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=57e82609f413c88720ec90ed64877ede694585115e55bf0256d08e8274436d4f; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=a61e159bfab77c22fcaf14b3184217c41205fa0610d3753eab9bab9cd0b737ae; snapshot_sha256=64c2d9a61ca4f7c80ec2811854a5fa9eed4bbdb28f39cfa28c6b781afe741f6d
+- Behavior: Implemented a new settings page despite missing product/design basis and created untracked files.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-8-direct-specialist-bypass-gate/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-8-direct-specialist-bypass-gate/comparison.md
@@ -14,12 +14,12 @@
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-8-direct-specialist-bypass-gate`.
 - Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
 - Prompt SHA-256: `827e1eab57730473669ffa6562263ebb5fcf35595b38ae224272aca2a629a167`
-- Repository HEAD: `33a503192c752d6227de1bc0d8d8a2e78e31cdf5`
+- Repository HEAD: `715bd6b76fcd6f14f475aeabe141543063d431ba`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `8b87fb93cdb85ecb0436a61b1aedfcf9c8b41c4cd8f9eff41c412a3196c1d245`
-- Skill overlay SHA-256: `56390e18f057b654978938889dac7daf0263eaaf39d741419b573d12bff2c198`
+- Target skill tree SHA-256: `be11ec63823b148323fef6c35d27c0861bd093b24d683f705e846234e98b7baa`
+- Skill overlay SHA-256: `961e7aacbdec2d154ad578bc7bf54d5d734f34031af1384fb20aa67a8e2d392a`
 - Judge schema SHA-256: `d4acd94dda2c52416ad87fb2e12177cf797b75ea923eded4095dac24f71a6a61`
-- Eval definition SHA-256: `b9fa50e25ae21150a7999f6d53a6c6d8b0466463a4d2f36c8c86411a0483e826`
+- Eval definition SHA-256: `cd9751a8b092fc6d7d98d6022afbbb3ec1c871d784270dc60d0af08525fe28a3`
 - Metadata SHA-256: `484b4662019ef115d32bbdc63a4fe4cffc2cd503d4cd9fc5262185023225f4ca`
 - Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
 - Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
@@ -31,20 +31,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `routing_decision_present` | PASS | 明确输出 Routing decision，包含 selected_owner 为 pm-agent:idea-to-spec、entry_basis: missing，以及 execution_boundary，并将请求路由到 PM 承接。 |
-| `requires_product_and_engineering_basis` | PASS | 明确要求先完成需求发现、PRD/DECISIONS、技术设计和确认范围，并指出当前缺少用户目标、业务规则、技术设计及验收依据。 |
-| `blocks_implementation` | PASS | 明确停留在 greenfield-discovery，声明暂不写代码、测试或技术实现计划；锁定 git 证据显示无文件、索引或提交变更。 |
+| `routing_decision_present` | PASS | With-skill output explicitly routes the request to `idea-to-spec`, identifies the new and undefined scope, sets `entry_basis: missing`, and states the PM execution boundary. |
+| `requires_product_and_engineering_basis` | PASS | The output identifies missing requirements, scope, and technical design, requires PRD/DECISIONS and confirmed scope before Engineer work, and does not claim implementation readiness. |
+| `blocks_implementation` | PASS | With-skill delivery snapshot is empty and git evidence shows no worktree, index, branch, or commit changes; the output explicitly prohibits coding, tests, and implementation planning. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=827e1eab57730473669ffa6562263ebb5fcf35595b38ae224272aca2a629a167; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=0edef3ea8623a77736974bf10f8c80835bdfa813cb5ef9cc89ed3c7968bdcd39; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 先进行 PM 路由和范围确认，停留在 greenfield-discovery，未执行实现。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=827e1eab57730473669ffa6562263ebb5fcf35595b38ae224272aca2a629a167; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=ff856e933c4f7eac9254af40e7c9ba315c0b46be32846466d2229b6cf3cc6d4a; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly performs PM routing, identifies missing product and technical basis, asks for scope confirmation, and makes no implementation mutation.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=827e1eab57730473669ffa6562263ebb5fcf35595b38ae224272aca2a629a167; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=40a51f29c8ee21293d942f8bc4961d1158ef35c73a70b98cb42358fa61dc0894; snapshot_sha256=a2c623a34a7efe69b9d4841e0be754625c07524e12082b8146c9d8e6c979617d
-- Behavior: 直接假设账号资料功能并创建 API、源码和测试，之后才列出待确认事项。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=827e1eab57730473669ffa6562263ebb5fcf35595b38ae224272aca2a629a167; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=b6632abac8ce81504d6bfc77ffb1cbc865b0db9f748b5a85068b199af86eaebf; snapshot_sha256=3b9bd70b33b0105978b55cdc3c76350bc5b90ef9fd1f8bdde5c07366f871ef62
+- Behavior: Fresh baseline immediately implemented an assumed account-center backend and tests despite missing product and engineering basis.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-8-direct-specialist-bypass-gate/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-8-direct-specialist-bypass-gate/comparison.md
@@ -14,43 +14,43 @@
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-8-direct-specialist-bypass-gate`.
 - Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
 - Prompt SHA-256: `827e1eab57730473669ffa6562263ebb5fcf35595b38ae224272aca2a629a167`
-- Repository HEAD: `715bd6b76fcd6f14f475aeabe141543063d431ba`
+- Repository HEAD: `8813f864e743f7c83dc2e51e0b5add79f312e870`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `be11ec63823b148323fef6c35d27c0861bd093b24d683f705e846234e98b7baa`
-- Skill overlay SHA-256: `961e7aacbdec2d154ad578bc7bf54d5d734f34031af1384fb20aa67a8e2d392a`
+- Target skill tree SHA-256: `0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7`
+- Skill overlay SHA-256: `4d4a580c5e7c36b9199abb80221829f90c900c96463581d7f87c6d7ccc538bd7`
 - Judge schema SHA-256: `d4acd94dda2c52416ad87fb2e12177cf797b75ea923eded4095dac24f71a6a61`
 - Eval definition SHA-256: `cd9751a8b092fc6d7d98d6022afbbb3ec1c871d784270dc60d0af08525fe28a3`
 - Metadata SHA-256: `484b4662019ef115d32bbdc63a4fe4cffc2cd503d4cd9fc5262185023225f4ca`
 - Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
 - Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
-- Coverage result: **FULL**
-Overall result: PASS
+- Coverage result: **PARTIAL**
+Overall result: PASS (partial coverage)
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `routing_decision_present` | PASS | With-skill output explicitly routes the request to `idea-to-spec`, identifies the new and undefined scope, sets `entry_basis: missing`, and states the PM execution boundary. |
-| `requires_product_and_engineering_basis` | PASS | The output identifies missing requirements, scope, and technical design, requires PRD/DECISIONS and confirmed scope before Engineer work, and does not claim implementation readiness. |
-| `blocks_implementation` | PASS | With-skill delivery snapshot is empty and git evidence shows no worktree, index, branch, or commit changes; the output explicitly prohibits coding, tests, and implementation planning. |
+| `routing_decision_present` | PASS | With_skill output provides a Routing decision naming `selected_owner: idea-to-spec`, `entry_basis: missing`, unresolved scope, and an explicit execution boundary prohibiting planning, design, coding, and testing; it keeps the request in PM discovery. |
+| `requires_product_and_engineering_basis` | NOT_EXERCISED | The candidate correctly states that PRD, technical design, and confirmed scope are missing and refuses to produce a credible implementation plan, but the later confirmation and TRD stages cannot be exercised before user input. |
+| `blocks_implementation` | PASS | With_skill output explicitly prohibits implementation and the locked workspace evidence shows no delivered files, git changes, or implementation/testing actions. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=827e1eab57730473669ffa6562263ebb5fcf35595b38ae224272aca2a629a167; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=ff856e933c4f7eac9254af40e7c9ba315c0b46be32846466d2229b6cf3cc6d4a; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly performs PM routing, identifies missing product and technical basis, asks for scope confirmation, and makes no implementation mutation.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=827e1eab57730473669ffa6562263ebb5fcf35595b38ae224272aca2a629a167; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=86560df66be1336515f9ab483dfbdd8e34e8b488fc0c61c0fd518fcacdafd8ae; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Routes the vague feature request to PM discovery, records missing entry basis and unresolved scope, asks one narrowing question, and blocks implementation.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=827e1eab57730473669ffa6562263ebb5fcf35595b38ae224272aca2a629a167; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=b6632abac8ce81504d6bfc77ffb1cbc865b0db9f748b5a85068b199af86eaebf; snapshot_sha256=3b9bd70b33b0105978b55cdc3c76350bc5b90ef9fd1f8bdde5c07366f871ef62
-- Behavior: Fresh baseline immediately implemented an assumed account-center backend and tests despite missing product and engineering basis.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=827e1eab57730473669ffa6562263ebb5fcf35595b38ae224272aca2a629a167; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=a743fdc5612fce5601d3a16cd313cfe99ba8c8f806e1b63716a20a56b0ccd2ee; snapshot_sha256=5af0294f1e38bb2b97f3261212ce12cfa1be58009dec51da143c1bb94a32edf8
+- Behavior: Fresh baseline immediately created and delivered an account-center code skeleton despite missing product and technical basis.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: None.
+- Next: After the user confirms the feature direction, complete PM scope and PRD/decision artifacts, then obtain technical design and confirmed implementation scope before planning implementation.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-9-missing-handoff-target-unavailable/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-9-missing-handoff-target-unavailable/comparison.md
@@ -14,10 +14,10 @@
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-9-missing-handoff-target-unavailable`.
 - Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
 - Prompt SHA-256: `5230fc275f473a55b5d59c172358aff82cf42415f36da1a920c1b4fa1e1e3cc1`
-- Repository HEAD: `33a503192c752d6227de1bc0d8d8a2e78e31cdf5`
+- Repository HEAD: `715bd6b76fcd6f14f475aeabe141543063d431ba`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `8b87fb93cdb85ecb0436a61b1aedfcf9c8b41c4cd8f9eff41c412a3196c1d245`
-- Skill overlay SHA-256: `56390e18f057b654978938889dac7daf0263eaaf39d741419b573d12bff2c198`
+- Target skill tree SHA-256: `be11ec63823b148323fef6c35d27c0861bd093b24d683f705e846234e98b7baa`
+- Skill overlay SHA-256: `961e7aacbdec2d154ad578bc7bf54d5d734f34031af1384fb20aa67a8e2d392a`
 - Judge schema SHA-256: `45aa95828b353344675a6e62421acac466500932a42ce4d64f8f43969bd5bb6d`
 - Eval definition SHA-256: `ea4ff3ed92cd6df9743d23b747dc29d9087560d5cfa7f5f4525b8e146b0b7e97`
 - Metadata SHA-256: `f52777a03f0c132438bf125e153205560b01f6abb53fcb15add6a3552b96312b`
@@ -31,20 +31,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `detect_missing_target` | PASS | With-skill output explicitly states that `designer-agent` is unavailable/not present and repeats that the available skills do not include it. |
-| `mark_handoff_blocked` | PASS | The routing YAML sets `entry_basis: blocked`, lists the missing `designer-agent` capability as a blocker, and says to install and enable it. |
-| `do_not_perform_missing_role` | PASS | The output limits execution to PM routing and blocker explanation, explicitly refuses to substitute for Designer or produce design deliverables, and no delivery snapshot exists. |
+| `detect_missing_target` | PASS | With-skill output explicitly states that `designer-agent` is not installed and design capability is unavailable. |
+| `mark_handoff_blocked` | PASS | With-skill routing sets `entry_basis: blocked`, lists the unavailable capability, and states that `designer-agent` must be installed. |
+| `do_not_perform_missing_role` | PASS | With-skill output preserves PM classification and blocked handoff only; no design artifact or visual specification was delivered. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5230fc275f473a55b5d59c172358aff82cf42415f36da1a920c1b4fa1e1e3cc1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=e3faf24ab27f1e9c8c0461e2bac5cc42a46fa072280d072580ac903067e8ed63; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly detects the unavailable Designer target, marks the handoff blocked, identifies the required capability, and preserves role boundaries without producing design work.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5230fc275f473a55b5d59c172358aff82cf42415f36da1a920c1b4fa1e1e3cc1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=b8996b5dae0fb073e4d395ac26bc8599f20db997c392874de6a8316298c1c02d; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly detects the unavailable designer-agent, marks the handoff blocked, identifies installation as the required next step, and does not perform Designer work.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5230fc275f473a55b5d59c172358aff82cf42415f36da1a920c1b4fa1e1e3cc1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=8a0e97a8f3bc3d73bb6a9820d68633db050b5f2b5655bd7297691bec1dd97f02; snapshot_sha256=9a8ce62c030121ad804f1cac353b2d227e4f57d32ed71a125476c6ed16d03d8f
-- Behavior: Fresh baseline produced an unsolicited design handoff document instead of identifying the missing Designer capability or blocking the handoff.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5230fc275f473a55b5d59c172358aff82cf42415f36da1a920c1b4fa1e1e3cc1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=08ee042f682981fa76a827f06ca187dd34fd2da353ecc61906efd56dc501b18e; snapshot_sha256=3e5d261135862c81a81f5c6da62cbe44145317d3dd6ad02007ab85a16defb312
+- Behavior: Produced a design handoff document without identifying the unavailable designer-agent or blocking the handoff, illustrating the fresh baseline failure.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-9-missing-handoff-target-unavailable/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-9-missing-handoff-target-unavailable/comparison.md
@@ -14,10 +14,10 @@
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-9-missing-handoff-target-unavailable`.
 - Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
 - Prompt SHA-256: `5230fc275f473a55b5d59c172358aff82cf42415f36da1a920c1b4fa1e1e3cc1`
-- Repository HEAD: `715bd6b76fcd6f14f475aeabe141543063d431ba`
+- Repository HEAD: `8813f864e743f7c83dc2e51e0b5add79f312e870`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `be11ec63823b148323fef6c35d27c0861bd093b24d683f705e846234e98b7baa`
-- Skill overlay SHA-256: `961e7aacbdec2d154ad578bc7bf54d5d734f34031af1384fb20aa67a8e2d392a`
+- Target skill tree SHA-256: `0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7`
+- Skill overlay SHA-256: `4d4a580c5e7c36b9199abb80221829f90c900c96463581d7f87c6d7ccc538bd7`
 - Judge schema SHA-256: `45aa95828b353344675a6e62421acac466500932a42ce4d64f8f43969bd5bb6d`
 - Eval definition SHA-256: `ea4ff3ed92cd6df9743d23b747dc29d9087560d5cfa7f5f4525b8e146b0b7e97`
 - Metadata SHA-256: `f52777a03f0c132438bf125e153205560b01f6abb53fcb15add6a3552b96312b`
@@ -31,26 +31,26 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `detect_missing_target` | PASS | With-skill output explicitly states that `designer-agent` is not installed and design capability is unavailable. |
-| `mark_handoff_blocked` | PASS | With-skill routing sets `entry_basis: blocked`, lists the unavailable capability, and states that `designer-agent` must be installed. |
-| `do_not_perform_missing_role` | PASS | With-skill output preserves PM classification and blocked handoff only; no design artifact or visual specification was delivered. |
+| `detect_missing_target` | PASS | With_skill explicitly states that designer-agent or an equivalent design capability is unavailable. |
+| `mark_handoff_blocked` | PASS | With_skill explicitly marks the handoff as blocked and requests installing or enabling designer-agent. |
+| `do_not_perform_missing_role` | PASS | With_skill performs no design production; it keeps PM routing and states the execution boundary forbids substituting for Designer. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5230fc275f473a55b5d59c172358aff82cf42415f36da1a920c1b4fa1e1e3cc1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=b8996b5dae0fb073e4d395ac26bc8599f20db997c392874de6a8316298c1c02d; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly detects the unavailable designer-agent, marks the handoff blocked, identifies installation as the required next step, and does not perform Designer work.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5230fc275f473a55b5d59c172358aff82cf42415f36da1a920c1b4fa1e1e3cc1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=bc563a308901ee513841e5193a3a1da7a5dbcf3fe077e8a724f5efb209491abd; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly identifies the missing designer-agent capability, marks the handoff blocked, specifies the required enablement, and does not perform the missing design role.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5230fc275f473a55b5d59c172358aff82cf42415f36da1a920c1b4fa1e1e3cc1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=08ee042f682981fa76a827f06ca187dd34fd2da353ecc61906efd56dc501b18e; snapshot_sha256=3e5d261135862c81a81f5c6da62cbe44145317d3dd6ad02007ab85a16defb312
-- Behavior: Produced a design handoff document without identifying the unavailable designer-agent or blocking the handoff, illustrating the fresh baseline failure.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5230fc275f473a55b5d59c172358aff82cf42415f36da1a920c1b4fa1e1e3cc1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=f7ac53dcadcd6ca378adfe6923d6522cfaff58eb368615becaa983d793b1ae51; snapshot_sha256=eb74465208301e13b4e07b6b8b1acde0642e25d2d46d7a37f59400e1ce2e40f7
+- Behavior: Fresh baseline creates a generic design handoff template but does not identify the unavailable designer-agent or explicitly mark the handoff blocked.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: None.
+- Next: Install or enable designer-agent before continuing the formal design handoff.
 
 ## Runtime Artifact Policy
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -4,7 +4,7 @@
     "pm-agent": {
       "source": "agents/product_manager/skills/pm-agent",
       "sourceType": "local",
-      "computedHash": "a1416093476f1b0a7b0bbe4af8c8f72644ba1452dcdc93bceac322a24fa228b3"
+      "computedHash": "c76184ead334ff8883cc8b4ee578479b9dc9afc5213381af63816037baebc9cb"
     },
     "idea-to-spec": {
       "source": "agents/product_manager/skills/idea-to-spec",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -4,7 +4,7 @@
     "pm-agent": {
       "source": "agents/product_manager/skills/pm-agent",
       "sourceType": "local",
-      "computedHash": "30e41d8e06156dfec34629ee6583479e02b13ed1b1c0290f6199091299601418"
+      "computedHash": "a1416093476f1b0a7b0bbe4af8c8f72644ba1452dcdc93bceac322a24fa228b3"
     },
     "idea-to-spec": {
       "source": "agents/product_manager/skills/idea-to-spec",


### PR DESCRIPTION
## 变更内容

精简 `pm-agent` 用户可见的路由决策输出（issue #265）：

- **默认一行路由说明**：`已路由到 <skill>：<一句话原因>`，不再强制每次回复首行输出完整 `Routing decision` YAML 块
- **完整结构化信息仅按需输出**：用户明确要求 / 入口缺失或 blocked（说明缺口与禁止执行边界）/ 跨角色 handoff（完整 packet 供下游消费）/ 调试与 eval 场景
- **安全网保留**：业务规则或已批准预期变更、hotfix 判定场景，一行说明内仍显式呈现 `change_tier` 与 `hotfix_disposition` 字面值；入口分类、change tier 判定与下游 entry basis 门禁不变
- **连续追问不重复**：同一任务追问与状态更新不重复输出路由说明，除非 owner / scope / route 变化

## 修改文件

| 文件 | 改动 |
| --- | --- |
| `agents/product_manager/skills/pm-agent/SKILL.md` | Mandatory Entry Decision 与 Output Behavior 重构（净改约 120 行，无新增抽象） |
| `agents/product_manager/test/pm-agent/evals/evals.json` | eval-007/008 `routing_decision_present` 断言与 `expected_output` 改为语义断言 |
| 16 个 `comparison.md` | fresh paired eval 结果（gpt-5.6-luna，10 workers） |
| `skills-lock.json` | 刷新 pm-agent `computedHash` |

## 验证

- `check_repository_contract.py` / `check_eval_contract.py` / `check_eval_artifacts.py` / `check_doc_contract.py` 全部 PASS
- `test_pm_entry_eval.py` 11 个确定测试通过
- pm-agent 19 个 eval：16 个 fresh PASS / PASS (partial)，eval-007/008 断言语义化后收敛通过
- 下游 router 消费面核查：engineer/docs/security 等仅消费 PM handoff packet 语义对象，不受输出精简影响

## 已知遗留（本 PR 范围外）

eval-017/018/019（scope guard 系列，#272 新增）无法产出 fresh 证据：`migration-inventory.json` 冻结记录未包含这三个 eval，runner 报 `migration inventory must contain exactly one matching retained eval`。该问题是 #272 引入时的既有遗漏，涉及冻结契约（193 条记录数），需单独处理，本 PR 保持其 PENDING 状态（contract 合法）。

Closes #265
