### PR TITLE
fix(eval): 完成 #277 身份架构与缺陷修复

### DIFF
--- a/.agents/skills/skill-eval-runner/references/eval-runbook.md
+++ b/.agents/skills/skill-eval-runner/references/eval-runbook.md
@@ -103,6 +103,20 @@ stale. Historical freshness follows the target skill and the eval's own definiti
 metadata, fixture, judge schema, executor, and runtime inputs. Changing the dependency
 list still changes metadata identity and requires a rerun.
 
+The target state for Issue #277 is identity schema v2. Cross-run freshness will use
+exactly `target_skill_sha256`, `eval_definition_sha256`, `metadata_sha256`,
+`fixture_sha256`, `execution_protocol_sha256`, `runtime_protocol_sha256`, and
+`judge_schema_sha256`. Execution/judging and runtime/isolation own the two protocol
+hashes; persistence/inventory and report formatting do not participate in historical
+freshness. A complete source manifest across all participating modules remains locked
+within one run and any drift before persistence is `BLOCKED`.
+
+The repository is still migrating to this target. The one-time migration validates the
+legacy source and current inputs, writes v2 identities atomically, and leaves an audit
+report. After migration, the normal checker accepts v2 only and does not query Git or
+keep a v1 compatibility path. Do not treat the planned v2 behavior as implemented until
+the active implementation plan is confirmed and the deterministic migration gates pass.
+
 ## Isolation Preflight
 
 Each candidate context must prove:

--- a/agents/designer/test/designer-agent/evals/workspace/eval-003-engineer-ui-maintenance-handoff/comparison.md
+++ b/agents/designer/test/designer-agent/evals/workspace/eval-003-engineer-ui-maintenance-handoff/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `821c99c85df4188cff291d55bb3f776ec720f8cbbd3f93df4bf7a03b6520bf3a` from `agents/designer/test/designer-agent/evals/workspace/eval-003-engineer-ui-maintenance-handoff`.
-- Fixture SHA-256: `821c99c85df4188cff291d55bb3f776ec720f8cbbd3f93df4bf7a03b6520bf3a`
-- Prompt SHA-256: `92f4c4b043cb3aab774531019133e8d4e6f2d81d21a277f0cd9696a8cc0a58e7`
+- Identity schema: `2`
+- target_skill_sha256: `e8c75de1d6f9996313bad1fce4ede6ed7cde9c08fd07355edd02169db57e8e68`
+- eval_definition_sha256: `138aebdae4a1049db8b791a6754cc321fff06d447fcae99b0206d1d5aa26e929`
+- metadata_sha256: `f547a888a015d9e9862374a63fae63a3c03679e1e0f3c3c280b9cf0370c3b020`
+- fixture_sha256: `821c99c85df4188cff291d55bb3f776ec720f8cbbd3f93df4bf7a03b6520bf3a`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `642d6c7ee5330dc1af39bc9648e9c1bffdb74e1229fc98a9c317e40e13baaebf`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `e8c75de1d6f9996313bad1fce4ede6ed7cde9c08fd07355edd02169db57e8e68`
-- Skill overlay SHA-256: `a999946ff7bd8c02d585ab2a5420fd1a5c4016373f3e682b7b9832c315b881b3`
-- Judge schema SHA-256: `642d6c7ee5330dc1af39bc9648e9c1bffdb74e1229fc98a9c317e40e13baaebf`
-- Eval definition SHA-256: `138aebdae4a1049db8b791a6754cc321fff06d447fcae99b0206d1d5aa26e929`
-- Metadata SHA-256: `f547a888a015d9e9862374a63fae63a3c03679e1e0f3c3c280b9cf0370c3b020`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/designer/test/designer-agent/evals/workspace/eval-1-route-design-handoff/comparison.md
+++ b/agents/designer/test/designer-agent/evals/workspace/eval-1-route-design-handoff/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `318a6ed6ff151cee086f75e2b1924aa867c873c059722194e1d201fc514c9d89` from `agents/designer/test/designer-agent/evals/workspace/eval-1-route-design-handoff`.
-- Fixture SHA-256: `318a6ed6ff151cee086f75e2b1924aa867c873c059722194e1d201fc514c9d89`
-- Prompt SHA-256: `6928263198e744f0628528a64ad381eb51b57dfc5347279a1b5dc49c697dfc6c`
+- Identity schema: `2`
+- target_skill_sha256: `e8c75de1d6f9996313bad1fce4ede6ed7cde9c08fd07355edd02169db57e8e68`
+- eval_definition_sha256: `22532d649002dfa1851fec27c554d610e1ed3e70ab860965c5b4914f96d4ccce`
+- metadata_sha256: `b228adbda9579c0023d949fdd52d3bd090b6ff85b7c6c2610e5202c6900dbe10`
+- fixture_sha256: `318a6ed6ff151cee086f75e2b1924aa867c873c059722194e1d201fc514c9d89`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `463caa76fbf321564869d8651cfcd73afe8721c939c5039c5cfd81c4ab25d935`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `e8c75de1d6f9996313bad1fce4ede6ed7cde9c08fd07355edd02169db57e8e68`
-- Skill overlay SHA-256: `a999946ff7bd8c02d585ab2a5420fd1a5c4016373f3e682b7b9832c315b881b3`
-- Judge schema SHA-256: `463caa76fbf321564869d8651cfcd73afe8721c939c5039c5cfd81c4ab25d935`
-- Eval definition SHA-256: `22532d649002dfa1851fec27c554d610e1ed3e70ab860965c5b4914f96d4ccce`
-- Metadata SHA-256: `b228adbda9579c0023d949fdd52d3bd090b6ff85b7c6c2610e5202c6900dbe10`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/designer/test/designer-agent/evals/workspace/eval-2-feature-path-design-handoff/comparison.md
+++ b/agents/designer/test/designer-agent/evals/workspace/eval-2-feature-path-design-handoff/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `f51ab76601713bed8d87e8e33016aaf394374041676e06644b8b383a6a3f1ef6` from `agents/designer/test/designer-agent/evals/workspace/eval-2-feature-path-design-handoff`.
-- Fixture SHA-256: `f51ab76601713bed8d87e8e33016aaf394374041676e06644b8b383a6a3f1ef6`
-- Prompt SHA-256: `e85929c91fa7ac5d9cb93339a38a992d155e1c545a4c3e5f4af6c78a44404dd1`
+- Identity schema: `2`
+- target_skill_sha256: `e8c75de1d6f9996313bad1fce4ede6ed7cde9c08fd07355edd02169db57e8e68`
+- eval_definition_sha256: `53f91ea5792318b5883984b62004cc098b15b6389da8f0c2233bdab77fbf2aa6`
+- metadata_sha256: `e6f9e581a9240bd876422c7ab0f1f1ca860fda8f563a8f02f87555323c8c7b30`
+- fixture_sha256: `f51ab76601713bed8d87e8e33016aaf394374041676e06644b8b383a6a3f1ef6`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `173af1b9ec0e079651ca3a9820c63dda3723644385c5a202331578e8f1a93950`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `e8c75de1d6f9996313bad1fce4ede6ed7cde9c08fd07355edd02169db57e8e68`
-- Skill overlay SHA-256: `a999946ff7bd8c02d585ab2a5420fd1a5c4016373f3e682b7b9832c315b881b3`
-- Judge schema SHA-256: `173af1b9ec0e079651ca3a9820c63dda3723644385c5a202331578e8f1a93950`
-- Eval definition SHA-256: `53f91ea5792318b5883984b62004cc098b15b6389da8f0c2233bdab77fbf2aa6`
-- Metadata SHA-256: `e6f9e581a9240bd876422c7ab0f1f1ca860fda8f563a8f02f87555323c8c7b30`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/designer/test/ui-ux-design/evals/workspace/eval-002-ecommerce/comparison.md
+++ b/agents/designer/test/ui-ux-design/evals/workspace/eval-002-ecommerce/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `066b89d2cc1dd835345cd6d39e99316bc4d1c11f89b8739eb2d1941c8791d32f` from `agents/designer/test/ui-ux-design/evals/workspace/eval-002-ecommerce`.
-- Fixture SHA-256: `066b89d2cc1dd835345cd6d39e99316bc4d1c11f89b8739eb2d1941c8791d32f`
-- Prompt SHA-256: `eb90dbc90941b21fe1cf928c689f4703e38f536b24e4a881de504f524de89ea3`
+- Identity schema: `2`
+- target_skill_sha256: `a26ada6a2ba843cfb4e657c89ce7c3b76b2095d2b006f263e49042916f04185f`
+- eval_definition_sha256: `ca70808ebe45c256ed44d9380fa1c8f3bd3f78623591e611656fc168a26d9c94`
+- metadata_sha256: `40409fe16f5c840772ed9dc96d9a9bf18f86662171fdae939c0a1ec6acbc3c28`
+- fixture_sha256: `066b89d2cc1dd835345cd6d39e99316bc4d1c11f89b8739eb2d1941c8791d32f`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `5ac69cf52c4833a0e74ebe39318957376e1be2b4d8142bcff9072bdd02569746`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `a26ada6a2ba843cfb4e657c89ce7c3b76b2095d2b006f263e49042916f04185f`
-- Skill overlay SHA-256: `13d5aeae4de0778abedf019c42c5ddcea7b044ef968920e82526dafcc120c7ea`
-- Judge schema SHA-256: `5ac69cf52c4833a0e74ebe39318957376e1be2b4d8142bcff9072bdd02569746`
-- Eval definition SHA-256: `ca70808ebe45c256ed44d9380fa1c8f3bd3f78623591e611656fc168a26d9c94`
-- Metadata SHA-256: `40409fe16f5c840772ed9dc96d9a9bf18f86662171fdae939c0a1ec6acbc3c28`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/designer/test/ui-ux-design/evals/workspace/eval-003-with-reference/comparison.md
+++ b/agents/designer/test/ui-ux-design/evals/workspace/eval-003-with-reference/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `816b980f73797aa0bb179996356d70da27810eb91a7ac7c665a793e71da22e00` from `agents/designer/test/ui-ux-design/evals/workspace/eval-003-with-reference`.
-- Fixture SHA-256: `816b980f73797aa0bb179996356d70da27810eb91a7ac7c665a793e71da22e00`
-- Prompt SHA-256: `1d07d7029ac6afd6bdd8b3a0c089a71197a6e0caee2ba8f44e93457b9bde08dd`
+- Identity schema: `2`
+- target_skill_sha256: `a26ada6a2ba843cfb4e657c89ce7c3b76b2095d2b006f263e49042916f04185f`
+- eval_definition_sha256: `36f115852952f11f54a62c4ef547a3782cf81881da967b1b9e5b272fbfbef0f5`
+- metadata_sha256: `1297d3b18067ef541e85c715177821c621d61aa5e828ddc8a5fd239236e4a6ab`
+- fixture_sha256: `816b980f73797aa0bb179996356d70da27810eb91a7ac7c665a793e71da22e00`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `5ac69cf52c4833a0e74ebe39318957376e1be2b4d8142bcff9072bdd02569746`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `a26ada6a2ba843cfb4e657c89ce7c3b76b2095d2b006f263e49042916f04185f`
-- Skill overlay SHA-256: `13d5aeae4de0778abedf019c42c5ddcea7b044ef968920e82526dafcc120c7ea`
-- Judge schema SHA-256: `5ac69cf52c4833a0e74ebe39318957376e1be2b4d8142bcff9072bdd02569746`
-- Eval definition SHA-256: `36f115852952f11f54a62c4ef547a3782cf81881da967b1b9e5b272fbfbef0f5`
-- Metadata SHA-256: `1297d3b18067ef541e85c715177821c621d61aa5e828ddc8a5fd239236e4a6ab`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/designer/test/ui-ux-design/evals/workspace/eval-005-mapped-notification-ui/comparison.md
+++ b/agents/designer/test/ui-ux-design/evals/workspace/eval-005-mapped-notification-ui/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `cc899f673f7067e0f23d4e43273fcee59ea0d49ecc2127d06d0f6831a3eb4d0a` from `agents/designer/test/ui-ux-design/evals/workspace/eval-005-mapped-notification-ui`.
-- Fixture SHA-256: `cc899f673f7067e0f23d4e43273fcee59ea0d49ecc2127d06d0f6831a3eb4d0a`
-- Prompt SHA-256: `2797a1f8eaaa6ec1663895e21733e03c38b2053355b7534ad87b60c49209372a`
+- Identity schema: `2`
+- target_skill_sha256: `a26ada6a2ba843cfb4e657c89ce7c3b76b2095d2b006f263e49042916f04185f`
+- eval_definition_sha256: `25a9beaf5037d128f11073d7bdad29e775b60a170f80ba9b4b2cd556e1ef1469`
+- metadata_sha256: `10998afd499537d318b7152b7f04f522887c53c432e959ff9a023e23e13617cb`
+- fixture_sha256: `cc899f673f7067e0f23d4e43273fcee59ea0d49ecc2127d06d0f6831a3eb4d0a`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `a26ada6a2ba843cfb4e657c89ce7c3b76b2095d2b006f263e49042916f04185f`
-- Skill overlay SHA-256: `13d5aeae4de0778abedf019c42c5ddcea7b044ef968920e82526dafcc120c7ea`
-- Judge schema SHA-256: `6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda`
-- Eval definition SHA-256: `25a9beaf5037d128f11073d7bdad29e775b60a170f80ba9b4b2cd556e1ef1469`
-- Metadata SHA-256: `10998afd499537d318b7152b7f04f522887c53c432e959ff9a023e23e13617cb`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/designer/test/ui-ux-design/workspace/eval-1-saas-dashboard/comparison.md
+++ b/agents/designer/test/ui-ux-design/workspace/eval-1-saas-dashboard/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `0c6e97834bbed6c2319a5e523ec66e524f7cbbe181557cf3e6af4ae38b100532` from `agents/designer/test/ui-ux-design/workspace/eval-1-saas-dashboard`.
-- Fixture SHA-256: `0c6e97834bbed6c2319a5e523ec66e524f7cbbe181557cf3e6af4ae38b100532`
-- Prompt SHA-256: `f9bf4ccc3d0c86ca715af1c880c16aa04a3e494f2b6001d3d604b6428e7bc8b2`
+- Identity schema: `2`
+- target_skill_sha256: `a26ada6a2ba843cfb4e657c89ce7c3b76b2095d2b006f263e49042916f04185f`
+- eval_definition_sha256: `9dfc3c0232e65b50d6964b6b208307eca95842562a8965fcb0999b7dc0293b57`
+- metadata_sha256: `4806c6c3fd6574e59fbeca624e1db80b0abef304792432263a972f95ebcfa4e8`
+- fixture_sha256: `0c6e97834bbed6c2319a5e523ec66e524f7cbbe181557cf3e6af4ae38b100532`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `8d2763ec3401350181ee644de1028a6695d69fa18b5430a0edd7593fdf2e890a`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `a26ada6a2ba843cfb4e657c89ce7c3b76b2095d2b006f263e49042916f04185f`
-- Skill overlay SHA-256: `13d5aeae4de0778abedf019c42c5ddcea7b044ef968920e82526dafcc120c7ea`
-- Judge schema SHA-256: `8d2763ec3401350181ee644de1028a6695d69fa18b5430a0edd7593fdf2e890a`
-- Eval definition SHA-256: `9dfc3c0232e65b50d6964b6b208307eca95842562a8965fcb0999b7dc0293b57`
-- Metadata SHA-256: `4806c6c3fd6574e59fbeca624e1db80b0abef304792432263a972f95ebcfa4e8`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/designer/test/ui-ux-design/workspace/eval-4-pm-spec-handoff/comparison.md
+++ b/agents/designer/test/ui-ux-design/workspace/eval-4-pm-spec-handoff/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `0791241d90c35458117ad7afc41087d198e776e1bb0d176e05c3732f6be148a6` from `agents/designer/test/ui-ux-design/workspace/eval-4-pm-spec-handoff`.
-- Fixture SHA-256: `0791241d90c35458117ad7afc41087d198e776e1bb0d176e05c3732f6be148a6`
-- Prompt SHA-256: `34a9d38fc5d93e5c1a925aa7889e94a7727bc719382f01830a2c7b69cc7a8020`
+- Identity schema: `2`
+- target_skill_sha256: `a26ada6a2ba843cfb4e657c89ce7c3b76b2095d2b006f263e49042916f04185f`
+- eval_definition_sha256: `f5e031cd559d08b9cd37fee2f571fc541cf110879ad665b05952cb915a09fe63`
+- metadata_sha256: `a2b7d997dbacd7584fcef225254185f8826f79c87e7c30c69a40f24691946c86`
+- fixture_sha256: `0791241d90c35458117ad7afc41087d198e776e1bb0d176e05c3732f6be148a6`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `2f242e255f292a4598cb48c2bfc21dd7b56a2d6cda47e6a68b75b5c3321a2e98`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `a26ada6a2ba843cfb4e657c89ce7c3b76b2095d2b006f263e49042916f04185f`
-- Skill overlay SHA-256: `13d5aeae4de0778abedf019c42c5ddcea7b044ef968920e82526dafcc120c7ea`
-- Judge schema SHA-256: `2f242e255f292a4598cb48c2bfc21dd7b56a2d6cda47e6a68b75b5c3321a2e98`
-- Eval definition SHA-256: `f5e031cd559d08b9cd37fee2f571fc541cf110879ad665b05952cb915a09fe63`
-- Metadata SHA-256: `a2b7d997dbacd7584fcef225254185f8826f79c87e7c30c69a40f24691946c86`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/designer/test/visual-design/evals/workspace/eval-003-professional/comparison.md
+++ b/agents/designer/test/visual-design/evals/workspace/eval-003-professional/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `567d74ee90d360991ab613f98d8049d53202d95a2bc7caeb2b7d46b23846a5f0` from `agents/designer/test/visual-design/evals/workspace/eval-003-professional`.
-- Fixture SHA-256: `567d74ee90d360991ab613f98d8049d53202d95a2bc7caeb2b7d46b23846a5f0`
-- Prompt SHA-256: `fe1184ee76579ac0041ea69b2abac6b0897add864da628d5ff0192673c2c0220`
+- Identity schema: `2`
+- target_skill_sha256: `7b149b6fe06b79fc3d427a1960513a2a422e6be13b6ef797018ec31a49be8d0b`
+- eval_definition_sha256: `730e4eb8de3e03b346a013a3d5577a175072336c34214d71e41ce4685c2c2ee1`
+- metadata_sha256: `0f7ee2304f9494f523bf0e9ffeed979b5af06eb7930b9cda8b5ec89883762703`
+- fixture_sha256: `567d74ee90d360991ab613f98d8049d53202d95a2bc7caeb2b7d46b23846a5f0`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `5ac69cf52c4833a0e74ebe39318957376e1be2b4d8142bcff9072bdd02569746`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `7b149b6fe06b79fc3d427a1960513a2a422e6be13b6ef797018ec31a49be8d0b`
-- Skill overlay SHA-256: `2554105b4ea2c87016aca333585e3d86ab3f1c1372919c4f609315605a45fa25`
-- Judge schema SHA-256: `5ac69cf52c4833a0e74ebe39318957376e1be2b4d8142bcff9072bdd02569746`
-- Eval definition SHA-256: `730e4eb8de3e03b346a013a3d5577a175072336c34214d71e41ce4685c2c2ee1`
-- Metadata SHA-256: `0f7ee2304f9494f523bf0e9ffeed979b5af06eb7930b9cda8b5ec89883762703`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/designer/test/visual-design/workspace/eval-1-minimalist/comparison.md
+++ b/agents/designer/test/visual-design/workspace/eval-1-minimalist/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `89d144dafb490a68dbf1ec05d2336c43c874c81e51496b945ac9140ca757080a` from `agents/designer/test/visual-design/workspace/eval-1-minimalist`.
-- Fixture SHA-256: `89d144dafb490a68dbf1ec05d2336c43c874c81e51496b945ac9140ca757080a`
-- Prompt SHA-256: `c3c36cd66b9231c6a2156abc32bf00fb490f5264858737980fadf81d3240530f`
+- Identity schema: `2`
+- target_skill_sha256: `7b149b6fe06b79fc3d427a1960513a2a422e6be13b6ef797018ec31a49be8d0b`
+- eval_definition_sha256: `2ec4f897729f0820b0a7830a10f3f0348db98fac1c3a94d29404427ccb404465`
+- metadata_sha256: `a8c3886c0203449f24edc77c5c3e77a82c91f7ce462169d6c62325194a234222`
+- fixture_sha256: `89d144dafb490a68dbf1ec05d2336c43c874c81e51496b945ac9140ca757080a`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `e8bf769ac89a10c9a014e6b2e125d2d95f024ce8d37a4e4481c16c75936c71a8`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `7b149b6fe06b79fc3d427a1960513a2a422e6be13b6ef797018ec31a49be8d0b`
-- Skill overlay SHA-256: `2554105b4ea2c87016aca333585e3d86ab3f1c1372919c4f609315605a45fa25`
-- Judge schema SHA-256: `e8bf769ac89a10c9a014e6b2e125d2d95f024ce8d37a4e4481c16c75936c71a8`
-- Eval definition SHA-256: `2ec4f897729f0820b0a7830a10f3f0348db98fac1c3a94d29404427ccb404465`
-- Metadata SHA-256: `a8c3886c0203449f24edc77c5c3e77a82c91f7ce462169d6c62325194a234222`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/designer/test/visual-design/workspace/eval-2-reference-design-system/comparison.md
+++ b/agents/designer/test/visual-design/workspace/eval-2-reference-design-system/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `42400da86be636a5c48d6ced7acfe1114f7f3fc84e29109517e26b5a0856067c` from `agents/designer/test/visual-design/workspace/eval-2-reference-design-system`.
-- Fixture SHA-256: `42400da86be636a5c48d6ced7acfe1114f7f3fc84e29109517e26b5a0856067c`
-- Prompt SHA-256: `092b10f39d07502fd69cfd2b4992b956cec050d77722de8312a6a9dc94160cd6`
+- Identity schema: `2`
+- target_skill_sha256: `7b149b6fe06b79fc3d427a1960513a2a422e6be13b6ef797018ec31a49be8d0b`
+- eval_definition_sha256: `1e9739265f0721cb69546820ef87da3e0b8045e92accd200c449d4a7c5bab7c5`
+- metadata_sha256: `dea024aad09482b4b51327a960ae6e8c89fbc9764107a299297b588df52b9aa7`
+- fixture_sha256: `42400da86be636a5c48d6ced7acfe1114f7f3fc84e29109517e26b5a0856067c`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `b207ccfef6c29a46ee4c39ebd7d39f4af35c494d6c841b0789899fe237e9584b`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `7b149b6fe06b79fc3d427a1960513a2a422e6be13b6ef797018ec31a49be8d0b`
-- Skill overlay SHA-256: `2554105b4ea2c87016aca333585e3d86ab3f1c1372919c4f609315605a45fa25`
-- Judge schema SHA-256: `b207ccfef6c29a46ee4c39ebd7d39f4af35c494d6c841b0789899fe237e9584b`
-- Eval definition SHA-256: `1e9739265f0721cb69546820ef87da3e0b8045e92accd200c449d4a7c5bab7c5`
-- Metadata SHA-256: `dea024aad09482b4b51327a960ae6e8c89fbc9764107a299297b588df52b9aa7`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/devops/test/cicd-bootstrap/evals/workspace/eval-001-github-actions-docker/comparison.md
+++ b/agents/devops/test/cicd-bootstrap/evals/workspace/eval-001-github-actions-docker/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `343bcb839e30c78715e11895db5ff7bd71039ec73fe31429c1bbda5b9e3e2a90` from `agents/devops/test/cicd-bootstrap/evals/workspace/eval-001-github-actions-docker`.
-- Fixture SHA-256: `343bcb839e30c78715e11895db5ff7bd71039ec73fe31429c1bbda5b9e3e2a90`
-- Prompt SHA-256: `218d78b7a8ea97a45d92074ef7fdba8d569a39aa87d9b7e2b17fd38ac1491e6e`
+- Identity schema: `2`
+- target_skill_sha256: `86f7228d11d9f7ad3ec145d83be1c28f8a4bb93afea61016f55ed2860069bc68`
+- eval_definition_sha256: `e302fa46977944ed026b10f7f1ded4b3717a6c85f19be1f78da9c42d4b0c0b8d`
+- metadata_sha256: `9e986f54be95fd6454e99ce66dc884d4d84134a4b07d49e0942d5d6169d042bf`
+- fixture_sha256: `343bcb839e30c78715e11895db5ff7bd71039ec73fe31429c1bbda5b9e3e2a90`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `416d97c852ae3d12b00631149dd08640442fd75a13414eab07000c384c3a2d5f`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `86f7228d11d9f7ad3ec145d83be1c28f8a4bb93afea61016f55ed2860069bc68`
-- Skill overlay SHA-256: `c8eba5ff7fa14d3a9d17d2f0e6e7ee710355737a3424af1c887580cc79ea33c4`
-- Judge schema SHA-256: `416d97c852ae3d12b00631149dd08640442fd75a13414eab07000c384c3a2d5f`
-- Eval definition SHA-256: `e302fa46977944ed026b10f7f1ded4b3717a6c85f19be1f78da9c42d4b0c0b8d`
-- Metadata SHA-256: `9e986f54be95fd6454e99ce66dc884d4d84134a4b07d49e0942d5d6169d042bf`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/devops/test/cicd-bootstrap/evals/workspace/eval-002-mapped-doc-cicd/comparison.md
+++ b/agents/devops/test/cicd-bootstrap/evals/workspace/eval-002-mapped-doc-cicd/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `b0f5ab103062d754c225176fd1995f4f428e9f29340584ac86077ed978dc1482` from `agents/devops/test/cicd-bootstrap/evals/workspace/eval-002-mapped-doc-cicd`.
-- Fixture SHA-256: `b0f5ab103062d754c225176fd1995f4f428e9f29340584ac86077ed978dc1482`
-- Prompt SHA-256: `08a3ffdcb2251091cdf30040590082a976faabcf76e7e71f7124b4bb2d5a5ba4`
+- Identity schema: `2`
+- target_skill_sha256: `86f7228d11d9f7ad3ec145d83be1c28f8a4bb93afea61016f55ed2860069bc68`
+- eval_definition_sha256: `68a87fb5d229c5c451c4b7081adb9e28c9c2e68f2832958c12f8d53464b0ae13`
+- metadata_sha256: `a6802835ad6096782cd89b2c4280b4422a56ff9be96ac885a939daae8583297c`
+- fixture_sha256: `b0f5ab103062d754c225176fd1995f4f428e9f29340584ac86077ed978dc1482`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `86f7228d11d9f7ad3ec145d83be1c28f8a4bb93afea61016f55ed2860069bc68`
-- Skill overlay SHA-256: `c8eba5ff7fa14d3a9d17d2f0e6e7ee710355737a3424af1c887580cc79ea33c4`
-- Judge schema SHA-256: `6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda`
-- Eval definition SHA-256: `68a87fb5d229c5c451c4b7081adb9e28c9c2e68f2832958c12f8d53464b0ae13`
-- Metadata SHA-256: `a6802835ad6096782cd89b2c4280b4422a56ff9be96ac885a939daae8583297c`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/devops/test/cicd-bootstrap/evals/workspace/eval-003-docs-image-release-rules/comparison.md
+++ b/agents/devops/test/cicd-bootstrap/evals/workspace/eval-003-docs-image-release-rules/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `3676f277a876b41e1703c92d57107677efc45689334ecbdddc74bf8f7e7cb8bf` from `agents/devops/test/cicd-bootstrap/evals/workspace/eval-003-docs-image-release-rules`.
-- Fixture SHA-256: `3676f277a876b41e1703c92d57107677efc45689334ecbdddc74bf8f7e7cb8bf`
-- Prompt SHA-256: `d3c1631bc39b4cdb5a62c7ac02b9b6359957e5c2debaf73a2659a08294722209`
+- Identity schema: `2`
+- target_skill_sha256: `86f7228d11d9f7ad3ec145d83be1c28f8a4bb93afea61016f55ed2860069bc68`
+- eval_definition_sha256: `90a9cf04ee14bffff8a2eaca0298de327ed551cee77903fd69a219a57495281e`
+- metadata_sha256: `3fa9951d25624dea3daa1a46647a39c6e45e551d897c4684f13850f3c7afbfd4`
+- fixture_sha256: `3676f277a876b41e1703c92d57107677efc45689334ecbdddc74bf8f7e7cb8bf`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `8eaf2480ee518c77bc5e1ae8a7f25c0acfc010e7317cc45d7143e8591e25551c`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `86f7228d11d9f7ad3ec145d83be1c28f8a4bb93afea61016f55ed2860069bc68`
-- Skill overlay SHA-256: `c8eba5ff7fa14d3a9d17d2f0e6e7ee710355737a3424af1c887580cc79ea33c4`
-- Judge schema SHA-256: `8eaf2480ee518c77bc5e1ae8a7f25c0acfc010e7317cc45d7143e8591e25551c`
-- Eval definition SHA-256: `90a9cf04ee14bffff8a2eaca0298de327ed551cee77903fd69a219a57495281e`
-- Metadata SHA-256: `3fa9951d25624dea3daa1a46647a39c6e45e551d897c4684f13850f3c7afbfd4`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)

--- a/agents/devops/test/deployment-planner/evals/workspace/eval-001-nextjs-web-app/comparison.md
+++ b/agents/devops/test/deployment-planner/evals/workspace/eval-001-nextjs-web-app/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `06f8a5807d1130b7a91a700b2074192e6dfed0933a071ce16642b27aa050360d` from `agents/devops/test/deployment-planner/evals/workspace/eval-001-nextjs-web-app`.
-- Fixture SHA-256: `06f8a5807d1130b7a91a700b2074192e6dfed0933a071ce16642b27aa050360d`
-- Prompt SHA-256: `cd186dfdcf8b04b4e66f71faf5fd0b7ea6c6616c86ae2015f0fd5d6d730418e8`
+- Identity schema: `2`
+- target_skill_sha256: `e850d2052b73e431758456627cb816e0d9a45db383146d1349cf24ca05b2aec1`
+- eval_definition_sha256: `4ab6f3577023497f11197efb5117e95119ab70a437c95770925330f5be6aa5f2`
+- metadata_sha256: `be29fd9ddbc554b7d8ca7f9912c9d54f61470e99abd7c2e138b60022c4086794`
+- fixture_sha256: `06f8a5807d1130b7a91a700b2074192e6dfed0933a071ce16642b27aa050360d`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `8fdd554bf7008e1addc7b92301444335139887034f2813ab539445a1df4b82d6`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `e850d2052b73e431758456627cb816e0d9a45db383146d1349cf24ca05b2aec1`
-- Skill overlay SHA-256: `69cf7483c4142716ecdbb6a031121f60813fdaad8bcb74124bd2f705524d6549`
-- Judge schema SHA-256: `8fdd554bf7008e1addc7b92301444335139887034f2813ab539445a1df4b82d6`
-- Eval definition SHA-256: `4ab6f3577023497f11197efb5117e95119ab70a437c95770925330f5be6aa5f2`
-- Metadata SHA-256: `be29fd9ddbc554b7d8ca7f9912c9d54f61470e99abd7c2e138b60022c4086794`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/devops/test/deployment-planner/evals/workspace/eval-002-python-api-only/comparison.md
+++ b/agents/devops/test/deployment-planner/evals/workspace/eval-002-python-api-only/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `259dab4dbfe64941c0c3fdd5c97b56c6b90abb97168eeb7461bd9a7bf8e30888` from `agents/devops/test/deployment-planner/evals/workspace/eval-002-python-api-only`.
-- Fixture SHA-256: `259dab4dbfe64941c0c3fdd5c97b56c6b90abb97168eeb7461bd9a7bf8e30888`
-- Prompt SHA-256: `000bcbda1f774e89fec492193e606a35b1ac2f41c0b29e0c9ac66b491aa38c8b`
+- Identity schema: `2`
+- target_skill_sha256: `e850d2052b73e431758456627cb816e0d9a45db383146d1349cf24ca05b2aec1`
+- eval_definition_sha256: `f6bee599168504aabc5841db04bc20810e822fd2af8545bc98e19f6298c38285`
+- metadata_sha256: `cd34fc596ce17b79112511df2244a7b68d45546111925715157c8598360bb097`
+- fixture_sha256: `259dab4dbfe64941c0c3fdd5c97b56c6b90abb97168eeb7461bd9a7bf8e30888`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `6d6cb805f86354c5ca7fe62a901b9a052b0e2f5bc53f163da17451ac99ca29a5`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `e850d2052b73e431758456627cb816e0d9a45db383146d1349cf24ca05b2aec1`
-- Skill overlay SHA-256: `69cf7483c4142716ecdbb6a031121f60813fdaad8bcb74124bd2f705524d6549`
-- Judge schema SHA-256: `6d6cb805f86354c5ca7fe62a901b9a052b0e2f5bc53f163da17451ac99ca29a5`
-- Eval definition SHA-256: `f6bee599168504aabc5841db04bc20810e822fd2af8545bc98e19f6298c38285`
-- Metadata SHA-256: `cd34fc596ce17b79112511df2244a7b68d45546111925715157c8598360bb097`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/devops/test/deployment-planner/evals/workspace/eval-003-mapped-doc-deployment/comparison.md
+++ b/agents/devops/test/deployment-planner/evals/workspace/eval-003-mapped-doc-deployment/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `beceb4834aab461ec20117458ef66d8ba65e677ecbef5e80a9e59909d2fe5471` from `agents/devops/test/deployment-planner/evals/workspace/eval-003-mapped-doc-deployment`.
-- Fixture SHA-256: `beceb4834aab461ec20117458ef66d8ba65e677ecbef5e80a9e59909d2fe5471`
-- Prompt SHA-256: `40b086c239ff14f46936633adeb5d9079306a48046e93c803af236ab43d646d6`
+- Identity schema: `2`
+- target_skill_sha256: `e850d2052b73e431758456627cb816e0d9a45db383146d1349cf24ca05b2aec1`
+- eval_definition_sha256: `3a6f0e2dac2acec4b2146c1f3b14a82dc89e2d78da9249fb55fda45906586c82`
+- metadata_sha256: `d4f866ac92cff8803e8f120ce38631fed1d054cce30a482192275834ed6880bf`
+- fixture_sha256: `beceb4834aab461ec20117458ef66d8ba65e677ecbef5e80a9e59909d2fe5471`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `3fd213f6de3f610cad1c014e643471913a0678af0ef96531f1f973bd669f4005`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `e850d2052b73e431758456627cb816e0d9a45db383146d1349cf24ca05b2aec1`
-- Skill overlay SHA-256: `69cf7483c4142716ecdbb6a031121f60813fdaad8bcb74124bd2f705524d6549`
-- Judge schema SHA-256: `3fd213f6de3f610cad1c014e643471913a0678af0ef96531f1f973bd669f4005`
-- Eval definition SHA-256: `3a6f0e2dac2acec4b2146c1f3b14a82dc89e2d78da9249fb55fda45906586c82`
-- Metadata SHA-256: `d4f866ac92cff8803e8f120ce38631fed1d054cce30a482192275834ed6880bf`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/devops/test/deployment-planner/evals/workspace/eval-004-docs-build-variant-matrix/comparison.md
+++ b/agents/devops/test/deployment-planner/evals/workspace/eval-004-docs-build-variant-matrix/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `1133bdf01ec9b2682fe921196914971ab2c40caac0f63afd22f66198e7edede5` from `agents/devops/test/deployment-planner/evals/workspace/eval-004-docs-build-variant-matrix`.
-- Fixture SHA-256: `1133bdf01ec9b2682fe921196914971ab2c40caac0f63afd22f66198e7edede5`
-- Prompt SHA-256: `449e8afe22d56be4ea49871dccbdfe925565441c9990c7332f547cf304565087`
+- Identity schema: `2`
+- target_skill_sha256: `e850d2052b73e431758456627cb816e0d9a45db383146d1349cf24ca05b2aec1`
+- eval_definition_sha256: `4c14837e1c149db8fdda5fa172eb35b4e3c167d223226adbc87832c6a7126d6f`
+- metadata_sha256: `ae56541ba154741dfb7ef84587ce065786aeb8ae82c4a282fa656aa8884b399e`
+- fixture_sha256: `1133bdf01ec9b2682fe921196914971ab2c40caac0f63afd22f66198e7edede5`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `cfb4e9daef57a9f8f8f71bd53e7b9c04b3f443f035ca06014209a131297ec22b`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `e850d2052b73e431758456627cb816e0d9a45db383146d1349cf24ca05b2aec1`
-- Skill overlay SHA-256: `69cf7483c4142716ecdbb6a031121f60813fdaad8bcb74124bd2f705524d6549`
-- Judge schema SHA-256: `cfb4e9daef57a9f8f8f71bd53e7b9c04b3f443f035ca06014209a131297ec22b`
-- Eval definition SHA-256: `4c14837e1c149db8fdda5fa172eb35b4e3c167d223226adbc87832c6a7126d6f`
-- Metadata SHA-256: `ae56541ba154741dfb7ef84587ce065786aeb8ae82c4a282fa656aa8884b399e`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)

--- a/agents/devops/test/devops-agent/evals/workspace/eval-002-route-docs-site-completeness-chain/comparison.md
+++ b/agents/devops/test/devops-agent/evals/workspace/eval-002-route-docs-site-completeness-chain/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `db76812ee462c1a8d89decf8e6fae581930c1406d7c6f72f3847172ed0bb02f3` from `agents/devops/test/devops-agent/evals/workspace/eval-002-route-docs-site-completeness-chain`.
-- Fixture SHA-256: `db76812ee462c1a8d89decf8e6fae581930c1406d7c6f72f3847172ed0bb02f3`
-- Prompt SHA-256: `520c4aa6ac767af388d73d9adeec0eb6b05a688f692c19decf65da48e498c67e`
+- Identity schema: `2`
+- target_skill_sha256: `d688e19912770823b0aab741fb33c331e4eee7536315cf3080fbad81ca1e904f`
+- eval_definition_sha256: `dc1b04424607a1675278b8e310c3f7b0da94f3cf1e857f037b9a6a8dbbf9482f`
+- metadata_sha256: `2718def12280e05b73752266e8d3b39d6929d0781f7ca1aa2088b55bd4e38e9c`
+- fixture_sha256: `db76812ee462c1a8d89decf8e6fae581930c1406d7c6f72f3847172ed0bb02f3`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `fdb2fd9254bbcae4d1c5e9dd4a0df1a9be1ee48991c72d5d1ea96147641ed710`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `f2aa9b2c49be68550ec45538c221425607f428ce`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `d688e19912770823b0aab741fb33c331e4eee7536315cf3080fbad81ca1e904f`
-- Skill overlay SHA-256: `8e5e69b694cb8463a67c6335bf1f6964d0634491a467ae420d461fc438e03f6f`
-- Judge schema SHA-256: `fdb2fd9254bbcae4d1c5e9dd4a0df1a9be1ee48991c72d5d1ea96147641ed710`
-- Eval definition SHA-256: `dc1b04424607a1675278b8e310c3f7b0da94f3cf1e857f037b9a6a8dbbf9482f`
-- Metadata SHA-256: `2718def12280e05b73752266e8d3b39d6929d0781f7ca1aa2088b55bd4e38e9c`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/devops/test/devops-agent/evals/workspace/eval-1-route-ci-readiness/comparison.md
+++ b/agents/devops/test/devops-agent/evals/workspace/eval-1-route-ci-readiness/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `01efe0f9d93680399a4e60a121c590987f01c7feeb295910c354e36c32f0a756` from `agents/devops/test/devops-agent/evals/workspace/eval-1-route-ci-readiness`.
-- Fixture SHA-256: `01efe0f9d93680399a4e60a121c590987f01c7feeb295910c354e36c32f0a756`
-- Prompt SHA-256: `0724714db74641157eee897f7a5f22bd3898815bc5861281390b10275748d63d`
+- Identity schema: `2`
+- target_skill_sha256: `d688e19912770823b0aab741fb33c331e4eee7536315cf3080fbad81ca1e904f`
+- eval_definition_sha256: `bf26d801d111c094ffb06e4f6cd89e1f8a4b7c9a1e7fc76f302a33c493a411f4`
+- metadata_sha256: `7dd2e52b200852fa05d4eb58b51c5b9cc7af5f7c62ced61947f3e3d4b9b7a2c0`
+- fixture_sha256: `01efe0f9d93680399a4e60a121c590987f01c7feeb295910c354e36c32f0a756`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `c7039dc2c9d829f51219a90df8027752cbbdaa32f7d8b6eb4b07c94a61b14320`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `d688e19912770823b0aab741fb33c331e4eee7536315cf3080fbad81ca1e904f`
-- Skill overlay SHA-256: `a9b9ac261ea1b814dd735003762f1150235fa2f98b001a6f7886461be4a86198`
-- Judge schema SHA-256: `c7039dc2c9d829f51219a90df8027752cbbdaa32f7d8b6eb4b07c94a61b14320`
-- Eval definition SHA-256: `bf26d801d111c094ffb06e4f6cd89e1f8a4b7c9a1e7fc76f302a33c493a411f4`
-- Metadata SHA-256: `7dd2e52b200852fa05d4eb58b51c5b9cc7af5f7c62ced61947f3e3d4b9b7a2c0`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/devops/test/env-config-auditor/evals/workspace/eval-003-mapped-doc-config-audit/comparison.md
+++ b/agents/devops/test/env-config-auditor/evals/workspace/eval-003-mapped-doc-config-audit/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `d8b594c02acd54c63c782827a944b663d600d50c48ab45d0916be040dcdd3bf5` from `agents/devops/test/env-config-auditor/evals/workspace/eval-003-mapped-doc-config-audit`.
-- Fixture SHA-256: `d8b594c02acd54c63c782827a944b663d600d50c48ab45d0916be040dcdd3bf5`
-- Prompt SHA-256: `b79f24622b9644bbd1fa788251bd901e2da05ea7b38df10e90eb31488aa20956`
+- Identity schema: `2`
+- target_skill_sha256: `11f5a69db2a4c2ab81d782a866d9a88090a8560b5e61462d8af4e66c4376601f`
+- eval_definition_sha256: `745b306831066bee2a7ff3a7b48abf881c1196cfdb1e28206ff9239f069e955c`
+- metadata_sha256: `c5eaf2656d7227ecd689bf4922af4f6c541bc3cb4d63375292c5b605d7e8380c`
+- fixture_sha256: `d8b594c02acd54c63c782827a944b663d600d50c48ab45d0916be040dcdd3bf5`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `11f5a69db2a4c2ab81d782a866d9a88090a8560b5e61462d8af4e66c4376601f`
-- Skill overlay SHA-256: `5e8f780f2a23903ad4823430be6e0bdde57143815b657cdec9f983559a04ccae`
-- Judge schema SHA-256: `6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda`
-- Eval definition SHA-256: `745b306831066bee2a7ff3a7b48abf881c1196cfdb1e28206ff9239f069e955c`
-- Metadata SHA-256: `c5eaf2656d7227ecd689bf4922af4f6c541bc3cb4d63375292c5b605d7e8380c`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/devops/test/env-config-auditor/evals/workspace/eval-004-docs-entry-access-audit/comparison.md
+++ b/agents/devops/test/env-config-auditor/evals/workspace/eval-004-docs-entry-access-audit/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `2af9780db4417e1c98550fa0f1ac701b6027949cee7ad798872f862a34631218` from `agents/devops/test/env-config-auditor/evals/workspace/eval-004-docs-entry-access-audit`.
-- Fixture SHA-256: `2af9780db4417e1c98550fa0f1ac701b6027949cee7ad798872f862a34631218`
-- Prompt SHA-256: `d0a4d782a855fc779a0b6ac4bae5494cbfe62706b00fe098bafa54a0f2523712`
+- Identity schema: `2`
+- target_skill_sha256: `11f5a69db2a4c2ab81d782a866d9a88090a8560b5e61462d8af4e66c4376601f`
+- eval_definition_sha256: `7e8fed3827f899b24fa32a7e47350d1b61d93c36648369ee6fefd2624963c060`
+- metadata_sha256: `3f77718e244c5e457dcf111e54d39609c8dbea3f2bea11e11380c41c91504669`
+- fixture_sha256: `2af9780db4417e1c98550fa0f1ac701b6027949cee7ad798872f862a34631218`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `10734badb795d9dd2c7f522212860a120a71a582b6fdcf439619f31f19b4904f`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `11f5a69db2a4c2ab81d782a866d9a88090a8560b5e61462d8af4e66c4376601f`
-- Skill overlay SHA-256: `5e8f780f2a23903ad4823430be6e0bdde57143815b657cdec9f983559a04ccae`
-- Judge schema SHA-256: `10734badb795d9dd2c7f522212860a120a71a582b6fdcf439619f31f19b4904f`
-- Eval definition SHA-256: `7e8fed3827f899b24fa32a7e47350d1b61d93c36648369ee6fefd2624963c060`
-- Metadata SHA-256: `3f77718e244c5e457dcf111e54d39609c8dbea3f2bea11e11380c41c91504669`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/devops/test/env-config-auditor/workspace/eval-002-feature-path-audit/comparison.md
+++ b/agents/devops/test/env-config-auditor/workspace/eval-002-feature-path-audit/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `a481b5374544e745048b6d91a89eb4240f2b8d26afa6409ed21d0c822a29f8c9` from `agents/devops/test/env-config-auditor/workspace/eval-002-feature-path-audit`.
-- Fixture SHA-256: `a481b5374544e745048b6d91a89eb4240f2b8d26afa6409ed21d0c822a29f8c9`
-- Prompt SHA-256: `45dd97708d4498ba2c5e31fb882b1692d7db80756c144b5c54d249bddbdf8a4b`
+- Identity schema: `2`
+- target_skill_sha256: `11f5a69db2a4c2ab81d782a866d9a88090a8560b5e61462d8af4e66c4376601f`
+- eval_definition_sha256: `6efcde24d7900ac81923c70a8eb454a7b5687569fc19e166e7a2702223bf20b8`
+- metadata_sha256: `ed9d0f761d7a235166a80b0e2724cd90628f15321561b77d0b2d2233a2c87014`
+- fixture_sha256: `a481b5374544e745048b6d91a89eb4240f2b8d26afa6409ed21d0c822a29f8c9`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `542a3960b92dfab31d619dba36f1b4cd7435eaeb67ca74c65c1e8dc7cd584d0a`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `11f5a69db2a4c2ab81d782a866d9a88090a8560b5e61462d8af4e66c4376601f`
-- Skill overlay SHA-256: `5e8f780f2a23903ad4823430be6e0bdde57143815b657cdec9f983559a04ccae`
-- Judge schema SHA-256: `542a3960b92dfab31d619dba36f1b4cd7435eaeb67ca74c65c1e8dc7cd584d0a`
-- Eval definition SHA-256: `6efcde24d7900ac81923c70a8eb454a7b5687569fc19e166e7a2702223bf20b8`
-- Metadata SHA-256: `ed9d0f761d7a235166a80b0e2724cd90628f15321561b77d0b2d2233a2c87014`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)

--- a/agents/devops/test/env-config-auditor/workspace/iteration-1/eval-1-missing-variables/comparison.md
+++ b/agents/devops/test/env-config-auditor/workspace/iteration-1/eval-1-missing-variables/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `4e6c22cd2abded0cbcf31007050064d16e8cb14c8ccdda445c9587853833ba57` from `agents/devops/test/env-config-auditor/workspace/iteration-1/eval-1-missing-variables`.
-- Fixture SHA-256: `4e6c22cd2abded0cbcf31007050064d16e8cb14c8ccdda445c9587853833ba57`
-- Prompt SHA-256: `75e60dc10eb3fef811146cbd4dcc0df487be3bd537e40cef0747bad2cca106cf`
+- Identity schema: `2`
+- target_skill_sha256: `11f5a69db2a4c2ab81d782a866d9a88090a8560b5e61462d8af4e66c4376601f`
+- eval_definition_sha256: `5217a2bb49f0b8e0ba081e4029f81b07efd6b07af9fb34ce9773ecbde5d00a5b`
+- metadata_sha256: `f2d1d6d11daf93046843d6cf276fdc2c30cd77fd3602aa38ebdb9fcc3d6c1a85`
+- fixture_sha256: `4e6c22cd2abded0cbcf31007050064d16e8cb14c8ccdda445c9587853833ba57`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `7c0e897fa2e11e667f833a3bbf2e28e35b1c65790975d953ea93444f623ad66b`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `11f5a69db2a4c2ab81d782a866d9a88090a8560b5e61462d8af4e66c4376601f`
-- Skill overlay SHA-256: `5e8f780f2a23903ad4823430be6e0bdde57143815b657cdec9f983559a04ccae`
-- Judge schema SHA-256: `7c0e897fa2e11e667f833a3bbf2e28e35b1c65790975d953ea93444f623ad66b`
-- Eval definition SHA-256: `5217a2bb49f0b8e0ba081e4029f81b07efd6b07af9fb34ce9773ecbde5d00a5b`
-- Metadata SHA-256: `f2d1d6d11daf93046843d6cf276fdc2c30cd77fd3602aa38ebdb9fcc3d6c1a85`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/devops/test/incident-playbook-writer/evals/workspace/eval-001-docker-rollback/comparison.md
+++ b/agents/devops/test/incident-playbook-writer/evals/workspace/eval-001-docker-rollback/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `f3b605dee7b400a16cee380181367beb6aef0898c3081a8e6f89abd9e2c19e1a` from `agents/devops/test/incident-playbook-writer/evals/workspace/eval-001-docker-rollback`.
-- Fixture SHA-256: `f3b605dee7b400a16cee380181367beb6aef0898c3081a8e6f89abd9e2c19e1a`
-- Prompt SHA-256: `f9cbfa543cb8f8fa6c3d3f1e68b0eaa1e627427917cfa9b9970e909922356673`
+- Identity schema: `2`
+- target_skill_sha256: `500941dffb48347901d3283054321002e2a4be37cb509882170d999b6f27485f`
+- eval_definition_sha256: `ef78ea6924e16ad4c29c668948468977eb007b3ff9fb4e26733caf7d332c338d`
+- metadata_sha256: `aaf6d95692337cdac99edc2200f96e32a7dbdc444f3865d1a29464638703fbd4`
+- fixture_sha256: `f3b605dee7b400a16cee380181367beb6aef0898c3081a8e6f89abd9e2c19e1a`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `82478d5bfcdfccbe67817c9bfae394096b57b2c317a4413eadf1808b946de6d0`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `500941dffb48347901d3283054321002e2a4be37cb509882170d999b6f27485f`
-- Skill overlay SHA-256: `0151bb29c8ab6b6dd085b5d436ef141250c803b960f5e3053f171f45fe67f731`
-- Judge schema SHA-256: `82478d5bfcdfccbe67817c9bfae394096b57b2c317a4413eadf1808b946de6d0`
-- Eval definition SHA-256: `ef78ea6924e16ad4c29c668948468977eb007b3ff9fb4e26733caf7d332c338d`
-- Metadata SHA-256: `aaf6d95692337cdac99edc2200f96e32a7dbdc444f3865d1a29464638703fbd4`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/devops/test/incident-playbook-writer/evals/workspace/eval-002-mapped-doc-incident-playbook/comparison.md
+++ b/agents/devops/test/incident-playbook-writer/evals/workspace/eval-002-mapped-doc-incident-playbook/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `cd9e0e84ed5447d0b5fbaab481b132d7d6de821290e56efdee5b00d1661c9bf7` from `agents/devops/test/incident-playbook-writer/evals/workspace/eval-002-mapped-doc-incident-playbook`.
-- Fixture SHA-256: `cd9e0e84ed5447d0b5fbaab481b132d7d6de821290e56efdee5b00d1661c9bf7`
-- Prompt SHA-256: `27a471d4180c030327b87d22f79174352fdeffbbaace399da8cf913275d6b17e`
+- Identity schema: `2`
+- target_skill_sha256: `500941dffb48347901d3283054321002e2a4be37cb509882170d999b6f27485f`
+- eval_definition_sha256: `56f66c660609712980bbe29e190d00dff6d36c67cb844c6b5e1aa3d336dcd314`
+- metadata_sha256: `d30677e1d058f7ced7ac6b80a07136e834c175a519dc8964e75c167556348374`
+- fixture_sha256: `cd9e0e84ed5447d0b5fbaab481b132d7d6de821290e56efdee5b00d1661c9bf7`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `500941dffb48347901d3283054321002e2a4be37cb509882170d999b6f27485f`
-- Skill overlay SHA-256: `0151bb29c8ab6b6dd085b5d436ef141250c803b960f5e3053f171f45fe67f731`
-- Judge schema SHA-256: `6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda`
-- Eval definition SHA-256: `56f66c660609712980bbe29e190d00dff6d36c67cb844c6b5e1aa3d336dcd314`
-- Metadata SHA-256: `d30677e1d058f7ced7ac6b80a07136e834c175a519dc8964e75c167556348374`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/docs/test/docs-agent/evals/workspace/eval-001-route-formal-docs-sync/comparison.md
+++ b/agents/docs/test/docs-agent/evals/workspace/eval-001-route-formal-docs-sync/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `5bfe584ec04ca9f6271a87eb0a6a94432a493cce40c865cd7e77c63d4d5a5991` from `agents/docs/test/docs-agent/evals/workspace/eval-001-route-formal-docs-sync`.
-- Fixture SHA-256: `5bfe584ec04ca9f6271a87eb0a6a94432a493cce40c865cd7e77c63d4d5a5991`
-- Prompt SHA-256: `898aa52a50fa14b6ed2119a9c317cdc1f3e3e5286bf4d35a0cdd450c4352f602`
+- Identity schema: `2`
+- target_skill_sha256: `cf92649952a97be677cf5e900a4d9c793a6c0724813cf1fa3154f57e7d2c08f3`
+- eval_definition_sha256: `4f62b001057b225d1029a6284046afacf46248ad92aa43b0c065e0a0456b7450`
+- metadata_sha256: `320948f19ccb8c159c24fdc827ddc592aac02ee3f64236dd9e4896bae8e4979e`
+- fixture_sha256: `5bfe584ec04ca9f6271a87eb0a6a94432a493cce40c865cd7e77c63d4d5a5991`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `d9120b553be3673816559c0b102ba0210980dbae3daaf9eeba42b66ee4308ec2`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `f2aa9b2c49be68550ec45538c221425607f428ce`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `cf92649952a97be677cf5e900a4d9c793a6c0724813cf1fa3154f57e7d2c08f3`
-- Skill overlay SHA-256: `9667198915198da0404e03a7d4c962d38742b19c5de4de5f0cf1473f02db2bf1`
-- Judge schema SHA-256: `d9120b553be3673816559c0b102ba0210980dbae3daaf9eeba42b66ee4308ec2`
-- Eval definition SHA-256: `4f62b001057b225d1029a6284046afacf46248ad92aa43b0c065e0a0456b7450`
-- Metadata SHA-256: `320948f19ccb8c159c24fdc827ddc592aac02ee3f64236dd9e4896bae8e4979e`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/docs/test/docs-agent/evals/workspace/eval-002-missing-entry-basis/comparison.md
+++ b/agents/docs/test/docs-agent/evals/workspace/eval-002-missing-entry-basis/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/docs/test/docs-agent/evals/workspace/eval-002-missing-entry-basis`.
-- Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
-- Prompt SHA-256: `c8a665c7632c31fce83103a67e411115fa7f6c456ea2edd0094ff12d3cf4e103`
+- Identity schema: `2`
+- target_skill_sha256: `cf92649952a97be677cf5e900a4d9c793a6c0724813cf1fa3154f57e7d2c08f3`
+- eval_definition_sha256: `46e0e02295d606a359a2403ac234af592712f357041b544bb13a82efa1816296`
+- metadata_sha256: `9e2c43ddcdebfd4398d2a8f32a222c29dd71f706e06b85ffb24ea4623239c500`
+- fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `da898e3ecfd0169570b22be7c73cd730ef2fd22e3bf1c5b559383dc76454ff0d`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `cf92649952a97be677cf5e900a4d9c793a6c0724813cf1fa3154f57e7d2c08f3`
-- Skill overlay SHA-256: `444eb7d0916f27243a310cc7b8f382fb07237123ea8cdfe6523e034a4b226faa`
-- Judge schema SHA-256: `da898e3ecfd0169570b22be7c73cd730ef2fd22e3bf1c5b559383dc76454ff0d`
-- Eval definition SHA-256: `46e0e02295d606a359a2403ac234af592712f357041b544bb13a82efa1816296`
-- Metadata SHA-256: `9e2c43ddcdebfd4398d2a8f32a222c29dd71f706e06b85ffb24ea4623239c500`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/docs/test/docs-agent/evals/workspace/eval-003-route-release-audit/comparison.md
+++ b/agents/docs/test/docs-agent/evals/workspace/eval-003-route-release-audit/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `aea5c9e95cc3674c80708ee78ba0276fef121e6d5652789edf0421371d054bf6` from `agents/docs/test/docs-agent/evals/workspace/eval-003-route-release-audit`.
-- Fixture SHA-256: `aea5c9e95cc3674c80708ee78ba0276fef121e6d5652789edf0421371d054bf6`
-- Prompt SHA-256: `099569afeec045caa3e4e020611c72b9def7b5897f52222810916bd2477fd230`
+- Identity schema: `2`
+- target_skill_sha256: `cf92649952a97be677cf5e900a4d9c793a6c0724813cf1fa3154f57e7d2c08f3`
+- eval_definition_sha256: `76669427412e6a3d2662bf813faa0ce4c31fa19c75739559cabe530efd5682a6`
+- metadata_sha256: `d582bafa2b7d4e637ef2b4b71f14f435256d70c30e92f7097a43cd40dc9da750`
+- fixture_sha256: `aea5c9e95cc3674c80708ee78ba0276fef121e6d5652789edf0421371d054bf6`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `f4f786bd56d6a5cbcee24193816a462566a8caafb4c223ef38759bdf64ee0486`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `fecf485e8e3dcaf191b2b221d9cccbddfdea0b72`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `cf92649952a97be677cf5e900a4d9c793a6c0724813cf1fa3154f57e7d2c08f3`
-- Skill overlay SHA-256: `85c4ae0a1d58505c4a23c34e6f9116aed81a09b4b6270e3ce148424084f6c7e0`
-- Judge schema SHA-256: `f4f786bd56d6a5cbcee24193816a462566a8caafb4c223ef38759bdf64ee0486`
-- Eval definition SHA-256: `76669427412e6a3d2662bf813faa0ce4c31fa19c75739559cabe530efd5682a6`
-- Metadata SHA-256: `d582bafa2b7d4e637ef2b4b71f14f435256d70c30e92f7097a43cd40dc9da750`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **FAIL**
 - Coverage result: **FULL**
 Overall result: FAIL

--- a/agents/docs/test/docs-agent/evals/workspace/eval-004-route-release-notes/comparison.md
+++ b/agents/docs/test/docs-agent/evals/workspace/eval-004-route-release-notes/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `23d5701fab562491dfec3455fd6eabce7f6a6cba18940861023208d40f53fc3e` from `agents/docs/test/docs-agent/evals/workspace/eval-004-route-release-notes`.
-- Fixture SHA-256: `23d5701fab562491dfec3455fd6eabce7f6a6cba18940861023208d40f53fc3e`
-- Prompt SHA-256: `ab720b723fbaf54cc8b204eab97c1f0a7167519c350afdf3b475cf0b324862c8`
+- Identity schema: `2`
+- target_skill_sha256: `cf92649952a97be677cf5e900a4d9c793a6c0724813cf1fa3154f57e7d2c08f3`
+- eval_definition_sha256: `6d935c2fabb41ac4d322f49d33294bd64934555c17ee2ff70a64426da58d1b41`
+- metadata_sha256: `5831b803b3b347d7fd4611f1c19958d707ffe3e9ced4a78ed755e71f76a2c9b8`
+- fixture_sha256: `23d5701fab562491dfec3455fd6eabce7f6a6cba18940861023208d40f53fc3e`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `73f4addc59ec16b0f91c6a70a2a767ce7f6b4ad72612ca19a2131095a0722114`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `cf92649952a97be677cf5e900a4d9c793a6c0724813cf1fa3154f57e7d2c08f3`
-- Skill overlay SHA-256: `c7d3b6793c943fb4d4971cf0d6f11988326a2dff978353bf3c4327d4e24c17b7`
-- Judge schema SHA-256: `73f4addc59ec16b0f91c6a70a2a767ce7f6b4ad72612ca19a2131095a0722114`
-- Eval definition SHA-256: `6d935c2fabb41ac4d322f49d33294bd64934555c17ee2ff70a64426da58d1b41`
-- Metadata SHA-256: `5831b803b3b347d7fd4611f1c19958d707ffe3e9ced4a78ed755e71f76a2c9b8`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **FAIL**
 - Coverage result: **FULL**
 Overall result: FAIL

--- a/agents/docs/test/docs-agent/evals/workspace/eval-005-integration-release-chain/comparison.md
+++ b/agents/docs/test/docs-agent/evals/workspace/eval-005-integration-release-chain/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `69659db940208abe97ba4ab195a49c736d9a7ba7e1e880c287d3bf12132c10a3` from `agents/docs/test/docs-agent/evals/workspace/eval-005-integration-release-chain`.
-- Fixture SHA-256: `69659db940208abe97ba4ab195a49c736d9a7ba7e1e880c287d3bf12132c10a3`
-- Prompt SHA-256: `62a386a246bcb0c7c5b2df7096cfd60c5023a6b28473d50af8f99649d1d3480e`
+- Identity schema: `2`
+- target_skill_sha256: `cf92649952a97be677cf5e900a4d9c793a6c0724813cf1fa3154f57e7d2c08f3`
+- eval_definition_sha256: `05d8b9eb5ccf6bbc077dad850c79899562c5b4ed9bbb4187abffd82f21410ea3`
+- metadata_sha256: `af301306a3e584e9c32987cd73e02ac298dcd98f38208af58ca0764e8b5a4154`
+- fixture_sha256: `69659db940208abe97ba4ab195a49c736d9a7ba7e1e880c287d3bf12132c10a3`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `1f2ea17b811fce39b8e906ef0e0a70b6a6223a188a2f4a05f2f0a88c54c6aceb`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `f2aa9b2c49be68550ec45538c221425607f428ce`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `cf92649952a97be677cf5e900a4d9c793a6c0724813cf1fa3154f57e7d2c08f3`
-- Skill overlay SHA-256: `169fa6feaee2a3439ef1697f8695db0c122dae0703b31186cfbc7b44c0685be7`
-- Judge schema SHA-256: `1f2ea17b811fce39b8e906ef0e0a70b6a6223a188a2f4a05f2f0a88c54c6aceb`
-- Eval definition SHA-256: `05d8b9eb5ccf6bbc077dad850c79899562c5b4ed9bbb4187abffd82f21410ea3`
-- Metadata SHA-256: `af301306a3e584e9c32987cd73e02ac298dcd98f38208af58ca0764e8b5a4154`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **FAIL**
 - Coverage result: **FULL**
 Overall result: FAIL

--- a/agents/docs/test/docs-agent/evals/workspace/eval-006-preserve-independent-hosting/comparison.md
+++ b/agents/docs/test/docs-agent/evals/workspace/eval-006-preserve-independent-hosting/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `f6c421284ed0143d28fff161f0f4c1cd48b067505beae1d38677d871a066543f` from `agents/docs/test/docs-agent/evals/workspace/eval-006-preserve-independent-hosting`.
-- Fixture SHA-256: `f6c421284ed0143d28fff161f0f4c1cd48b067505beae1d38677d871a066543f`
-- Prompt SHA-256: `75b11cec554fb9cabf92f38559abd7d5bd8c24a6e4b7927952fa49a44fb00e8c`
+- Identity schema: `2`
+- target_skill_sha256: `cf92649952a97be677cf5e900a4d9c793a6c0724813cf1fa3154f57e7d2c08f3`
+- eval_definition_sha256: `8a4360282a35d2ba7a52bbb24d703648e9f263e7fbfc9516063ba62f62b92b92`
+- metadata_sha256: `62050136e2c1de0d65367ed4b1b1b706bb2211c3759fb54a832b8fd66233328b`
+- fixture_sha256: `f6c421284ed0143d28fff161f0f4c1cd48b067505beae1d38677d871a066543f`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `787b3941ec90b819758a9894561fa37e2c0eff7eedddb4c4a4d863809f28587f`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `f2aa9b2c49be68550ec45538c221425607f428ce`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `cf92649952a97be677cf5e900a4d9c793a6c0724813cf1fa3154f57e7d2c08f3`
-- Skill overlay SHA-256: `9667198915198da0404e03a7d4c962d38742b19c5de4de5f0cf1473f02db2bf1`
-- Judge schema SHA-256: `787b3941ec90b819758a9894561fa37e2c0eff7eedddb4c4a4d863809f28587f`
-- Eval definition SHA-256: `8a4360282a35d2ba7a52bbb24d703648e9f263e7fbfc9516063ba62f62b92b92`
-- Metadata SHA-256: `62050136e2c1de0d65367ed4b1b1b706bb2211c3759fb54a832b8fd66233328b`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **FAIL**
 - Coverage result: **FULL**
 Overall result: FAIL

--- a/agents/docs/test/docs-agent/evals/workspace/eval-007-route-manual-gen/comparison.md
+++ b/agents/docs/test/docs-agent/evals/workspace/eval-007-route-manual-gen/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `7e690828debd990987ec359671232498f20061c2fa6e2bbd324f99b92a7c2fc8` from `agents/docs/test/docs-agent/evals/workspace/eval-007-route-manual-gen`.
-- Fixture SHA-256: `7e690828debd990987ec359671232498f20061c2fa6e2bbd324f99b92a7c2fc8`
-- Prompt SHA-256: `a3cc737cbb46c53cc07ec65089d26bb1859146138c26d847279db190c633dcfa`
+- Identity schema: `2`
+- target_skill_sha256: `cf92649952a97be677cf5e900a4d9c793a6c0724813cf1fa3154f57e7d2c08f3`
+- eval_definition_sha256: `11398fbb2de74bd454f6e9c88338b5fcf6dffb0fd21436f1f6c99eaff5b1117d`
+- metadata_sha256: `31c2720a1114e612336c51527d7aae20dddb1f4e46b566ffffe4788d27952b8e`
+- fixture_sha256: `7e690828debd990987ec359671232498f20061c2fa6e2bbd324f99b92a7c2fc8`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `dfbcad96e39d7a0ba2503c7d345d86b54a6c9e1188ff1c09f99476b24380e820`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `cf92649952a97be677cf5e900a4d9c793a6c0724813cf1fa3154f57e7d2c08f3`
-- Skill overlay SHA-256: `6313e0e9db35ff19a83ce603b2d6fd37c38949f33c4534ab8f41ff96a5baa978`
-- Judge schema SHA-256: `dfbcad96e39d7a0ba2503c7d345d86b54a6c9e1188ff1c09f99476b24380e820`
-- Eval definition SHA-256: `11398fbb2de74bd454f6e9c88338b5fcf6dffb0fd21436f1f6c99eaff5b1117d`
-- Metadata SHA-256: `31c2720a1114e612336c51527d7aae20dddb1f4e46b566ffffe4788d27952b8e`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/docs/test/docs-audit/evals/workspace/eval-001-audit-mismatch/comparison.md
+++ b/agents/docs/test/docs-audit/evals/workspace/eval-001-audit-mismatch/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `dc67ea3252d72d2cb1006bd586833469bce9e6071957244105d8c4e3b86358a2` from `agents/docs/test/docs-audit/evals/workspace/eval-001-audit-mismatch`.
-- Fixture SHA-256: `dc67ea3252d72d2cb1006bd586833469bce9e6071957244105d8c4e3b86358a2`
-- Prompt SHA-256: `8d4dbdcc2ce0268c7dd2fa59f4c946f0acad002c9675a3357ceee8b115ffded1`
+- Identity schema: `2`
+- target_skill_sha256: `5b11b38c1c44c386fe19122dfb1ce5918b2bfbc4830ad32aa994d8a7e39f35e7`
+- eval_definition_sha256: `fee749f35b3bf7110eb1c6f38c918db3407b1a46ffa3ff2613c15b835398219e`
+- metadata_sha256: `23ce240f3f391bd560df8f9bbcf6e5d2ec76b8a3ffb73e38f416b3cdb2997a3a`
+- fixture_sha256: `dc67ea3252d72d2cb1006bd586833469bce9e6071957244105d8c4e3b86358a2`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `218cecf9b4e5893cf80d7edfea7d7877463de8efad846bf62ba5cba015ad2ed5`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `fecf485e8e3dcaf191b2b221d9cccbddfdea0b72`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `5b11b38c1c44c386fe19122dfb1ce5918b2bfbc4830ad32aa994d8a7e39f35e7`
-- Skill overlay SHA-256: `85c4ae0a1d58505c4a23c34e6f9116aed81a09b4b6270e3ce148424084f6c7e0`
-- Judge schema SHA-256: `218cecf9b4e5893cf80d7edfea7d7877463de8efad846bf62ba5cba015ad2ed5`
-- Eval definition SHA-256: `fee749f35b3bf7110eb1c6f38c918db3407b1a46ffa3ff2613c15b835398219e`
-- Metadata SHA-256: `23ce240f3f391bd560df8f9bbcf6e5d2ec76b8a3ffb73e38f416b3cdb2997a3a`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/docs/test/docs-audit/evals/workspace/eval-002-audit-stale-doc/comparison.md
+++ b/agents/docs/test/docs-audit/evals/workspace/eval-002-audit-stale-doc/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `7c0329b08b7d983c3fb25be26c421ff6963478e62486e2e0e75d22d246186583` from `agents/docs/test/docs-audit/evals/workspace/eval-002-audit-stale-doc`.
-- Fixture SHA-256: `7c0329b08b7d983c3fb25be26c421ff6963478e62486e2e0e75d22d246186583`
-- Prompt SHA-256: `a0986a693a041b20341e8fc74006f156b719dab648f0efc1ee18f7a27b8849f4`
+- Identity schema: `2`
+- target_skill_sha256: `5b11b38c1c44c386fe19122dfb1ce5918b2bfbc4830ad32aa994d8a7e39f35e7`
+- eval_definition_sha256: `65171d2c00ad7205a3b92eb523639da0ae1b9b851f9b225fb39f151ac8a09d1b`
+- metadata_sha256: `393d49433e1e9b818095a60378e27c82e27a5159f0878e57881a2872b5feee91`
+- fixture_sha256: `7c0329b08b7d983c3fb25be26c421ff6963478e62486e2e0e75d22d246186583`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `6c436d29e1c4d967534d387d71455397c2a958eb0e9fdd8f24d404e3a4bfc7c7`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `fecf485e8e3dcaf191b2b221d9cccbddfdea0b72`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `5b11b38c1c44c386fe19122dfb1ce5918b2bfbc4830ad32aa994d8a7e39f35e7`
-- Skill overlay SHA-256: `85c4ae0a1d58505c4a23c34e6f9116aed81a09b4b6270e3ce148424084f6c7e0`
-- Judge schema SHA-256: `6c436d29e1c4d967534d387d71455397c2a958eb0e9fdd8f24d404e3a4bfc7c7`
-- Eval definition SHA-256: `65171d2c00ad7205a3b92eb523639da0ae1b9b851f9b225fb39f151ac8a09d1b`
-- Metadata SHA-256: `393d49433e1e9b818095a60378e27c82e27a5159f0878e57881a2872b5feee91`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)

--- a/agents/docs/test/docs-audit/evals/workspace/eval-003-audit-pure-refactor/comparison.md
+++ b/agents/docs/test/docs-audit/evals/workspace/eval-003-audit-pure-refactor/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `a0071569c74867aaacfda16310f9f4a06e50a375aa0e6b62ee25e801db096677` from `agents/docs/test/docs-audit/evals/workspace/eval-003-audit-pure-refactor`.
-- Fixture SHA-256: `a0071569c74867aaacfda16310f9f4a06e50a375aa0e6b62ee25e801db096677`
-- Prompt SHA-256: `20617e4b8714b5129b537177e8c463822eec4083d7fdd0d6520c27013f94489f`
+- Identity schema: `2`
+- target_skill_sha256: `5b11b38c1c44c386fe19122dfb1ce5918b2bfbc4830ad32aa994d8a7e39f35e7`
+- eval_definition_sha256: `a7212e3282f2eaaa660e0675fb965d5050f366a07c153f3821d78fdab8976de5`
+- metadata_sha256: `1e20c97bb5ffc477023f6bbbd217e71d747297cb0b8f52652660b6b2d10adc7a`
+- fixture_sha256: `a0071569c74867aaacfda16310f9f4a06e50a375aa0e6b62ee25e801db096677`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `3e58dae2a34edb25f9589f7bddb4e3282cd1f66e3b0c3f35187db4ed16fd5f23`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `fecf485e8e3dcaf191b2b221d9cccbddfdea0b72`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `5b11b38c1c44c386fe19122dfb1ce5918b2bfbc4830ad32aa994d8a7e39f35e7`
-- Skill overlay SHA-256: `85c4ae0a1d58505c4a23c34e6f9116aed81a09b4b6270e3ce148424084f6c7e0`
-- Judge schema SHA-256: `3e58dae2a34edb25f9589f7bddb4e3282cd1f66e3b0c3f35187db4ed16fd5f23`
-- Eval definition SHA-256: `a7212e3282f2eaaa660e0675fb965d5050f366a07c153f3821d78fdab8976de5`
-- Metadata SHA-256: `1e20c97bb5ffc477023f6bbbd217e71d747297cb0b8f52652660b6b2d10adc7a`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)

--- a/agents/docs/test/docs-audit/evals/workspace/eval-004-audit-all-verified/comparison.md
+++ b/agents/docs/test/docs-audit/evals/workspace/eval-004-audit-all-verified/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `085a9df9c5171410b3af490aa0eb671dd955de6207e401089976f50095ed2897` from `agents/docs/test/docs-audit/evals/workspace/eval-004-audit-all-verified`.
-- Fixture SHA-256: `085a9df9c5171410b3af490aa0eb671dd955de6207e401089976f50095ed2897`
-- Prompt SHA-256: `f182723403634fcd32c050786ed55f612a9685f404b0e23235cff29b52f7174c`
+- Identity schema: `2`
+- target_skill_sha256: `5b11b38c1c44c386fe19122dfb1ce5918b2bfbc4830ad32aa994d8a7e39f35e7`
+- eval_definition_sha256: `9d29cd503dc3f38e1235bc8d674c667f9fc3bef38d94569b7888bb0dfed80506`
+- metadata_sha256: `4c1ab6c77122f43adf1cbc9d6f05aea7b2b047fe1e69ba225e32d03f006dc954`
+- fixture_sha256: `085a9df9c5171410b3af490aa0eb671dd955de6207e401089976f50095ed2897`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `a043187f1d82deb6ceb1f6f2a8dbb12db6dd01c71ced16d224de3ae50ca31c3b`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `fecf485e8e3dcaf191b2b221d9cccbddfdea0b72`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `5b11b38c1c44c386fe19122dfb1ce5918b2bfbc4830ad32aa994d8a7e39f35e7`
-- Skill overlay SHA-256: `85c4ae0a1d58505c4a23c34e6f9116aed81a09b4b6270e3ce148424084f6c7e0`
-- Judge schema SHA-256: `a043187f1d82deb6ceb1f6f2a8dbb12db6dd01c71ced16d224de3ae50ca31c3b`
-- Eval definition SHA-256: `9d29cd503dc3f38e1235bc8d674c667f9fc3bef38d94569b7888bb0dfed80506`
-- Metadata SHA-256: `4c1ab6c77122f43adf1cbc9d6f05aea7b2b047fe1e69ba225e32d03f006dc954`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/docs/test/docs-audit/evals/workspace/eval-005-audit-doc-only-error/comparison.md
+++ b/agents/docs/test/docs-audit/evals/workspace/eval-005-audit-doc-only-error/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `126b82b218c4429d9a8e50c428008903893e0b48fd89e0ee4186368ab968404a` from `agents/docs/test/docs-audit/evals/workspace/eval-005-audit-doc-only-error`.
-- Fixture SHA-256: `126b82b218c4429d9a8e50c428008903893e0b48fd89e0ee4186368ab968404a`
-- Prompt SHA-256: `59ccd7c8df4ada989871eac608af9fe615691e1a2d925c63deac93d4d7d56264`
+- Identity schema: `2`
+- target_skill_sha256: `5b11b38c1c44c386fe19122dfb1ce5918b2bfbc4830ad32aa994d8a7e39f35e7`
+- eval_definition_sha256: `1f7d058864bf71ce0402d8ada31c06c85782a25b93779e842d80b5a98766c9d9`
+- metadata_sha256: `63b77017b252b389a44397720be8380b6bee7f6a85225c5d210accca792fc487`
+- fixture_sha256: `126b82b218c4429d9a8e50c428008903893e0b48fd89e0ee4186368ab968404a`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `d804d7eed6dff47b2c8744abfb057fce66d8fde2359e03e7f21e978c34808373`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `fecf485e8e3dcaf191b2b221d9cccbddfdea0b72`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `5b11b38c1c44c386fe19122dfb1ce5918b2bfbc4830ad32aa994d8a7e39f35e7`
-- Skill overlay SHA-256: `85c4ae0a1d58505c4a23c34e6f9116aed81a09b4b6270e3ce148424084f6c7e0`
-- Judge schema SHA-256: `d804d7eed6dff47b2c8744abfb057fce66d8fde2359e03e7f21e978c34808373`
-- Eval definition SHA-256: `1f7d058864bf71ce0402d8ada31c06c85782a25b93779e842d80b5a98766c9d9`
-- Metadata SHA-256: `63b77017b252b389a44397720be8380b6bee7f6a85225c5d210accca792fc487`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/docs/test/docs-audit/evals/workspace/eval-006-audit-no-version-anchor/comparison.md
+++ b/agents/docs/test/docs-audit/evals/workspace/eval-006-audit-no-version-anchor/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `82b55bed70c9cef729375a3351448011b6841c9c9416854e0ef1fd304e6c48bb` from `agents/docs/test/docs-audit/evals/workspace/eval-006-audit-no-version-anchor`.
-- Fixture SHA-256: `82b55bed70c9cef729375a3351448011b6841c9c9416854e0ef1fd304e6c48bb`
-- Prompt SHA-256: `dfb1de5ef05668c278fa0bfcea0c360fed3169b7b4bae6483c3fb5fedeccf198`
+- Identity schema: `2`
+- target_skill_sha256: `5b11b38c1c44c386fe19122dfb1ce5918b2bfbc4830ad32aa994d8a7e39f35e7`
+- eval_definition_sha256: `405d79374055fe033af3883c346829478f3f76cf09e82f4870928a5901ad3a47`
+- metadata_sha256: `953ef09fb5962b093fa646d68b6f137fe0b19f6ba0157a6c58aae94c9c50c930`
+- fixture_sha256: `82b55bed70c9cef729375a3351448011b6841c9c9416854e0ef1fd304e6c48bb`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `7c0884fab11b08d46eb01de89abfa2125334493a96c7805f68a7161e9d7bff70`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `fecf485e8e3dcaf191b2b221d9cccbddfdea0b72`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `5b11b38c1c44c386fe19122dfb1ce5918b2bfbc4830ad32aa994d8a7e39f35e7`
-- Skill overlay SHA-256: `85c4ae0a1d58505c4a23c34e6f9116aed81a09b4b6270e3ce148424084f6c7e0`
-- Judge schema SHA-256: `7c0884fab11b08d46eb01de89abfa2125334493a96c7805f68a7161e9d7bff70`
-- Eval definition SHA-256: `405d79374055fe033af3883c346829478f3f76cf09e82f4870928a5901ad3a47`
-- Metadata SHA-256: `953ef09fb5962b093fa646d68b6f137fe0b19f6ba0157a6c58aae94c9c50c930`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/docs/test/docs-audit/evals/workspace/eval-007-frontmatter-contract-fixtures/comparison.md
+++ b/agents/docs/test/docs-audit/evals/workspace/eval-007-frontmatter-contract-fixtures/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `1219a80a8f97201ae3cdd929f2d631a2ba100cf6ab153bec6afe2b6d163ff59f` from `agents/docs/test/docs-audit/evals/workspace/eval-007-frontmatter-contract-fixtures`.
-- Fixture SHA-256: `1219a80a8f97201ae3cdd929f2d631a2ba100cf6ab153bec6afe2b6d163ff59f`
-- Prompt SHA-256: `49a9f020c04120ad8bdb6f9b036cf5ce5bd9266f99e431e7e0059400223b90de`
+- Identity schema: `2`
+- target_skill_sha256: `5b11b38c1c44c386fe19122dfb1ce5918b2bfbc4830ad32aa994d8a7e39f35e7`
+- eval_definition_sha256: `6bde344495a08502946e81bb93f2ae1c40e1aff64c95e853b673dd5a307e9ade`
+- metadata_sha256: `ac5c625c3b447eed92814a4915de66331bf3c2449cbef00676c3c687ad5d80de`
+- fixture_sha256: `1219a80a8f97201ae3cdd929f2d631a2ba100cf6ab153bec6afe2b6d163ff59f`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `216827bc3e07bc68d228647a6fadcd479f48a986964f70c0c40f48052e42886f`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `fecf485e8e3dcaf191b2b221d9cccbddfdea0b72`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `5b11b38c1c44c386fe19122dfb1ce5918b2bfbc4830ad32aa994d8a7e39f35e7`
-- Skill overlay SHA-256: `85c4ae0a1d58505c4a23c34e6f9116aed81a09b4b6270e3ce148424084f6c7e0`
-- Judge schema SHA-256: `216827bc3e07bc68d228647a6fadcd479f48a986964f70c0c40f48052e42886f`
-- Eval definition SHA-256: `6bde344495a08502946e81bb93f2ae1c40e1aff64c95e853b673dd5a307e9ade`
-- Metadata SHA-256: `ac5c625c3b447eed92814a4915de66331bf3c2449cbef00676c3c687ad5d80de`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)

--- a/agents/docs/test/docs-audit/evals/workspace/eval-008-pre-tag-success/comparison.md
+++ b/agents/docs/test/docs-audit/evals/workspace/eval-008-pre-tag-success/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `188f1d4d85d9c539fa3ce7acd636673ee316e8a8c7f692533cb806966484f84f` from `agents/docs/test/docs-audit/evals/workspace/eval-008-pre-tag-success`.
-- Fixture SHA-256: `188f1d4d85d9c539fa3ce7acd636673ee316e8a8c7f692533cb806966484f84f`
-- Prompt SHA-256: `c716eb0f2d2753ceb3a2258e2367701a57faeef420e346b4fa18dc3a1677c0e3`
+- Identity schema: `2`
+- target_skill_sha256: `5b11b38c1c44c386fe19122dfb1ce5918b2bfbc4830ad32aa994d8a7e39f35e7`
+- eval_definition_sha256: `4d1aa7f3a07c406f7e925f931c91ea28170bd7650629aa75bcd06b4f58bba0c7`
+- metadata_sha256: `6adbc51a2dc07674edf9fca71addc72bccaccf75ae663c41fbf3725d8c48b107`
+- fixture_sha256: `188f1d4d85d9c539fa3ce7acd636673ee316e8a8c7f692533cb806966484f84f`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `4cd14ef8cd033d31b5bb9ce50a786ad0b7d18c7ff4f682d88505eac53b634ecf`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `fecf485e8e3dcaf191b2b221d9cccbddfdea0b72`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `5b11b38c1c44c386fe19122dfb1ce5918b2bfbc4830ad32aa994d8a7e39f35e7`
-- Skill overlay SHA-256: `85c4ae0a1d58505c4a23c34e6f9116aed81a09b4b6270e3ce148424084f6c7e0`
-- Judge schema SHA-256: `4cd14ef8cd033d31b5bb9ce50a786ad0b7d18c7ff4f682d88505eac53b634ecf`
-- Eval definition SHA-256: `4d1aa7f3a07c406f7e925f931c91ea28170bd7650629aa75bcd06b4f58bba0c7`
-- Metadata SHA-256: `6adbc51a2dc07674edf9fca71addc72bccaccf75ae663c41fbf3725d8c48b107`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/docs/test/docs-audit/evals/workspace/eval-009-pre-tag-blocked/comparison.md
+++ b/agents/docs/test/docs-audit/evals/workspace/eval-009-pre-tag-blocked/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `0c59dd74f98f557b12899cbca54adf5aa4fe8aa94d37037f8495e06f83e726c0` from `agents/docs/test/docs-audit/evals/workspace/eval-009-pre-tag-blocked`.
-- Fixture SHA-256: `0c59dd74f98f557b12899cbca54adf5aa4fe8aa94d37037f8495e06f83e726c0`
-- Prompt SHA-256: `542a6dbc4e91378f219fb9c7b639cb7670be62733499a20407d8c4586f25b852`
+- Identity schema: `2`
+- target_skill_sha256: `5b11b38c1c44c386fe19122dfb1ce5918b2bfbc4830ad32aa994d8a7e39f35e7`
+- eval_definition_sha256: `d573477cbe6d660b40a0fd1ef0416d1d407e28ca525b29d8ef8303b282fe7f56`
+- metadata_sha256: `2fa243367a1e388253aea518818683b603664720294e82f2ffeeeebe3d5f82e8`
+- fixture_sha256: `0c59dd74f98f557b12899cbca54adf5aa4fe8aa94d37037f8495e06f83e726c0`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `7dbaa3390632c779b209a0992154e3a2f393b139ccab7a74c59a949526e90023`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `fecf485e8e3dcaf191b2b221d9cccbddfdea0b72`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `5b11b38c1c44c386fe19122dfb1ce5918b2bfbc4830ad32aa994d8a7e39f35e7`
-- Skill overlay SHA-256: `85c4ae0a1d58505c4a23c34e6f9116aed81a09b4b6270e3ce148424084f6c7e0`
-- Judge schema SHA-256: `7dbaa3390632c779b209a0992154e3a2f393b139ccab7a74c59a949526e90023`
-- Eval definition SHA-256: `d573477cbe6d660b40a0fd1ef0416d1d407e28ca525b29d8ef8303b282fe7f56`
-- Metadata SHA-256: `2fa243367a1e388253aea518818683b603664720294e82f2ffeeeebe3d5f82e8`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/docs/test/docs-audit/evals/workspace/eval-010-post-tag-match/comparison.md
+++ b/agents/docs/test/docs-audit/evals/workspace/eval-010-post-tag-match/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `43a1d01505e6c9e0f71431fdaeb75fea6b1939424f6c22775d15a970f4b73518` from `agents/docs/test/docs-audit/evals/workspace/eval-010-post-tag-match`.
-- Fixture SHA-256: `43a1d01505e6c9e0f71431fdaeb75fea6b1939424f6c22775d15a970f4b73518`
-- Prompt SHA-256: `47c14febb101f8d485b3785bf3ac63c5d627ee1f25999068d61918f6bfa13143`
+- Identity schema: `2`
+- target_skill_sha256: `5b11b38c1c44c386fe19122dfb1ce5918b2bfbc4830ad32aa994d8a7e39f35e7`
+- eval_definition_sha256: `f4b575228474dd8bb2a93bb17a067f25252f9c293e1f78393d445c449385e8d2`
+- metadata_sha256: `12f75879efa3cacf943ae19595239a747563947015e4033eed4ea7f4a51a5b47`
+- fixture_sha256: `43a1d01505e6c9e0f71431fdaeb75fea6b1939424f6c22775d15a970f4b73518`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `f64d4542aa97d4b9bcd4bc655a5e70fec7d827a5ea9e9f63067fde8d7b819748`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `fecf485e8e3dcaf191b2b221d9cccbddfdea0b72`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `5b11b38c1c44c386fe19122dfb1ce5918b2bfbc4830ad32aa994d8a7e39f35e7`
-- Skill overlay SHA-256: `85c4ae0a1d58505c4a23c34e6f9116aed81a09b4b6270e3ce148424084f6c7e0`
-- Judge schema SHA-256: `f64d4542aa97d4b9bcd4bc655a5e70fec7d827a5ea9e9f63067fde8d7b819748`
-- Eval definition SHA-256: `f4b575228474dd8bb2a93bb17a067f25252f9c293e1f78393d445c449385e8d2`
-- Metadata SHA-256: `12f75879efa3cacf943ae19595239a747563947015e4033eed4ea7f4a51a5b47`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/docs/test/docs-audit/evals/workspace/eval-011-post-tag-mismatch/comparison.md
+++ b/agents/docs/test/docs-audit/evals/workspace/eval-011-post-tag-mismatch/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `580d96fbd8d2adf79b801381050e6b3b9bfc58b8f39d636b27ce9f575d873d86` from `agents/docs/test/docs-audit/evals/workspace/eval-011-post-tag-mismatch`.
-- Fixture SHA-256: `580d96fbd8d2adf79b801381050e6b3b9bfc58b8f39d636b27ce9f575d873d86`
-- Prompt SHA-256: `63cc630aa7fe4e8caac8407e8b4008bbc49c2b73e376868bcef067409538b2ed`
+- Identity schema: `2`
+- target_skill_sha256: `5b11b38c1c44c386fe19122dfb1ce5918b2bfbc4830ad32aa994d8a7e39f35e7`
+- eval_definition_sha256: `dd2f814bca5d9dce6fed31e09545467860903a50efd0252401f17372eb85d63c`
+- metadata_sha256: `44f3e50cd86c78b14f58e8584dc26444f39390cb3ef1d6e88051fdaf94a2e89e`
+- fixture_sha256: `580d96fbd8d2adf79b801381050e6b3b9bfc58b8f39d636b27ce9f575d873d86`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `87ef764041bed9ee9555b42ac224112964f5f9e1229cf61ab18c2da424e966e8`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `fecf485e8e3dcaf191b2b221d9cccbddfdea0b72`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `5b11b38c1c44c386fe19122dfb1ce5918b2bfbc4830ad32aa994d8a7e39f35e7`
-- Skill overlay SHA-256: `85c4ae0a1d58505c4a23c34e6f9116aed81a09b4b6270e3ce148424084f6c7e0`
-- Judge schema SHA-256: `87ef764041bed9ee9555b42ac224112964f5f9e1229cf61ab18c2da424e966e8`
-- Eval definition SHA-256: `dd2f814bca5d9dce6fed31e09545467860903a50efd0252401f17372eb85d63c`
-- Metadata SHA-256: `44f3e50cd86c78b14f58e8584dc26444f39390cb3ef1d6e88051fdaf94a2e89e`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/docs/test/docs-audit/evals/workspace/eval-012-staged-metadata-rollback/comparison.md
+++ b/agents/docs/test/docs-audit/evals/workspace/eval-012-staged-metadata-rollback/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `1013313f9177f2e4b64118a15325ba0a4da0ec26b6c32604368f1f754b57e620` from `agents/docs/test/docs-audit/evals/workspace/eval-012-staged-metadata-rollback`.
-- Fixture SHA-256: `1013313f9177f2e4b64118a15325ba0a4da0ec26b6c32604368f1f754b57e620`
-- Prompt SHA-256: `4c059264a7527dcf6082f43bc5cacdf327f947505e6d5f9721fd10e71b64fdcb`
+- Identity schema: `2`
+- target_skill_sha256: `5b11b38c1c44c386fe19122dfb1ce5918b2bfbc4830ad32aa994d8a7e39f35e7`
+- eval_definition_sha256: `885108a0e0e9ce48751816455b91da0ec400a08bb7d3a722984a36e4221d1938`
+- metadata_sha256: `86b2ab0ad4bcb3fb98728ca8ff1375ff58d1094876353cbeafc325bf7593eb63`
+- fixture_sha256: `1013313f9177f2e4b64118a15325ba0a4da0ec26b6c32604368f1f754b57e620`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `73f9308006ffa877e1ed5f74c8eef2e3a2b3222e98dd5485cfd0ba5e210de92a`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `fecf485e8e3dcaf191b2b221d9cccbddfdea0b72`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `5b11b38c1c44c386fe19122dfb1ce5918b2bfbc4830ad32aa994d8a7e39f35e7`
-- Skill overlay SHA-256: `85c4ae0a1d58505c4a23c34e6f9116aed81a09b4b6270e3ce148424084f6c7e0`
-- Judge schema SHA-256: `73f9308006ffa877e1ed5f74c8eef2e3a2b3222e98dd5485cfd0ba5e210de92a`
-- Eval definition SHA-256: `885108a0e0e9ce48751816455b91da0ec400a08bb7d3a722984a36e4221d1938`
-- Metadata SHA-256: `86b2ab0ad4bcb3fb98728ca8ff1375ff58d1094876353cbeafc325bf7593eb63`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **FAIL**
 - Coverage result: **PARTIAL**
 Overall result: FAIL

--- a/agents/docs/test/docs-audit/evals/workspace/eval-013-version-normalization-boundaries/comparison.md
+++ b/agents/docs/test/docs-audit/evals/workspace/eval-013-version-normalization-boundaries/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `1cee6041bd72db3f52d6c6c5a5cd2b2192f387347cccb99c7f5a1da1c4e1e970` from `agents/docs/test/docs-audit/evals/workspace/eval-013-version-normalization-boundaries`.
-- Fixture SHA-256: `1cee6041bd72db3f52d6c6c5a5cd2b2192f387347cccb99c7f5a1da1c4e1e970`
-- Prompt SHA-256: `e4e9083fe5f80e87e2a90dbd2508e2ce8a005911bcd108e280ebfcc392bef53e`
+- Identity schema: `2`
+- target_skill_sha256: `5b11b38c1c44c386fe19122dfb1ce5918b2bfbc4830ad32aa994d8a7e39f35e7`
+- eval_definition_sha256: `5705e506f62200b76867ebca90e47274aa68bc0ca81a7790a3ab2ac8baafd194`
+- metadata_sha256: `de723686d571b59f10dc657eaf98d1d9ad27c06a9381fcb0dfee19364fb401ec`
+- fixture_sha256: `1cee6041bd72db3f52d6c6c5a5cd2b2192f387347cccb99c7f5a1da1c4e1e970`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `3cb4db02fceb3a963ab35cfa46d9bd95146e58bed4f92e90064a4aa2fe2f0404`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `fecf485e8e3dcaf191b2b221d9cccbddfdea0b72`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `5b11b38c1c44c386fe19122dfb1ce5918b2bfbc4830ad32aa994d8a7e39f35e7`
-- Skill overlay SHA-256: `85c4ae0a1d58505c4a23c34e6f9116aed81a09b4b6270e3ce148424084f6c7e0`
-- Judge schema SHA-256: `3cb4db02fceb3a963ab35cfa46d9bd95146e58bed4f92e90064a4aa2fe2f0404`
-- Eval definition SHA-256: `5705e506f62200b76867ebca90e47274aa68bc0ca81a7790a3ab2ac8baafd194`
-- Metadata SHA-256: `de723686d571b59f10dc657eaf98d1d9ad27c06a9381fcb0dfee19364fb401ec`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)

--- a/agents/docs/test/docs-audit/evals/workspace/eval-014-conditional-deployment-recheck/comparison.md
+++ b/agents/docs/test/docs-audit/evals/workspace/eval-014-conditional-deployment-recheck/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `02024e6f0aaa0bcf6615062b3d8a31430a90f2e0a76edad7ce1044c04423eb52` from `agents/docs/test/docs-audit/evals/workspace/eval-014-conditional-deployment-recheck`.
-- Fixture SHA-256: `02024e6f0aaa0bcf6615062b3d8a31430a90f2e0a76edad7ce1044c04423eb52`
-- Prompt SHA-256: `cb27f98c195c0adaa2bc7ce90eded119c590e29ff34ec55cdd7a71187adb71ba`
+- Identity schema: `2`
+- target_skill_sha256: `5b11b38c1c44c386fe19122dfb1ce5918b2bfbc4830ad32aa994d8a7e39f35e7`
+- eval_definition_sha256: `3b49ebce5564e2973a0e2404ae2204baef9f3926736e7959e09be720ea423b90`
+- metadata_sha256: `2b29c083a590a4eda139a3861e29b83daf406cc100d9a6f0e884225e104c8734`
+- fixture_sha256: `02024e6f0aaa0bcf6615062b3d8a31430a90f2e0a76edad7ce1044c04423eb52`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `b484eac80dd3c83d19d6e2564672bb72616ee37e54370c5c00059bfaaa781dcf`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `fecf485e8e3dcaf191b2b221d9cccbddfdea0b72`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `5b11b38c1c44c386fe19122dfb1ce5918b2bfbc4830ad32aa994d8a7e39f35e7`
-- Skill overlay SHA-256: `85c4ae0a1d58505c4a23c34e6f9116aed81a09b4b6270e3ce148424084f6c7e0`
-- Judge schema SHA-256: `b484eac80dd3c83d19d6e2564672bb72616ee37e54370c5c00059bfaaa781dcf`
-- Eval definition SHA-256: `3b49ebce5564e2973a0e2404ae2204baef9f3926736e7959e09be720ea423b90`
-- Metadata SHA-256: `2b29c083a590a4eda139a3861e29b83daf406cc100d9a6f0e884225e104c8734`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)

--- a/agents/docs/test/docs-audit/evals/workspace/eval-015-manual-page-evidence/comparison.md
+++ b/agents/docs/test/docs-audit/evals/workspace/eval-015-manual-page-evidence/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `1c27cfa2f41ff48338bb4acbfdb7cd16614fdaed5b9fc59cbb0ed2df02c327ad` from `agents/docs/test/docs-audit/evals/workspace/eval-015-manual-page-evidence`.
-- Fixture SHA-256: `1c27cfa2f41ff48338bb4acbfdb7cd16614fdaed5b9fc59cbb0ed2df02c327ad`
-- Prompt SHA-256: `9c90b10bde8bbda672daf3c3fd6d8b4bfbcd80966d8091d82aceff2f385c4210`
+- Identity schema: `2`
+- target_skill_sha256: `5b11b38c1c44c386fe19122dfb1ce5918b2bfbc4830ad32aa994d8a7e39f35e7`
+- eval_definition_sha256: `aa707a4a153cd14f8630bcfdbc7593482bcfc1de05bf7582ac2eeb6f645afb7d`
+- metadata_sha256: `2b093794d817fa1de245fdac944141cf26e940fab11bd3c871b66f71a9c40eac`
+- fixture_sha256: `1c27cfa2f41ff48338bb4acbfdb7cd16614fdaed5b9fc59cbb0ed2df02c327ad`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `cde7d254babf29e4546bfe9e69c491c81147f2f6aec782f40fd9d10a9dc4b4fd`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `fecf485e8e3dcaf191b2b221d9cccbddfdea0b72`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `5b11b38c1c44c386fe19122dfb1ce5918b2bfbc4830ad32aa994d8a7e39f35e7`
-- Skill overlay SHA-256: `85c4ae0a1d58505c4a23c34e6f9116aed81a09b4b6270e3ce148424084f6c7e0`
-- Judge schema SHA-256: `cde7d254babf29e4546bfe9e69c491c81147f2f6aec782f40fd9d10a9dc4b4fd`
-- Eval definition SHA-256: `aa707a4a153cd14f8630bcfdbc7593482bcfc1de05bf7582ac2eeb6f645afb7d`
-- Metadata SHA-256: `2b093794d817fa1de245fdac944141cf26e940fab11bd3c871b66f71a9c40eac`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **FAIL**
 - Coverage result: **FULL**
 Overall result: FAIL

--- a/agents/docs/test/docs-site-bootstrap/evals/workspace/eval-001-bootstrap-empty-workspace/comparison.md
+++ b/agents/docs/test/docs-site-bootstrap/evals/workspace/eval-001-bootstrap-empty-workspace/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/docs/test/docs-site-bootstrap/evals/workspace/eval-001-bootstrap-empty-workspace`.
-- Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
-- Prompt SHA-256: `8294223a6cc9320411b7f3ca9761133eeb49b555e990170abcfa40eeb8076bd8`
+- Identity schema: `2`
+- target_skill_sha256: `f74a445a21eabfad3f25cc38a5190833cf5fc52294bb0054a41378fe894ddd82`
+- eval_definition_sha256: `0028d93b645e269e09fc6f6345ad073b0c2386395ad858bbd7693d057a9eca5f`
+- metadata_sha256: `72695cba8eaf9810a85aa17ba3cc9622de1dd39f4d06db93fe0728a19509d73b`
+- fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `373ba2965836f0cc6198ffb0151c12c61c34831fe45aaa5ef665fae7d893acbc`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `f74a445a21eabfad3f25cc38a5190833cf5fc52294bb0054a41378fe894ddd82`
-- Skill overlay SHA-256: `b193497852920517172f09f5d68ba6d13d4646f7f71948ca300566e66c51cb59`
-- Judge schema SHA-256: `373ba2965836f0cc6198ffb0151c12c61c34831fe45aaa5ef665fae7d893acbc`
-- Eval definition SHA-256: `0028d93b645e269e09fc6f6345ad073b0c2386395ad858bbd7693d057a9eca5f`
-- Metadata SHA-256: `72695cba8eaf9810a85aa17ba3cc9622de1dd39f4d06db93fe0728a19509d73b`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/docs/test/docs-site-bootstrap/evals/workspace/eval-002-repeat-bootstrap-idempotent/comparison.md
+++ b/agents/docs/test/docs-site-bootstrap/evals/workspace/eval-002-repeat-bootstrap-idempotent/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `970626314f80eb97fc008436179e977f3b31875ef015d6a3dcce0205080e223e` from `agents/docs/test/docs-site-bootstrap/evals/workspace/eval-002-repeat-bootstrap-idempotent`.
-- Fixture SHA-256: `970626314f80eb97fc008436179e977f3b31875ef015d6a3dcce0205080e223e`
-- Prompt SHA-256: `1e8516931ef9c5300021c46d1671fb3fb195b5fe4d687cb8133fc778b15a0158`
+- Identity schema: `2`
+- target_skill_sha256: `f74a445a21eabfad3f25cc38a5190833cf5fc52294bb0054a41378fe894ddd82`
+- eval_definition_sha256: `67789de316a1ba3d112d33eabc20baa992cdfc352bddac2855c6bcc9a3f93650`
+- metadata_sha256: `421f80bf3da30d58b5b544d4c2e96b4cfdc1446ea641a3ffc3d654e2472f3421`
+- fixture_sha256: `970626314f80eb97fc008436179e977f3b31875ef015d6a3dcce0205080e223e`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `08c04fe57b81475dd890de6778e0567d043b2de7ae5ceb0392b2f8c748e60f69`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `f74a445a21eabfad3f25cc38a5190833cf5fc52294bb0054a41378fe894ddd82`
-- Skill overlay SHA-256: `b193497852920517172f09f5d68ba6d13d4646f7f71948ca300566e66c51cb59`
-- Judge schema SHA-256: `08c04fe57b81475dd890de6778e0567d043b2de7ae5ceb0392b2f8c748e60f69`
-- Eval definition SHA-256: `67789de316a1ba3d112d33eabc20baa992cdfc352bddac2855c6bcc9a3f93650`
-- Metadata SHA-256: `421f80bf3da30d58b5b544d4c2e96b4cfdc1446ea641a3ffc3d654e2472f3421`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/docs/test/docs-site-bootstrap/evals/workspace/eval-003-block-bootstrap-conflict/comparison.md
+++ b/agents/docs/test/docs-site-bootstrap/evals/workspace/eval-003-block-bootstrap-conflict/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `67d646aaa1407e943f08140487b646ac63c9406ed33f7972e7921d67116c9f4a` from `agents/docs/test/docs-site-bootstrap/evals/workspace/eval-003-block-bootstrap-conflict`.
-- Fixture SHA-256: `67d646aaa1407e943f08140487b646ac63c9406ed33f7972e7921d67116c9f4a`
-- Prompt SHA-256: `7e27a0b4acbeb0bbab6d1ce4f4eaef1707f80d3f366d62ddd92d0e2d6f621f17`
+- Identity schema: `2`
+- target_skill_sha256: `f74a445a21eabfad3f25cc38a5190833cf5fc52294bb0054a41378fe894ddd82`
+- eval_definition_sha256: `ef71b65d8d90e0a7a85b11140f77333b6bccfac4b39b25f67875d33153f0ebea`
+- metadata_sha256: `dd91ae0a6e0ac8c19ffeb9b16bf575dc1d6e559c0626e7027f9e04c671f270d0`
+- fixture_sha256: `67d646aaa1407e943f08140487b646ac63c9406ed33f7972e7921d67116c9f4a`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `8fb0a4310aa73072ce3915bd9569df86e49409cfb5df2e41bfa626f79fa1e1ef`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `f74a445a21eabfad3f25cc38a5190833cf5fc52294bb0054a41378fe894ddd82`
-- Skill overlay SHA-256: `b193497852920517172f09f5d68ba6d13d4646f7f71948ca300566e66c51cb59`
-- Judge schema SHA-256: `8fb0a4310aa73072ce3915bd9569df86e49409cfb5df2e41bfa626f79fa1e1ef`
-- Eval definition SHA-256: `ef71b65d8d90e0a7a85b11140f77333b6bccfac4b39b25f67875d33153f0ebea`
-- Metadata SHA-256: `dd91ae0a6e0ac8c19ffeb9b16bf575dc1d6e559c0626e7027f9e04c671f270d0`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/docs/test/docs-site-bootstrap/evals/workspace/eval-004-deployment-completeness-trigger/comparison.md
+++ b/agents/docs/test/docs-site-bootstrap/evals/workspace/eval-004-deployment-completeness-trigger/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `4e3ac8498634ec41445a5f746933f338a50d3c3d4cae8d2f058bd619e288d842` from `agents/docs/test/docs-site-bootstrap/evals/workspace/eval-004-deployment-completeness-trigger`.
-- Fixture SHA-256: `4e3ac8498634ec41445a5f746933f338a50d3c3d4cae8d2f058bd619e288d842`
-- Prompt SHA-256: `a857fcf2c722711dbe976f85685cf13e950a1e35983a7408a6a97bb35347ed24`
+- Identity schema: `2`
+- target_skill_sha256: `f74a445a21eabfad3f25cc38a5190833cf5fc52294bb0054a41378fe894ddd82`
+- eval_definition_sha256: `f0a0699462419947dfa64649c390cf74a3d370111b9c3ea826e84a8d4dc9f735`
+- metadata_sha256: `abed400d8529a0bd91cc069fda9057f38aa9e64b1a632698bb6d1e29c26ae6e8`
+- fixture_sha256: `4e3ac8498634ec41445a5f746933f338a50d3c3d4cae8d2f058bd619e288d842`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `84cb88cc9e25dde2fbf0d2a0fb5349bfe630e32b333634cfdb918d30e60002a8`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `f74a445a21eabfad3f25cc38a5190833cf5fc52294bb0054a41378fe894ddd82`
-- Skill overlay SHA-256: `b193497852920517172f09f5d68ba6d13d4646f7f71948ca300566e66c51cb59`
-- Judge schema SHA-256: `84cb88cc9e25dde2fbf0d2a0fb5349bfe630e32b333634cfdb918d30e60002a8`
-- Eval definition SHA-256: `f0a0699462419947dfa64649c390cf74a3d370111b9c3ea826e84a8d4dc9f735`
-- Metadata SHA-256: `abed400d8529a0bd91cc069fda9057f38aa9e64b1a632698bb6d1e29c26ae6e8`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-001-sync-feature-api/comparison.md
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-001-sync-feature-api/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `19be975a76919e1880464ff6b63104dc042d768be1d80c006b73e28d58ffabfa` from `agents/docs/test/formal-docs-sync/evals/workspace/eval-001-sync-feature-api`.
-- Fixture SHA-256: `19be975a76919e1880464ff6b63104dc042d768be1d80c006b73e28d58ffabfa`
-- Prompt SHA-256: `cd2f08c41a6ec95815793c80de00d9c220026a6632090c7da71f54b61e0f767a`
+- Identity schema: `2`
+- target_skill_sha256: `dd975083d3977d90b71b3396dff2498ef2b7e8d49c50fab50b5462a26f3248ee`
+- eval_definition_sha256: `ce743547e06014367140716bb2c97c1db58eb733e797662e8b4bd6eca00be3ee`
+- metadata_sha256: `f8156f035dafc132a200ab0fabf455e3a12e92c380c1e7265ae20e3e3df0c170`
+- fixture_sha256: `19be975a76919e1880464ff6b63104dc042d768be1d80c006b73e28d58ffabfa`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `b75531387a8a9fcbe3680466e0062ed9ca0b3db6341639dbf81c051b7647e990`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `f2aa9b2c49be68550ec45538c221425607f428ce`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `dd975083d3977d90b71b3396dff2498ef2b7e8d49c50fab50b5462a26f3248ee`
-- Skill overlay SHA-256: `9667198915198da0404e03a7d4c962d38742b19c5de4de5f0cf1473f02db2bf1`
-- Judge schema SHA-256: `b75531387a8a9fcbe3680466e0062ed9ca0b3db6341639dbf81c051b7647e990`
-- Eval definition SHA-256: `ce743547e06014367140716bb2c97c1db58eb733e797662e8b4bd6eca00be3ee`
-- Metadata SHA-256: `f8156f035dafc132a200ab0fabf455e3a12e92c380c1e7265ae20e3e3df0c170`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-002-plan-backfill-batches/comparison.md
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-002-plan-backfill-batches/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `d39e08e3921dea4ed3620111c7989cda61f1e85ab306939032821affe0218f45` from `agents/docs/test/formal-docs-sync/evals/workspace/eval-002-plan-backfill-batches`.
-- Fixture SHA-256: `d39e08e3921dea4ed3620111c7989cda61f1e85ab306939032821affe0218f45`
-- Prompt SHA-256: `8abbeebf58a017f34c7b7989f0280e2daf82af8f4daf404a0ba21c98f5540049`
+- Identity schema: `2`
+- target_skill_sha256: `dd975083d3977d90b71b3396dff2498ef2b7e8d49c50fab50b5462a26f3248ee`
+- eval_definition_sha256: `ac42526e36e715108f7b75fd8273d1a27b06b53f2d88401d4e0acf869a7f27d9`
+- metadata_sha256: `5fd28d9378e7eecda587e4671ac17460a0dd3663cff48d75fd068b1dc2cb5f0c`
+- fixture_sha256: `d39e08e3921dea4ed3620111c7989cda61f1e85ab306939032821affe0218f45`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `9176713527a4959d0641a1feea488e487885b76c3aa23f11bb3b81f29825c3ae`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `f2aa9b2c49be68550ec45538c221425607f428ce`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `dd975083d3977d90b71b3396dff2498ef2b7e8d49c50fab50b5462a26f3248ee`
-- Skill overlay SHA-256: `9667198915198da0404e03a7d4c962d38742b19c5de4de5f0cf1473f02db2bf1`
-- Judge schema SHA-256: `9176713527a4959d0641a1feea488e487885b76c3aa23f11bb3b81f29825c3ae`
-- Eval definition SHA-256: `ac42526e36e715108f7b75fd8273d1a27b06b53f2d88401d4e0acf869a7f27d9`
-- Metadata SHA-256: `5fd28d9378e7eecda587e4671ac17460a0dd3663cff48d75fd068b1dc2cb5f0c`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-003-design-gate-incomplete-scope/comparison.md
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-003-design-gate-incomplete-scope/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `8aa9df65b73215302e91c3f000b2e01777ac5c79a5e42d477647ee57db58af66` from `agents/docs/test/formal-docs-sync/evals/workspace/eval-003-design-gate-incomplete-scope`.
-- Fixture SHA-256: `8aa9df65b73215302e91c3f000b2e01777ac5c79a5e42d477647ee57db58af66`
-- Prompt SHA-256: `56246c4cc2593a4f68a5cab876eaee6a48761e04188d3c231558d5894f290174`
+- Identity schema: `2`
+- target_skill_sha256: `dd975083d3977d90b71b3396dff2498ef2b7e8d49c50fab50b5462a26f3248ee`
+- eval_definition_sha256: `b2bf4f8fb3d18226f8bc19c0ca91afcf8f927301ac6d8c89204f1fa6248c4f6b`
+- metadata_sha256: `60fd8d12ce139674523c1a361254f5e8a91b8a162c74d8b2d6b08ca495888809`
+- fixture_sha256: `8aa9df65b73215302e91c3f000b2e01777ac5c79a5e42d477647ee57db58af66`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `4b5a2072f392f239ebcef5483d2cd7f59525e9dddc22047a3017a3927cbc8008`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `f2aa9b2c49be68550ec45538c221425607f428ce`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `dd975083d3977d90b71b3396dff2498ef2b7e8d49c50fab50b5462a26f3248ee`
-- Skill overlay SHA-256: `9667198915198da0404e03a7d4c962d38742b19c5de4de5f0cf1473f02db2bf1`
-- Judge schema SHA-256: `4b5a2072f392f239ebcef5483d2cd7f59525e9dddc22047a3017a3927cbc8008`
-- Eval definition SHA-256: `b2bf4f8fb3d18226f8bc19c0ca91afcf8f927301ac6d8c89204f1fa6248c4f6b`
-- Metadata SHA-256: `60fd8d12ce139674523c1a361254f5e8a91b8a162c74d8b2d6b08ca495888809`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **FAIL**
 - Coverage result: **FULL**
 Overall result: FAIL

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-004-design-gate-failing-tests/comparison.md
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-004-design-gate-failing-tests/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `888ec3cd17fb382d54d3506afed12dac820d7455abc356bb02ec550713d0ad9f` from `agents/docs/test/formal-docs-sync/evals/workspace/eval-004-design-gate-failing-tests`.
-- Fixture SHA-256: `888ec3cd17fb382d54d3506afed12dac820d7455abc356bb02ec550713d0ad9f`
-- Prompt SHA-256: `b1f3e3ab8206fcdb669e596904dfb22d806d7f56cf42f82f0bf3acedbbed78d7`
+- Identity schema: `2`
+- target_skill_sha256: `dd975083d3977d90b71b3396dff2498ef2b7e8d49c50fab50b5462a26f3248ee`
+- eval_definition_sha256: `ba23dfdb0f9a8ca4993196db1cc72ad98dc4f1e2f6b1b9055f218642fc040702`
+- metadata_sha256: `b892d7f11434df5d87e026ef6208862e030c7c37761a266263d03ebecbf3949f`
+- fixture_sha256: `888ec3cd17fb382d54d3506afed12dac820d7455abc356bb02ec550713d0ad9f`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `0669292f176355ed06a0f6f5bb030af6a23cb5add4a747bfc08b3a96f60fa065`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `f2aa9b2c49be68550ec45538c221425607f428ce`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `dd975083d3977d90b71b3396dff2498ef2b7e8d49c50fab50b5462a26f3248ee`
-- Skill overlay SHA-256: `9667198915198da0404e03a7d4c962d38742b19c5de4de5f0cf1473f02db2bf1`
-- Judge schema SHA-256: `0669292f176355ed06a0f6f5bb030af6a23cb5add4a747bfc08b3a96f60fa065`
-- Eval definition SHA-256: `ba23dfdb0f9a8ca4993196db1cc72ad98dc4f1e2f6b1b9055f218642fc040702`
-- Metadata SHA-256: `b892d7f11434df5d87e026ef6208862e030c7c37761a266263d03ebecbf3949f`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-005-design-gate-mismatched-evidence/comparison.md
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-005-design-gate-mismatched-evidence/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `9ee09a35ffbbce09e9a24f1afab930b7c3820a015f0b4c8a431f51638de5592f` from `agents/docs/test/formal-docs-sync/evals/workspace/eval-005-design-gate-mismatched-evidence`.
-- Fixture SHA-256: `9ee09a35ffbbce09e9a24f1afab930b7c3820a015f0b4c8a431f51638de5592f`
-- Prompt SHA-256: `cc15a608e753e009b625973b3297598562e26547f4019135f4ff1cee37bc04f0`
+- Identity schema: `2`
+- target_skill_sha256: `dd975083d3977d90b71b3396dff2498ef2b7e8d49c50fab50b5462a26f3248ee`
+- eval_definition_sha256: `9b46c27014c750c2c7c902ee9b735c340d6216e70bd1db10e9ac7cfe4ffa72b8`
+- metadata_sha256: `8201495b57b213f9db3f5219d86222ff877b211b7bfe7d5c149fe15482812507`
+- fixture_sha256: `9ee09a35ffbbce09e9a24f1afab930b7c3820a015f0b4c8a431f51638de5592f`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `c9b93b28ac72af6810f4752921bb72d418af8d9162ae5d66c15fe90f929562c8`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `f2aa9b2c49be68550ec45538c221425607f428ce`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `dd975083d3977d90b71b3396dff2498ef2b7e8d49c50fab50b5462a26f3248ee`
-- Skill overlay SHA-256: `9667198915198da0404e03a7d4c962d38742b19c5de4de5f0cf1473f02db2bf1`
-- Judge schema SHA-256: `c9b93b28ac72af6810f4752921bb72d418af8d9162ae5d66c15fe90f929562c8`
-- Eval definition SHA-256: `9b46c27014c750c2c7c902ee9b735c340d6216e70bd1db10e9ac7cfe4ffa72b8`
-- Metadata SHA-256: `8201495b57b213f9db3f5219d86222ff877b211b7bfe7d5c149fe15482812507`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **FAIL**
 - Coverage result: **FULL**
 Overall result: FAIL

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-006-design-gate-all-passed/comparison.md
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-006-design-gate-all-passed/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `98bf611a541c8fe0137472ae23a2bee304eb1dd895062850790d9e776e872e75` from `agents/docs/test/formal-docs-sync/evals/workspace/eval-006-design-gate-all-passed`.
-- Fixture SHA-256: `98bf611a541c8fe0137472ae23a2bee304eb1dd895062850790d9e776e872e75`
-- Prompt SHA-256: `c76b170dd7794d3734918c7a765e05580924d97e899b93480f8dc75124874544`
+- Identity schema: `2`
+- target_skill_sha256: `dd975083d3977d90b71b3396dff2498ef2b7e8d49c50fab50b5462a26f3248ee`
+- eval_definition_sha256: `409f0dff74eed97473da7310514056fa3150a1bcc243e245700365b8124e237d`
+- metadata_sha256: `d850062d9ab19e577fb519798bc20c97592f06bfa16acdff382b6c2af72957e7`
+- fixture_sha256: `98bf611a541c8fe0137472ae23a2bee304eb1dd895062850790d9e776e872e75`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `ebe36ab58d09b32dcb1d3a0e60e80a8c30163db5b3f4afa9ec0da402309c3c17`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `f2aa9b2c49be68550ec45538c221425607f428ce`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `dd975083d3977d90b71b3396dff2498ef2b7e8d49c50fab50b5462a26f3248ee`
-- Skill overlay SHA-256: `9667198915198da0404e03a7d4c962d38742b19c5de4de5f0cf1473f02db2bf1`
-- Judge schema SHA-256: `ebe36ab58d09b32dcb1d3a0e60e80a8c30163db5b3f4afa9ec0da402309c3c17`
-- Eval definition SHA-256: `409f0dff74eed97473da7310514056fa3150a1bcc243e245700365b8124e237d`
-- Metadata SHA-256: `d850062d9ab19e577fb519798bc20c97592f06bfa16acdff382b6c2af72957e7`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-007-feature-database-design/comparison.md
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-007-feature-database-design/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `de57a3e2c20f574e81d3d9803c1ae3a7c2c6c83bbead7114e75685122bb01a81` from `agents/docs/test/formal-docs-sync/evals/workspace/eval-007-feature-database-design`.
-- Fixture SHA-256: `de57a3e2c20f574e81d3d9803c1ae3a7c2c6c83bbead7114e75685122bb01a81`
-- Prompt SHA-256: `97f82a75c78275f5f504c11fb93e67755d5b6d9f65a9ef9273ee264808b8d9c8`
+- Identity schema: `2`
+- target_skill_sha256: `dd975083d3977d90b71b3396dff2498ef2b7e8d49c50fab50b5462a26f3248ee`
+- eval_definition_sha256: `dd84eeaf9ea9452e584f740ec00a1edde6c8e5bfae2ef83da4e9e416f2e769fe`
+- metadata_sha256: `23140221449282820c7da53fcdbe46ce5ee1169aff6e90986ef0dbd09c5f9120`
+- fixture_sha256: `de57a3e2c20f574e81d3d9803c1ae3a7c2c6c83bbead7114e75685122bb01a81`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `289a3b63a3dcdcdc4cc6c4b994a40567f085f301732b94d5ab13b0e67247a316`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `f2aa9b2c49be68550ec45538c221425607f428ce`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `dd975083d3977d90b71b3396dff2498ef2b7e8d49c50fab50b5462a26f3248ee`
-- Skill overlay SHA-256: `9667198915198da0404e03a7d4c962d38742b19c5de4de5f0cf1473f02db2bf1`
-- Judge schema SHA-256: `289a3b63a3dcdcdc4cc6c4b994a40567f085f301732b94d5ab13b0e67247a316`
-- Eval definition SHA-256: `dd84eeaf9ea9452e584f740ec00a1edde6c8e5bfae2ef83da4e9e416f2e769fe`
-- Metadata SHA-256: `23140221449282820c7da53fcdbe46ce5ee1169aff6e90986ef0dbd09c5f9120`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-008-deployment-ops-upgrade/comparison.md
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-008-deployment-ops-upgrade/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `214f53e3513d921f93697a6af50dd22ab635d80910879e93ccbc5d847195e845` from `agents/docs/test/formal-docs-sync/evals/workspace/eval-008-deployment-ops-upgrade`.
-- Fixture SHA-256: `214f53e3513d921f93697a6af50dd22ab635d80910879e93ccbc5d847195e845`
-- Prompt SHA-256: `47aecb4a312eb41566bd1acc858dd108cbb65075c955dc6992e37865198bfec5`
+- Identity schema: `2`
+- target_skill_sha256: `dd975083d3977d90b71b3396dff2498ef2b7e8d49c50fab50b5462a26f3248ee`
+- eval_definition_sha256: `7fe3c7ecf4038349101f98fb6f2ef19330f01c150bee2276a165994129650157`
+- metadata_sha256: `2f78367477eb99dc045585689bae85fd3302b30aa534650ea910cd64f9bdfbbe`
+- fixture_sha256: `214f53e3513d921f93697a6af50dd22ab635d80910879e93ccbc5d847195e845`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `f5d562d8581b8e42e3d9fc6fee3e3cf82b682235e3b52ce9b9c4f91a22e1e752`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `f2aa9b2c49be68550ec45538c221425607f428ce`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `dd975083d3977d90b71b3396dff2498ef2b7e8d49c50fab50b5462a26f3248ee`
-- Skill overlay SHA-256: `9667198915198da0404e03a7d4c962d38742b19c5de4de5f0cf1473f02db2bf1`
-- Judge schema SHA-256: `f5d562d8581b8e42e3d9fc6fee3e3cf82b682235e3b52ce9b9c4f91a22e1e752`
-- Eval definition SHA-256: `7fe3c7ecf4038349101f98fb6f2ef19330f01c150bee2276a165994129650157`
-- Metadata SHA-256: `2f78367477eb99dc045585689bae85fd3302b30aa534650ea910cd64f9bdfbbe`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **FAIL**
 - Coverage result: **PARTIAL**
 Overall result: FAIL

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-009-release-product-ops/comparison.md
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-009-release-product-ops/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `88db6a4117456e7d2f0e14115ea2a173ee0022fedba47576986e4b24262edb75` from `agents/docs/test/formal-docs-sync/evals/workspace/eval-009-release-product-ops`.
-- Fixture SHA-256: `88db6a4117456e7d2f0e14115ea2a173ee0022fedba47576986e4b24262edb75`
-- Prompt SHA-256: `8feaf10d86a83aace4d8ae6456c2cfec394b2d1dd27b83a16d97b82d9a82c1f2`
+- Identity schema: `2`
+- target_skill_sha256: `dd975083d3977d90b71b3396dff2498ef2b7e8d49c50fab50b5462a26f3248ee`
+- eval_definition_sha256: `c9bcafbf3ecc8c0e0ac28908b463b075e9d1371a95444953a8afc3d41757e192`
+- metadata_sha256: `d04b92e9a3754ad51ae5d707b3601a2084dc53a6e309122269ca881bc88a10ef`
+- fixture_sha256: `88db6a4117456e7d2f0e14115ea2a173ee0022fedba47576986e4b24262edb75`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `56b98af2f6fc5a04535db999157836236eb69830528cbecc99ca00f23b4d8d9e`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `f2aa9b2c49be68550ec45538c221425607f428ce`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `dd975083d3977d90b71b3396dff2498ef2b7e8d49c50fab50b5462a26f3248ee`
-- Skill overlay SHA-256: `9667198915198da0404e03a7d4c962d38742b19c5de4de5f0cf1473f02db2bf1`
-- Judge schema SHA-256: `56b98af2f6fc5a04535db999157836236eb69830528cbecc99ca00f23b4d8d9e`
-- Eval definition SHA-256: `c9bcafbf3ecc8c0e0ac28908b463b075e9d1371a95444953a8afc3d41757e192`
-- Metadata SHA-256: `d04b92e9a3754ad51ae5d707b3601a2084dc53a6e309122269ca881bc88a10ef`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-010-release-notes-boundary/comparison.md
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-010-release-notes-boundary/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `f62e3d002a3d849e5b28b313abce4433afd4885459572da3c6552b50d7fc432c` from `agents/docs/test/formal-docs-sync/evals/workspace/eval-010-release-notes-boundary`.
-- Fixture SHA-256: `f62e3d002a3d849e5b28b313abce4433afd4885459572da3c6552b50d7fc432c`
-- Prompt SHA-256: `59f3f4b07b3e4d027f3b554bec6c0d7c22a2923908783529642641c26634e91f`
+- Identity schema: `2`
+- target_skill_sha256: `dd975083d3977d90b71b3396dff2498ef2b7e8d49c50fab50b5462a26f3248ee`
+- eval_definition_sha256: `73a1610671f9f97761837a796f3ae7908687bbe25fc17ad4582a0bb4ee5c7fae`
+- metadata_sha256: `2352ae604513521c63a446b6d886e6c879f4a0cef5861b4ee1c9c3ee9f319eba`
+- fixture_sha256: `f62e3d002a3d849e5b28b313abce4433afd4885459572da3c6552b50d7fc432c`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `b3a1a852c447e6e1ef51ed958da793390c6914ade2f68188c4962daac377d01b`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `f2aa9b2c49be68550ec45538c221425607f428ce`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `dd975083d3977d90b71b3396dff2498ef2b7e8d49c50fab50b5462a26f3248ee`
-- Skill overlay SHA-256: `9667198915198da0404e03a7d4c962d38742b19c5de4de5f0cf1473f02db2bf1`
-- Judge schema SHA-256: `b3a1a852c447e6e1ef51ed958da793390c6914ade2f68188c4962daac377d01b`
-- Eval definition SHA-256: `73a1610671f9f97761837a796f3ae7908687bbe25fc17ad4582a0bb4ee5c7fae`
-- Metadata SHA-256: `2352ae604513521c63a446b6d886e6c879f4a0cef5861b4ee1c9c3ee9f319eba`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-011-deployment-three-class-backfill/comparison.md
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-011-deployment-three-class-backfill/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `4d8408c1113f0b188f486ff52a1805928dda107a5b4bcef41d15ff086a7d524c` from `agents/docs/test/formal-docs-sync/evals/workspace/eval-011-deployment-three-class-backfill`.
-- Fixture SHA-256: `4d8408c1113f0b188f486ff52a1805928dda107a5b4bcef41d15ff086a7d524c`
-- Prompt SHA-256: `bed66a02e7102d84cc8988d8318b854a858b57d12888f0168cc60650b6d45cd2`
+- Identity schema: `2`
+- target_skill_sha256: `dd975083d3977d90b71b3396dff2498ef2b7e8d49c50fab50b5462a26f3248ee`
+- eval_definition_sha256: `75d9816433885deaa537c3684a33cbf77a210bf3435c193880901b7467aafb6d`
+- metadata_sha256: `e1dbc6626788bdd9110a7a2968862f7b97506d86b4133c4cf183a556eecf36ce`
+- fixture_sha256: `4d8408c1113f0b188f486ff52a1805928dda107a5b4bcef41d15ff086a7d524c`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `2e68facf61317de81b206f59b17f3e724dc3951afae11b2a8c4aad6ddba91a26`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `f2aa9b2c49be68550ec45538c221425607f428ce`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `dd975083d3977d90b71b3396dff2498ef2b7e8d49c50fab50b5462a26f3248ee`
-- Skill overlay SHA-256: `9667198915198da0404e03a7d4c962d38742b19c5de4de5f0cf1473f02db2bf1`
-- Judge schema SHA-256: `2e68facf61317de81b206f59b17f3e724dc3951afae11b2a8c4aad6ddba91a26`
-- Eval definition SHA-256: `75d9816433885deaa537c3684a33cbf77a210bf3435c193880901b7467aafb6d`
-- Metadata SHA-256: `e1dbc6626788bdd9110a7a2968862f7b97506d86b4133c4cf183a556eecf36ce`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **FAIL**
 - Coverage result: **FULL**
 Overall result: FAIL

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-012-deployment-class-evidence-gap/comparison.md
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-012-deployment-class-evidence-gap/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `94a440475528b183f978a35b0a119247396e300b3f4d27c6c1d0f2046bc60924` from `agents/docs/test/formal-docs-sync/evals/workspace/eval-012-deployment-class-evidence-gap`.
-- Fixture SHA-256: `94a440475528b183f978a35b0a119247396e300b3f4d27c6c1d0f2046bc60924`
-- Prompt SHA-256: `d22f5a61b9778737597225188b6c8c34747660b197372bd350dcfc64d227e5ff`
+- Identity schema: `2`
+- target_skill_sha256: `dd975083d3977d90b71b3396dff2498ef2b7e8d49c50fab50b5462a26f3248ee`
+- eval_definition_sha256: `649fb22000e8030404ac6361df8372e15d8183baaa675df886e6c740c229829a`
+- metadata_sha256: `9b6d976d4601ac0de151b2a46d4bd90f68a76a475f804b7878df438cf1dba8d6`
+- fixture_sha256: `94a440475528b183f978a35b0a119247396e300b3f4d27c6c1d0f2046bc60924`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `e93bcd19b2a81fd498c0a0b76bf2788577403b4eb3f684a80f1adbb170c93ef8`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `f2aa9b2c49be68550ec45538c221425607f428ce`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `dd975083d3977d90b71b3396dff2498ef2b7e8d49c50fab50b5462a26f3248ee`
-- Skill overlay SHA-256: `9667198915198da0404e03a7d4c962d38742b19c5de4de5f0cf1473f02db2bf1`
-- Judge schema SHA-256: `e93bcd19b2a81fd498c0a0b76bf2788577403b4eb3f684a80f1adbb170c93ef8`
-- Eval definition SHA-256: `649fb22000e8030404ac6361df8372e15d8183baaa675df886e6c740c229829a`
-- Metadata SHA-256: `9b6d976d4601ac0de151b2a46d4bd90f68a76a475f804b7878df438cf1dba8d6`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-013-deployment-aggregate-migration/comparison.md
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-013-deployment-aggregate-migration/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `b9cf5f02e5624842eefaa770fff8e84ccfc602f0eed28accf48a25400705d39e` from `agents/docs/test/formal-docs-sync/evals/workspace/eval-013-deployment-aggregate-migration`.
-- Fixture SHA-256: `b9cf5f02e5624842eefaa770fff8e84ccfc602f0eed28accf48a25400705d39e`
-- Prompt SHA-256: `ef6288663966feaaf953d5b243a6dc9ee464a3ae22e56d91ba3c5352bb37ed40`
+- Identity schema: `2`
+- target_skill_sha256: `dd975083d3977d90b71b3396dff2498ef2b7e8d49c50fab50b5462a26f3248ee`
+- eval_definition_sha256: `2adf472912fe37066628cc2da23affed241d146a6c7c80728c7df93b4f2fccc7`
+- metadata_sha256: `1730a36a001d532f328500208fe2ccb136183d8551b840ea714421749b8365ea`
+- fixture_sha256: `b9cf5f02e5624842eefaa770fff8e84ccfc602f0eed28accf48a25400705d39e`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `cb68cc7396b4ed1007a2bd5b5970baa015053110168fade98a969dbebc84c1b1`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `f2aa9b2c49be68550ec45538c221425607f428ce`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `dd975083d3977d90b71b3396dff2498ef2b7e8d49c50fab50b5462a26f3248ee`
-- Skill overlay SHA-256: `9667198915198da0404e03a7d4c962d38742b19c5de4de5f0cf1473f02db2bf1`
-- Judge schema SHA-256: `cb68cc7396b4ed1007a2bd5b5970baa015053110168fade98a969dbebc84c1b1`
-- Eval definition SHA-256: `2adf472912fe37066628cc2da23affed241d146a6c7c80728c7df93b4f2fccc7`
-- Metadata SHA-256: `1730a36a001d532f328500208fe2ccb136183d8551b840ea714421749b8365ea`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **FAIL**
 - Coverage result: **FULL**
 Overall result: FAIL

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-014-existing-site-deployment-recheck/comparison.md
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-014-existing-site-deployment-recheck/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `af01acec7b20eeddc434bb03589d582f709819c1284ea057c0edd1ee4d701107` from `agents/docs/test/formal-docs-sync/evals/workspace/eval-014-existing-site-deployment-recheck`.
-- Fixture SHA-256: `af01acec7b20eeddc434bb03589d582f709819c1284ea057c0edd1ee4d701107`
-- Prompt SHA-256: `1fa72144e806cf52f8fd8fbc5b8cac36763c1b6d96e197c5c1ebe4dd6e004c69`
+- Identity schema: `2`
+- target_skill_sha256: `dd975083d3977d90b71b3396dff2498ef2b7e8d49c50fab50b5462a26f3248ee`
+- eval_definition_sha256: `db9d705a02de2df76d9e1b62334995eac21d110dc172ed350d92306793043708`
+- metadata_sha256: `88632df23697500a0c7c41e94fb02d6159ef73b07b033169b66f45a2a56cdd01`
+- fixture_sha256: `af01acec7b20eeddc434bb03589d582f709819c1284ea057c0edd1ee4d701107`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `4b8356273a26d14ecc55ebfe7a9a2e541bdc3539a06437a0f30fb3a0dc7cbd4b`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `f2aa9b2c49be68550ec45538c221425607f428ce`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `dd975083d3977d90b71b3396dff2498ef2b7e8d49c50fab50b5462a26f3248ee`
-- Skill overlay SHA-256: `9667198915198da0404e03a7d4c962d38742b19c5de4de5f0cf1473f02db2bf1`
-- Judge schema SHA-256: `4b8356273a26d14ecc55ebfe7a9a2e541bdc3539a06437a0f30fb3a0dc7cbd4b`
-- Eval definition SHA-256: `db9d705a02de2df76d9e1b62334995eac21d110dc172ed350d92306793043708`
-- Metadata SHA-256: `88632df23697500a0c7c41e94fb02d6159ef73b07b033169b66f45a2a56cdd01`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **FAIL**
 - Coverage result: **FULL**
 Overall result: FAIL

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-015-flat-hierarchy-migration-proposal/comparison.md
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-015-flat-hierarchy-migration-proposal/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `687c8c162f66866c443380eff16dcacb1132beefea8bacd8446882557f88aaac` from `agents/docs/test/formal-docs-sync/evals/workspace/eval-015-flat-hierarchy-migration-proposal`.
-- Fixture SHA-256: `687c8c162f66866c443380eff16dcacb1132beefea8bacd8446882557f88aaac`
-- Prompt SHA-256: `02d5619a5b35a2cb54dbb7f3f19b3f4325fef0a1206d2f3f66f83a6cc1613ad3`
+- Identity schema: `2`
+- target_skill_sha256: `dd975083d3977d90b71b3396dff2498ef2b7e8d49c50fab50b5462a26f3248ee`
+- eval_definition_sha256: `b33925735dcdc1c16e96ba8e543e331eebb29f1fb2575eb75afef7012c2934cd`
+- metadata_sha256: `1745a4b411c4974d9b158bc811fac50658345383bc93cab2e1df286dcb1629d0`
+- fixture_sha256: `687c8c162f66866c443380eff16dcacb1132beefea8bacd8446882557f88aaac`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `162b3544cbde876f526df1805303ea3ab78e34b2ebde819bbdbfe83bc8251b8c`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `f2aa9b2c49be68550ec45538c221425607f428ce`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `dd975083d3977d90b71b3396dff2498ef2b7e8d49c50fab50b5462a26f3248ee`
-- Skill overlay SHA-256: `9667198915198da0404e03a7d4c962d38742b19c5de4de5f0cf1473f02db2bf1`
-- Judge schema SHA-256: `162b3544cbde876f526df1805303ea3ab78e34b2ebde819bbdbfe83bc8251b8c`
-- Eval definition SHA-256: `b33925735dcdc1c16e96ba8e543e331eebb29f1fb2575eb75afef7012c2934cd`
-- Metadata SHA-256: `1745a4b411c4974d9b158bc811fac50658345383bc93cab2e1df286dcb1629d0`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/docs/test/release-notes-gen/evals/workspace/eval-001-generate-site-release-notes/comparison.md
+++ b/agents/docs/test/release-notes-gen/evals/workspace/eval-001-generate-site-release-notes/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `5f0f5b3062eae992b755cdc1ae78582ce41bb32058f8a49d6044db233c5966f5` from `agents/docs/test/release-notes-gen/evals/workspace/eval-001-generate-site-release-notes`.
-- Fixture SHA-256: `5f0f5b3062eae992b755cdc1ae78582ce41bb32058f8a49d6044db233c5966f5`
-- Prompt SHA-256: `abdc82e3242ddb2aafb79bd48f7c9ee0c804dc864021f0a687923bb4dc7de750`
+- Identity schema: `2`
+- target_skill_sha256: `c8459f189e8d92d91e1c7ede8875090bfc1c2e1e04b8f18983b4339e6b65ba34`
+- eval_definition_sha256: `65fbac4fd20096e04fd9044ef9811d00f14a304548ada95a65b3bc87c1320345`
+- metadata_sha256: `f1489da43deb17946a7db1865ce4492ffcbc2d33d7073fbbdc572711b748a76c`
+- fixture_sha256: `5f0f5b3062eae992b755cdc1ae78582ce41bb32058f8a49d6044db233c5966f5`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `37b31d01c6d97d7403db04c5a14501c9f7c823331bdaca410487353335744541`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `c8459f189e8d92d91e1c7ede8875090bfc1c2e1e04b8f18983b4339e6b65ba34`
-- Skill overlay SHA-256: `c7d3b6793c943fb4d4971cf0d6f11988326a2dff978353bf3c4327d4e24c17b7`
-- Judge schema SHA-256: `37b31d01c6d97d7403db04c5a14501c9f7c823331bdaca410487353335744541`
-- Eval definition SHA-256: `65fbac4fd20096e04fd9044ef9811d00f14a304548ada95a65b3bc87c1320345`
-- Metadata SHA-256: `f1489da43deb17946a7db1865ce4492ffcbc2d33d7073fbbdc572711b748a76c`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/docs/test/release-notes-gen/evals/workspace/eval-002-confirmation-gate/comparison.md
+++ b/agents/docs/test/release-notes-gen/evals/workspace/eval-002-confirmation-gate/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `d8d3cd2bcfa848d5848a9287f747e035b721f3a64f1b4c03c2359e2a75f040bc` from `agents/docs/test/release-notes-gen/evals/workspace/eval-002-confirmation-gate`.
-- Fixture SHA-256: `d8d3cd2bcfa848d5848a9287f747e035b721f3a64f1b4c03c2359e2a75f040bc`
-- Prompt SHA-256: `7064d6e7dd15f0c86ca51cdae30720bfc492837e0e9ed31705f989006960c692`
+- Identity schema: `2`
+- target_skill_sha256: `c8459f189e8d92d91e1c7ede8875090bfc1c2e1e04b8f18983b4339e6b65ba34`
+- eval_definition_sha256: `734d8912f6102b866e236fb845ac847f11fde3651b05c29ee143e730ba9a8ce3`
+- metadata_sha256: `244623c4cb29666e66fbef86938647497dad20990909aac70827020a236484a7`
+- fixture_sha256: `d8d3cd2bcfa848d5848a9287f747e035b721f3a64f1b4c03c2359e2a75f040bc`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `f52a12716f836504537cf75e93c1e10d802a32eb7ad0a9945e2057c1a94c3f7c`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `c8459f189e8d92d91e1c7ede8875090bfc1c2e1e04b8f18983b4339e6b65ba34`
-- Skill overlay SHA-256: `c7d3b6793c943fb4d4971cf0d6f11988326a2dff978353bf3c4327d4e24c17b7`
-- Judge schema SHA-256: `f52a12716f836504537cf75e93c1e10d802a32eb7ad0a9945e2057c1a94c3f7c`
-- Eval definition SHA-256: `734d8912f6102b866e236fb845ac847f11fde3651b05c29ee143e730ba9a8ce3`
-- Metadata SHA-256: `244623c4cb29666e66fbef86938647497dad20990909aac70827020a236484a7`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/docs/test/release-notes-gen/evals/workspace/eval-003-github-release-boundary/comparison.md
+++ b/agents/docs/test/release-notes-gen/evals/workspace/eval-003-github-release-boundary/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `b6c1fa26768d6c9af6d59884eea70e6437cb9644150d6247f56b09929c6c2720` from `agents/docs/test/release-notes-gen/evals/workspace/eval-003-github-release-boundary`.
-- Fixture SHA-256: `b6c1fa26768d6c9af6d59884eea70e6437cb9644150d6247f56b09929c6c2720`
-- Prompt SHA-256: `761d6ada5782aed911f08ad61db425bc070c8bdb36e85c9be9e952ce71ac3d5e`
+- Identity schema: `2`
+- target_skill_sha256: `c8459f189e8d92d91e1c7ede8875090bfc1c2e1e04b8f18983b4339e6b65ba34`
+- eval_definition_sha256: `05f16fbca1905a6bf2d3e5279f6310a7d3001480023c03eb422e696627b86d5d`
+- metadata_sha256: `79c5171e280a55a386cc65ee64ce2254d37bdb1b11edec578be748642efe98aa`
+- fixture_sha256: `b6c1fa26768d6c9af6d59884eea70e6437cb9644150d6247f56b09929c6c2720`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `b3d43ca97793c6a0f8faf70ea92518e7709890635e7a921da0c1ddde071762ab`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `c8459f189e8d92d91e1c7ede8875090bfc1c2e1e04b8f18983b4339e6b65ba34`
-- Skill overlay SHA-256: `c7d3b6793c943fb4d4971cf0d6f11988326a2dff978353bf3c4327d4e24c17b7`
-- Judge schema SHA-256: `b3d43ca97793c6a0f8faf70ea92518e7709890635e7a921da0c1ddde071762ab`
-- Eval definition SHA-256: `05f16fbca1905a6bf2d3e5279f6310a7d3001480023c03eb422e696627b86d5d`
-- Metadata SHA-256: `79c5171e280a55a386cc65ee64ce2254d37bdb1b11edec578be748642efe98aa`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/docs/test/release-notes-gen/evals/workspace/eval-004-conditional-deployment-recheck/comparison.md
+++ b/agents/docs/test/release-notes-gen/evals/workspace/eval-004-conditional-deployment-recheck/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `1d05a5ef6eacf2734acacac9c7f138205eacee50a9bb44893b96aa9bb0d64d31` from `agents/docs/test/release-notes-gen/evals/workspace/eval-004-conditional-deployment-recheck`.
-- Fixture SHA-256: `1d05a5ef6eacf2734acacac9c7f138205eacee50a9bb44893b96aa9bb0d64d31`
-- Prompt SHA-256: `5b0a2bb08468867270b5e33622f2c669d7709f2935d65084fe81cdc7c550d3b1`
+- Identity schema: `2`
+- target_skill_sha256: `c8459f189e8d92d91e1c7ede8875090bfc1c2e1e04b8f18983b4339e6b65ba34`
+- eval_definition_sha256: `34ab52326e403178b3c65c89903f9ce3ed937721059a083b8dcd35f212e12e18`
+- metadata_sha256: `026d3644999635bf9397130063cb1f65e3467ff790b1fe892aa83df25be7904c`
+- fixture_sha256: `1d05a5ef6eacf2734acacac9c7f138205eacee50a9bb44893b96aa9bb0d64d31`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `f6ca8293d29d78d2f2b85bd613e1f25b3aa93a647c64e21ca6731d5a228a1284`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `c8459f189e8d92d91e1c7ede8875090bfc1c2e1e04b8f18983b4339e6b65ba34`
-- Skill overlay SHA-256: `c7d3b6793c943fb4d4971cf0d6f11988326a2dff978353bf3c4327d4e24c17b7`
-- Judge schema SHA-256: `f6ca8293d29d78d2f2b85bd613e1f25b3aa93a647c64e21ca6731d5a228a1284`
-- Eval definition SHA-256: `34ab52326e403178b3c65c89903f9ce3ed937721059a083b8dcd35f212e12e18`
-- Metadata SHA-256: `026d3644999635bf9397130063cb1f65e3467ff790b1fe892aa83df25be7904c`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)

--- a/agents/docs/test/release-notes-gen/evals/workspace/eval-004-confirmed-release-delivery/comparison.md
+++ b/agents/docs/test/release-notes-gen/evals/workspace/eval-004-confirmed-release-delivery/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `c11c4570536758cb911b613643632dd7b15e8b492fb6a5c6cb788342176462bf` from `agents/docs/test/release-notes-gen/evals/workspace/eval-004-confirmed-release-delivery`.
-- Fixture SHA-256: `c11c4570536758cb911b613643632dd7b15e8b492fb6a5c6cb788342176462bf`
-- Prompt SHA-256: `5d2eb8fee66e709ed28ba5aa53ac1e57295ed25d74500a43d924b8fbc434431e`
+- Identity schema: `2`
+- target_skill_sha256: `c8459f189e8d92d91e1c7ede8875090bfc1c2e1e04b8f18983b4339e6b65ba34`
+- eval_definition_sha256: `6ba71c78dee7f69b879178b4307965fc8b664b773fca948482dc1711c289b5ad`
+- metadata_sha256: `2e15aaf06f83170c681a449f442bd9946bbef263dbea552644182da638b4addc`
+- fixture_sha256: `c11c4570536758cb911b613643632dd7b15e8b492fb6a5c6cb788342176462bf`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `5f19f02b941db43659fbfb03cc28f127d2b4bbc556ed59290b7811c966f30dc8`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `c8459f189e8d92d91e1c7ede8875090bfc1c2e1e04b8f18983b4339e6b65ba34`
-- Skill overlay SHA-256: `c7d3b6793c943fb4d4971cf0d6f11988326a2dff978353bf3c4327d4e24c17b7`
-- Judge schema SHA-256: `5f19f02b941db43659fbfb03cc28f127d2b4bbc556ed59290b7811c966f30dc8`
-- Eval definition SHA-256: `6ba71c78dee7f69b879178b4307965fc8b664b773fca948482dc1711c289b5ad`
-- Metadata SHA-256: `2e15aaf06f83170c681a449f442bd9946bbef263dbea552644182da638b4addc`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/engineer/skills/trd-gen/SKILL.md
+++ b/agents/engineer/skills/trd-gen/SKILL.md
@@ -41,10 +41,19 @@ It also renders `document_subagent_availability`, `document_author`,
 unavailable, all three owner fields identify the main process and the result
 states that it retained the PM/Engineer source context and completed the final
 traceability/repository-fit review; reporting only “unavailable” is incomplete.
-Always render `implementation_plan_handoff_owner: feature-implementor` and
+In the delivery summary, always render
+`implementation_plan_handoff_owner: feature-implementor` and
 `implementation_plan_handoff_path:
-docs/engineer/{feature_path}/IMPLEMENTATION_PLAN.md`. Open technical questions
+docs/engineer/{feature_path}/IMPLEMENTATION_PLAN.md`. These fields describe a
+pending downstream boundary; they do not authorize or perform the handoff and
+must not be written as routing instructions in the TRD body. Until the Engineer
+documents are confirmed and continuation is requested or authorized, do not
+claim that the work was handed off, routed, or started. Open technical questions
 may keep that handoff blocked, but must not erase its owner or target path.
+Keep every downstream owner, implementation-plan path, routing instruction,
+handoff status, and `blocked_downstream` list in the delivery summary only.
+Before writing the target document, remove those operational handoff details
+from the TRD body; before delivery, reopen the TRD and correct any occurrence.
 Render the ownership as `engineer_document_owner: engineer-agent:trd-gen` and
 apply it to every requested Engineer document in the current scope, including
 TRD, API, and ADR artifacts; `generated_by: trd-gen` alone is not the ownership
@@ -277,6 +286,14 @@ notice — deprecation is part of the API contract lifecycle, and consolidation
 applies only to endpoints that are truly removed or superseded. Ledger-style
 docs (`DECISIONS.md`, ADRs) keep history — that is their design intent, and the
 same PM-side rule explicitly exempts them.
+
+Before delivering an updated current-state document, reopen it and verify that
+the body contains no superseded design or status annotation that preserves one,
+that every removal is recorded in the YAML frontmatter `changelog` rather than
+only in a body section, that the frontmatter version was updated, and that no
+downstream routing, handoff owner/path, or blocked-downstream instruction appears
+in the body. Correct the document before reporting completion when any check
+fails.
 
 ## Quality Checks
 

--- a/agents/engineer/test/codebase-analyzer/evals/workspace/eval-001-analyze-nodejs-project/comparison.md
+++ b/agents/engineer/test/codebase-analyzer/evals/workspace/eval-001-analyze-nodejs-project/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `70d2400afd3b1f84a7248de72cf04a9e4741bffe1ed6525d4f1cdd2942b2f522` from `agents/engineer/test/codebase-analyzer/evals/workspace/eval-001-analyze-nodejs-project`.
-- Fixture SHA-256: `70d2400afd3b1f84a7248de72cf04a9e4741bffe1ed6525d4f1cdd2942b2f522`
-- Prompt SHA-256: `cad1b3715da2e128465b3215c9e0ead310ad90fc998d9d73f08f99586980cace`
+- Identity schema: `2`
+- target_skill_sha256: `de6d27a82a6affa1d54b83f57c4eb1889c4977944cd8849112c1a97798fbfd77`
+- eval_definition_sha256: `dad930e2f7ff239d93a7a9675b382ce2b702f6090d6d7cc66b26e7ea598351d6`
+- metadata_sha256: `5ca1d6325e7d73a97605eeb110ddc4062765b77075b5da8df9a904201e44cb60`
+- fixture_sha256: `70d2400afd3b1f84a7248de72cf04a9e4741bffe1ed6525d4f1cdd2942b2f522`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `4a44af8c4f43ac2a76bbdbb1c44519dabd549bb54a1dc48487259a1d80539946`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `de6d27a82a6affa1d54b83f57c4eb1889c4977944cd8849112c1a97798fbfd77`
-- Skill overlay SHA-256: `2437579eab93080a360f91c28589c43439611fa078f69b97d2ce2bd37e59a941`
-- Judge schema SHA-256: `4a44af8c4f43ac2a76bbdbb1c44519dabd549bb54a1dc48487259a1d80539946`
-- Eval definition SHA-256: `dad930e2f7ff239d93a7a9675b382ce2b702f6090d6d7cc66b26e7ea598351d6`
-- Metadata SHA-256: `5ca1d6325e7d73a97605eeb110ddc4062765b77075b5da8df9a904201e44cb60`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/engineer/test/codebase-analyzer/evals/workspace/eval-002-detect-monorepo/comparison.md
+++ b/agents/engineer/test/codebase-analyzer/evals/workspace/eval-002-detect-monorepo/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `f21b114551d8be3583bc722843216a52ebb44b2de4870be6c6e960ab6597a69f` from `agents/engineer/test/codebase-analyzer/evals/workspace/eval-002-detect-monorepo`.
-- Fixture SHA-256: `f21b114551d8be3583bc722843216a52ebb44b2de4870be6c6e960ab6597a69f`
-- Prompt SHA-256: `4a44a53303527788f0fdde89c2cf0711930adcb2731bd7176d57421ed0f8220c`
+- Identity schema: `2`
+- target_skill_sha256: `de6d27a82a6affa1d54b83f57c4eb1889c4977944cd8849112c1a97798fbfd77`
+- eval_definition_sha256: `9a583203eacc9eba1f7a8bc21f635feb6ed3d4608d62de30920ed955c3d1edca`
+- metadata_sha256: `c7ae12e62e0a39a4d07a2a609b69c812f1e0369799ab62ccf27310eb616d8c85`
+- fixture_sha256: `f21b114551d8be3583bc722843216a52ebb44b2de4870be6c6e960ab6597a69f`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `34f896897fd86f962fdde3e8fbee4d88ed3d89310d32aa50bf9d05459ebc08b8`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `de6d27a82a6affa1d54b83f57c4eb1889c4977944cd8849112c1a97798fbfd77`
-- Skill overlay SHA-256: `2437579eab93080a360f91c28589c43439611fa078f69b97d2ce2bd37e59a941`
-- Judge schema SHA-256: `34f896897fd86f962fdde3e8fbee4d88ed3d89310d32aa50bf9d05459ebc08b8`
-- Eval definition SHA-256: `9a583203eacc9eba1f7a8bc21f635feb6ed3d4608d62de30920ed955c3d1edca`
-- Metadata SHA-256: `c7ae12e62e0a39a4d07a2a609b69c812f1e0369799ab62ccf27310eb616d8c85`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/engineer/test/codebase-analyzer/evals/workspace/eval-003-mapped-search-architecture/comparison.md
+++ b/agents/engineer/test/codebase-analyzer/evals/workspace/eval-003-mapped-search-architecture/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `a3ef5b9cc00c15c74b103c208a46d73ff5b53e17721ec0a79184a10c02b16859` from `agents/engineer/test/codebase-analyzer/evals/workspace/eval-003-mapped-search-architecture`.
-- Fixture SHA-256: `a3ef5b9cc00c15c74b103c208a46d73ff5b53e17721ec0a79184a10c02b16859`
-- Prompt SHA-256: `0f34452462bbb10e7f7328b054a3e1b0e6f741b40ba12100a356dcedfa512f9c`
+- Identity schema: `2`
+- target_skill_sha256: `de6d27a82a6affa1d54b83f57c4eb1889c4977944cd8849112c1a97798fbfd77`
+- eval_definition_sha256: `df0ea3b9e16f84cfa3123784feaff62e9978d327069fdb7ff40819c75c9ebde1`
+- metadata_sha256: `c79f8b60b8eda49d60383374b0b105b8c506dcb4b757a67593ed9721a0d169df`
+- fixture_sha256: `a3ef5b9cc00c15c74b103c208a46d73ff5b53e17721ec0a79184a10c02b16859`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `953cf0ea99b9840a17c7b6706052165ac0b5ad2da8cf5b30696958f911637de4`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `de6d27a82a6affa1d54b83f57c4eb1889c4977944cd8849112c1a97798fbfd77`
-- Skill overlay SHA-256: `2437579eab93080a360f91c28589c43439611fa078f69b97d2ce2bd37e59a941`
-- Judge schema SHA-256: `953cf0ea99b9840a17c7b6706052165ac0b5ad2da8cf5b30696958f911637de4`
-- Eval definition SHA-256: `df0ea3b9e16f84cfa3123784feaff62e9978d327069fdb7ff40819c75c9ebde1`
-- Metadata SHA-256: `c79f8b60b8eda49d60383374b0b105b8c506dcb4b757a67593ed9721a0d169df`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/engineer/test/debugger/evals/workspace/eval-001-fix-failing-test/comparison.md
+++ b/agents/engineer/test/debugger/evals/workspace/eval-001-fix-failing-test/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `5c2aa809e84372707ac261c141dd4e1423c9e30cd9e6ea24a75c119a154d7dff` from `agents/engineer/test/debugger/evals/workspace/eval-001-fix-failing-test`.
-- Fixture SHA-256: `5c2aa809e84372707ac261c141dd4e1423c9e30cd9e6ea24a75c119a154d7dff`
-- Prompt SHA-256: `466181e7694b25aaf0cac9d93d523254287de12a8ec17c132e46918754d64666`
+- Identity schema: `2`
+- target_skill_sha256: `acf0c5d2caeeb9edf300e1f0c7701e33bb6c45afbe3042c358a9c6ee00d796a7`
+- eval_definition_sha256: `a64fd90ac10a25e027c288e912b74561949edde0e4324959b4f6359f344c4587`
+- metadata_sha256: `b2ee79c4493432ae5076e82b907d6b1be7ab09583eef30c12a61c6ba0cd38123`
+- fixture_sha256: `5c2aa809e84372707ac261c141dd4e1423c9e30cd9e6ea24a75c119a154d7dff`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `a8da760bc70af1b8443957d6d0e0908d94f04e37f7d5a4ff6aab844f06d89c5a`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `acf0c5d2caeeb9edf300e1f0c7701e33bb6c45afbe3042c358a9c6ee00d796a7`
-- Skill overlay SHA-256: `fe7a8ba393fe785cea7c7f8aebc226c5d2d3fa7e0ca885b983992d7f1c96a094`
-- Judge schema SHA-256: `a8da760bc70af1b8443957d6d0e0908d94f04e37f7d5a4ff6aab844f06d89c5a`
-- Eval definition SHA-256: `a64fd90ac10a25e027c288e912b74561949edde0e4324959b4f6359f344c4587`
-- Metadata SHA-256: `b2ee79c4493432ae5076e82b907d6b1be7ab09583eef30c12a61c6ba0cd38123`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)

--- a/agents/engineer/test/debugger/evals/workspace/eval-002-repair-plan-confirmation-gate/comparison.md
+++ b/agents/engineer/test/debugger/evals/workspace/eval-002-repair-plan-confirmation-gate/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `cb0f3c3b3299f6d7c5c59f8e23f6486f0ceb71f6128a3055fbac267527c0d07e` from `agents/engineer/test/debugger/evals/workspace/eval-002-repair-plan-confirmation-gate`.
-- Fixture SHA-256: `cb0f3c3b3299f6d7c5c59f8e23f6486f0ceb71f6128a3055fbac267527c0d07e`
-- Prompt SHA-256: `665db040735beea5cd9a54d5fea883336b5acadf81472985dbcc094ec677dd55`
+- Identity schema: `2`
+- target_skill_sha256: `acf0c5d2caeeb9edf300e1f0c7701e33bb6c45afbe3042c358a9c6ee00d796a7`
+- eval_definition_sha256: `024f4702e0fa8869af3d3c3109a71208ab006a57b0857bf3decfc75788b86ec1`
+- metadata_sha256: `7d2fe0fce1e70425553acde36f203e00cc70ea5e32d8f50bf9a3232445ec4c62`
+- fixture_sha256: `cb0f3c3b3299f6d7c5c59f8e23f6486f0ceb71f6128a3055fbac267527c0d07e`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `02d5b7800830ae12f2a9e99e570ad3aff880c5fd3790b18a9b48bd3dab3b6e8d`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `acf0c5d2caeeb9edf300e1f0c7701e33bb6c45afbe3042c358a9c6ee00d796a7`
-- Skill overlay SHA-256: `fe7a8ba393fe785cea7c7f8aebc226c5d2d3fa7e0ca885b983992d7f1c96a094`
-- Judge schema SHA-256: `02d5b7800830ae12f2a9e99e570ad3aff880c5fd3790b18a9b48bd3dab3b6e8d`
-- Eval definition SHA-256: `024f4702e0fa8869af3d3c3109a71208ab006a57b0857bf3decfc75788b86ec1`
-- Metadata SHA-256: `7d2fe0fce1e70425553acde36f203e00cc70ea5e32d8f50bf9a3232445ec4c62`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/engineer/test/debugger/evals/workspace/eval-003-bug-report-conflicts-with-prd/comparison.md
+++ b/agents/engineer/test/debugger/evals/workspace/eval-003-bug-report-conflicts-with-prd/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `b9cb551f52561a96ecca0df5c9b20f04fdacfc0ec8b6db0f67266ab529420ef6` from `agents/engineer/test/debugger/evals/workspace/eval-003-bug-report-conflicts-with-prd`.
-- Fixture SHA-256: `b9cb551f52561a96ecca0df5c9b20f04fdacfc0ec8b6db0f67266ab529420ef6`
-- Prompt SHA-256: `86a3ada212136d13171426579f0eb442cf8d67a9050df5093eea8ab964daf7e3`
+- Identity schema: `2`
+- target_skill_sha256: `acf0c5d2caeeb9edf300e1f0c7701e33bb6c45afbe3042c358a9c6ee00d796a7`
+- eval_definition_sha256: `1b0128e389f23ce11fa7b4c38a0b662507e4f8c62e4b45bb6324446e6c6f6b76`
+- metadata_sha256: `83547cd6afd667b78b8f3a62b333fd240958e2bcd69f2565824d154532321924`
+- fixture_sha256: `b9cb551f52561a96ecca0df5c9b20f04fdacfc0ec8b6db0f67266ab529420ef6`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `a8bfc4df337c13eb13450fd2790a0adaaa6e985db2ba520873d18d41987ab63d`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `acf0c5d2caeeb9edf300e1f0c7701e33bb6c45afbe3042c358a9c6ee00d796a7`
-- Skill overlay SHA-256: `fe7a8ba393fe785cea7c7f8aebc226c5d2d3fa7e0ca885b983992d7f1c96a094`
-- Judge schema SHA-256: `a8bfc4df337c13eb13450fd2790a0adaaa6e985db2ba520873d18d41987ab63d`
-- Eval definition SHA-256: `1b0128e389f23ce11fa7b4c38a0b662507e4f8c62e4b45bb6324446e6c6f6b76`
-- Metadata SHA-256: `83547cd6afd667b78b8f3a62b333fd240958e2bcd69f2565824d154532321924`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)

--- a/agents/engineer/test/debugger/evals/workspace/eval-004-nested-feature-path-bug-alignment/comparison.md
+++ b/agents/engineer/test/debugger/evals/workspace/eval-004-nested-feature-path-bug-alignment/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `1e51e9c8d509d705021a998a8e3fa6c6c2d1f11f8d331f94d613c603fe3acfe0` from `agents/engineer/test/debugger/evals/workspace/eval-004-nested-feature-path-bug-alignment`.
-- Fixture SHA-256: `1e51e9c8d509d705021a998a8e3fa6c6c2d1f11f8d331f94d613c603fe3acfe0`
-- Prompt SHA-256: `c6a119a607cc22724566b0886d0898a2191f1291f5ef19216b2d283dcf9bdf94`
+- Identity schema: `2`
+- target_skill_sha256: `acf0c5d2caeeb9edf300e1f0c7701e33bb6c45afbe3042c358a9c6ee00d796a7`
+- eval_definition_sha256: `4ed41777f0081de6b22c8d5c1da9d06cff7a26fda1bb09b0b22361f263f5eaee`
+- metadata_sha256: `92b34bddeb11ae5b3c6841a7115ad004679cbe8ce0c62b863a34d672cce43c83`
+- fixture_sha256: `1e51e9c8d509d705021a998a8e3fa6c6c2d1f11f8d331f94d613c603fe3acfe0`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `8752855324ba03bc8e8e5d406c04e9f47ee4871f83be7779dbe93e460aa8eb03`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `acf0c5d2caeeb9edf300e1f0c7701e33bb6c45afbe3042c358a9c6ee00d796a7`
-- Skill overlay SHA-256: `fe7a8ba393fe785cea7c7f8aebc226c5d2d3fa7e0ca885b983992d7f1c96a094`
-- Judge schema SHA-256: `8752855324ba03bc8e8e5d406c04e9f47ee4871f83be7779dbe93e460aa8eb03`
-- Eval definition SHA-256: `4ed41777f0081de6b22c8d5c1da9d06cff7a26fda1bb09b0b22361f263f5eaee`
-- Metadata SHA-256: `92b34bddeb11ae5b3c6841a7115ad004679cbe8ce0c62b863a34d672cce43c83`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)

--- a/agents/engineer/test/debugger/evals/workspace/eval-005-mapped-cache-debug-evidence/comparison.md
+++ b/agents/engineer/test/debugger/evals/workspace/eval-005-mapped-cache-debug-evidence/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `5265284c4bc9506c9aff21630151842110054255967ea23b3c9669fa67c6063d` from `agents/engineer/test/debugger/evals/workspace/eval-005-mapped-cache-debug-evidence`.
-- Fixture SHA-256: `5265284c4bc9506c9aff21630151842110054255967ea23b3c9669fa67c6063d`
-- Prompt SHA-256: `f67ee52e742cb8b8fa4a2e4a8def50688400c24b6328050c434ae918f3f4101b`
+- Identity schema: `2`
+- target_skill_sha256: `acf0c5d2caeeb9edf300e1f0c7701e33bb6c45afbe3042c358a9c6ee00d796a7`
+- eval_definition_sha256: `793c3f5cce4575964aaa387ece63f94a0f71e528641010e1ee2d932bd04007a8`
+- metadata_sha256: `296cf62658138bf9e31e0fd2b92d8abed954cf84bd5c6bd08af68865f72fdfc1`
+- fixture_sha256: `5265284c4bc9506c9aff21630151842110054255967ea23b3c9669fa67c6063d`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `acf0c5d2caeeb9edf300e1f0c7701e33bb6c45afbe3042c358a9c6ee00d796a7`
-- Skill overlay SHA-256: `fe7a8ba393fe785cea7c7f8aebc226c5d2d3fa7e0ca885b983992d7f1c96a094`
-- Judge schema SHA-256: `6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda`
-- Eval definition SHA-256: `793c3f5cce4575964aaa387ece63f94a0f71e528641010e1ee2d932bd04007a8`
-- Metadata SHA-256: `296cf62658138bf9e31e0fd2b92d8abed954cf84bd5c6bd08af68865f72fdfc1`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/engineer/test/delivery/evals/workspace/eval-001-create-pr-with-commits/comparison.md
+++ b/agents/engineer/test/delivery/evals/workspace/eval-001-create-pr-with-commits/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `415df27ebd271a5c6f0949b6abe147a826b07a65acc211cf3185fa0d7f9c490e` from `agents/engineer/test/delivery/evals/workspace/eval-001-create-pr-with-commits`.
-- Fixture SHA-256: `415df27ebd271a5c6f0949b6abe147a826b07a65acc211cf3185fa0d7f9c490e`
-- Prompt SHA-256: `0b44a24f8cc1cd09df29f861e75c80120390e6bd31b5f661fccd1e0a1e7be7a5`
+- Identity schema: `2`
+- target_skill_sha256: `80143710c96793bf7a6f9a4804a3d60ffaac7dece4a2f7557d0f1f0713ea31bd`
+- eval_definition_sha256: `7e02d3842aadb84c2bf63d29c927cc522ebed52b96eed1878122982c38563924`
+- metadata_sha256: `ddad21037c097d13ee42c91b495c2c2326e53dc9044ae9a3b160a51decc6ffbb`
+- fixture_sha256: `415df27ebd271a5c6f0949b6abe147a826b07a65acc211cf3185fa0d7f9c490e`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `eaac8d5ec4179daca7a6c1c98e4847ae0114d9d33168a84593f70ca6474abe10`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `80143710c96793bf7a6f9a4804a3d60ffaac7dece4a2f7557d0f1f0713ea31bd`
-- Skill overlay SHA-256: `c8b7fb40dd202ef7d4a2346a2ebf1af166a6cf34ac5e5f640ac543c8febcfa5e`
-- Judge schema SHA-256: `eaac8d5ec4179daca7a6c1c98e4847ae0114d9d33168a84593f70ca6474abe10`
-- Eval definition SHA-256: `7e02d3842aadb84c2bf63d29c927cc522ebed52b96eed1878122982c38563924`
-- Metadata SHA-256: `ddad21037c097d13ee42c91b495c2c2326e53dc9044ae9a3b160a51decc6ffbb`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)

--- a/agents/engineer/test/engineer-agent/evals/workspace/eval-002-existing-feature-alignment-gate/comparison.md
+++ b/agents/engineer/test/engineer-agent/evals/workspace/eval-002-existing-feature-alignment-gate/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/engineer/test/engineer-agent/evals/workspace/eval-002-existing-feature-alignment-gate`.
-- Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
-- Prompt SHA-256: `d08d04c31266e7709df236e5a84b0516db051d4099fdd86927601fc672aa3954`
+- Identity schema: `2`
+- target_skill_sha256: `a0945f69a591a803cbdf998f521f63c8cd89a50d9611edf8290964f39919f246`
+- eval_definition_sha256: `35bf0057341046be2b5db3cd90c99d825b61efaf315ed25428b5eda571894209`
+- metadata_sha256: `43542dab517c382c8ae0bc3c7332df9e98a97a6229686bf334f88c000c1ef95a`
+- fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `fd74eb5f01d1266986de0e63d98b09a328266b3f4b3b37579328c75fc417b428`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `a0945f69a591a803cbdf998f521f63c8cd89a50d9611edf8290964f39919f246`
-- Skill overlay SHA-256: `9a7303ba5cad830c4f006356c75d5caf882ecf0cba962488589ee499a487871f`
-- Judge schema SHA-256: `fd74eb5f01d1266986de0e63d98b09a328266b3f4b3b37579328c75fc417b428`
-- Eval definition SHA-256: `35bf0057341046be2b5db3cd90c99d825b61efaf315ed25428b5eda571894209`
-- Metadata SHA-256: `43542dab517c382c8ae0bc3c7332df9e98a97a6229686bf334f88c000c1ef95a`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)

--- a/agents/engineer/test/engineer-agent/evals/workspace/eval-003-nested-feature-alignment-routing/comparison.md
+++ b/agents/engineer/test/engineer-agent/evals/workspace/eval-003-nested-feature-alignment-routing/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `fce695dea6b3b91d6d3888c03505a121b7361b20c47f0ec1866020880becfe0b` from `agents/engineer/test/engineer-agent/evals/workspace/eval-003-nested-feature-alignment-routing`.
-- Fixture SHA-256: `fce695dea6b3b91d6d3888c03505a121b7361b20c47f0ec1866020880becfe0b`
-- Prompt SHA-256: `8df8927fae8a7a05a0bc46dd68c9ebf5573f79304565b07745939c992b9c20d9`
+- Identity schema: `2`
+- target_skill_sha256: `a0945f69a591a803cbdf998f521f63c8cd89a50d9611edf8290964f39919f246`
+- eval_definition_sha256: `6c7cc377f055d604b202feb40d5d2142b855d0368cb0621fa60f17937cec9872`
+- metadata_sha256: `cc9d0ea1f23672ef6b7d553053f01b0836b8fd341a707c6f88e853c6256fb3fb`
+- fixture_sha256: `fce695dea6b3b91d6d3888c03505a121b7361b20c47f0ec1866020880becfe0b`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `2c28cd5019db4aa28a9d236d016e67174df115cef2180ca189d432ec28ba579c`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `a0945f69a591a803cbdf998f521f63c8cd89a50d9611edf8290964f39919f246`
-- Skill overlay SHA-256: `9a7303ba5cad830c4f006356c75d5caf882ecf0cba962488589ee499a487871f`
-- Judge schema SHA-256: `2c28cd5019db4aa28a9d236d016e67174df115cef2180ca189d432ec28ba579c`
-- Eval definition SHA-256: `6c7cc377f055d604b202feb40d5d2142b855d0368cb0621fa60f17937cec9872`
-- Metadata SHA-256: `cc9d0ea1f23672ef6b7d553053f01b0836b8fd341a707c6f88e853c6256fb3fb`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)

--- a/agents/engineer/test/engineer-agent/evals/workspace/eval-004-frontend-ui-routing-contract/comparison.md
+++ b/agents/engineer/test/engineer-agent/evals/workspace/eval-004-frontend-ui-routing-contract/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `ec60268c3cba621e7690e34a6ae14bc9ac52429e90275b6d4c2fdedef202a8df` from `agents/engineer/test/engineer-agent/evals/workspace/eval-004-frontend-ui-routing-contract`.
-- Fixture SHA-256: `ec60268c3cba621e7690e34a6ae14bc9ac52429e90275b6d4c2fdedef202a8df`
-- Prompt SHA-256: `c7cb9273b0ca01f312d499d16a87d54a68980710efc17abee5e6a4600012b8c0`
+- Identity schema: `2`
+- target_skill_sha256: `a0945f69a591a803cbdf998f521f63c8cd89a50d9611edf8290964f39919f246`
+- eval_definition_sha256: `bfc10d83b8c5a5962987ac2605d966a1788bde7de31566b4d329601b6b214354`
+- metadata_sha256: `4906971d417635b5c425ac490e57080c03cc4473b36cee23eaff89fa06fe26b0`
+- fixture_sha256: `ec60268c3cba621e7690e34a6ae14bc9ac52429e90275b6d4c2fdedef202a8df`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `e2168c580c03f1c43acee8d4077b4a9553410b224e0542721c19d2cc8e09e39c`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `a0945f69a591a803cbdf998f521f63c8cd89a50d9611edf8290964f39919f246`
-- Skill overlay SHA-256: `9a7303ba5cad830c4f006356c75d5caf882ecf0cba962488589ee499a487871f`
-- Judge schema SHA-256: `e2168c580c03f1c43acee8d4077b4a9553410b224e0542721c19d2cc8e09e39c`
-- Eval definition SHA-256: `bfc10d83b8c5a5962987ac2605d966a1788bde7de31566b4d329601b6b214354`
-- Metadata SHA-256: `4906971d417635b5c425ac490e57080c03cc4473b36cee23eaff89fa06fe26b0`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/engineer/test/engineer-agent/evals/workspace/eval-1-route-implementation-chain/comparison.md
+++ b/agents/engineer/test/engineer-agent/evals/workspace/eval-1-route-implementation-chain/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `6901f5611ca2fe3ad6e90465dd3d2fa7fe65487d3ee792571b1138447aa07b62` from `agents/engineer/test/engineer-agent/evals/workspace/eval-1-route-implementation-chain`.
-- Fixture SHA-256: `6901f5611ca2fe3ad6e90465dd3d2fa7fe65487d3ee792571b1138447aa07b62`
-- Prompt SHA-256: `9fc8881f18737830e6fd3bd600a3e0c2e55655ace219e4ac6560b9a3b9b10408`
+- Identity schema: `2`
+- target_skill_sha256: `a0945f69a591a803cbdf998f521f63c8cd89a50d9611edf8290964f39919f246`
+- eval_definition_sha256: `c64c3e656d8dd56f539b8d46bbf02d2891b999db368472657d75c526ab878d79`
+- metadata_sha256: `8b67b33f30d9db399127d2f1e52b999931f8055d9c101157fccc82071f88b519`
+- fixture_sha256: `6901f5611ca2fe3ad6e90465dd3d2fa7fe65487d3ee792571b1138447aa07b62`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `a1e6bf4e08477989b26fffa805de56b77288d345cfdf1b16c76dd2c7ddf824f4`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `a0945f69a591a803cbdf998f521f63c8cd89a50d9611edf8290964f39919f246`
-- Skill overlay SHA-256: `9a7303ba5cad830c4f006356c75d5caf882ecf0cba962488589ee499a487871f`
-- Judge schema SHA-256: `a1e6bf4e08477989b26fffa805de56b77288d345cfdf1b16c76dd2c7ddf824f4`
-- Eval definition SHA-256: `c64c3e656d8dd56f539b8d46bbf02d2891b999db368472657d75c526ab878d79`
-- Metadata SHA-256: `8b67b33f30d9db399127d2f1e52b999931f8055d9c101157fccc82071f88b519`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-001-implement-from-prd-trd/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-001-implement-from-prd-trd/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `6fefdc42c8b398b33bf8d36b081a2d2c404ba55841f19917d1bf8a129df36ca6` from `agents/engineer/test/feature-implementor/evals/workspace/eval-001-implement-from-prd-trd`.
-- Fixture SHA-256: `6fefdc42c8b398b33bf8d36b081a2d2c404ba55841f19917d1bf8a129df36ca6`
-- Prompt SHA-256: `2b7b36d4bdea5793eaf1494d70b7d895d20a1213d115ce56d29616224f8e44f7`
+- Identity schema: `2`
+- target_skill_sha256: `2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82`
+- eval_definition_sha256: `fdd6ce4f4f12ff2cfeb67956eb31c203d7cf49aba2742edf2df400fcb4ed7d44`
+- metadata_sha256: `5513e853bb936ee74aa78321c2888f8103020519d504b58c9b057a2fb3fd33ff`
+- fixture_sha256: `6fefdc42c8b398b33bf8d36b081a2d2c404ba55841f19917d1bf8a129df36ca6`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `beede515c8e2f36efe8ae181f94762d96db69fb2e24a26068fcdd2ef262c1f48`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `7ac19d358ca18ef7b2d109aeec17239bc9d0f4c0`
 - Repository worktree state: **CLEAN**
-- Target skill tree SHA-256: `2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82`
-- Skill overlay SHA-256: `06e677e2d778ad6e9070a73693d2a9f47819f161c623014f6e26b508a4d8e533`
-- Judge schema SHA-256: `beede515c8e2f36efe8ae181f94762d96db69fb2e24a26068fcdd2ef262c1f48`
-- Eval definition SHA-256: `fdd6ce4f4f12ff2cfeb67956eb31c203d7cf49aba2742edf2df400fcb4ed7d44`
-- Metadata SHA-256: `5513e853bb936ee74aa78321c2888f8103020519d504b58c9b057a2fb3fd33ff`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-002-subagent-division-from-docs/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-002-subagent-division-from-docs/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `65a99fdb8c4d1c46befd98fefb9960ee9aae1f97faab8a74ba30b0fffe3597a9` from `agents/engineer/test/feature-implementor/evals/workspace/eval-002-subagent-division-from-docs`.
-- Fixture SHA-256: `65a99fdb8c4d1c46befd98fefb9960ee9aae1f97faab8a74ba30b0fffe3597a9`
-- Prompt SHA-256: `8ee9b69232c9ce95b799be0d259b297845a3badf592141bec3518643c9781de5`
+- Identity schema: `2`
+- target_skill_sha256: `2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82`
+- eval_definition_sha256: `5c62d2cc73fb2bf0752465157043f4f8dd87b392fc0487e4305ab334ca2facef`
+- metadata_sha256: `0a81d92a9af555dbb300e83a7ff4d8024a21161273fe243a2bbb1dbd8da3747a`
+- fixture_sha256: `65a99fdb8c4d1c46befd98fefb9960ee9aae1f97faab8a74ba30b0fffe3597a9`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `1e433f2d38239fdd1f4633433c706d2dafc7492741c63113035a8d0975b21d23`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `7ac19d358ca18ef7b2d109aeec17239bc9d0f4c0`
 - Repository worktree state: **CLEAN**
-- Target skill tree SHA-256: `2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82`
-- Skill overlay SHA-256: `06e677e2d778ad6e9070a73693d2a9f47819f161c623014f6e26b508a4d8e533`
-- Judge schema SHA-256: `1e433f2d38239fdd1f4633433c706d2dafc7492741c63113035a8d0975b21d23`
-- Eval definition SHA-256: `5c62d2cc73fb2bf0752465157043f4f8dd87b392fc0487e4305ab334ca2facef`
-- Metadata SHA-256: `0a81d92a9af555dbb300e83a7ff4d8024a21161273fe243a2bbb1dbd8da3747a`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-003-missing-trd-handoff/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-003-missing-trd-handoff/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `ab5acf9561757cd60998119f1643fd8622ced39a8046dbb107e9cf8100e1110f` from `agents/engineer/test/feature-implementor/evals/workspace/eval-003-missing-trd-handoff`.
-- Fixture SHA-256: `ab5acf9561757cd60998119f1643fd8622ced39a8046dbb107e9cf8100e1110f`
-- Prompt SHA-256: `b3686b3e49b5b805ba890514f93468b848aeefc3a94d03ef515571046a19d7e0`
+- Identity schema: `2`
+- target_skill_sha256: `2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82`
+- eval_definition_sha256: `beeebfd4f2a4eb407e840ff01043296b9db4c0e70af2a9d7de790cf54280c082`
+- metadata_sha256: `b646b97a67422c086871d592a86b4ef2968c69945b431fbbc93a36b8db79d701`
+- fixture_sha256: `ab5acf9561757cd60998119f1643fd8622ced39a8046dbb107e9cf8100e1110f`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `e6ae86389c4cff0bdb9cc29f2e8bb068759de0c10b4021f42a0673c6cbfc39d1`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `7ac19d358ca18ef7b2d109aeec17239bc9d0f4c0`
 - Repository worktree state: **CLEAN**
-- Target skill tree SHA-256: `2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82`
-- Skill overlay SHA-256: `06e677e2d778ad6e9070a73693d2a9f47819f161c623014f6e26b508a4d8e533`
-- Judge schema SHA-256: `e6ae86389c4cff0bdb9cc29f2e8bb068759de0c10b4021f42a0673c6cbfc39d1`
-- Eval definition SHA-256: `beeebfd4f2a4eb407e840ff01043296b9db4c0e70af2a9d7de790cf54280c082`
-- Metadata SHA-256: `b646b97a67422c086871d592a86b4ef2968c69945b431fbbc93a36b8db79d701`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-004-small-change-plan-gate/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-004-small-change-plan-gate/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `08e37b0f6a888462b39d6fb25d39b0f94b11e631f275f2f0a4af2411345138b6` from `agents/engineer/test/feature-implementor/evals/workspace/eval-004-small-change-plan-gate`.
-- Fixture SHA-256: `08e37b0f6a888462b39d6fb25d39b0f94b11e631f275f2f0a4af2411345138b6`
-- Prompt SHA-256: `334abb7e4defb6a609eb3e27f2a8ee311f59dfd40169a8f184ac8785cb43611a`
+- Identity schema: `2`
+- target_skill_sha256: `2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82`
+- eval_definition_sha256: `7ad36e3dae8256ee32b41e326daa72d3992661ae3195905ab94c0de9d5bb4663`
+- metadata_sha256: `62fa61590c7d39e5404273472c64cb54c1f2eedc4a5d8859470cb476742b524a`
+- fixture_sha256: `08e37b0f6a888462b39d6fb25d39b0f94b11e631f275f2f0a4af2411345138b6`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `133a3fd5fa38d2737eb59228058522a6b1f1268ab7cae969d1962b0b8a3f990f`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `7ac19d358ca18ef7b2d109aeec17239bc9d0f4c0`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82`
-- Skill overlay SHA-256: `06e677e2d778ad6e9070a73693d2a9f47819f161c623014f6e26b508a4d8e533`
-- Judge schema SHA-256: `133a3fd5fa38d2737eb59228058522a6b1f1268ab7cae969d1962b0b8a3f990f`
-- Eval definition SHA-256: `7ad36e3dae8256ee32b41e326daa72d3992661ae3195905ab94c0de9d5bb4663`
-- Metadata SHA-256: `62fa61590c7d39e5404273472c64cb54c1f2eedc4a5d8859470cb476742b524a`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-005-existing-behavior-change-needs-pm/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-005-existing-behavior-change-needs-pm/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/engineer/test/feature-implementor/evals/workspace/eval-005-existing-behavior-change-needs-pm`.
-- Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
-- Prompt SHA-256: `5f81869b673853f146ffc9b6b0265765a906f1c4c8ed1c32a5df3f964238d63c`
+- Identity schema: `2`
+- target_skill_sha256: `2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82`
+- eval_definition_sha256: `a4e07ef6b983fa7473b530066460795acade377b6663bfa81c7266e9bd35ec21`
+- metadata_sha256: `4d7d33b92b764b2a122613cfa3d9e97d80ead9fb721df6a2df123d3fcb35534c`
+- fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `c708196a2509f10ac671d636aa20ae05a664bdf496710d323db28c9149713561`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `7ac19d358ca18ef7b2d109aeec17239bc9d0f4c0`
 - Repository worktree state: **CLEAN**
-- Target skill tree SHA-256: `2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82`
-- Skill overlay SHA-256: `06e677e2d778ad6e9070a73693d2a9f47819f161c623014f6e26b508a4d8e533`
-- Judge schema SHA-256: `c708196a2509f10ac671d636aa20ae05a664bdf496710d323db28c9149713561`
-- Eval definition SHA-256: `a4e07ef6b983fa7473b530066460795acade377b6663bfa81c7266e9bd35ec21`
-- Metadata SHA-256: `4d7d33b92b764b2a122613cfa3d9e97d80ead9fb721df6a2df123d3fcb35534c`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-006-small-bug-fix-plan-gate/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-006-small-bug-fix-plan-gate/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `189adddf12b53efb048e7c5d0b3605c9ce9d7f6b01023de7e418b715817c16f4` from `agents/engineer/test/feature-implementor/evals/workspace/eval-006-small-bug-fix-plan-gate`.
-- Fixture SHA-256: `189adddf12b53efb048e7c5d0b3605c9ce9d7f6b01023de7e418b715817c16f4`
-- Prompt SHA-256: `3ca6a3518bdc8bcc3b18e69a3a095ab08898901d1b98a9feaebe381c01e9564a`
+- Identity schema: `2`
+- target_skill_sha256: `2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82`
+- eval_definition_sha256: `eedd6f2658d30fa0d35d3b4c542f62bf462bc6c1940c310dab2dd6d4429a52b7`
+- metadata_sha256: `e36d75fac31fda1c2cb2830fe86474e7378a0134e27ed358915e6d77bdb6c000`
+- fixture_sha256: `189adddf12b53efb048e7c5d0b3605c9ce9d7f6b01023de7e418b715817c16f4`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `077d595387f9ef0925e654ba0704bfaf70b2ff427013d3059de96bcadac4157a`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `7ac19d358ca18ef7b2d109aeec17239bc9d0f4c0`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82`
-- Skill overlay SHA-256: `06e677e2d778ad6e9070a73693d2a9f47819f161c623014f6e26b508a4d8e533`
-- Judge schema SHA-256: `077d595387f9ef0925e654ba0704bfaf70b2ff427013d3059de96bcadac4157a`
-- Eval definition SHA-256: `eedd6f2658d30fa0d35d3b4c542f62bf462bc6c1940c310dab2dd6d4429a52b7`
-- Metadata SHA-256: `e36d75fac31fda1c2cb2830fe86474e7378a0134e27ed358915e6d77bdb6c000`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-007-missing-nested-trd-handoff/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-007-missing-nested-trd-handoff/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `60bf457213c5027b1b635e439080d394ebbdbc0aadd1b41efc4678ffe172a846` from `agents/engineer/test/feature-implementor/evals/workspace/eval-007-missing-nested-trd-handoff`.
-- Fixture SHA-256: `60bf457213c5027b1b635e439080d394ebbdbc0aadd1b41efc4678ffe172a846`
-- Prompt SHA-256: `d732b4fc551c7ddc0d501adf12269e3428615ca56319eb8c1c10baf4e47a40bc`
+- Identity schema: `2`
+- target_skill_sha256: `2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82`
+- eval_definition_sha256: `b5bb3aa99b72ccf5e21dcb20544d88f2d186af2b99e158d4fcf19d8c4d0e753d`
+- metadata_sha256: `bebe0f9634c14237118b72776255b4f9bb880a6d0204ec8383ca70e9eff7d678`
+- fixture_sha256: `60bf457213c5027b1b635e439080d394ebbdbc0aadd1b41efc4678ffe172a846`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `80868b5a1dbdaaeaae58f1b6f4c234d150c4534f0ca9af8c7d89fa4350b459f6`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `7ac19d358ca18ef7b2d109aeec17239bc9d0f4c0`
 - Repository worktree state: **CLEAN**
-- Target skill tree SHA-256: `2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82`
-- Skill overlay SHA-256: `06e677e2d778ad6e9070a73693d2a9f47819f161c623014f6e26b508a4d8e533`
-- Judge schema SHA-256: `80868b5a1dbdaaeaae58f1b6f4c234d150c4534f0ca9af8c7d89fa4350b459f6`
-- Eval definition SHA-256: `b5bb3aa99b72ccf5e21dcb20544d88f2d186af2b99e158d4fcf19d8c4d0e753d`
-- Metadata SHA-256: `bebe0f9634c14237118b72776255b4f9bb880a6d0204ec8383ca70e9eff7d678`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-008-feature-path-mismatch-blocked/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-008-feature-path-mismatch-blocked/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `fa61fddb39b3b74bc77db4e82386f7b1f9cd3a070d4333160570607ea9172a8d` from `agents/engineer/test/feature-implementor/evals/workspace/eval-008-feature-path-mismatch-blocked`.
-- Fixture SHA-256: `fa61fddb39b3b74bc77db4e82386f7b1f9cd3a070d4333160570607ea9172a8d`
-- Prompt SHA-256: `9ba9f5f01cabbae62ba3bf40c7c99d8dc7f337984c8ca4277c6f238b4df6793e`
+- Identity schema: `2`
+- target_skill_sha256: `2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82`
+- eval_definition_sha256: `66c4bea185008e1b43202328d058ecaa9e2ff572bdfe8be7d346a358d1c56597`
+- metadata_sha256: `3365bfe92db70d4ff5499652a29702f93ac57621aa93b249c4712559af86079a`
+- fixture_sha256: `fa61fddb39b3b74bc77db4e82386f7b1f9cd3a070d4333160570607ea9172a8d`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `33864756672d39ea5d3d054f279e52d6c05b6ece12eef5c3a61c53de61073a90`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `7ac19d358ca18ef7b2d109aeec17239bc9d0f4c0`
 - Repository worktree state: **CLEAN**
-- Target skill tree SHA-256: `2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82`
-- Skill overlay SHA-256: `06e677e2d778ad6e9070a73693d2a9f47819f161c623014f6e26b508a4d8e533`
-- Judge schema SHA-256: `33864756672d39ea5d3d054f279e52d6c05b6ece12eef5c3a61c53de61073a90`
-- Eval definition SHA-256: `66c4bea185008e1b43202328d058ecaa9e2ff572bdfe8be7d346a358d1c56597`
-- Metadata SHA-256: `3365bfe92db70d4ff5499652a29702f93ac57621aa93b249c4712559af86079a`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-009-ui-design-handoff-gate/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-009-ui-design-handoff-gate/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `e933472ac04a2cc28b54c89f863b1b89688bd67af1793cbac5f728cf5ae72984` from `agents/engineer/test/feature-implementor/evals/workspace/eval-009-ui-design-handoff-gate`.
-- Fixture SHA-256: `e933472ac04a2cc28b54c89f863b1b89688bd67af1793cbac5f728cf5ae72984`
-- Prompt SHA-256: `ddb6591b250157e73a35cd94cd577e9355400395f2d96425bab34fbb48bb56d6`
+- Identity schema: `2`
+- target_skill_sha256: `2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82`
+- eval_definition_sha256: `a313159478f71f3c53034d04181e6cf7f6ee092241472cdee4c99fbe2b9042fc`
+- metadata_sha256: `5e7a0cec3496b476d745c2e2e1792aa7fe5d0f1912d30b7047f5ac770f4cdb1c`
+- fixture_sha256: `e933472ac04a2cc28b54c89f863b1b89688bd67af1793cbac5f728cf5ae72984`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `2ecaa597e1be5d2c7100696a1bf5cce49ac2b021a5cc8ab7c690c99ac2883c0d`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `7ac19d358ca18ef7b2d109aeec17239bc9d0f4c0`
 - Repository worktree state: **CLEAN**
-- Target skill tree SHA-256: `2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82`
-- Skill overlay SHA-256: `06e677e2d778ad6e9070a73693d2a9f47819f161c623014f6e26b508a4d8e533`
-- Judge schema SHA-256: `2ecaa597e1be5d2c7100696a1bf5cce49ac2b021a5cc8ab7c690c99ac2883c0d`
-- Eval definition SHA-256: `a313159478f71f3c53034d04181e6cf7f6ee092241472cdee4c99fbe2b9042fc`
-- Metadata SHA-256: `5e7a0cec3496b476d745c2e2e1792aa7fe5d0f1912d30b7047f5ac770f4cdb1c`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-010-implementation-plan-closeout-sync/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-010-implementation-plan-closeout-sync/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `b472a02faf2f5e271bff5cfda7f77a99314d4a0e9e7388442ee7140ff824b071` from `agents/engineer/test/feature-implementor/evals/workspace/eval-010-implementation-plan-closeout-sync`.
-- Fixture SHA-256: `b472a02faf2f5e271bff5cfda7f77a99314d4a0e9e7388442ee7140ff824b071`
-- Prompt SHA-256: `c3ffcc020a63823b1bc5160a6102e792071ef85d1d8fe0aee0513d9e308a0fbf`
+- Identity schema: `2`
+- target_skill_sha256: `2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82`
+- eval_definition_sha256: `20499e40a806229e21ef95ff8d5fbc24188637283192bc707a4d5fd2332a9e7d`
+- metadata_sha256: `8cc2bbac5be951408272dda8df48e23d4c89655790723f30b56076864a8cfafc`
+- fixture_sha256: `b472a02faf2f5e271bff5cfda7f77a99314d4a0e9e7388442ee7140ff824b071`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `fb8321bee2e5348476e997d826ae18ebe45fbbe3e17a6d49b5ba543f9a119c27`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `7ac19d358ca18ef7b2d109aeec17239bc9d0f4c0`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82`
-- Skill overlay SHA-256: `06e677e2d778ad6e9070a73693d2a9f47819f161c623014f6e26b508a4d8e533`
-- Judge schema SHA-256: `fb8321bee2e5348476e997d826ae18ebe45fbbe3e17a6d49b5ba543f9a119c27`
-- Eval definition SHA-256: `20499e40a806229e21ef95ff8d5fbc24188637283192bc707a4d5fd2332a9e7d`
-- Metadata SHA-256: `8cc2bbac5be951408272dda8df48e23d4c89655790723f30b56076864a8cfafc`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-011-four-level-feature-path-plan-gate/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-011-four-level-feature-path-plan-gate/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `6c438d1edc9a89256655ae36e972b31a4929ddc7fe5b5f285e888975f24e8b68` from `agents/engineer/test/feature-implementor/evals/workspace/eval-011-four-level-feature-path-plan-gate`.
-- Fixture SHA-256: `6c438d1edc9a89256655ae36e972b31a4929ddc7fe5b5f285e888975f24e8b68`
-- Prompt SHA-256: `e0c7bd09477fcc6f52d75011fdf516c41f01082c930d49e3864459c1ec60e40b`
+- Identity schema: `2`
+- target_skill_sha256: `2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82`
+- eval_definition_sha256: `7d6cafded24992611b95dfc908abe3d7611f7857dadb745152c30089566b43d2`
+- metadata_sha256: `3668a072214fe6498899f002deadbb563dcff96e3a3df4bc0dd68e0b0df02057`
+- fixture_sha256: `6c438d1edc9a89256655ae36e972b31a4929ddc7fe5b5f285e888975f24e8b68`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `daa05dfde11fd09221d4ad9b38d9b74b58a7b93050ec83c55293e7ca9eae6a7e`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `7ac19d358ca18ef7b2d109aeec17239bc9d0f4c0`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82`
-- Skill overlay SHA-256: `06e677e2d778ad6e9070a73693d2a9f47819f161c623014f6e26b508a4d8e533`
-- Judge schema SHA-256: `daa05dfde11fd09221d4ad9b38d9b74b58a7b93050ec83c55293e7ca9eae6a7e`
-- Eval definition SHA-256: `7d6cafded24992611b95dfc908abe3d7611f7857dadb745152c30089566b43d2`
-- Metadata SHA-256: `3668a072214fe6498899f002deadbb563dcff96e3a3df4bc0dd68e0b0df02057`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-012-implementation-plan-archive-preflight/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-012-implementation-plan-archive-preflight/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `681e197eb0a978ca201707a3d3b58dd8ed78255de8e5033ca94ef611ea90807e` from `agents/engineer/test/feature-implementor/evals/workspace/eval-012-implementation-plan-archive-preflight`.
-- Fixture SHA-256: `681e197eb0a978ca201707a3d3b58dd8ed78255de8e5033ca94ef611ea90807e`
-- Prompt SHA-256: `9c7650cd9313e12223d2a68ebc3c37905ca839128cbb6b36d20fc7541af57b74`
+- Identity schema: `2`
+- target_skill_sha256: `2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82`
+- eval_definition_sha256: `7f61bff44513e544647aa068492b4fc39b7ba0f0b8a502c36472dbc74575e45e`
+- metadata_sha256: `158f5bafaa3ad4ac6ba561642292db5794c29432044a423049518391aa4f0dbd`
+- fixture_sha256: `681e197eb0a978ca201707a3d3b58dd8ed78255de8e5033ca94ef611ea90807e`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `097d311377d0abb4f2fcb1bfa46de1df83e6feccaa7b6f38bb1fb185a5118ab5`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `7ac19d358ca18ef7b2d109aeec17239bc9d0f4c0`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82`
-- Skill overlay SHA-256: `06e677e2d778ad6e9070a73693d2a9f47819f161c623014f6e26b508a4d8e533`
-- Judge schema SHA-256: `097d311377d0abb4f2fcb1bfa46de1df83e6feccaa7b6f38bb1fb185a5118ab5`
-- Eval definition SHA-256: `7f61bff44513e544647aa068492b4fc39b7ba0f0b8a502c36472dbc74575e45e`
-- Metadata SHA-256: `158f5bafaa3ad4ac6ba561642292db5794c29432044a423049518391aa4f0dbd`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-013-implementation-plan-archive-allows-next-plan/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-013-implementation-plan-archive-allows-next-plan/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `4ef8c6418e526050652f1a037736acaff4cffdb17b27acf4e8f94adbd8c3be96` from `agents/engineer/test/feature-implementor/evals/workspace/eval-013-implementation-plan-archive-allows-next-plan`.
-- Fixture SHA-256: `4ef8c6418e526050652f1a037736acaff4cffdb17b27acf4e8f94adbd8c3be96`
-- Prompt SHA-256: `fead462ed6258e1fbe13bf1caae06939d2877c023c15076e0ceb2b67cbc05022`
+- Identity schema: `2`
+- target_skill_sha256: `2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82`
+- eval_definition_sha256: `e7ce63b1af29ecd94dfeb7909e7f066642dfdd9e9e7c1c834d32f01202820dcf`
+- metadata_sha256: `09c697e47642eeb80d16370a2788d572a97cb4a1e71356745930b9203f62054c`
+- fixture_sha256: `4ef8c6418e526050652f1a037736acaff4cffdb17b27acf4e8f94adbd8c3be96`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `92c95ee84208d5ddf7a774382e98fb939786b7da025643fcac881491d89921d5`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `7ac19d358ca18ef7b2d109aeec17239bc9d0f4c0`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82`
-- Skill overlay SHA-256: `06e677e2d778ad6e9070a73693d2a9f47819f161c623014f6e26b508a4d8e533`
-- Judge schema SHA-256: `92c95ee84208d5ddf7a774382e98fb939786b7da025643fcac881491d89921d5`
-- Eval definition SHA-256: `e7ce63b1af29ecd94dfeb7909e7f066642dfdd9e9e7c1c834d32f01202820dcf`
-- Metadata SHA-256: `09c697e47642eeb80d16370a2788d572a97cb4a1e71356745930b9203f62054c`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-014-mapped-session-plan-evidence/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-014-mapped-session-plan-evidence/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `ebf98490e96d51646bb08c2897d26dd073cad98267ddc69d86f17d77581f2927` from `agents/engineer/test/feature-implementor/evals/workspace/eval-014-mapped-session-plan-evidence`.
-- Fixture SHA-256: `ebf98490e96d51646bb08c2897d26dd073cad98267ddc69d86f17d77581f2927`
-- Prompt SHA-256: `2f129ddb28e1f1e80d9edd6a2ff9482f3bf6168c9099228d14be2ebcaee2b61a`
+- Identity schema: `2`
+- target_skill_sha256: `2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82`
+- eval_definition_sha256: `51a5d5a4f671b1df617b81a97fb84c601259cd9a8d3901d74d7d41b70d44d966`
+- metadata_sha256: `85958a0c5140b007348a2041b6f7a9c97d73f65f93f4fafa12ba3e42d03d7a13`
+- fixture_sha256: `ebf98490e96d51646bb08c2897d26dd073cad98267ddc69d86f17d77581f2927`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `7ac19d358ca18ef7b2d109aeec17239bc9d0f4c0`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82`
-- Skill overlay SHA-256: `06e677e2d778ad6e9070a73693d2a9f47819f161c623014f6e26b508a4d8e533`
-- Judge schema SHA-256: `6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda`
-- Eval definition SHA-256: `51a5d5a4f671b1df617b81a97fb84c601259cd9a8d3901d74d7d41b70d44d966`
-- Metadata SHA-256: `85958a0c5140b007348a2041b6f7a9c97d73f65f93f4fafa12ba3e42d03d7a13`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-015-implemented-status-detected-from-fixture/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-015-implemented-status-detected-from-fixture/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `081f99f1748dae6b1e4b0b232ec7c1df3a484b0c63d868321dc8a1e16a817449` from `agents/engineer/test/feature-implementor/evals/workspace/eval-015-implemented-status-detected-from-fixture`.
-- Fixture SHA-256: `081f99f1748dae6b1e4b0b232ec7c1df3a484b0c63d868321dc8a1e16a817449`
-- Prompt SHA-256: `94992d68c84f843faca4d58c6bb2c604bfcff22e23ecd95ba7c0c306fd36011b`
+- Identity schema: `2`
+- target_skill_sha256: `2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82`
+- eval_definition_sha256: `b2cb611a2eb526b32fe7d8233b7af41b5dc9690189d7d476ddf33384f3fb4855`
+- metadata_sha256: `b8899bf7ae5f8fcc629e9bed966ceb9612aaea2fc7055363d1e8ea6b2efd4e30`
+- fixture_sha256: `081f99f1748dae6b1e4b0b232ec7c1df3a484b0c63d868321dc8a1e16a817449`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `923a1c7b31287566dcbc7acd5bf79481560908bbcc5207920a4090de9501eef3`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `7ac19d358ca18ef7b2d109aeec17239bc9d0f4c0`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82`
-- Skill overlay SHA-256: `06e677e2d778ad6e9070a73693d2a9f47819f161c623014f6e26b508a4d8e533`
-- Judge schema SHA-256: `923a1c7b31287566dcbc7acd5bf79481560908bbcc5207920a4090de9501eef3`
-- Eval definition SHA-256: `b2cb611a2eb526b32fe7d8233b7af41b5dc9690189d7d476ddf33384f3fb4855`
-- Metadata SHA-256: `b8899bf7ae5f8fcc629e9bed966ceb9612aaea2fc7055363d1e8ea6b2efd4e30`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-016-draft-status-continues-current-plan/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-016-draft-status-continues-current-plan/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `20e27cdb155a076474a45e3e1e88d991a8bc4e1c3723a56f9fad5436bddd121e` from `agents/engineer/test/feature-implementor/evals/workspace/eval-016-draft-status-continues-current-plan`.
-- Fixture SHA-256: `20e27cdb155a076474a45e3e1e88d991a8bc4e1c3723a56f9fad5436bddd121e`
-- Prompt SHA-256: `b545dbdf7b14573cc5aa0b9db7a4defefe66a311f4d3b98d9f23cd367fdfa1aa`
+- Identity schema: `2`
+- target_skill_sha256: `2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82`
+- eval_definition_sha256: `86c8e37f3b454c4b68e8a8e0d79eed844e522098807d679c66512f9c18daf3b3`
+- metadata_sha256: `566e39d7363acab918c0b8b38f7cebac43ee4f4a9069dd6e8b635d61f1c29eb0`
+- fixture_sha256: `20e27cdb155a076474a45e3e1e88d991a8bc4e1c3723a56f9fad5436bddd121e`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `b61097c2327e4512b0954be7440f9efb0288869d119e12aff21af89d2a1a48fa`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `7ac19d358ca18ef7b2d109aeec17239bc9d0f4c0`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82`
-- Skill overlay SHA-256: `06e677e2d778ad6e9070a73693d2a9f47819f161c623014f6e26b508a4d8e533`
-- Judge schema SHA-256: `b61097c2327e4512b0954be7440f9efb0288869d119e12aff21af89d2a1a48fa`
-- Eval definition SHA-256: `86c8e37f3b454c4b68e8a8e0d79eed844e522098807d679c66512f9c18daf3b3`
-- Metadata SHA-256: `566e39d7363acab918c0b8b38f7cebac43ee4f4a9069dd6e8b635d61f1c29eb0`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-017-abandoned-draft-can-be-superseded/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-017-abandoned-draft-can-be-superseded/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `c0e7350515f9e8f3a166039b0e6d074b044f7918d0abfcaabf64ea0fd4ef53cb` from `agents/engineer/test/feature-implementor/evals/workspace/eval-017-abandoned-draft-can-be-superseded`.
-- Fixture SHA-256: `c0e7350515f9e8f3a166039b0e6d074b044f7918d0abfcaabf64ea0fd4ef53cb`
-- Prompt SHA-256: `9ebe9d873c66a07a5ecd0428e103d2f74136e9e17f4f22b79640f42f218d18ee`
+- Identity schema: `2`
+- target_skill_sha256: `2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82`
+- eval_definition_sha256: `92bf4838a78758f537ca7650dd1be190ad947406f8ab40d6ace62d644c28dc37`
+- metadata_sha256: `21a9c9ae11f8c9b8058a429c319a4f2a640a6b07fdf2d71e259bbc158caa4e24`
+- fixture_sha256: `c0e7350515f9e8f3a166039b0e6d074b044f7918d0abfcaabf64ea0fd4ef53cb`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `a264d3282fcfebf29821ed24d8e702134594b3cc4be72cd72f03b0e03e92c160`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `7ac19d358ca18ef7b2d109aeec17239bc9d0f4c0`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82`
-- Skill overlay SHA-256: `06e677e2d778ad6e9070a73693d2a9f47819f161c623014f6e26b508a4d8e533`
-- Judge schema SHA-256: `a264d3282fcfebf29821ed24d8e702134594b3cc4be72cd72f03b0e03e92c160`
-- Eval definition SHA-256: `92bf4838a78758f537ca7650dd1be190ad947406f8ab40d6ace62d644c28dc37`
-- Metadata SHA-256: `21a9c9ae11f8c9b8058a429c319a4f2a640a6b07fdf2d71e259bbc158caa4e24`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/engineer/test/test-writer/evals/workspace/eval-001-write-tests-from-spec/comparison.md
+++ b/agents/engineer/test/test-writer/evals/workspace/eval-001-write-tests-from-spec/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `1fc33cc2cafe76721e09e39f06834f83330e227e59b4aed334bc003945dfdf3c` from `agents/engineer/test/test-writer/evals/workspace/eval-001-write-tests-from-spec`.
-- Fixture SHA-256: `1fc33cc2cafe76721e09e39f06834f83330e227e59b4aed334bc003945dfdf3c`
-- Prompt SHA-256: `46eea12ac62f02ceb89a8418aeab70d2e5bbf720f6ba0edc42f3a9c58a443a5e`
+- Identity schema: `2`
+- target_skill_sha256: `8676e9bdfb5dcb168ade64b20ca31fd5f471aaa2778319375ec606582ddd34da`
+- eval_definition_sha256: `efd5ef5afb815bd08b4891a7e8121a2425c0d9fa58d54ab02bb52d9e0279793d`
+- metadata_sha256: `f070f60ff223bb6ed508e78cdd69bdde29b46feeccf2713b0da03a7503f77d6f`
+- fixture_sha256: `1fc33cc2cafe76721e09e39f06834f83330e227e59b4aed334bc003945dfdf3c`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `76acf51e56db3c0b81097f6bd3d6543ba266417fd8281a9ea540a61e66eb1dc7`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `8676e9bdfb5dcb168ade64b20ca31fd5f471aaa2778319375ec606582ddd34da`
-- Skill overlay SHA-256: `366b4a2398e19f83568cd66e852162fc58fb6933917f93836fccd17c7c2cfc59`
-- Judge schema SHA-256: `76acf51e56db3c0b81097f6bd3d6543ba266417fd8281a9ea540a61e66eb1dc7`
-- Eval definition SHA-256: `efd5ef5afb815bd08b4891a7e8121a2425c0d9fa58d54ab02bb52d9e0279793d`
-- Metadata SHA-256: `f070f60ff223bb6ed508e78cdd69bdde29b46feeccf2713b0da03a7503f77d6f`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/engineer/test/test-writer/evals/workspace/eval-002-mapped-pagination-tests/comparison.md
+++ b/agents/engineer/test/test-writer/evals/workspace/eval-002-mapped-pagination-tests/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `866e2c4f7a812e0445a49d5de640bceae9b9dcd49ee9a3bd9c91db26e366238d` from `agents/engineer/test/test-writer/evals/workspace/eval-002-mapped-pagination-tests`.
-- Fixture SHA-256: `866e2c4f7a812e0445a49d5de640bceae9b9dcd49ee9a3bd9c91db26e366238d`
-- Prompt SHA-256: `868c36ff31e91e90391d3fe2090275a44a955f72894e47ed070c10d12b284428`
+- Identity schema: `2`
+- target_skill_sha256: `8676e9bdfb5dcb168ade64b20ca31fd5f471aaa2778319375ec606582ddd34da`
+- eval_definition_sha256: `dffdc1de9650924aeba7f48471eac1b4c1592e52cef441419d14a463af648ff5`
+- metadata_sha256: `6a60b69beab2bdd4c854670cd54e7749219cde65551c8e29d984d322f4c34c88`
+- fixture_sha256: `866e2c4f7a812e0445a49d5de640bceae9b9dcd49ee9a3bd9c91db26e366238d`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `8676e9bdfb5dcb168ade64b20ca31fd5f471aaa2778319375ec606582ddd34da`
-- Skill overlay SHA-256: `366b4a2398e19f83568cd66e852162fc58fb6933917f93836fccd17c7c2cfc59`
-- Judge schema SHA-256: `6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda`
-- Eval definition SHA-256: `dffdc1de9650924aeba7f48471eac1b4c1592e52cef441419d14a463af648ff5`
-- Metadata SHA-256: `6a60b69beab2bdd4c854670cd54e7749219cde65551c8e29d984d322f4c34c88`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/engineer/test/trd-gen/evals/evals.json
+++ b/agents/engineer/test/trd-gen/evals/evals.json
@@ -275,7 +275,7 @@
         {
           "id": "updates_existing_trd",
           "description": "更新目标 TRD 正文",
-          "text": "输出是更新 docs/engineer/delivery-pipeline/TRD.md 的正文与版本，不新建其他 feature 文档，也不把任务路由给别人"
+          "text": "输出必须由 trd-gen 完成 docs/engineer/delivery-pipeline/TRD.md 的正文与版本更新，不新建其他 feature 文档；交付摘要可以声明 TRD 确认后的 feature-implementor owner/path，但 TRD 正文不得写 routing 指令，未获确认和继续授权时不得声称已移交、启动或路由后续任务"
         },
         {
           "id": "body_consolidation",

--- a/agents/engineer/test/trd-gen/evals/workspace/eval-001-prd-to-engineer-trd/comparison.md
+++ b/agents/engineer/test/trd-gen/evals/workspace/eval-001-prd-to-engineer-trd/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `874c9a19c616d97ed625612e04c37ce561c010e8908c127503ea72d53817db55` from `agents/engineer/test/trd-gen/evals/workspace/eval-001-prd-to-engineer-trd`.
-- Fixture SHA-256: `874c9a19c616d97ed625612e04c37ce561c010e8908c127503ea72d53817db55`
+- Identity schema: `2`
+- target_skill_sha256: `7350d982beaf3dbc1ec747d4598f05c9a1dfb9b1eb61dcb04ae43dfd72f6fcfd`
+- eval_definition_sha256: `541dd03d893d7d5a4e9f69c81d6344de365e55718cc67a40980e3cbdb34c6a30`
+- metadata_sha256: `b33234ce56a0b715b632f392ff44ba7c27cad834dbc654110228254e610f01ec`
+- fixture_sha256: `874c9a19c616d97ed625612e04c37ce561c010e8908c127503ea72d53817db55`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `4d4b8ebdf0eaf847b9097b848450fa85763a3e1f30bf1bb128228339ff87a28d`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `59315add19ee6ece2648d62000ea89257cb037f1973ece31adc62018b509f700`
-- Repository HEAD: `7ac19d358ca18ef7b2d109aeec17239bc9d0f4c0`
+- Repository HEAD: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `241887560d0522d91eee495434f78fbbe72dd8e5d7ed6c58dce70753634045ba`
-- Skill overlay SHA-256: `1701eca585dc754d5c838c067ffd884a80205302462ac0a542c908fd069ff822`
-- Judge schema SHA-256: `4d4b8ebdf0eaf847b9097b848450fa85763a3e1f30bf1bb128228339ff87a28d`
-- Eval definition SHA-256: `541dd03d893d7d5a4e9f69c81d6344de365e55718cc67a40980e3cbdb34c6a30`
-- Metadata SHA-256: `b33234ce56a0b715b632f392ff44ba7c27cad834dbc654110228254e610f01ec`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
+- Skill overlay SHA-256: `41df440b7248e793c6d9703098fb03264d5ab1871ee7f72726859596ddf5327e`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -31,29 +33,30 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `engineer_owns_trd` | PASS | TRD.md states Engineer owns the TRD and is at docs/engineer/capture-loop/TRD.md. |
-| `prd_confirmed_handoff` | PASS | The delivered TRD identifies confirmed PRD and DECISIONS documents as the PM entry basis, and the trace states PRD confirmation precedes the Engineer TRD stage. |
-| `document_subagent` | PASS | TRD.md records document-subagent availability as unavailable, assigns authorship, source-context ownership, and final review to the main process, and states no delegation occurred. |
-| `implementation_plan_handoff` | PASS | The delivered TRD states that after Engineer-document confirmation, handoff goes to feature-implementor for docs/engineer/capture-loop/IMPLEMENTATION_PLAN.md before implementation. |
-| `qa_e2e_after_confirmed_plan` | NOT_EXERCISED | QA E2E is explicitly blocked downstream and no QA E2E expectations are created by the TRD; the confirmed implementation-plan and implementation-completion handoff have not occurred in this run. |
-| `no_code_implementation` | PASS | Locked git evidence shows only untracked Engineer documentation, with no code or test changes; the TRD also explicitly states it does not implement code or tests. |
+| `engineer_owns_trd` | PASS | TRD frontmatter names `engineer_document_owner: engineer-agent:trd-gen`, and the delivered file is `docs/engineer/capture-loop/TRD.md`. |
+| `prd_confirmed_handoff` | PASS | The TRD states that product scope is confirmed in PRD and DECISIONS and that it does not change the confirmed product scope; the trace also records that PRD and decisions are confirmed before entering the Engineer TRD stage. |
+| `document_subagent` | PASS | The final output truthfully states that the document-writing sub-agent was unavailable, while the main process retained source context and performed final review. The trace does not independently establish delegation, but no delegation claim was made. |
+| `implementation_plan_handoff` | PASS | The TRD says implementation planning must wait for document confirmation; the final output identifies `feature-implementor` and `docs/engineer/capture-loop/IMPLEMENTATION_PLAN.md`, and states that implementation planning has not yet been handed off. |
+| `qa_e2e_after_confirmed_plan` | NOT_EXERCISED | The delivered TRD explicitly keeps QA E2E outside its scope and no QA E2E document was created. The later QA handoff cannot yet be exercised because confirmed TRD, confirmed implementation plan, and completed implementation evidence are not present. |
+| `no_code_implementation` | PASS | Locked delivery snapshots contain only TRD/API/ADR documentation, and the trace states that code or an implementation plan will not be created. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=59315add19ee6ece2648d62000ea89257cb037f1973ece31adc62018b509f700; fixture_sha256=874c9a19c616d97ed625612e04c37ce561c010e8908c127503ea72d53817db55; output_sha256=17689cf5fb65ecda59c6ffcf359305d6a1ad55a8a69e533946bf2385708239f0; snapshot_sha256=c3206f5b85fdfc47905df173230171e0e4f8d4c047d78a78adf2b1ce9ded97c9
-- Behavior: Produced Engineer-owned TRD/API/ADR documentation at the correct docs/engineer/capture-loop path, preserved the main-process review boundary, documented the feature-implementor handoff, and made no code changes.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=59315add19ee6ece2648d62000ea89257cb037f1973ece31adc62018b509f700; fixture_sha256=874c9a19c616d97ed625612e04c37ce561c010e8908c127503ea72d53817db55; output_sha256=3445a37436e45ad4c5dd50e24ba81a8feab6f26e1fa2d9ee46d984bd9f873033; snapshot_sha256=91ed2d09aac2a23a5becdf95aa966274b6b15f5a6a3b0c0bfc93764c798ade26
+- Behavior: Produced Engineer-owned TRD documentation at the required path, accurately handled unavailable document-subagent capability, and described downstream implementation-plan handoff without implementing code.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=59315add19ee6ece2648d62000ea89257cb037f1973ece31adc62018b509f700; fixture_sha256=874c9a19c616d97ed625612e04c37ce561c010e8908c127503ea72d53817db55; output_sha256=c0b34f7ded06d20178a1bf9986325a6a6c1c6b516a63045d529439773b9cd7d9; snapshot_sha256=284b1302dd6f549f4de84b5eecf5bb08e9b3d1fdf2bb5fb9d6a9676caf6bd6ea
-- Behavior: Produced a TRD at the incorrect docs/eng/capture-loop path and did not demonstrate the required Engineer ownership, confirmation gates, sub-agent boundary, downstream handoff, or QA sequencing.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=59315add19ee6ece2648d62000ea89257cb037f1973ece31adc62018b509f700; fixture_sha256=874c9a19c616d97ed625612e04c37ce561c010e8908c127503ea72d53817db55; output_sha256=22d7db6a3676d34614379130920727b8d413a6487b26f3cd4be07b42803e9bb4; snapshot_sha256=4094932e4c19bf62ef65e794829c71b313d27af52e5ddf8b41446761931f50eb
+- Behavior: Produced a PM-side TECHNICAL_DESIGN.md directly under docs/pm and did not provide the required Engineer TRD workflow or downstream handoff semantics.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Confirm the Engineer document set, then hand off to feature-implementor for IMPLEMENTATION_PLAN.md; after its confirmation and implementation-completion handoff, exercise QA E2E.
+- Next: Confirm the TRD and resolve the documented technical questions before feature-implementor writes IMPLEMENTATION_PLAN.md.
+- Next: After the confirmed implementation plan and completed implementation handoff package exist, perform the QA E2E documentation handoff.
 
 ## Runtime Artifact Policy
 

--- a/agents/engineer/test/trd-gen/evals/workspace/eval-002-resolve-trd-gap-packet/comparison.md
+++ b/agents/engineer/test/trd-gen/evals/workspace/eval-002-resolve-trd-gap-packet/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `d58240709fd95e80376991be4d5ae0d8785faa7c898ac347279a20ad514acd7a` from `agents/engineer/test/trd-gen/evals/workspace/eval-002-resolve-trd-gap-packet`.
-- Fixture SHA-256: `d58240709fd95e80376991be4d5ae0d8785faa7c898ac347279a20ad514acd7a`
+- Identity schema: `2`
+- target_skill_sha256: `7350d982beaf3dbc1ec747d4598f05c9a1dfb9b1eb61dcb04ae43dfd72f6fcfd`
+- eval_definition_sha256: `96fd70658261e3a17be616b06efc13bb061ebd641ee5ed5f4b30d21e34984bf7`
+- metadata_sha256: `4025e3b1dd282f00d05c7506655215876b7bcc3af8d7657c77ae8574687fce25`
+- fixture_sha256: `d58240709fd95e80376991be4d5ae0d8785faa7c898ac347279a20ad514acd7a`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `3fb0bf5bc301ce78a33402f806b0b810ed122ae2263b6d9be14f49634de42f79`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `bc732b2f79cac8748a3ffddfa2548eb3ee6c28a29e001f66a5d7af673ecfa482`
-- Repository HEAD: `7ac19d358ca18ef7b2d109aeec17239bc9d0f4c0`
+- Repository HEAD: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `241887560d0522d91eee495434f78fbbe72dd8e5d7ed6c58dce70753634045ba`
-- Skill overlay SHA-256: `1701eca585dc754d5c838c067ffd884a80205302462ac0a542c908fd069ff822`
-- Judge schema SHA-256: `3fb0bf5bc301ce78a33402f806b0b810ed122ae2263b6d9be14f49634de42f79`
-- Eval definition SHA-256: `96fd70658261e3a17be616b06efc13bb061ebd641ee5ed5f4b30d21e34984bf7`
-- Metadata SHA-256: `4025e3b1dd282f00d05c7506655215876b7bcc3af8d7657c77ae8574687fce25`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
+- Skill overlay SHA-256: `41df440b7248e793c6d9703098fb03264d5ab1871ee7f72726859596ddf5327e`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -31,22 +33,22 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `accepts_gap_packet_as_trd_work` | PASS | TRD.md identifies the gap finder as supplying questions and `engineer-agent:trd-gen` as resolving them; implementation-plan ownership is handed off to feature-implementor without creating the plan or code. |
-| `resolves_named_gap_categories` | PASS | TRD.md and API.md cover component ownership, event/API contracts, integration and validation commands, rolling deployment/rollback, retry and permanent-error handling, observability, and organization-boundary security. |
-| `keeps_finder_trd_gen_boundary` | PASS | TRD.md explicitly records `finder_boundary: gap finder supplied the missing questions and evidence` and `trd_owner_boundary: trd-gen resolved the questions in Engineer documents`. |
-| `unresolved_gap_blocks_e2e` | PASS | The locked TRD snapshot states that no open technical question remains and sets `blocked_downstream: []`; therefore the conditional blocking requirement is not triggered. |
-| `no_implementation_plan_or_code` | PASS | The with_skill delivery snapshot contains only TRD/API/ADR documents; git status shows only `?? docs/engineer/`, with no IMPLEMENTATION_PLAN.md, code, tests, or delivery handoff executed. |
+| `accepts_gap_packet_as_trd_work` | PASS | With-skill delivery identifies the work as Engineer-owned `trd-gen` TRD/ADR work, with the finder supplying gaps and `trd-gen` resolving them; it explicitly says implementation has not started. |
+| `resolves_named_gap_categories` | PASS | The delivered TRD covers component ownership, event/data flow and internal interfaces, validation commands and test cases, rollout/rollback, error classification, observability, and security. |
+| `keeps_finder_trd_gen_boundary` | PASS | The trace states the gap finder supplies gaps/evidence while `engineer-agent:trd-gen` owns the same-path Engineer documents; delivered documents carry the `trd-gen` owner metadata. |
+| `unresolved_gap_blocks_e2e` | PASS | The delivery records open technical questions and explicitly marks `feature-implementor`, `debugger`, and `qa-e2e` as blocked; no QA E2E or implementation-plan file was delivered. |
+| `no_implementation_plan_or_code` | PASS | Locked delivery snapshots contain only TRD/ADR documents; trace file changes show only `docs/engineer/.../TRD.md`, with no implementation plan, source-code, or test-file changes. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=bc732b2f79cac8748a3ffddfa2548eb3ee6c28a29e001f66a5d7af673ecfa482; fixture_sha256=d58240709fd95e80376991be4d5ae0d8785faa7c898ac347279a20ad514acd7a; output_sha256=19d6a5641da5cd3c441e776e2ef8f4efd4980516a132c349218599728abf2a5b; snapshot_sha256=2515a41267a540fef95a0a95824f955006139c309db2d2d6a411f8c35d3ed3e2
-- Behavior: Produced a complete Engineer TRD document set resolving the named gaps, preserved finder/trd-gen/feature-implementor boundaries, and stopped before implementation.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=bc732b2f79cac8748a3ffddfa2548eb3ee6c28a29e001f66a5d7af673ecfa482; fixture_sha256=d58240709fd95e80376991be4d5ae0d8785faa7c898ac347279a20ad514acd7a; output_sha256=194717408622f703244d49245f2b5ce38b3af534d43316044de454e3e467934a; snapshot_sha256=f5b16255b5c3d021999b65e7172be7ea487707a14a51ba2d833c95029350dc62
+- Behavior: Produced Engineer-owned TRD and ADR documents resolving the named technical gaps, recorded remaining blockers, and stopped before implementation or downstream E2E work.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=bc732b2f79cac8748a3ffddfa2548eb3ee6c28a29e001f66a5d7af673ecfa482; fixture_sha256=d58240709fd95e80376991be4d5ae0d8785faa7c898ac347279a20ad514acd7a; output_sha256=21f196878111aad2298a2cc03f6e7f2ea236f56f49b5840c00515e0cd07f1b0a; snapshot_sha256=d1780b059cb6bd109d7e59ea153adae3b2322bafdd6358ddd588ce77394c6d14
-- Behavior: Updated TRD_GAP_PACKET.md with extensive technical decisions but did not deliver the Engineer TRD document set or explicitly establish the finder/trd-gen boundary.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=bc732b2f79cac8748a3ffddfa2548eb3ee6c28a29e001f66a5d7af673ecfa482; fixture_sha256=d58240709fd95e80376991be4d5ae0d8785faa7c898ac347279a20ad514acd7a; output_sha256=b5d1b53accf68a66334deb2e746b7bebf7d8a8b934ace488a371697281756ea7; snapshot_sha256=f52b6df9940274c173a3f440288c3d9c55d1b6a841b30d7635ca118a10966ed0
+- Behavior: Produced a technically detailed rewrite of `TRD_GAP_PACKET.md`, but did not establish the trd-gen/finder boundary or downstream blocking conditions in its user-visible delivery.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/engineer/test/trd-gen/evals/workspace/eval-003-nested-prd-to-engineer-trd/comparison.md
+++ b/agents/engineer/test/trd-gen/evals/workspace/eval-003-nested-prd-to-engineer-trd/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `9c19cf5e49c59929ac5b070de11f3df7bfcbee1e79646cc4eec47c40b398a1bc` from `agents/engineer/test/trd-gen/evals/workspace/eval-003-nested-prd-to-engineer-trd`.
-- Fixture SHA-256: `9c19cf5e49c59929ac5b070de11f3df7bfcbee1e79646cc4eec47c40b398a1bc`
+- Identity schema: `2`
+- target_skill_sha256: `7350d982beaf3dbc1ec747d4598f05c9a1dfb9b1eb61dcb04ae43dfd72f6fcfd`
+- eval_definition_sha256: `f3397b62fc4d049158e92b00f525e136ca990d6c804b1f211ce557bfaf30d03e`
+- metadata_sha256: `de0335f1a182c8496f115f68dc77dc691a79abeae555386cc002141eada43865`
+- fixture_sha256: `9c19cf5e49c59929ac5b070de11f3df7bfcbee1e79646cc4eec47c40b398a1bc`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `10a807298f91a20d6e9b68f75881e7ea6287d8afeff10727bea551d980d3535f`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `8d0ccec5c9709506559aa1f8a5acdfd87e4bb71acf3bdaa8439f052c01aabae4`
-- Repository HEAD: `7ac19d358ca18ef7b2d109aeec17239bc9d0f4c0`
+- Repository HEAD: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `241887560d0522d91eee495434f78fbbe72dd8e5d7ed6c58dce70753634045ba`
-- Skill overlay SHA-256: `1701eca585dc754d5c838c067ffd884a80205302462ac0a542c908fd069ff822`
-- Judge schema SHA-256: `10a807298f91a20d6e9b68f75881e7ea6287d8afeff10727bea551d980d3535f`
-- Eval definition SHA-256: `f3397b62fc4d049158e92b00f525e136ca990d6c804b1f211ce557bfaf30d03e`
-- Metadata SHA-256: `de0335f1a182c8496f115f68dc77dc691a79abeae555386cc002141eada43865`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
+- Skill overlay SHA-256: `41df440b7248e793c6d9703098fb03264d5ab1871ee7f72726859596ddf5327e`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -31,22 +33,22 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `mirrors_nested_feature_path` | PASS | Locked delivery_snapshot contains the file at docs/engineer/chat-interface/messages/history/search/TRD.md, with no forbidden shorter or flattened target path. |
-| `preserves_feature_metadata` | PASS | TRD frontmatter contains feature_path chat-interface/messages/history/search, parent_feature chat-interface/messages/history, and feature_level 4. |
-| `related_prd_matches_path` | PASS | TRD frontmatter contains related_prd: docs/pm/chat-interface/messages/history/search/PRD.md. |
-| `blocks_on_missing_or_unclear_prd_path` | NOT_EXERCISED | The fixture PRD path and parent ownership are clear, so the missing-or-unclear PRD blocking branch was not exercised. |
-| `no_plan_or_code` | PASS | Git evidence shows only the TRD was added; no implementation plan, code, or tests were created, and the locked document explicitly states it does not implement code or create that plan. |
+| `mirrors_nested_feature_path` | PASS | 锁定 delivery_snapshot 直接显示文件路径为 docs/engineer/chat-interface/messages/history/search/TRD.md。 |
+| `preserves_feature_metadata` | PASS | TRD frontmatter 直接包含 feature_path、parent_feature，以及 feature_level: "4"。 |
+| `related_prd_matches_path` | PASS | TRD frontmatter 直接包含 related_prd: "docs/pm/chat-interface/messages/history/search/PRD.md"。 |
+| `blocks_on_missing_or_unclear_prd_path` | NOT_EXERCISED | 本次原始证据中的 PRD 路径和归属均清晰，因此缺失或不明确 PRD 路径的阻断分支未被 exercised。 |
+| `no_plan_or_code` | PASS | 锁定交付快照仅包含 TRD 文件；git 证据显示仅新增 docs/engineer/，未显示 IMPLEMENTATION_PLAN.md、代码或测试文件。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=8d0ccec5c9709506559aa1f8a5acdfd87e4bb71acf3bdaa8439f052c01aabae4; fixture_sha256=9c19cf5e49c59929ac5b070de11f3df7bfcbee1e79646cc4eec47c40b398a1bc; output_sha256=5ac242d78c9b8dfba7986be184640915135b099f575fe8c1115e15d312645e37; snapshot_sha256=0c6243bd5a2d0c233e4abe5f03f21cbbd7bc6e0f797bb32c0e2536ee8c1af607
-- Behavior: Created the nested Engineer TRD at the exact mirrored feature path, preserved required metadata and PRD linkage, and stopped before implementation.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=8d0ccec5c9709506559aa1f8a5acdfd87e4bb71acf3bdaa8439f052c01aabae4; fixture_sha256=9c19cf5e49c59929ac5b070de11f3df7bfcbee1e79646cc4eec47c40b398a1bc; output_sha256=3c373c73aaf039b34879b6dcb99f0ecea304a7d721139df154b23d918e5c21eb; snapshot_sha256=c3ad44afe115c45722f0258ab1ded4f8144e5e609d634dac3a1f10927e3c3609
+- Behavior: 生成了位于正确嵌套 feature_path 下的 TRD，并保留所需元数据及 related_prd；未进入代码或实现计划交付。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=8d0ccec5c9709506559aa1f8a5acdfd87e4bb71acf3bdaa8439f052c01aabae4; fixture_sha256=9c19cf5e49c59929ac5b070de11f3df7bfcbee1e79646cc4eec47c40b398a1bc; output_sha256=9eeb639d0b258df8c19a4c6b346928fc657877d8a5fa56beea205d54b051a4db; snapshot_sha256=74a202e461603650869761df0114b0ad7e32840f260c8f0c587184f3d26a87bd
-- Behavior: Created a technical design under docs/tech with the nested directory but used the wrong document type/path convention and did not provide the required related_prd field.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=8d0ccec5c9709506559aa1f8a5acdfd87e4bb71acf3bdaa8439f052c01aabae4; fixture_sha256=9c19cf5e49c59929ac5b070de11f3df7bfcbee1e79646cc4eec47c40b398a1bc; output_sha256=c423951b11b949dfb4156e8eef0d54e753d9c91e6c12fb941502d2d5825597a0; snapshot_sha256=f94687e4d44446c0d0ca1dee0456b72245fc6e989073ee8758b8eec040bcdd83
+- Behavior: 生成了 docs/tech 下的 TECHNICAL_PLAN.md，而非要求的 Engineer TRD，且未提供 related_prd 和 feature_level 元数据。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/engineer/test/trd-gen/evals/workspace/eval-004-api-adr-owned-by-engineer/comparison.md
+++ b/agents/engineer/test/trd-gen/evals/workspace/eval-004-api-adr-owned-by-engineer/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `7b6820d67dd73e9499a1ca84c463bfc82e890640eeaf8c3154b04834d8479116` from `agents/engineer/test/trd-gen/evals/workspace/eval-004-api-adr-owned-by-engineer`.
-- Fixture SHA-256: `7b6820d67dd73e9499a1ca84c463bfc82e890640eeaf8c3154b04834d8479116`
+- Identity schema: `2`
+- target_skill_sha256: `7350d982beaf3dbc1ec747d4598f05c9a1dfb9b1eb61dcb04ae43dfd72f6fcfd`
+- eval_definition_sha256: `c2e125b845f0cfd23a8b77d0953e79c0dfdb8a47bc09cbe45bf84d70fdf9a2db`
+- metadata_sha256: `d32be481f3b029c028aa82a9a8adf92bda8ff5084062b1a65511dd3d764980a1`
+- fixture_sha256: `7b6820d67dd73e9499a1ca84c463bfc82e890640eeaf8c3154b04834d8479116`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `2fb0119eb77903cfe9db053e59a3c85f9fb841609febdeb77953e7bac06ea0fe`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `825205d6124cce58172b3b6756f4b557e630d638b9032e293e0df1661f6c8e2b`
-- Repository HEAD: `7ac19d358ca18ef7b2d109aeec17239bc9d0f4c0`
+- Repository HEAD: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `241887560d0522d91eee495434f78fbbe72dd8e5d7ed6c58dce70753634045ba`
-- Skill overlay SHA-256: `1701eca585dc754d5c838c067ffd884a80205302462ac0a542c908fd069ff822`
-- Judge schema SHA-256: `2fb0119eb77903cfe9db053e59a3c85f9fb841609febdeb77953e7bac06ea0fe`
-- Eval definition SHA-256: `c2e125b845f0cfd23a8b77d0953e79c0dfdb8a47bc09cbe45bf84d70fdf9a2db`
-- Metadata SHA-256: `d32be481f3b029c028aa82a9a8adf92bda8ff5084062b1a65511dd3d764980a1`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
+- Skill overlay SHA-256: `41df440b7248e793c6d9703098fb03264d5ab1871ee7f72726859596ddf5327e`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -31,22 +33,22 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `engineer_owns_api_and_adr` | PASS | With-skill delivery_snapshot files identify `engineer_document_owner: engineer-agent:trd-gen` for TRD, API, and ADR. |
-| `writes_all_engineer_docs_under_feature_path` | PASS | With-skill delivery_snapshot contains exactly TRD.md, API.md, and ADR-001-search-index.md under `docs/engineer/chat-interface/history-search/`. |
-| `preserves_related_prd_and_metadata` | PASS | All three with-skill files contain the required feature metadata and `related_prd: docs/pm/chat-interface/history-search/PRD.md`. |
-| `does_not_use_pm_generators` | PASS | With-skill files use `generated_by: trd-gen`; no PM `api-gen` or `adr-gen` route appears in locked file or command evidence. |
-| `no_plan_or_code` | PASS | Locked git evidence shows only the three Engineer documentation files were added; no implementation plan, code, tests, or QA delivery files were created. |
+| `engineer_owns_api_and_adr` | PASS | With-skill output and all three locked Engineer document frontmatters identify `engineer_document_owner: engineer-agent:trd-gen`. |
+| `writes_all_engineer_docs_under_feature_path` | PASS | Locked delivery snapshots contain TRD.md, API.md, and ADR-001-postgresql-full-text-search.md under `docs/engineer/chat-interface/history-search/`. |
+| `preserves_related_prd_and_metadata` | PASS | All three locked Engineer documents contain the required feature metadata and `related_prd: docs/pm/chat-interface/history-search/PRD.md`. |
+| `does_not_use_pm_generators` | PASS | The with-skill delivery routes artifacts to Engineer paths and locked trace/git evidence shows no PM `api-gen` or `adr-gen` routing. |
+| `no_plan_or_code` | PASS | Locked git evidence shows only Engineer documentation files were added; no implementation plan, code, or test changes are present. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=825205d6124cce58172b3b6756f4b557e630d638b9032e293e0df1661f6c8e2b; fixture_sha256=7b6820d67dd73e9499a1ca84c463bfc82e890640eeaf8c3154b04834d8479116; output_sha256=a55080733e294aacd959f926cde60527060bd13819450f45cd4f5f35214bbe98; snapshot_sha256=de2c29f0098ec93b56893d5a0a39207154397fd0c48ceec1ded2fdd4bf8f55d1
-- Behavior: Produced the required Engineer-owned TRD, API, and ADR under the mirrored feature path, preserving metadata and stopping before implementation.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=825205d6124cce58172b3b6756f4b557e630d638b9032e293e0df1661f6c8e2b; fixture_sha256=7b6820d67dd73e9499a1ca84c463bfc82e890640eeaf8c3154b04834d8479116; output_sha256=9516bd1445d513c044b474094abcd8acbe9fcc1bb4d13a800093d36ef8b799de; snapshot_sha256=a6230bd6e5be52ee8d7f62c2b0e5888680d1601033b7feee021a54f567bdb1f4
+- Behavior: Produced the requested Engineer-owned TRD, API, and ADR under the mirrored feature path, with required metadata and no implementation work.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=825205d6124cce58172b3b6756f4b557e630d638b9032e293e0df1661f6c8e2b; fixture_sha256=7b6820d67dd73e9499a1ca84c463bfc82e890640eeaf8c3154b04834d8479116; output_sha256=23997271b647d774cd1ee2752b72e7fdb8aea7c2dd29185d7ad381ee26924e5a; snapshot_sha256=77b74cff0c55cf4a10c09fcd4fef82a902a523eb515e0aa7796db5cb4635e544
-- Behavior: Produced technical, API, and ADR documents under the PM path, failing to mirror the Engineer ownership and destination requirements.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=825205d6124cce58172b3b6756f4b557e630d638b9032e293e0df1661f6c8e2b; fixture_sha256=7b6820d67dd73e9499a1ca84c463bfc82e890640eeaf8c3154b04834d8479116; output_sha256=6959ad788bf4db0085b551ffdc7428be5ff6a9418067cad5379cb2fd5d3fbf33; snapshot_sha256=b6e7cacb16a2cc4adc26ee3b207fd5ed047e0a1ab50668e1027ef09af39af529
+- Behavior: Produced technically detailed documents under the PM path, demonstrating the fresh baseline's ownership and path failures.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/engineer/test/trd-gen/evals/workspace/eval-005-mapped-upload-trd-evidence/comparison.md
+++ b/agents/engineer/test/trd-gen/evals/workspace/eval-005-mapped-upload-trd-evidence/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `b9272be266caff6ac38d8060f5dbdbc6e981647729fe1530cfc53ca05b58b007` from `agents/engineer/test/trd-gen/evals/workspace/eval-005-mapped-upload-trd-evidence`.
-- Fixture SHA-256: `b9272be266caff6ac38d8060f5dbdbc6e981647729fe1530cfc53ca05b58b007`
+- Identity schema: `2`
+- target_skill_sha256: `7350d982beaf3dbc1ec747d4598f05c9a1dfb9b1eb61dcb04ae43dfd72f6fcfd`
+- eval_definition_sha256: `ed02404d14ffd40d542c29f44a74caf2fc5696740b01f75b11e50dfad6379f60`
+- metadata_sha256: `cfc84017a2f6130d5f5d58c0d09338a6a3beaaf2ead3e34eb6d3229566da0300`
+- fixture_sha256: `b9272be266caff6ac38d8060f5dbdbc6e981647729fe1530cfc53ca05b58b007`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `415550072b82b1b3b236c15b45beda7e56782899611899aec658b78876563888`
-- Repository HEAD: `7ac19d358ca18ef7b2d109aeec17239bc9d0f4c0`
+- Repository HEAD: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `241887560d0522d91eee495434f78fbbe72dd8e5d7ed6c58dce70753634045ba`
-- Skill overlay SHA-256: `1701eca585dc754d5c838c067ffd884a80205302462ac0a542c908fd069ff822`
-- Judge schema SHA-256: `6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda`
-- Eval definition SHA-256: `ed02404d14ffd40d542c29f44a74caf2fc5696740b01f75b11e50dfad6379f60`
-- Metadata SHA-256: `cfc84017a2f6130d5f5d58c0d09338a6a3beaaf2ead3e34eb6d3229566da0300`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
+- Skill overlay SHA-256: `41df440b7248e793c6d9703098fb03264d5ab1871ee7f72726859596ddf5327e`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -31,26 +33,26 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `reads_mapped_docs_first` | PASS | with_skill trace reads docs/site/standards/change-map.yaml, then reads its mapped docs/site/api/upload.md; the workspace-wide command only enumerates paths and does not read unrelated document contents. |
-| `verifies_against_code` | NOT_EXERCISED | The with_skill output identifies src/upload/limits.txt as the 10 MB single-request configuration and records the 20 MB documentation conflict plus its impact on compatibility and the need for a product decision. A formal TRD artifact was blocked by missing PM confirmation, so the later TRD-evidence portion was not exercised. |
-| `treats_unverified_as_low_trust` | PASS | The output explicitly marks last_verified_version: unverified as low-trust navigation and leaves the final limit and related design decisions for confirmation rather than treating the documentation as authoritative. |
+| `reads_mapped_docs_first` | PASS | with_skill trace item_4 reads change-map.yaml, then the mapped upload.md and limits.txt; the broad file listing only inventories paths and does not read unrelated documents. |
+| `verifies_against_code` | NOT_EXERCISED | with_skill directly verified limits.txt as 10 MB and preserved the 20 MB documentation conflict and impact in its evidence summary, but no TRD artifact was created because the required PM handoff and feature_path were missing; the TRD-specific portion was not exercised. |
+| `treats_unverified_as_low_trust` | PASS | with_skill explicitly treats last_verified_version: unverified as lowest-trust navigation evidence and does not use the page alone to determine interface behavior or the technical plan. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=415550072b82b1b3b236c15b45beda7e56782899611899aec658b78876563888; fixture_sha256=b9272be266caff6ac38d8060f5dbdbc6e981647729fe1530cfc53ca05b58b007; output_sha256=49baf75ccf690178f5438a5a76590eb239d5ab936225a58cffe980997f9cc10f; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Followed the mapped-document workflow, verified the 10 MB fixture against the conflicting unverified 20 MB documentation, and produced a cautious gap assessment while blocking formal TRD work pending confirmation.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=415550072b82b1b3b236c15b45beda7e56782899611899aec658b78876563888; fixture_sha256=b9272be266caff6ac38d8060f5dbdbc6e981647729fe1530cfc53ca05b58b007; output_sha256=27c8d388f92b8daa71f7ecebdcf9a114aa828eb4466c22c73474c058e5dfd473; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Followed the mapped-document and low-trust workflow, verified the code-side limit and documented the conflict, then correctly stopped at the Engineer entry gate.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=415550072b82b1b3b236c15b45beda7e56782899611899aec658b78876563888; fixture_sha256=b9272be266caff6ac38d8060f5dbdbc6e981647729fe1530cfc53ca05b58b007; output_sha256=a9e0491909fada6abd92df9b0ccfbfdcceafa9edadfc38662885b2399868b135; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Produced a useful baseline report that also found the 10 MB versus 20 MB conflict and proposed a multipart design, but did not provide the skill-specific blocked-TRD handoff context.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=415550072b82b1b3b236c15b45beda7e56782899611899aec658b78876563888; fixture_sha256=b9272be266caff6ac38d8060f5dbdbc6e981647729fe1530cfc53ca05b58b007; output_sha256=0f89339583e9b10f5a7b7e9ee25dceb3fbbecc5a39adf9813863920c20a5318b; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Produced a broad technical proposal and correctly identified the 10 MB versus 20 MB conflict, but did not demonstrate mapped-document-first process evidence.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Obtain PM confirmation of scope, size limits, compatibility, storage, and feature path; then generate the formal TRD evidence.
+- Next: Obtain the confirmed PM handoff, product decisions, and feature_path, then exercise the TRD evidence requirement.
 
 ## Runtime Artifact Policy
 

--- a/agents/engineer/test/trd-gen/evals/workspace/eval-006-delivery-polling-to-events/comparison.md
+++ b/agents/engineer/test/trd-gen/evals/workspace/eval-006-delivery-polling-to-events/comparison.md
@@ -12,50 +12,48 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `26621a90d557560b63afa9dd1b1ebe2dbb9f05568b574efca78ec5babe092c74` from `agents/engineer/test/trd-gen/evals/workspace/eval-006-delivery-polling-to-events`.
-- Fixture SHA-256: `26621a90d557560b63afa9dd1b1ebe2dbb9f05568b574efca78ec5babe092c74`
+- Identity schema: `2`
+- target_skill_sha256: `7350d982beaf3dbc1ec747d4598f05c9a1dfb9b1eb61dcb04ae43dfd72f6fcfd`
+- eval_definition_sha256: `3255bddbc0ba9d00273a741fab78b9e223454656c0b7cbcdb74a3b3b193952f9`
+- metadata_sha256: `c58e464b2f51cbecc05208e0f4320ff2bade980227072a25840336ba048c489e`
+- fixture_sha256: `26621a90d557560b63afa9dd1b1ebe2dbb9f05568b574efca78ec5babe092c74`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `58d5f8c73c18457a8d0864b8f5e21613dc914d57c8f96acc11ce98a78c601f05`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `4d55ba6ecaf12e0a768970bba911c34982402774916977cdba5d537398d0d4ea`
-- Repository HEAD: `7ac19d358ca18ef7b2d109aeec17239bc9d0f4c0`
+- Repository HEAD: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `241887560d0522d91eee495434f78fbbe72dd8e5d7ed6c58dce70753634045ba`
-- Skill overlay SHA-256: `1701eca585dc754d5c838c067ffd884a80205302462ac0a542c908fd069ff822`
-- Judge schema SHA-256: `58d5f8c73c18457a8d0864b8f5e21613dc914d57c8f96acc11ce98a78c601f05`
-- Eval definition SHA-256: `ec0b30178f28a00245f34e8794f34ea3d889794c5e097f45505840818ce3d657`
-- Metadata SHA-256: `c58e464b2f51cbecc05208e0f4320ff2bade980227072a25840336ba048c489e`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
-- Behavior result: **FAIL**
+- Skill overlay SHA-256: `41df440b7248e793c6d9703098fb03264d5ab1871ee7f72726859596ddf5327e`
+- Behavior result: **PASS**
 - Coverage result: **FULL**
-Overall result: FAIL
+Overall result: PASS
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `updates_existing_trd` | FAIL | with_skill 的 delivery_snapshot 仅更新目标 TRD，但正文第 9 节及最终输出明确将实现计划移交给 feature-implementor，违反“不把任务路由给别人”。 |
-| `body_consolidation` | FAIL | with_skill 的 TRD 正文第 5 节保留“现有 TRD 中的轮询调度与批量扫描不属于当前目标架构”，属于以状态标注保留旧方案。 |
-| `removal_recorded_in_changelog` | FAIL | with_skill 的 frontmatter 没有 changelog；变更记录位于正文第 8 节，而要求记录在 frontmatter。版本号已更新为 1.2.0。 |
-| `no_implementation_plan_or_code` | PASS | 锁定 delivery_snapshot 仅包含 TRD.md，没有 IMPLEMENTATION_PLAN.md、代码或测试文件；验证策略仍属于 TRD 正文内容。 |
+| `updates_existing_trd` | PASS | With-skill delivery snapshot contains only the existing TRD, with version 1.2.0 and generated_by: trd-gen; its body has no routing instructions. The summary names the owner/path without claiming transfer, start, or routing. |
+| `body_consolidation` | PASS | The locked TRD body describes the event-driven design and contains no retained polling plan or deprecation-status wording. |
+| `removal_recorded_in_changelog` | PASS | Frontmatter includes a changelog with the 1.2.0 update and prior 1.1.0 entry; the version was updated from 1.1.0 to 1.2.0. |
+| `no_implementation_plan_or_code` | PASS | The delivery snapshot contains only TRD.md; no implementation plan, source-code, or test-file mutation is evidenced. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4d55ba6ecaf12e0a768970bba911c34982402774916977cdba5d537398d0d4ea; fixture_sha256=26621a90d557560b63afa9dd1b1ebe2dbb9f05568b574efca78ec5babe092c74; output_sha256=2adcde8d0adc262e0c52c45024540428f657933db3a8739e95f3519a421e3f91; snapshot_sha256=549ce70cb2f5c120e7484c2e5151430005b3702f9fd0878b0b6542de98f970b4
-- Behavior: 更新了目标 TRD 并切换为事件驱动，但保留了不应出现的移交信息和正文旧方案状态说明，且 changelog 位置错误。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4d55ba6ecaf12e0a768970bba911c34982402774916977cdba5d537398d0d4ea; fixture_sha256=26621a90d557560b63afa9dd1b1ebe2dbb9f05568b574efca78ec5babe092c74; output_sha256=ee26287fc58756a1916e0e1446e2fa7bcb1ce88e62d1b7b2c79f35d3de45c0d8; snapshot_sha256=6a31c9c534f8b1311aea0b5b4a9eba9808ef141aab1976a3166bd2b6241319fa
+- Behavior: Updated the existing TRD into a detailed event-driven specification with generated-by provenance, changelog, and no downstream execution claim.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4d55ba6ecaf12e0a768970bba911c34982402774916977cdba5d537398d0d4ea; fixture_sha256=26621a90d557560b63afa9dd1b1ebe2dbb9f05568b574efca78ec5babe092c74; output_sha256=fb374e7191c9247c57c47154649cc0caf26a04ae926eade3d427d094b75b9692; snapshot_sha256=7287e564dc77138e88eebe437956ef48b2d9ec7c5c31a07591c3826759611bf7
-- Behavior: 更新目标 TRD 为事件驱动，未新增其他文件；作为对照，其正文更简洁且未显示移交信息或保留旧轮询状态说明。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4d55ba6ecaf12e0a768970bba911c34982402774916977cdba5d537398d0d4ea; fixture_sha256=26621a90d557560b63afa9dd1b1ebe2dbb9f05568b574efca78ec5babe092c74; output_sha256=9a698def02f4cdf1fbf6288f9cc272608de72abf6db798e94a77579e171c5fa7; snapshot_sha256=ac45d65ebd638d80574971ce7cd5854efc950aee2f709850219a997355b5ab30
+- Behavior: Updated the existing TRD to an event-driven design, but the snapshot omitted the required changelog and trd-gen provenance.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- with_skill 违反了不得将任务路由给其他角色的要求。
-- with_skill 在正文保留了带状态标注的轮询旧方案。
-- with_skill 未将删除记录写入 frontmatter changelog。
-- Next: 移除 TRD 正文中的实现计划移交、角色归属和 IMPLEMENTATION_PLAN.md 路由内容。
-- Next: 删除正文中“不属于当前目标架构”等轮询旧方案状态说明。
-- Next: 在 frontmatter 中新增 changelog 并记录轮询方案移除，同时保留版本更新。
+- None.
+- Next: None.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/skills/pm-agent/SKILL.md
+++ b/agents/product_manager/skills/pm-agent/SKILL.md
@@ -65,7 +65,9 @@ the project path by itself.
   short-circuits the Mandatory Entry Decision.
 - **Explicit invocation**: when the user's message names `pm-agent`, a role
   agent, or a skill from this marketplace, proceed normally from any
-  directory.
+  directory. Once this branch matches, the Out-of-scope branch is unavailable:
+  do not reuse its “general/local-machine request” or “directory not enabled”
+  stop notice later in the response.
 
 Project-oriented requests (product, engineering, QA, deployment, security,
 formal documentation, delivery) proceed normally and follow the Mandatory
@@ -73,9 +75,12 @@ Entry Decision below; the guard only stops general, non-project requests in
 unenabled directories. When an explicit invocation or an enabled directory
 lets a general request through, proceed into the classification protocol; a
 request that fits no PM category or downstream role is answered with a
-one-line honest notice and kept in PM — no Routing decision is required for
-it, and never force a fake `request_type` or owner that contradicts its
-content.
+one-line honest classification result that explicitly says classification ran,
+no PM category or downstream role matched, and the request remains in PM — no
+Routing decision is required for it, and never force a fake `request_type` or
+owner that contradicts its content. This classification result is not a Scope
+Guard rejection and must not claim that the explicit request was blocked
+because it is a local-machine or generic-file operation.
 
 ## Mandatory Entry Decision
 

--- a/agents/product_manager/test/changelog-gen/evals/workspace/eval-001-unreleased-mode/comparison.md
+++ b/agents/product_manager/test/changelog-gen/evals/workspace/eval-001-unreleased-mode/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `6c891edd0d2edaa974f9696bff7fd8bce1989edc225daec7356e08843c3ccf17` from `agents/product_manager/test/changelog-gen/evals/workspace/eval-001-unreleased-mode`.
-- Fixture SHA-256: `6c891edd0d2edaa974f9696bff7fd8bce1989edc225daec7356e08843c3ccf17`
-- Prompt SHA-256: `43cfb6c692393c921f5bd34fe732149f7950dd5ff91e898df22a516e60d25811`
+- Identity schema: `2`
+- target_skill_sha256: `53f035563de038125d09b7a8997f87e900d099e00223f427a7c690e11ebbe449`
+- eval_definition_sha256: `f643e5a44adc95dee4686543e115df7acb899ebc5dec146519d9991e82db553d`
+- metadata_sha256: `95c0dae43621d97267d71f9000473df424f0f20875022c90f8a0826f1615ee52`
+- fixture_sha256: `6c891edd0d2edaa974f9696bff7fd8bce1989edc225daec7356e08843c3ccf17`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `e87b7560e9b11fe6dfc954d0faa2696f04b98bb48f59af2eb521a8e8cfed4660`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `53f035563de038125d09b7a8997f87e900d099e00223f427a7c690e11ebbe449`
-- Skill overlay SHA-256: `9534a5bf71391ac48cfd6a48ca8f80e93da520d6ea9d2026741fd864da0cb720`
-- Judge schema SHA-256: `e87b7560e9b11fe6dfc954d0faa2696f04b98bb48f59af2eb521a8e8cfed4660`
-- Eval definition SHA-256: `f643e5a44adc95dee4686543e115df7acb899ebc5dec146519d9991e82db553d`
-- Metadata SHA-256: `95c0dae43621d97267d71f9000473df424f0f20875022c90f8a0826f1615ee52`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/product_manager/test/changelog-gen/evals/workspace/eval-002-single-version-mode/comparison.md
+++ b/agents/product_manager/test/changelog-gen/evals/workspace/eval-002-single-version-mode/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `835e6d91014bb254ac4027a75b2b94fcac8cc02efcf4ee8832fb73ee44824c88` from `agents/product_manager/test/changelog-gen/evals/workspace/eval-002-single-version-mode`.
-- Fixture SHA-256: `835e6d91014bb254ac4027a75b2b94fcac8cc02efcf4ee8832fb73ee44824c88`
-- Prompt SHA-256: `d5b776b3a900ef058dd8e13d5ff0673d61e60850257603b59fa1902a93991031`
+- Identity schema: `2`
+- target_skill_sha256: `53f035563de038125d09b7a8997f87e900d099e00223f427a7c690e11ebbe449`
+- eval_definition_sha256: `8e1f2a2b7cff1dcc676c7dcd6956883a0a24ee6d97754afcf56bc59fdaf06a61`
+- metadata_sha256: `814184c8bd7a959b3f0695c85bef4dd34c73bd316a08d00ccc354207f37fabc9`
+- fixture_sha256: `835e6d91014bb254ac4027a75b2b94fcac8cc02efcf4ee8832fb73ee44824c88`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `609660421781976ec561327c947a31da6f7d421bc63e99d2f3f00692dcdf763a`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `53f035563de038125d09b7a8997f87e900d099e00223f427a7c690e11ebbe449`
-- Skill overlay SHA-256: `9534a5bf71391ac48cfd6a48ca8f80e93da520d6ea9d2026741fd864da0cb720`
-- Judge schema SHA-256: `609660421781976ec561327c947a31da6f7d421bc63e99d2f3f00692dcdf763a`
-- Eval definition SHA-256: `8e1f2a2b7cff1dcc676c7dcd6956883a0a24ee6d97754afcf56bc59fdaf06a61`
-- Metadata SHA-256: `814184c8bd7a959b3f0695c85bef4dd34c73bd316a08d00ccc354207f37fabc9`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/product_manager/test/changelog-gen/evals/workspace/eval-003-prefix-classification/comparison.md
+++ b/agents/product_manager/test/changelog-gen/evals/workspace/eval-003-prefix-classification/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/changelog-gen/evals/workspace/eval-003-prefix-classification`.
-- Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
-- Prompt SHA-256: `9be6d0e23157c436ac95fa175b7c253fc5c8a58bd7930d5f75b8e2f143978496`
+- Identity schema: `2`
+- target_skill_sha256: `53f035563de038125d09b7a8997f87e900d099e00223f427a7c690e11ebbe449`
+- eval_definition_sha256: `02c7a6bcc66679fa2f47687ffd7cdba26fff303adab62c4e3435b49f28878db8`
+- metadata_sha256: `7c295252d061c5f27afb73a5d2bc7ec230ac3e0e3896f6109062c7b18ee9cf2e`
+- fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `cc05e28bb9aed099804431e1cee55bda0cec7614cc8c780d6f8ad4d50c137367`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `53f035563de038125d09b7a8997f87e900d099e00223f427a7c690e11ebbe449`
-- Skill overlay SHA-256: `9534a5bf71391ac48cfd6a48ca8f80e93da520d6ea9d2026741fd864da0cb720`
-- Judge schema SHA-256: `cc05e28bb9aed099804431e1cee55bda0cec7614cc8c780d6f8ad4d50c137367`
-- Eval definition SHA-256: `02c7a6bcc66679fa2f47687ffd7cdba26fff303adab62c4e3435b49f28878db8`
-- Metadata SHA-256: `7c295252d061c5f27afb73a5d2bc7ec230ac3e0e3896f6109062c7b18ee9cf2e`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/product_manager/test/competitive-brief/evals/workspace/eval-001-positioning-gap-brief/comparison.md
+++ b/agents/product_manager/test/competitive-brief/evals/workspace/eval-001-positioning-gap-brief/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/competitive-brief/evals/workspace/eval-001-positioning-gap-brief`.
-- Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
-- Prompt SHA-256: `adf7889b0d876e991ee47320ba8f46f60cd10315ed2d153b1c81fce9f52aed9b`
+- Identity schema: `2`
+- target_skill_sha256: `64a375a1a490fa251e9b252ef3a7787f55ca6a4fd08e5d401228a899b274ed39`
+- eval_definition_sha256: `97a23b71b146f4c0d34488da4fd45ddfa63b73d91d16deb5d2e03fbe4f5d01f6`
+- metadata_sha256: `253b7cd58ea1d83c5776d9de8bd0332f1de43ff8d162b4ae1c25de74c0394acf`
+- fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `9482baaf8c9e8ed2c6d5d65dd72ca668fb6cc639dacfe10c14d42e2f2d0f4c53`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `64a375a1a490fa251e9b252ef3a7787f55ca6a4fd08e5d401228a899b274ed39`
-- Skill overlay SHA-256: `c1341cebf983202b3c2101489252c70818305b548c111af4817c833b2dd4164f`
-- Judge schema SHA-256: `9482baaf8c9e8ed2c6d5d65dd72ca668fb6cc639dacfe10c14d42e2f2d0f4c53`
-- Eval definition SHA-256: `97a23b71b146f4c0d34488da4fd45ddfa63b73d91d16deb5d2e03fbe4f5d01f6`
-- Metadata SHA-256: `253b7cd58ea1d83c5776d9de8bd0332f1de43ff8d162b4ae1c25de74c0394acf`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/product_manager/test/competitive-brief/evals/workspace/eval-002-battlecard-mode/comparison.md
+++ b/agents/product_manager/test/competitive-brief/evals/workspace/eval-002-battlecard-mode/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `580131b9961f88dece682fec7455c21af018b400a3742eb37ae40114374aeae0` from `agents/product_manager/test/competitive-brief/evals/workspace/eval-002-battlecard-mode`.
-- Fixture SHA-256: `580131b9961f88dece682fec7455c21af018b400a3742eb37ae40114374aeae0`
-- Prompt SHA-256: `e54579ea27411964e085efe779b45a83156d8efbd3908b273d472904914675a2`
+- Identity schema: `2`
+- target_skill_sha256: `64a375a1a490fa251e9b252ef3a7787f55ca6a4fd08e5d401228a899b274ed39`
+- eval_definition_sha256: `a7454ae2eccc665064a08c31fc99de3b8f0a596f72811f2e5035b12f267e9fe8`
+- metadata_sha256: `be38b1b419460352b11de0cc1468d57c031f7575d697be3bf617760a456d47f3`
+- fixture_sha256: `580131b9961f88dece682fec7455c21af018b400a3742eb37ae40114374aeae0`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `e42897afb6931d7065c6aa9ac71e607d574f057396cd3a30a0419c210f3be3cb`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `64a375a1a490fa251e9b252ef3a7787f55ca6a4fd08e5d401228a899b274ed39`
-- Skill overlay SHA-256: `c1341cebf983202b3c2101489252c70818305b548c111af4817c833b2dd4164f`
-- Judge schema SHA-256: `e42897afb6931d7065c6aa9ac71e607d574f057396cd3a30a0419c210f3be3cb`
-- Eval definition SHA-256: `a7454ae2eccc665064a08c31fc99de3b8f0a596f72811f2e5035b12f267e9fe8`
-- Metadata SHA-256: `be38b1b419460352b11de0cc1468d57c031f7575d697be3bf617760a456d47f3`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/product_manager/test/feature-catalog/evals/workspace/eval-001-legacy-project-catalog/comparison.md
+++ b/agents/product_manager/test/feature-catalog/evals/workspace/eval-001-legacy-project-catalog/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `fa295db805350878180b0b5d2e6fc6d21188b2866a3c61c345e1f1875b201554` from `agents/product_manager/test/feature-catalog/evals/workspace/eval-001-legacy-project-catalog`.
-- Fixture SHA-256: `fa295db805350878180b0b5d2e6fc6d21188b2866a3c61c345e1f1875b201554`
-- Prompt SHA-256: `35596dbabe7e81489226405d1f4c2c66e846066917c0ef619ae5a1e2332558a2`
+- Identity schema: `2`
+- target_skill_sha256: `272c84e241c5d52534922fccf2bc6732492a0d70c9f6e2ab8dc1eff2533f7b0c`
+- eval_definition_sha256: `6316196cbc0024d8a369162c20842d191078adb23f3f59cfbc5541923081da5e`
+- metadata_sha256: `aa9b419ec00ff2ce5f9c2775fc1e620cf1eb45a8d316e5adf573b14f5b74c3e2`
+- fixture_sha256: `fa295db805350878180b0b5d2e6fc6d21188b2866a3c61c345e1f1875b201554`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `6731c51ff9f69981e5ade0a40fa5fb4f93b6c439e428212a1b46155c6fa123f1`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `272c84e241c5d52534922fccf2bc6732492a0d70c9f6e2ab8dc1eff2533f7b0c`
-- Skill overlay SHA-256: `9fb06b39d6c186c13ce243a925511364a66cb0da19ef72dd5c8e3b46dd2b75b8`
-- Judge schema SHA-256: `6731c51ff9f69981e5ade0a40fa5fb4f93b6c439e428212a1b46155c6fa123f1`
-- Eval definition SHA-256: `6316196cbc0024d8a369162c20842d191078adb23f3f59cfbc5541923081da5e`
-- Metadata SHA-256: `aa9b419ec00ff2ce5f9c2775fc1e620cf1eb45a8d316e5adf573b14f5b74c3e2`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)

--- a/agents/product_manager/test/feature-catalog/evals/workspace/eval-002-child-feature-under-parent-prd/comparison.md
+++ b/agents/product_manager/test/feature-catalog/evals/workspace/eval-002-child-feature-under-parent-prd/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `e64d0dc500eb5720a57f43e64b9a52c75b87f674117c2e966a459db4cd412910` from `agents/product_manager/test/feature-catalog/evals/workspace/eval-002-child-feature-under-parent-prd`.
-- Fixture SHA-256: `e64d0dc500eb5720a57f43e64b9a52c75b87f674117c2e966a459db4cd412910`
-- Prompt SHA-256: `d30a63f3453aaf3bd01618d870dc101f5d610329fec8c95cdf338a27c46a679e`
+- Identity schema: `2`
+- target_skill_sha256: `272c84e241c5d52534922fccf2bc6732492a0d70c9f6e2ab8dc1eff2533f7b0c`
+- eval_definition_sha256: `381b074083537f3d71cb0a28bd3dbbcbf80ece8371ca5fba3a891d822f995603`
+- metadata_sha256: `9511751d671a5ae5883161ea664a79cdce7fc89cb2e17e607a976174a239c8f6`
+- fixture_sha256: `e64d0dc500eb5720a57f43e64b9a52c75b87f674117c2e966a459db4cd412910`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `c03c0410b926db4903e624e0fe3e993a88d8b355caa51278c9f027aa7078ef66`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `272c84e241c5d52534922fccf2bc6732492a0d70c9f6e2ab8dc1eff2533f7b0c`
-- Skill overlay SHA-256: `9fb06b39d6c186c13ce243a925511364a66cb0da19ef72dd5c8e3b46dd2b75b8`
-- Judge schema SHA-256: `c03c0410b926db4903e624e0fe3e993a88d8b355caa51278c9f027aa7078ef66`
-- Eval definition SHA-256: `381b074083537f3d71cb0a28bd3dbbcbf80ece8371ca5fba3a891d822f995603`
-- Metadata SHA-256: `9511751d671a5ae5883161ea664a79cdce7fc89cb2e17e607a976174a239c8f6`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)

--- a/agents/product_manager/test/feature-catalog/evals/workspace/eval-003-monorepo-scope-clarification/comparison.md
+++ b/agents/product_manager/test/feature-catalog/evals/workspace/eval-003-monorepo-scope-clarification/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `c414562285f1c022777b6125d75fb56cbbd795475c5bf83bc97b862a14abc6d3` from `agents/product_manager/test/feature-catalog/evals/workspace/eval-003-monorepo-scope-clarification`.
-- Fixture SHA-256: `c414562285f1c022777b6125d75fb56cbbd795475c5bf83bc97b862a14abc6d3`
-- Prompt SHA-256: `592a8806afad3bd6928b7ec27d5b10ebdae9bb0b86dd82cabdc2f71dc5d37c25`
+- Identity schema: `2`
+- target_skill_sha256: `272c84e241c5d52534922fccf2bc6732492a0d70c9f6e2ab8dc1eff2533f7b0c`
+- eval_definition_sha256: `221668759d9b3f1847f350986e591b6defbd71cd5f83a296b96e5736de8e7ceb`
+- metadata_sha256: `8aa1f1f970ba708ba203aa964e23b048bfd278c5cd0d04094602a65c55ad9476`
+- fixture_sha256: `c414562285f1c022777b6125d75fb56cbbd795475c5bf83bc97b862a14abc6d3`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `fe7ee6212a0514e053db6b490f2fd78c74a3e6115f5b789e3e3734a9d7b1be8b`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `272c84e241c5d52534922fccf2bc6732492a0d70c9f6e2ab8dc1eff2533f7b0c`
-- Skill overlay SHA-256: `9fb06b39d6c186c13ce243a925511364a66cb0da19ef72dd5c8e3b46dd2b75b8`
-- Judge schema SHA-256: `fe7ee6212a0514e053db6b490f2fd78c74a3e6115f5b789e3e3734a9d7b1be8b`
-- Eval definition SHA-256: `221668759d9b3f1847f350986e591b6defbd71cd5f83a296b96e5736de8e7ceb`
-- Metadata SHA-256: `8aa1f1f970ba708ba203aa964e23b048bfd278c5cd0d04094602a65c55ad9476`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/product_manager/test/feature-catalog/evals/workspace/eval-004-catalog-mapped-billing-feature/comparison.md
+++ b/agents/product_manager/test/feature-catalog/evals/workspace/eval-004-catalog-mapped-billing-feature/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `dbc5593a346cec17c758e623e41d968d8b062bb60f1c6687047b79f186d5a5fa` from `agents/product_manager/test/feature-catalog/evals/workspace/eval-004-catalog-mapped-billing-feature`.
-- Fixture SHA-256: `dbc5593a346cec17c758e623e41d968d8b062bb60f1c6687047b79f186d5a5fa`
-- Prompt SHA-256: `18727fc23cb0e6511e466aafaee8dc2b3d50aa38834ef79db9cd3a99a2690d99`
+- Identity schema: `2`
+- target_skill_sha256: `272c84e241c5d52534922fccf2bc6732492a0d70c9f6e2ab8dc1eff2533f7b0c`
+- eval_definition_sha256: `8d7030970f6fab5f1056baaa7f97792f12e093b11e3211055d5ae790cf0d3bc2`
+- metadata_sha256: `b6e639db89ad7dc9c01b74ff5037844027a7f93b1a684864779b0328b14ee4bc`
+- fixture_sha256: `dbc5593a346cec17c758e623e41d968d8b062bb60f1c6687047b79f186d5a5fa`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `272c84e241c5d52534922fccf2bc6732492a0d70c9f6e2ab8dc1eff2533f7b0c`
-- Skill overlay SHA-256: `9fb06b39d6c186c13ce243a925511364a66cb0da19ef72dd5c8e3b46dd2b75b8`
-- Judge schema SHA-256: `6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda`
-- Eval definition SHA-256: `8d7030970f6fab5f1056baaa7f97792f12e093b11e3211055d5ae790cf0d3bc2`
-- Metadata SHA-256: `b6e639db89ad7dc9c01b74ff5037844027a7f93b1a684864779b0328b14ee4bc`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **FAIL**
 - Coverage result: **FULL**
 Overall result: FAIL

--- a/agents/product_manager/test/github-reader/evals/workspace/eval-001-full-status/comparison.md
+++ b/agents/product_manager/test/github-reader/evals/workspace/eval-001-full-status/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `0519c739e4c8d28c0f994ae12773611385afed7d111bc3d263905cd5dd009c56` from `agents/product_manager/test/github-reader/evals/workspace/eval-001-full-status`.
-- Fixture SHA-256: `0519c739e4c8d28c0f994ae12773611385afed7d111bc3d263905cd5dd009c56`
-- Prompt SHA-256: `01e34273d27e520aa4245ba28190974384941538e5ce7197f3456329c6301565`
+- Identity schema: `2`
+- target_skill_sha256: `8b55857ad21cc937337dcf6bc1fa19fcc7f833c3e9c078d89a5db79725e98233`
+- eval_definition_sha256: `a688cc91089931e5821e56e4470a0bc8844e7a9c13d1b4c5bcc8d2e3929da0ce`
+- metadata_sha256: `94b279ac62424134e6355f46df23e4185fa4034dd04349372cf9178ca3c8c29f`
+- fixture_sha256: `0519c739e4c8d28c0f994ae12773611385afed7d111bc3d263905cd5dd009c56`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `9f1a7ae2ae5e175ed8e057b35c400ea4c201e7779a64206f11bbe6bac585e282`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `8b55857ad21cc937337dcf6bc1fa19fcc7f833c3e9c078d89a5db79725e98233`
-- Skill overlay SHA-256: `b0004c5792dae6a7d4050cf6839b7073909210717e4fcd3dd4b28188da158276`
-- Judge schema SHA-256: `9f1a7ae2ae5e175ed8e057b35c400ea4c201e7779a64206f11bbe6bac585e282`
-- Eval definition SHA-256: `a688cc91089931e5821e56e4470a0bc8844e7a9c13d1b4c5bcc8d2e3929da0ce`
-- Metadata SHA-256: `94b279ac62424134e6355f46df23e4185fa4034dd04349372cf9178ca3c8c29f`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/product_manager/test/github-reader/evals/workspace/eval-002-focused-pr-query/comparison.md
+++ b/agents/product_manager/test/github-reader/evals/workspace/eval-002-focused-pr-query/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `c47404a9f5ea07f17a4bfb2e97874d6684926d30ff0b484abac088755424ca88` from `agents/product_manager/test/github-reader/evals/workspace/eval-002-focused-pr-query`.
-- Fixture SHA-256: `c47404a9f5ea07f17a4bfb2e97874d6684926d30ff0b484abac088755424ca88`
-- Prompt SHA-256: `468124d8eedb8d3a589e16901dfd4143cfa89af6e4b45d88eb587edfeea38b16`
+- Identity schema: `2`
+- target_skill_sha256: `8b55857ad21cc937337dcf6bc1fa19fcc7f833c3e9c078d89a5db79725e98233`
+- eval_definition_sha256: `f5bead0980a8f345220f5b383eac5991e933d1b98e28d8a0a232f76e705ff52b`
+- metadata_sha256: `c5e584cdac5929bc66cbb7a8b1f6027ddae3cc40fe09b2afaf2c981fd146a7b2`
+- fixture_sha256: `c47404a9f5ea07f17a4bfb2e97874d6684926d30ff0b484abac088755424ca88`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `ddb9410329ada83c41bd4e356f1396d4382d0277cddc70506d8c08ee4b2fa89f`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `8b55857ad21cc937337dcf6bc1fa19fcc7f833c3e9c078d89a5db79725e98233`
-- Skill overlay SHA-256: `b0004c5792dae6a7d4050cf6839b7073909210717e4fcd3dd4b28188da158276`
-- Judge schema SHA-256: `ddb9410329ada83c41bd4e356f1396d4382d0277cddc70506d8c08ee4b2fa89f`
-- Eval definition SHA-256: `f5bead0980a8f345220f5b383eac5991e933d1b98e28d8a0a232f76e705ff52b`
-- Metadata SHA-256: `c5e584cdac5929bc66cbb7a8b1f6027ddae3cc40fe09b2afaf2c981fd146a7b2`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/product_manager/test/github-reader/evals/workspace/eval-003-milestone-focused/comparison.md
+++ b/agents/product_manager/test/github-reader/evals/workspace/eval-003-milestone-focused/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `2ba90e4cae03b1fd07ce6567f8fe44587f4577228f679c498afbf0484b96f05c` from `agents/product_manager/test/github-reader/evals/workspace/eval-003-milestone-focused`.
-- Fixture SHA-256: `2ba90e4cae03b1fd07ce6567f8fe44587f4577228f679c498afbf0484b96f05c`
-- Prompt SHA-256: `6506b5ece3ae9322200484db667c39628a3ba1c5902c8e50dced665ef74216a2`
+- Identity schema: `2`
+- target_skill_sha256: `8b55857ad21cc937337dcf6bc1fa19fcc7f833c3e9c078d89a5db79725e98233`
+- eval_definition_sha256: `42081b8248822116670301abef5c529a038e386c92ca99283441306b2d8ac307`
+- metadata_sha256: `99e5bae99fd448ea8124895faf739aa4393a75e56feb8e7b78841ca027a5f393`
+- fixture_sha256: `2ba90e4cae03b1fd07ce6567f8fe44587f4577228f679c498afbf0484b96f05c`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `e8bf769ac89a10c9a014e6b2e125d2d95f024ce8d37a4e4481c16c75936c71a8`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `8b55857ad21cc937337dcf6bc1fa19fcc7f833c3e9c078d89a5db79725e98233`
-- Skill overlay SHA-256: `b0004c5792dae6a7d4050cf6839b7073909210717e4fcd3dd4b28188da158276`
-- Judge schema SHA-256: `e8bf769ac89a10c9a014e6b2e125d2d95f024ce8d37a4e4481c16c75936c71a8`
-- Eval definition SHA-256: `42081b8248822116670301abef5c529a038e386c92ca99283441306b2d8ac307`
-- Metadata SHA-256: `99e5bae99fd448ea8124895faf739aa4393a75e56feb8e7b78841ca027a5f393`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/product_manager/test/github-reader/evals/workspace/eval-004-mapped-export-status-context/comparison.md
+++ b/agents/product_manager/test/github-reader/evals/workspace/eval-004-mapped-export-status-context/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `b91f8ca3f3681cf4c1a336f7748050f27d679c67ce39092970202362aab7af63` from `agents/product_manager/test/github-reader/evals/workspace/eval-004-mapped-export-status-context`.
-- Fixture SHA-256: `b91f8ca3f3681cf4c1a336f7748050f27d679c67ce39092970202362aab7af63`
-- Prompt SHA-256: `c3d78f9b9bc67f2a85f690ebb4f7d73fa301b8da080d83b39bba1b815957de1c`
+- Identity schema: `2`
+- target_skill_sha256: `8b55857ad21cc937337dcf6bc1fa19fcc7f833c3e9c078d89a5db79725e98233`
+- eval_definition_sha256: `c9320af546c098adb51ac45faa524e2216c221f13ecd2b33fb2f8f822f024522`
+- metadata_sha256: `d12a4df00a2f5f04d2bf0e553078ba3dc62e403dd0f77a037fb5796abdce7123`
+- fixture_sha256: `b91f8ca3f3681cf4c1a336f7748050f27d679c67ce39092970202362aab7af63`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `8b55857ad21cc937337dcf6bc1fa19fcc7f833c3e9c078d89a5db79725e98233`
-- Skill overlay SHA-256: `b0004c5792dae6a7d4050cf6839b7073909210717e4fcd3dd4b28188da158276`
-- Judge schema SHA-256: `6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda`
-- Eval definition SHA-256: `c9320af546c098adb51ac45faa524e2216c221f13ecd2b33fb2f8f822f024522`
-- Metadata SHA-256: `d12a4df00a2f5f04d2bf0e553078ba3dc62e403dd0f77a037fb5796abdce7123`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/product_manager/test/github-reader/evals/workspace/eval-005-feed-mode-completeness/comparison.md
+++ b/agents/product_manager/test/github-reader/evals/workspace/eval-005-feed-mode-completeness/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `740d701b2570cd48dc39895eb6dad24e4e63318905be6af74ad27b07c8129f82` from `agents/product_manager/test/github-reader/evals/workspace/eval-005-feed-mode-completeness`.
-- Fixture SHA-256: `740d701b2570cd48dc39895eb6dad24e4e63318905be6af74ad27b07c8129f82`
-- Prompt SHA-256: `733e42077f632553b5cf8048118a1b14f8ea055ecbaf96d2e6e26af0ff51b1b5`
+- Identity schema: `2`
+- target_skill_sha256: `8b55857ad21cc937337dcf6bc1fa19fcc7f833c3e9c078d89a5db79725e98233`
+- eval_definition_sha256: `c049e8ab5f946f319bc21927957f6fda02a148471bd8950bd306a941a14167f6`
+- metadata_sha256: `07ab98c6d1c3adcc9277e1cfe784f8d017e9650890973540f2c3871622f64ed2`
+- fixture_sha256: `740d701b2570cd48dc39895eb6dad24e4e63318905be6af74ad27b07c8129f82`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `4f066e3762e89c228d67c784e34a35c0c16edf603d99427b4a0ebdaa56519646`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `8b55857ad21cc937337dcf6bc1fa19fcc7f833c3e9c078d89a5db79725e98233`
-- Skill overlay SHA-256: `b0004c5792dae6a7d4050cf6839b7073909210717e4fcd3dd4b28188da158276`
-- Judge schema SHA-256: `4f066e3762e89c228d67c784e34a35c0c16edf603d99427b4a0ebdaa56519646`
-- Eval definition SHA-256: `c049e8ab5f946f319bc21927957f6fda02a148471bd8950bd306a941a14167f6`
-- Metadata SHA-256: `07ab98c6d1c3adcc9277e1cfe784f8d017e9650890973540f2c3871622f64ed2`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/product_manager/test/github-release-gen/evals/workspace/eval-001-block-without-ready-handoff/comparison.md
+++ b/agents/product_manager/test/github-release-gen/evals/workspace/eval-001-block-without-ready-handoff/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `7971e90a4d24648a705271605d4ebb4560650bfee70305b5f8ad9d95d2e46900` from `agents/product_manager/test/github-release-gen/evals/workspace/eval-001-block-without-ready-handoff`.
-- Fixture SHA-256: `7971e90a4d24648a705271605d4ebb4560650bfee70305b5f8ad9d95d2e46900`
-- Prompt SHA-256: `286c359d7bf7fac12beb682b18d5fbc5dfddaa2eb888069325d5cedb93a5c23c`
+- Identity schema: `2`
+- target_skill_sha256: `0c9b1305da43afbfc22e6d563651831ce45be05793224d552c008cc393a37b1e`
+- eval_definition_sha256: `f104e1c59d5fad76689ae01a26b19666b3049ba013ffcdc08c70032e1a95c629`
+- metadata_sha256: `9990f4cbb2adede98186059b8ed7e0088b4cd2cc6d822272edf43193f350dfdf`
+- fixture_sha256: `7971e90a4d24648a705271605d4ebb4560650bfee70305b5f8ad9d95d2e46900`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `00bb3d210a5b206a0ac9f62c0fe5d7e4f8787acdaa15b33827594f02c88b5a24`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `0c9b1305da43afbfc22e6d563651831ce45be05793224d552c008cc393a37b1e`
-- Skill overlay SHA-256: `2f0de1beb8d9a238bffa058ef4ccfb94546f593a81b4fc6e5c1f6bcddf8dbe71`
-- Judge schema SHA-256: `00bb3d210a5b206a0ac9f62c0fe5d7e4f8787acdaa15b33827594f02c88b5a24`
-- Eval definition SHA-256: `f104e1c59d5fad76689ae01a26b19666b3049ba013ffcdc08c70032e1a95c629`
-- Metadata SHA-256: `9990f4cbb2adede98186059b8ed7e0088b4cd2cc6d822272edf43193f350dfdf`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/product_manager/test/github-release-gen/evals/workspace/eval-002-enforce-release-sequence-gates/comparison.md
+++ b/agents/product_manager/test/github-release-gen/evals/workspace/eval-002-enforce-release-sequence-gates/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `d16b0aba9c42c15bb50cb2e6533059095747e0b241aeb84f42387b57f3c93839` from `agents/product_manager/test/github-release-gen/evals/workspace/eval-002-enforce-release-sequence-gates`.
-- Fixture SHA-256: `d16b0aba9c42c15bb50cb2e6533059095747e0b241aeb84f42387b57f3c93839`
-- Prompt SHA-256: `2a564a9812a9893c6d440f3a82f58d1b6e03bc64e97e5dd9f393ca99e3af9583`
+- Identity schema: `2`
+- target_skill_sha256: `0c9b1305da43afbfc22e6d563651831ce45be05793224d552c008cc393a37b1e`
+- eval_definition_sha256: `4ae771ce624f2d4218d5a0892756a08ab5deb5771e2156fa84d9cebf89f45e20`
+- metadata_sha256: `6e1c66d9908de26eec5a81a59cb64d6d09ad4a2d9291406739a3d318995009f5`
+- fixture_sha256: `d16b0aba9c42c15bb50cb2e6533059095747e0b241aeb84f42387b57f3c93839`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `7387039bc0ee52f805d2ca2d9e0306841c5745b2dec693f7be7ed2c655d6f462`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `0c9b1305da43afbfc22e6d563651831ce45be05793224d552c008cc393a37b1e`
-- Skill overlay SHA-256: `2f0de1beb8d9a238bffa058ef4ccfb94546f593a81b4fc6e5c1f6bcddf8dbe71`
-- Judge schema SHA-256: `7387039bc0ee52f805d2ca2d9e0306841c5745b2dec693f7be7ed2c655d6f462`
-- Eval definition SHA-256: `4ae771ce624f2d4218d5a0892756a08ab5deb5771e2156fa84d9cebf89f45e20`
-- Metadata SHA-256: `6e1c66d9908de26eec5a81a59cb64d6d09ad4a2d9291406739a3d318995009f5`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)

--- a/agents/product_manager/test/github-release-gen/evals/workspace/eval-003-preserve-facts-and-add-traceability/comparison.md
+++ b/agents/product_manager/test/github-release-gen/evals/workspace/eval-003-preserve-facts-and-add-traceability/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `da29a479071012ab3bfa3af5ab47af8541f3b6d49a5ec8e88304fa50a27aed17` from `agents/product_manager/test/github-release-gen/evals/workspace/eval-003-preserve-facts-and-add-traceability`.
-- Fixture SHA-256: `da29a479071012ab3bfa3af5ab47af8541f3b6d49a5ec8e88304fa50a27aed17`
-- Prompt SHA-256: `1f72f4ad91d022aceb74cd22a41be167aaa46a8a39f2494e69954624a58e1ac6`
+- Identity schema: `2`
+- target_skill_sha256: `0c9b1305da43afbfc22e6d563651831ce45be05793224d552c008cc393a37b1e`
+- eval_definition_sha256: `95f3370a6690706f871a83ed16fd2ea4af289f136e5af47351107d1ec6c06fc2`
+- metadata_sha256: `9e52b1a05d9dc7bd3856fe83df9035077725f4a4387447107b2ae09c5bfbb539`
+- fixture_sha256: `da29a479071012ab3bfa3af5ab47af8541f3b6d49a5ec8e88304fa50a27aed17`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `13218ab4a7abff52fb220f782ffa27173bde4d7c9a5b1ae26ef3115112e26b3d`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `0c9b1305da43afbfc22e6d563651831ce45be05793224d552c008cc393a37b1e`
-- Skill overlay SHA-256: `2f0de1beb8d9a238bffa058ef4ccfb94546f593a81b4fc6e5c1f6bcddf8dbe71`
-- Judge schema SHA-256: `13218ab4a7abff52fb220f782ffa27173bde4d7c9a5b1ae26ef3115112e26b3d`
-- Eval definition SHA-256: `95f3370a6690706f871a83ed16fd2ea4af289f136e5af47351107d1ec6c06fc2`
-- Metadata SHA-256: `9e52b1a05d9dc7bd3856fe83df9035077725f4a4387447107b2ae09c5bfbb539`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)

--- a/agents/product_manager/test/github-release-gen/evals/workspace/eval-004-zero-site-and-tag-writes/comparison.md
+++ b/agents/product_manager/test/github-release-gen/evals/workspace/eval-004-zero-site-and-tag-writes/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `a74185c0f265c7463444aa160a9976a1ef120533a9280afc72706076cc5c1626` from `agents/product_manager/test/github-release-gen/evals/workspace/eval-004-zero-site-and-tag-writes`.
-- Fixture SHA-256: `a74185c0f265c7463444aa160a9976a1ef120533a9280afc72706076cc5c1626`
-- Prompt SHA-256: `1db93b427a92207a25326b835a99580d099361beaf054fde25062b79bf7ca135`
+- Identity schema: `2`
+- target_skill_sha256: `0c9b1305da43afbfc22e6d563651831ce45be05793224d552c008cc393a37b1e`
+- eval_definition_sha256: `266baf4d19e4ef318c97a6eab3bf8e029fbe8357edfa824c6d453c40e91b2d33`
+- metadata_sha256: `12fc2cb8802eb1dba2db5f0429fdb4322d489582597f6f44ee10596dc46d8d26`
+- fixture_sha256: `a74185c0f265c7463444aa160a9976a1ef120533a9280afc72706076cc5c1626`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `80b618e955757ddc076d881c72f5f8be648700b5dd3e7c6b222dd59ecfccd495`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `0c9b1305da43afbfc22e6d563651831ce45be05793224d552c008cc393a37b1e`
-- Skill overlay SHA-256: `2f0de1beb8d9a238bffa058ef4ccfb94546f593a81b4fc6e5c1f6bcddf8dbe71`
-- Judge schema SHA-256: `80b618e955757ddc076d881c72f5f8be648700b5dd3e7c6b222dd59ecfccd495`
-- Eval definition SHA-256: `266baf4d19e4ef318c97a6eab3bf8e029fbe8357edfa824c6d453c40e91b2d33`
-- Metadata SHA-256: `12fc2cb8802eb1dba2db5f0429fdb4322d489582597f6f44ee10596dc46d8d26`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/product_manager/test/github-release-gen/evals/workspace/eval-005-outline-sections-quality-exclusion/comparison.md
+++ b/agents/product_manager/test/github-release-gen/evals/workspace/eval-005-outline-sections-quality-exclusion/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `f342d8ca65c8f77883288a82a7edf00ac90a64350a66217406a6bf2cc1477c79` from `agents/product_manager/test/github-release-gen/evals/workspace/eval-005-outline-sections-quality-exclusion`.
-- Fixture SHA-256: `f342d8ca65c8f77883288a82a7edf00ac90a64350a66217406a6bf2cc1477c79`
-- Prompt SHA-256: `1f72f4ad91d022aceb74cd22a41be167aaa46a8a39f2494e69954624a58e1ac6`
+- Identity schema: `2`
+- target_skill_sha256: `0c9b1305da43afbfc22e6d563651831ce45be05793224d552c008cc393a37b1e`
+- eval_definition_sha256: `5768440d836f6d58f2492f6254c4eaae18fe913a310437aaee98134c39857a50`
+- metadata_sha256: `a9879c47e38cec76a35a3ff0087c5b764086d8e7ca04745f8977bbd30db8f459`
+- fixture_sha256: `f342d8ca65c8f77883288a82a7edf00ac90a64350a66217406a6bf2cc1477c79`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `f3cdc20a6c2d6d35b8761172794fe96e07166b0922a8d802a01f520259d39177`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `0c9b1305da43afbfc22e6d563651831ce45be05793224d552c008cc393a37b1e`
-- Skill overlay SHA-256: `2f0de1beb8d9a238bffa058ef4ccfb94546f593a81b4fc6e5c1f6bcddf8dbe71`
-- Judge schema SHA-256: `f3cdc20a6c2d6d35b8761172794fe96e07166b0922a8d802a01f520259d39177`
-- Eval definition SHA-256: `5768440d836f6d58f2492f6254c4eaae18fe913a310437aaee98134c39857a50`
-- Metadata SHA-256: `a9879c47e38cec76a35a3ff0087c5b764086d8e7ca04745f8977bbd30db8f459`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/product_manager/test/github-release-gen/evals/workspace/eval-006-site-less-degraded-gate/comparison.md
+++ b/agents/product_manager/test/github-release-gen/evals/workspace/eval-006-site-less-degraded-gate/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `411862fab7a80dddacd42426a98282018153d50c9458b43edec6c0056c4dce20` from `agents/product_manager/test/github-release-gen/evals/workspace/eval-006-site-less-degraded-gate`.
-- Fixture SHA-256: `411862fab7a80dddacd42426a98282018153d50c9458b43edec6c0056c4dce20`
-- Prompt SHA-256: `3543da7f86f46fe1ddba91b579642c6082b99cf4ee707ac9b96a7d9fcb3ea3e7`
+- Identity schema: `2`
+- target_skill_sha256: `0c9b1305da43afbfc22e6d563651831ce45be05793224d552c008cc393a37b1e`
+- eval_definition_sha256: `ee0644452d121d4667c014aaf941ed770c3978ba415b0f3ee7cfc601dc801335`
+- metadata_sha256: `d64e10da3608725d47dc87efed91ed453ddbf43cfa5350e92eb1e539cf16b5a4`
+- fixture_sha256: `411862fab7a80dddacd42426a98282018153d50c9458b43edec6c0056c4dce20`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `b8169d6d4489fefe59aefe4458af6c4e8108513691e18f7c250f5d7f5c9b7ba5`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `0c9b1305da43afbfc22e6d563651831ce45be05793224d552c008cc393a37b1e`
-- Skill overlay SHA-256: `2f0de1beb8d9a238bffa058ef4ccfb94546f593a81b4fc6e5c1f6bcddf8dbe71`
-- Judge schema SHA-256: `b8169d6d4489fefe59aefe4458af6c4e8108513691e18f7c250f5d7f5c9b7ba5`
-- Eval definition SHA-256: `ee0644452d121d4667c014aaf941ed770c3978ba415b0f3ee7cfc601dc801335`
-- Metadata SHA-256: `d64e10da3608725d47dc87efed91ed453ddbf43cfa5350e92eb1e539cf16b5a4`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/product_manager/test/github-release-gen/evals/workspace/eval-007-marketplace-full-capability-upgrade-note/comparison.md
+++ b/agents/product_manager/test/github-release-gen/evals/workspace/eval-007-marketplace-full-capability-upgrade-note/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `dc5fdc0f377589e2a17429105072ec9f0f122806b4874d8f07072dd9a6c6c26b` from `agents/product_manager/test/github-release-gen/evals/workspace/eval-007-marketplace-full-capability-upgrade-note`.
-- Fixture SHA-256: `dc5fdc0f377589e2a17429105072ec9f0f122806b4874d8f07072dd9a6c6c26b`
-- Prompt SHA-256: `a62a94b930216669961977d81dd33c33ea8ab99e80d1ccbdd52769d4a9afaf75`
+- Identity schema: `2`
+- target_skill_sha256: `0c9b1305da43afbfc22e6d563651831ce45be05793224d552c008cc393a37b1e`
+- eval_definition_sha256: `ddd9a7434f92d092aeb7262a95bca81739e99a684c38e41461345200798e8931`
+- metadata_sha256: `b64763ea1d58b4c3c1d7a3e95d4a1d7bd5f4195151868d0276dd82eda387eb3e`
+- fixture_sha256: `dc5fdc0f377589e2a17429105072ec9f0f122806b4874d8f07072dd9a6c6c26b`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `03a8fb59a79fd1eace9e70a8f76361828e062efb8e2ad27720ecf0844391b693`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `0c9b1305da43afbfc22e6d563651831ce45be05793224d552c008cc393a37b1e`
-- Skill overlay SHA-256: `2f0de1beb8d9a238bffa058ef4ccfb94546f593a81b4fc6e5c1f6bcddf8dbe71`
-- Judge schema SHA-256: `03a8fb59a79fd1eace9e70a8f76361828e062efb8e2ad27720ecf0844391b693`
-- Eval definition SHA-256: `ddd9a7434f92d092aeb7262a95bca81739e99a684c38e41461345200798e8931`
-- Metadata SHA-256: `b64763ea1d58b4c3c1d7a3e95d4a1d7bd5f4195151868d0276dd82eda387eb3e`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/product_manager/test/github-release-gen/evals/workspace/eval-008-marketplace-historical-tag-limit-upgrade-note/comparison.md
+++ b/agents/product_manager/test/github-release-gen/evals/workspace/eval-008-marketplace-historical-tag-limit-upgrade-note/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `17e20791a9c9288907fb214989bbc6378e7d64a98732f68a5c493285ff25f933` from `agents/product_manager/test/github-release-gen/evals/workspace/eval-008-marketplace-historical-tag-limit-upgrade-note`.
-- Fixture SHA-256: `17e20791a9c9288907fb214989bbc6378e7d64a98732f68a5c493285ff25f933`
-- Prompt SHA-256: `734c4a4cb7e543db5091d9f1c4a08014e2d017a93f5c1b82e54e15f916eb8fba`
+- Identity schema: `2`
+- target_skill_sha256: `0c9b1305da43afbfc22e6d563651831ce45be05793224d552c008cc393a37b1e`
+- eval_definition_sha256: `ca7c0b18d751c17e3675256471abe2e22f05a84c6ec6d780c8a51c53156008f9`
+- metadata_sha256: `a37c69100d8b09e8a32fd7ae07c266ac1aa0ef65dd08a89916726ecd29694ad7`
+- fixture_sha256: `17e20791a9c9288907fb214989bbc6378e7d64a98732f68a5c493285ff25f933`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `df39efd24a07751331d3b8f08b12fab041cb7e732754feb1dfc8bc4a96c5fe1a`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `0c9b1305da43afbfc22e6d563651831ce45be05793224d552c008cc393a37b1e`
-- Skill overlay SHA-256: `2f0de1beb8d9a238bffa058ef4ccfb94546f593a81b4fc6e5c1f6bcddf8dbe71`
-- Judge schema SHA-256: `df39efd24a07751331d3b8f08b12fab041cb7e732754feb1dfc8bc4a96c5fe1a`
-- Eval definition SHA-256: `ca7c0b18d751c17e3675256471abe2e22f05a84c6ec6d780c8a51c53156008f9`
-- Metadata SHA-256: `a37c69100d8b09e8a32fd7ae07c266ac1aa0ef65dd08a89916726ecd29694ad7`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/product_manager/test/idea-to-spec/evals/workspace/eval-008-mapped-notification-update/comparison.md
+++ b/agents/product_manager/test/idea-to-spec/evals/workspace/eval-008-mapped-notification-update/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `177b1f9c445f127660775572bba7b23413067a88e77389cbdec983886f090960` from `agents/product_manager/test/idea-to-spec/evals/workspace/eval-008-mapped-notification-update`.
-- Fixture SHA-256: `177b1f9c445f127660775572bba7b23413067a88e77389cbdec983886f090960`
-- Prompt SHA-256: `8d974654e1fcdbd5fc645c2a9f10feef6661d70a858e4722087a732bb9d82274`
+- Identity schema: `2`
+- target_skill_sha256: `a5ef9beb8352f2c9b4cfde83ccd9caf0accd15d632ffa2d78214f3c51045041a`
+- eval_definition_sha256: `130498c1a4cc1643bdf013127365b28e5fdc8391203daf304f2cdc0ef5bc97d2`
+- metadata_sha256: `071b1907c18a80afba8338dbc482c47ee9a6fa479b963c4fb7d1e4c62363e556`
+- fixture_sha256: `177b1f9c445f127660775572bba7b23413067a88e77389cbdec983886f090960`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `7ac19d358ca18ef7b2d109aeec17239bc9d0f4c0`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `a5ef9beb8352f2c9b4cfde83ccd9caf0accd15d632ffa2d78214f3c51045041a`
-- Skill overlay SHA-256: `1701eca585dc754d5c838c067ffd884a80205302462ac0a542c908fd069ff822`
-- Judge schema SHA-256: `6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda`
-- Eval definition SHA-256: `130498c1a4cc1643bdf013127365b28e5fdc8391203daf304f2cdc0ef5bc97d2`
-- Metadata SHA-256: `071b1907c18a80afba8338dbc482c47ee9a6fa479b963c4fb7d1e4c62363e556`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/product_manager/test/idea-to-spec/workspace/eval-009-prd-iteration-split-proposal/comparison.md
+++ b/agents/product_manager/test/idea-to-spec/workspace/eval-009-prd-iteration-split-proposal/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `cda1a0661ddb58fa697ce0a283dc50943986240370fdcd97782d5714af75a997` from `agents/product_manager/test/idea-to-spec/workspace/eval-009-prd-iteration-split-proposal`.
-- Fixture SHA-256: `cda1a0661ddb58fa697ce0a283dc50943986240370fdcd97782d5714af75a997`
-- Prompt SHA-256: `ae03344941a8a5473fce84f07af68d8bb42c4c4dd8dbaf557b909886adf20c98`
+- Identity schema: `2`
+- target_skill_sha256: `a5ef9beb8352f2c9b4cfde83ccd9caf0accd15d632ffa2d78214f3c51045041a`
+- eval_definition_sha256: `8ef466ccd13d937453c02f105817ced47839fb573011ea1ee300be62facb6b71`
+- metadata_sha256: `ae189abbce9ec160b22d49ab4f79a0a7a8f521d1a6e2046930669caf75d7dab0`
+- fixture_sha256: `cda1a0661ddb58fa697ce0a283dc50943986240370fdcd97782d5714af75a997`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `9c9a733fc3c46fd3cb1cdea794218e66a7a987137063c1a3c970e8e9386d1a58`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `7ac19d358ca18ef7b2d109aeec17239bc9d0f4c0`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `a5ef9beb8352f2c9b4cfde83ccd9caf0accd15d632ffa2d78214f3c51045041a`
-- Skill overlay SHA-256: `1701eca585dc754d5c838c067ffd884a80205302462ac0a542c908fd069ff822`
-- Judge schema SHA-256: `9c9a733fc3c46fd3cb1cdea794218e66a7a987137063c1a3c970e8e9386d1a58`
-- Eval definition SHA-256: `8ef466ccd13d937453c02f105817ced47839fb573011ea1ee300be62facb6b71`
-- Metadata SHA-256: `ae189abbce9ec160b22d49ab4f79a0a7a8f521d1a6e2046930669caf75d7dab0`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)

--- a/agents/product_manager/test/idea-to-spec/workspace/iteration-1/eval-1-existing-project-feature/comparison.md
+++ b/agents/product_manager/test/idea-to-spec/workspace/iteration-1/eval-1-existing-project-feature/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `2a0d3945e9442edd7c1ef55752552e4a49ef23e35e942cd87d1e31a4fa5138fc` from `agents/product_manager/test/idea-to-spec/workspace/iteration-1/eval-1-existing-project-feature`.
-- Fixture SHA-256: `2a0d3945e9442edd7c1ef55752552e4a49ef23e35e942cd87d1e31a4fa5138fc`
-- Prompt SHA-256: `989dc53f5a8c8fb9df9263c550c8d2965414d618ab35b7c932c180c33869ec1b`
+- Identity schema: `2`
+- target_skill_sha256: `a5ef9beb8352f2c9b4cfde83ccd9caf0accd15d632ffa2d78214f3c51045041a`
+- eval_definition_sha256: `fbb5377843587b9c6261e61b2a81e3a48d39c5e7814d8290865e02fe8eb5ec41`
+- metadata_sha256: `ff56c9c4026c02d3f3b5f70e58cc2a2e628e1817de3ecbec4d01c2d2b3fe50bc`
+- fixture_sha256: `2a0d3945e9442edd7c1ef55752552e4a49ef23e35e942cd87d1e31a4fa5138fc`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `dbe3f262003438ea2a4caaa2b38e4ab353ee29def3530b27abe04d98b19dfd03`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `7ac19d358ca18ef7b2d109aeec17239bc9d0f4c0`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `a5ef9beb8352f2c9b4cfde83ccd9caf0accd15d632ffa2d78214f3c51045041a`
-- Skill overlay SHA-256: `1701eca585dc754d5c838c067ffd884a80205302462ac0a542c908fd069ff822`
-- Judge schema SHA-256: `dbe3f262003438ea2a4caaa2b38e4ab353ee29def3530b27abe04d98b19dfd03`
-- Eval definition SHA-256: `fbb5377843587b9c6261e61b2a81e3a48d39c5e7814d8290865e02fe8eb5ec41`
-- Metadata SHA-256: `ff56c9c4026c02d3f3b5f70e58cc2a2e628e1817de3ecbec4d01c2d2b3fe50bc`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/product_manager/test/idea-to-spec/workspace/iteration-1/eval-2-existing-project-update/comparison.md
+++ b/agents/product_manager/test/idea-to-spec/workspace/iteration-1/eval-2-existing-project-update/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `4a0c4f24287b030b034f66b2e9e0787c5b6e4b2e4a40435cb46ef2275f03923a` from `agents/product_manager/test/idea-to-spec/workspace/iteration-1/eval-2-existing-project-update`.
-- Fixture SHA-256: `4a0c4f24287b030b034f66b2e9e0787c5b6e4b2e4a40435cb46ef2275f03923a`
-- Prompt SHA-256: `6aaa57677f60fb06006df08dac712b315ee95015f718fd4450b32d594a455441`
+- Identity schema: `2`
+- target_skill_sha256: `a5ef9beb8352f2c9b4cfde83ccd9caf0accd15d632ffa2d78214f3c51045041a`
+- eval_definition_sha256: `2eb26345c0320238f13795dd231ba4c205d452d230de64d35bcf4cc4acb002f8`
+- metadata_sha256: `d7142d966569c4d32f40a170b0f92f6780789b8a982e6faeead586a238a9f649`
+- fixture_sha256: `4a0c4f24287b030b034f66b2e9e0787c5b6e4b2e4a40435cb46ef2275f03923a`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `34ccc67474b5d5409e42b47f3e143e51f307a39f3959fa17d3be62715a379bc6`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `7ac19d358ca18ef7b2d109aeec17239bc9d0f4c0`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `a5ef9beb8352f2c9b4cfde83ccd9caf0accd15d632ffa2d78214f3c51045041a`
-- Skill overlay SHA-256: `1701eca585dc754d5c838c067ffd884a80205302462ac0a542c908fd069ff822`
-- Judge schema SHA-256: `34ccc67474b5d5409e42b47f3e143e51f307a39f3959fa17d3be62715a379bc6`
-- Eval definition SHA-256: `2eb26345c0320238f13795dd231ba4c205d452d230de64d35bcf4cc4acb002f8`
-- Metadata SHA-256: `d7142d966569c4d32f40a170b0f92f6780789b8a982e6faeead586a238a9f649`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/product_manager/test/idea-to-spec/workspace/iteration-1/eval-3-greenfield-discovery/comparison.md
+++ b/agents/product_manager/test/idea-to-spec/workspace/iteration-1/eval-3-greenfield-discovery/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `a4faa6eb1bc545a0fcd2b0f3491c8b376050fe70e6b532b62cd5d45f16655b85` from `agents/product_manager/test/idea-to-spec/workspace/iteration-1/eval-3-greenfield-discovery`.
-- Fixture SHA-256: `a4faa6eb1bc545a0fcd2b0f3491c8b376050fe70e6b532b62cd5d45f16655b85`
-- Prompt SHA-256: `0af25e0d51f2fb040654e6f1d54a6ad79ea082de53fb485f0d81b3fe8a3d6ee6`
+- Identity schema: `2`
+- target_skill_sha256: `a5ef9beb8352f2c9b4cfde83ccd9caf0accd15d632ffa2d78214f3c51045041a`
+- eval_definition_sha256: `c665f0cae1373d04b176b75bc723732674aeb9f3630f01eadac8f7310d65bdb7`
+- metadata_sha256: `aa700f49d0f32cf47f3b535bd526e4ad2ade501da428e296936ddccef0bcdcbd`
+- fixture_sha256: `a4faa6eb1bc545a0fcd2b0f3491c8b376050fe70e6b532b62cd5d45f16655b85`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `e8bf769ac89a10c9a014e6b2e125d2d95f024ce8d37a4e4481c16c75936c71a8`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `7ac19d358ca18ef7b2d109aeec17239bc9d0f4c0`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `a5ef9beb8352f2c9b4cfde83ccd9caf0accd15d632ffa2d78214f3c51045041a`
-- Skill overlay SHA-256: `1701eca585dc754d5c838c067ffd884a80205302462ac0a542c908fd069ff822`
-- Judge schema SHA-256: `e8bf769ac89a10c9a014e6b2e125d2d95f024ce8d37a4e4481c16c75936c71a8`
-- Eval definition SHA-256: `c665f0cae1373d04b176b75bc723732674aeb9f3630f01eadac8f7310d65bdb7`
-- Metadata SHA-256: `aa700f49d0f32cf47f3b535bd526e4ad2ade501da428e296936ddccef0bcdcbd`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)

--- a/agents/product_manager/test/idea-to-spec/workspace/iteration-2/eval-4-greenfield-bootstrap-routing/comparison.md
+++ b/agents/product_manager/test/idea-to-spec/workspace/iteration-2/eval-4-greenfield-bootstrap-routing/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/idea-to-spec/workspace/iteration-2/eval-4-greenfield-bootstrap-routing`.
-- Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
-- Prompt SHA-256: `47f636262c26b6b99c860d59ef8342eebebbd60397f192a193020f82c13fa42c`
+- Identity schema: `2`
+- target_skill_sha256: `a5ef9beb8352f2c9b4cfde83ccd9caf0accd15d632ffa2d78214f3c51045041a`
+- eval_definition_sha256: `8e113c060d578c3d672e422d3214efcf8ef5f3dc4a4d591f825ce19450902064`
+- metadata_sha256: `af73e5b9a9192eb83b6e3ca2d5cae73fe4fd2b14b49ac401fa1a5f606db4bd6c`
+- fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `333e583cf4bb11484925925c3c083e2f295eb8670599a3d04a51d2b749c8668a`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `7ac19d358ca18ef7b2d109aeec17239bc9d0f4c0`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `a5ef9beb8352f2c9b4cfde83ccd9caf0accd15d632ffa2d78214f3c51045041a`
-- Skill overlay SHA-256: `1701eca585dc754d5c838c067ffd884a80205302462ac0a542c908fd069ff822`
-- Judge schema SHA-256: `333e583cf4bb11484925925c3c083e2f295eb8670599a3d04a51d2b749c8668a`
-- Eval definition SHA-256: `8e113c060d578c3d672e422d3214efcf8ef5f3dc4a4d591f825ce19450902064`
-- Metadata SHA-256: `af73e5b9a9192eb83b6e3ca2d5cae73fe4fd2b14b49ac401fa1a5f606db4bd6c`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/product_manager/test/idea-to-spec/workspace/iteration-2/eval-5-pm-agent-direct-delegation/comparison.md
+++ b/agents/product_manager/test/idea-to-spec/workspace/iteration-2/eval-5-pm-agent-direct-delegation/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/idea-to-spec/workspace/iteration-2/eval-5-pm-agent-direct-delegation`.
-- Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
-- Prompt SHA-256: `acbae9b70ef204aa5ea01807d9cde8c1bfaf036424605400b24871c7a447ebef`
+- Identity schema: `2`
+- target_skill_sha256: `a5ef9beb8352f2c9b4cfde83ccd9caf0accd15d632ffa2d78214f3c51045041a`
+- eval_definition_sha256: `073eeac01923328bf5fb812c3ab5852d6edb01936d4f17fc20c69c0d80324b2c`
+- metadata_sha256: `2ddab779806f9b6e5f9359612bd5cef16f9b4ffd4913ec9f35576d1c0f06be89`
+- fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `d5a49beb6f0959828703001ca6c478b09bfa703290aa048a42e8e1be6bc28cde`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `7ac19d358ca18ef7b2d109aeec17239bc9d0f4c0`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `a5ef9beb8352f2c9b4cfde83ccd9caf0accd15d632ffa2d78214f3c51045041a`
-- Skill overlay SHA-256: `1701eca585dc754d5c838c067ffd884a80205302462ac0a542c908fd069ff822`
-- Judge schema SHA-256: `d5a49beb6f0959828703001ca6c478b09bfa703290aa048a42e8e1be6bc28cde`
-- Eval definition SHA-256: `073eeac01923328bf5fb812c3ab5852d6edb01936d4f17fc20c69c0d80324b2c`
-- Metadata SHA-256: `2ddab779806f9b6e5f9359612bd5cef16f9b4ffd4913ec9f35576d1c0f06be89`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/product_manager/test/idea-to-spec/workspace/iteration-3/eval-6-nested-feature-path/comparison.md
+++ b/agents/product_manager/test/idea-to-spec/workspace/iteration-3/eval-6-nested-feature-path/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `7749eb192d7baaaa2204b646c198e25edb560363b060536f8cc66b5b6a90c8e7` from `agents/product_manager/test/idea-to-spec/workspace/iteration-3/eval-6-nested-feature-path`.
-- Fixture SHA-256: `7749eb192d7baaaa2204b646c198e25edb560363b060536f8cc66b5b6a90c8e7`
-- Prompt SHA-256: `c1a9a695ac306d56eb35a4b41b4c84d037d6f92a7cc3a09d8d7f11f8de78d818`
+- Identity schema: `2`
+- target_skill_sha256: `a5ef9beb8352f2c9b4cfde83ccd9caf0accd15d632ffa2d78214f3c51045041a`
+- eval_definition_sha256: `0d6c5b2207f916945e44c4152d1df1a5456bcf63eecb7a912ef1fe1811598afa`
+- metadata_sha256: `4835f86af8c88f61556ab924715c5dc8125d2c5616e22976f405e64c105bc13a`
+- fixture_sha256: `7749eb192d7baaaa2204b646c198e25edb560363b060536f8cc66b5b6a90c8e7`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `4fbce5299edbfab7f3f9e314d3ad852d562878858c404b524820ab2f7613136e`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `7ac19d358ca18ef7b2d109aeec17239bc9d0f4c0`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `a5ef9beb8352f2c9b4cfde83ccd9caf0accd15d632ffa2d78214f3c51045041a`
-- Skill overlay SHA-256: `1701eca585dc754d5c838c067ffd884a80205302462ac0a542c908fd069ff822`
-- Judge schema SHA-256: `4fbce5299edbfab7f3f9e314d3ad852d562878858c404b524820ab2f7613136e`
-- Eval definition SHA-256: `0d6c5b2207f916945e44c4152d1df1a5456bcf63eecb7a912ef1fe1811598afa`
-- Metadata SHA-256: `4835f86af8c88f61556ab924715c5dc8125d2c5616e22976f405e64c105bc13a`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/product_manager/test/idea-to-spec/workspace/iteration-3/eval-7-api-adr-engineer-handoff/comparison.md
+++ b/agents/product_manager/test/idea-to-spec/workspace/iteration-3/eval-7-api-adr-engineer-handoff/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `7b6820d67dd73e9499a1ca84c463bfc82e890640eeaf8c3154b04834d8479116` from `agents/product_manager/test/idea-to-spec/workspace/iteration-3/eval-7-api-adr-engineer-handoff`.
-- Fixture SHA-256: `7b6820d67dd73e9499a1ca84c463bfc82e890640eeaf8c3154b04834d8479116`
-- Prompt SHA-256: `2ab3ca8b74dd55c90856f6dfac8c03932d3fb9eacb469271c944f9a989eec4b0`
+- Identity schema: `2`
+- target_skill_sha256: `a5ef9beb8352f2c9b4cfde83ccd9caf0accd15d632ffa2d78214f3c51045041a`
+- eval_definition_sha256: `02e5d899a7687cd28d5b7fe3ed85f267cd9ce62f15d9844aa4281eff90859ac1`
+- metadata_sha256: `6b28964c95e54c379988fdfd7c54f486a5c872824039a926ede4358e3117f378`
+- fixture_sha256: `7b6820d67dd73e9499a1ca84c463bfc82e890640eeaf8c3154b04834d8479116`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `7d015813fae4cd945c52acc28425338fd81878adf050d1ecc956ba13abe7bc00`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `7ac19d358ca18ef7b2d109aeec17239bc9d0f4c0`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `a5ef9beb8352f2c9b4cfde83ccd9caf0accd15d632ffa2d78214f3c51045041a`
-- Skill overlay SHA-256: `1701eca585dc754d5c838c067ffd884a80205302462ac0a542c908fd069ff822`
-- Judge schema SHA-256: `7d015813fae4cd945c52acc28425338fd81878adf050d1ecc956ba13abe7bc00`
-- Eval definition SHA-256: `02e5d899a7687cd28d5b7fe3ed85f267cd9ce62f15d9844aa4281eff90859ac1`
-- Metadata SHA-256: `6b28964c95e54c379988fdfd7c54f486a5c872824039a926ede4358e3117f378`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-015-route-docs-site-deployment-gap/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-015-route-docs-site-deployment-gap/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `16e3b6cbbbae6769ac6b5ead7bae34214b3dd90e3e6c4d5fad97cfd7d3784013` from `agents/product_manager/test/pm-agent/evals/workspace/eval-015-route-docs-site-deployment-gap`.
-- Fixture SHA-256: `16e3b6cbbbae6769ac6b5ead7bae34214b3dd90e3e6c4d5fad97cfd7d3784013`
+- Identity schema: `2`
+- target_skill_sha256: `6f8f132bc1f6eba3f9eb10727126ee30960b503351486b4fb6204e20571ffb35`
+- eval_definition_sha256: `8bc69d85fc3ff063d885b8a2c4d7a9ea83b6dca3de23a034dba15fb34f1ba98e`
+- metadata_sha256: `e7a743e88e4c53094e4afe2903a87ebcc467ace2dc58c61ccb0a0dcf64ebf2fd`
+- fixture_sha256: `16e3b6cbbbae6769ac6b5ead7bae34214b3dd90e3e6c4d5fad97cfd7d3784013`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `69f2798cad12b0dd0ca3c224e3cfd6cf611a315695684db1b07a23452b52a60e`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `f6c9996daf9a7bdf78228fb674eccb457f386d1e74abf9925ac4646e4da1c9d4`
-- Repository HEAD: `8813f864e743f7c83dc2e51e0b5add79f312e870`
+- Repository HEAD: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7`
-- Skill overlay SHA-256: `4d4a580c5e7c36b9199abb80221829f90c900c96463581d7f87c6d7ccc538bd7`
-- Judge schema SHA-256: `69f2798cad12b0dd0ca3c224e3cfd6cf611a315695684db1b07a23452b52a60e`
-- Eval definition SHA-256: `8bc69d85fc3ff063d885b8a2c4d7a9ea83b6dca3de23a034dba15fb34f1ba98e`
-- Metadata SHA-256: `e7a743e88e4c53094e4afe2903a87ebcc467ace2dc58c61ccb0a0dcf64ebf2fd`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
+- Skill overlay SHA-256: `6c6b79d36b8b3a1bf132fd82bfece3cf6e7b256e3a9a58a0cdb78f4a09e26e69`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -31,26 +33,26 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `blocks_unknown_evidence` | PASS | with_skill 明确使用 entry_basis: blocked，列出 devops-agent 不可用、未确认 internal 变体及禁止提交/发布/部署等阻塞，没有将状态表述为 ready 或 integrated handoff。 |
-| `builds_repo_wide_deployment_packet` | PASS | with_skill 输出包含 request_type: deployment、feature/parent_feature/feature_level/feature_path 为 N/A、feature_path_evidence: []，并在 source_documents 列出四份真实材料、在 blockers_risks 列出环境不可用、授权边界和 internal 变体未确认等证据。 |
-| `routes_devops_ordered_chain` | NOT_EXERCISED | with_skill 仅完成了向 devops-agent 的下一步路由，并明确 devops-agent 当前不可用；没有可证明后续 devops-agent:deployment-planner → devops-agent:cicd-bootstrap → devops-agent:env-config-auditor → docs-agent:formal-docs-sync 已执行或完成的锁定证据。 |
+| `blocks_unknown_evidence` | PASS | with_skill 输出以 entry_basis: blocked 明确当前未就绪，列出 CI/Helm 范围不一致、devops-agent 不可用及禁止发布等缺口，并明确不能直接发布。 |
+| `builds_repo_wide_deployment_packet` | PASS | with_skill 输出包含 request_type: deployment；feature_path、feature、parent_feature、feature_level 均为 N/A；feature_path_evidence 为空数组；source_documents 和 blockers_risks 保留了真实材料与风险。 |
+| `routes_devops_ordered_chain` | NOT_EXERCISED | with_skill 只完成了 DevOps 入口的阻塞式路由，并明确 devops-agent 未安装；锁定证据未显示后续 deployment-planner、cicd-bootstrap、env-config-auditor 或 docs-agent 阶段可执行，因此后续有序链未被行使。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f6c9996daf9a7bdf78228fb674eccb457f386d1e74abf9925ac4646e4da1c9d4; fixture_sha256=16e3b6cbbbae6769ac6b5ead7bae34214b3dd90e3e6c4d5fad97cfd7d3784013; output_sha256=fa32d5b3b29e90ebfbc36a77af39181348c9e9d3c2712eddc98e7391f26456e4; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 正确识别受限状态并生成 deployment handoff packet，完成首个 DevOps 路由；后续有序链未执行。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f6c9996daf9a7bdf78228fb674eccb457f386d1e74abf9925ac4646e4da1c9d4; fixture_sha256=16e3b6cbbbae6769ac6b5ead7bae34214b3dd90e3e6c4d5fad97cfd7d3784013; output_sha256=b474f4d6f058d96d1c9c4e4f7c5bd5408bd309c6518db8bd93a222f15f03d7db; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 生成了阻塞状态的 repo-wide deployment handoff，保留证据并停止在不可用的 DevOps 入口。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f6c9996daf9a7bdf78228fb674eccb457f386d1e74abf9925ac4646e4da1c9d4; fixture_sha256=16e3b6cbbbae6769ac6b5ead7bae34214b3dd90e3e6c4d5fad97cfd7d3784013; output_sha256=1f43be5befe6e77636122d2a67734006eedf7bae3d6a120fac343acfaf98daaa; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 给出有依据的部署前建议并识别 CI/Helm 不完整，但未生成标准 deployment packet，也未执行规定的角色路由链。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f6c9996daf9a7bdf78228fb674eccb457f386d1e74abf9925ac4646e4da1c9d4; fixture_sha256=16e3b6cbbbae6769ac6b5ead7bae34214b3dd90e3e6c4d5fad97cfd7d3784013; output_sha256=d361e4b930d606622bd17bd4ebf54c30925212426af68286bdfba20cfdcb031e; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 提供了基于材料的范围建议，但未生成结构化 deployment handoff，也未形成下游有序路由链。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: 在 devops-agent 可用且获得后续确认后，继续执行规定的 DevOps 顺序链；仅在运维事实落地并验证后进行 Docs 同步。
+- Next: 安装或提供 devops-agent 后继续执行 deployment-planner → cicd-bootstrap → env-config-auditor → formal-docs-sync。
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-016-route-document-structure-governance/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-016-route-document-structure-governance/comparison.md
@@ -12,47 +12,49 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `1a6d7fa4c22a394f3c854eef7a25f4d0cf2e6b4ecd7c7a3d3bf15d295d6e43f8` from `agents/product_manager/test/pm-agent/evals/workspace/eval-016-route-document-structure-governance`.
-- Fixture SHA-256: `1a6d7fa4c22a394f3c854eef7a25f4d0cf2e6b4ecd7c7a3d3bf15d295d6e43f8`
+- Identity schema: `2`
+- target_skill_sha256: `6f8f132bc1f6eba3f9eb10727126ee30960b503351486b4fb6204e20571ffb35`
+- eval_definition_sha256: `ba37454a106688e9f5f2e2586231a60f2093e364612eb14bfa53540c9e2d1589`
+- metadata_sha256: `fe53b448dd4fd2693ceb179d875dd617b7b717601fc7d9d3214cab940b4cdef7`
+- fixture_sha256: `1a6d7fa4c22a394f3c854eef7a25f4d0cf2e6b4ecd7c7a3d3bf15d295d6e43f8`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `c8400122a967de4e5b8b409bbe920fe16ec946724a3aa7d4b3077b3582a3f2f0`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `78a9ed4a2ff6af194b93c81277958547f5a87533a70b2aa14e43822f139e54d3`
-- Repository HEAD: `8813f864e743f7c83dc2e51e0b5add79f312e870`
+- Repository HEAD: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7`
-- Skill overlay SHA-256: `4d4a580c5e7c36b9199abb80221829f90c900c96463581d7f87c6d7ccc538bd7`
-- Judge schema SHA-256: `c8400122a967de4e5b8b409bbe920fe16ec946724a3aa7d4b3077b3582a3f2f0`
-- Eval definition SHA-256: `ba37454a106688e9f5f2e2586231a60f2093e364612eb14bfa53540c9e2d1589`
-- Metadata SHA-256: `fe53b448dd4fd2693ceb179d875dd617b7b717601fc7d9d3214cab940b4cdef7`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
-- Behavior result: **PASS**
+- Skill overlay SHA-256: `6c6b79d36b8b3a1bf132fd82bfece3cf6e7b256e3a9a58a0cdb78f4a09e26e69`
+- Behavior result: **FAIL**
 - Coverage result: **FULL**
-Overall result: PASS
+Overall result: FAIL
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `routes_to_structure_governance` | PASS | 原始 trace 明确路由至 `pm-agent:idea-to-spec:structure-governance`。 |
-| `read_only_audit` | PASS | 候选输出明确声明只读审计；git evidence 显示 HEAD、分支和工作区均未改变。 |
-| `report_form` | PASS | 原始 trace 证明报告写入 `/tmp/structure-governance.8tcJjR/structure-governance-report.html`，并在对话中提供结论摘要。 |
-| `scope_six_role_dirs` | PASS | 原始 trace 检查了 `docs/pm`、`docs/engineer`、`docs/design`、`docs/qa`、`docs/devops`、`docs/security` 六个目录；HTML 报告也覆盖六角色。 |
-| `structural_change_requires_confirmation` | PASS | 报告明确表示当前不执行 merge/split/move，并规定未来结构实施须用户确认且使用 `change_tier: major`；git evidence 显示未执行结构变更。 |
+| `routes_to_structure_governance` | FAIL | With-skill output does not state or show a main route to `idea-to-spec:structure-governance`; the trace shows an initial `pm-agent` message and later structure-governance instructions, but no explicit required route. |
+| `read_only_audit` | PASS | The with-skill report states the audit was read-only and no repository files were modified; git evidence shows unchanged HEAD, branch, status, and diffs. |
+| `report_form` | PASS | Locked raw trace shows an HTML report created under `/tmp/structure-governance.YbUSId/structure-governance-report.html`, validated for content and size, while git evidence shows no repository changes; the final output provides the report path and summary. |
+| `scope_six_role_dirs` | PASS | The locked report content explicitly lists and scans `docs/pm`, `docs/engineer`, `docs/design`, `docs/qa`, `docs/devops`, and `docs/security`, identifying four missing roots as audit limitations. |
+| `structural_change_requires_confirmation` | PASS | The locked report and final output state that future move/split actions require confirmation and that approved structural implementation is `change_tier: major`; no structural mutation occurred. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=78a9ed4a2ff6af194b93c81277958547f5a87533a70b2aa14e43822f139e54d3; fixture_sha256=1a6d7fa4c22a394f3c854eef7a25f4d0cf2e6b4ecd7c7a3d3bf15d295d6e43f8; output_sha256=3d544c1b2ad47aa0a8b336fdf31f4190b64038a9d2c37fa456526c08bd86f149; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 完成结构治理路由、六角色只读审计、临时 HTML 报告交付和结构变更确认约束；未修改仓库。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=78a9ed4a2ff6af194b93c81277958547f5a87533a70b2aa14e43822f139e54d3; fixture_sha256=1a6d7fa4c22a394f3c854eef7a25f4d0cf2e6b4ecd7c7a3d3bf15d295d6e43f8; output_sha256=a973ee17e3fbdb19de2c533c4ca3fbf4d1f5380bef86fc0048816976bfbc9189; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Produced a read-only six-role structure audit, generated a validated HTML report in runtime tmp, preserved the repository, and required confirmation for major structural changes, but omitted the required explicit route statement.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=78a9ed4a2ff6af194b93c81277958547f5a87533a70b2aa14e43822f139e54d3; fixture_sha256=1a6d7fa4c22a394f3c854eef7a25f4d0cf2e6b4ecd7c7a3d3bf15d295d6e43f8; output_sha256=f36b8b3c8690c8569966b24cb7f30babb2f33780274861d5359ce121321b4804; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 完成基础只读文档检查并给出摘要，但仅覆盖 PM 和 Engineer，未交付 HTML 报告，也未证明结构治理路由或变更确认约束。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=78a9ed4a2ff6af194b93c81277958547f5a87533a70b2aa14e43822f139e54d3; fixture_sha256=1a6d7fa4c22a394f3c854eef7a25f4d0cf2e6b4ecd7c7a3d3bf15d295d6e43f8; output_sha256=a671a1cf4376c8728c9d3f152c780a1241695623d99e48909f3d5e21c5d2c4e1; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Produced a narrower PM/Engineer-only prose audit with no HTML report or six-role coverage; repository remained unchanged.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- None.
-- Next: None.
+- The with-skill lane did not provide the required explicit main route to `idea-to-spec:structure-governance`.
+- Next: Add the explicit main route statement to `idea-to-spec:structure-governance` before inspection.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-1-route-greenfield-product-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-1-route-greenfield-product-request/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-1-route-greenfield-product-request`.
-- Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
+- Identity schema: `2`
+- target_skill_sha256: `6f8f132bc1f6eba3f9eb10727126ee30960b503351486b4fb6204e20571ffb35`
+- eval_definition_sha256: `4e776e14ac2c8d3f3aa33718b92238355ee2d15eab3267a50cdada6bb3d4a1de`
+- metadata_sha256: `98a5616a9f22e4ba7d6ed10c98a36b572ccd9f5c0bfcfaf868ea982ef672635f`
+- fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `8e99b873e976898a8a9714405f69dce2d81e6c553f7d4c2b0a99b8b832eee831`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `acfb6edf3aff0b94988c5e9a7ff435967801458a79c851afd902400163536b81`
-- Repository HEAD: `8813f864e743f7c83dc2e51e0b5add79f312e870`
+- Repository HEAD: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7`
-- Skill overlay SHA-256: `4d4a580c5e7c36b9199abb80221829f90c900c96463581d7f87c6d7ccc538bd7`
-- Judge schema SHA-256: `8e99b873e976898a8a9714405f69dce2d81e6c553f7d4c2b0a99b8b832eee831`
-- Eval definition SHA-256: `4e776e14ac2c8d3f3aa33718b92238355ee2d15eab3267a50cdada6bb3d4a1de`
-- Metadata SHA-256: `98a5616a9f22e4ba7d6ed10c98a36b572ccd9f5c0bfcfaf868ea982ef672635f`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
+- Skill overlay SHA-256: `6c6b79d36b8b3a1bf132fd82bfece3cf6e7b256e3a9a58a0cdb78f4a09e26e69`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -31,28 +33,28 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `route_to_idea_to_spec` | PASS | With-skill output identifies the work as greenfield product discovery and the locked trace records routing to idea-to-spec; it remains in PM discovery. |
-| `pm_first_guardrail` | PASS | With-skill output explicitly confirms an empty project, keeps technology pending, requires product-position confirmation, and states that no code will be written. |
-| `context_to_collect` | PASS | With-skill output asks the user to identify the primary audience and scenario, offering focused options. |
-| `expected_pm_artifacts` | NOT_EXERCISED | The candidate is still waiting for the user's answer and explicitly marks PRD and DECISIONS.md as pending, so this assertion is not exercised. |
-| `handoff_boundary` | NOT_EXERCISED | No handoff occurs while the candidate waits for product-position confirmation, so this assertion is not exercised. |
+| `route_to_idea_to_spec` | PASS | With-skill output explicitly states it entered `idea-to-spec` and `greenfield-discovery`, with product-definition work as the current output and no engineering execution. |
+| `pm_first_guardrail` | PASS | It identifies the workspace as an empty directory/new feature, keeps the work in PM discovery, and explicitly defers code, technical selection, and formal implementation. |
+| `context_to_collect` | PASS | It asks a high-information discovery question about the target user/use case and offers concrete user categories, while inviting the user to describe the context. |
+| `expected_pm_artifacts` | NOT_EXERCISED | The lane is explicitly waiting for the user's answer to the first discovery question and has no delivered PM artifacts, so this assertion is not exercised. |
+| `handoff_boundary` | NOT_EXERCISED | No handoff occurs; the candidate remains in discovery awaiting clarification, so the later handoff boundary is not exercised. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=acfb6edf3aff0b94988c5e9a7ff435967801458a79c851afd902400163536b81; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=af660b402b7ed70efd901044495c4d633ea2a7062e5583ece40650b35d2d56e1; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Stayed in PM-first greenfield discovery, identified the empty project, deferred implementation, and asked a focused product-discovery question.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=acfb6edf3aff0b94988c5e9a7ff435967801458a79c851afd902400163536b81; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=c0bc09ad697450aa2ec776d6696879e71412f246249e73a072e0cdd9404f9632; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Stayed in greenfield PM discovery, identified the empty-directory context, deferred implementation, and asked the first product-discovery question.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=acfb6edf3aff0b94988c5e9a7ff435967801458a79c851afd902400163536b81; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=b286246d470a9dabf8fd385f3c535911c47344aa9caf4e79d07ab4d0ea2f3084; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Did not mutate the empty workspace and offered a broad MVP and technical direction, but did not establish the focused PM discovery route as clearly.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=acfb6edf3aff0b94988c5e9a7ff435967801458a79c851afd902400163536b81; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=e08b8d9dad7ca44ea0a9d82835bd6ba6b90d13cb09a68b13db0fca51f72f56f6; snapshot_sha256=71caad971fa4e71bb31925076eb8462b195754f155010a7f081e48deb682f0c5
+- Behavior: Produced PRODUCT_PLAN and DECISIONS artifacts and declared the project ready for design/development before resolving the initial product-discovery question.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Await the user's answer about the primary audience and core scenario before producing PM artifacts or considering handoff.
+- Next: Collect the user's answer to the target-user/core-use-case question, then continue scope and acceptance-criteria discovery before producing PM artifacts or handing off.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-10-change-tier-hotfix-fast-lane/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-10-change-tier-hotfix-fast-lane/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-10-change-tier-hotfix-fast-lane`.
-- Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
+- Identity schema: `2`
+- target_skill_sha256: `6f8f132bc1f6eba3f9eb10727126ee30960b503351486b4fb6204e20571ffb35`
+- eval_definition_sha256: `47a19a6c15b443fba6827b5bff8e5f73b3367c26176898038b1822e6a445e0c6`
+- metadata_sha256: `dd7edb355d66e4505d2039e9fe3eb4eb203c3d8b2cfcc299410f099efef7e166`
+- fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `bb0ee0282945f3d4f9dce339b9d8538e36a23ce40cb0cf92b33dc2be95234be0`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `c8036aad85835ee733e12f58737233d7e9bc1a90da347bec50e7094cf58797ad`
-- Repository HEAD: `8813f864e743f7c83dc2e51e0b5add79f312e870`
+- Repository HEAD: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7`
-- Skill overlay SHA-256: `4d4a580c5e7c36b9199abb80221829f90c900c96463581d7f87c6d7ccc538bd7`
-- Judge schema SHA-256: `bb0ee0282945f3d4f9dce339b9d8538e36a23ce40cb0cf92b33dc2be95234be0`
-- Eval definition SHA-256: `47a19a6c15b443fba6827b5bff8e5f73b3367c26176898038b1822e6a445e0c6`
-- Metadata SHA-256: `dd7edb355d66e4505d2039e9fe3eb4eb203c3d8b2cfcc299410f099efef7e166`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
+- Skill overlay SHA-256: `6c6b79d36b8b3a1bf132fd82bfece3cf6e7b256e3a9a58a0cdb78f4a09e26e69`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -31,26 +33,26 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `classify_hotfix` | PASS | with_skill explicitly sets `change_tier: hotfix` and explains the README-only, no-functional-change scope plus one-link verification basis. |
-| `allow_fast_lane` | PASS | with_skill explicitly sets `fast_lane: allowed_after_classification`, establishing that fast lane is allowed for this classified hotfix delivery. |
-| `preserve_evidence` | PASS | with_skill preserves confirmed scope, source documents, and verification evidence stating the new link was locally verified; it does not omit verification because this is a hotfix. |
+| `classify_hotfix` | PASS | with_skill 明确将 change_tier 设为 hotfix，并说明 README 单一错误链接修复且功能预期不变。 |
+| `allow_fast_lane` | PASS | with_skill 明确给出 request_type: delivery、fast_lane: allowed_after_classification，体现 fast lane 在 hotfix 分类之后允许。 |
+| `preserve_evidence` | PASS | with_skill 保留 confirmed_scope、source_documents，并记录用户已验证新链接可打开及所需验证交付物。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c8036aad85835ee733e12f58737233d7e9bc1a90da347bec50e7094cf58797ad; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=5c4fdaf574f62984e70a778eee6b9161261fd51bb0ec01bbb21b2021243e8029; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly classified the request as an allowed hotfix fast-lane delivery and preserved scope/source/verification evidence, while accurately reporting the workspace and agent blockers.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c8036aad85835ee733e12f58737233d7e9bc1a90da347bec50e7094cf58797ad; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=7d531604001ccbc442ce6031a51c7351a51550b062508af1af0d73a2b03f32dc; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 正确完成 hotfix 分类、分类后 fast lane 判定，并保留范围、来源与验证证据；因工作区为空而阻止后续执行。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c8036aad85835ee733e12f58737233d7e9bc1a90da347bec50e7094cf58797ad; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=889d18a4c6e3da06d4666e144a45393dc9f3a33912800503460034add40e98a9; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Fresh baseline found an empty repository and stopped without making a routing classification or delivery handoff.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c8036aad85835ee733e12f58737233d7e9bc1a90da347bec50e7094cf58797ad; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=1e2984dcceb4a2a2e8ecd7f5dc34a60146afa237e29d91597b348f02eae36952; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 仅报告空仓库并请求提供正确仓库，未提供路由分类或证据保留要求。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Provide a workspace containing the README and enable engineer-agent to perform the requested delivery.
+- Next: None.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-11-change-tier-standard-full-gate/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-11-change-tier-standard-full-gate/comparison.md
@@ -12,45 +12,47 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-11-change-tier-standard-full-gate`.
-- Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
+- Identity schema: `2`
+- target_skill_sha256: `6f8f132bc1f6eba3f9eb10727126ee30960b503351486b4fb6204e20571ffb35`
+- eval_definition_sha256: `da85ba336c757be6c6ca84ef12c1d1a20655adb3e82559a2c2234b5462387973`
+- metadata_sha256: `6652dce9ab8a85ed09b58d853b1bdac1fd0f6f3e5ccd74f38c1d4aa6171a8cf4`
+- fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `e0fce32f646911cc00fe0709c7d0e934a3657054c9fc5a2efda7653a3ac97ea6`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `2c9f63eba393d7546f89112ce3f1659145dc2f6ca60bdba6ba71df10258a35a4`
-- Repository HEAD: `8813f864e743f7c83dc2e51e0b5add79f312e870`
+- Repository HEAD: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7`
-- Skill overlay SHA-256: `4d4a580c5e7c36b9199abb80221829f90c900c96463581d7f87c6d7ccc538bd7`
-- Judge schema SHA-256: `e0fce32f646911cc00fe0709c7d0e934a3657054c9fc5a2efda7653a3ac97ea6`
-- Eval definition SHA-256: `da85ba336c757be6c6ca84ef12c1d1a20655adb3e82559a2c2234b5462387973`
-- Metadata SHA-256: `6652dce9ab8a85ed09b58d853b1bdac1fd0f6f3e5ccd74f38c1d4aa6171a8cf4`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
+- Skill overlay SHA-256: `6c6b79d36b8b3a1bf132fd82bfece3cf6e7b256e3a9a58a0cdb78f4a09e26e69`
 - Behavior result: **PASS**
-- Coverage result: **FULL**
-Overall result: PASS
+- Coverage result: **PARTIAL**
+Overall result: PASS (partial coverage)
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `classify_standard` | PASS | With_skill output explicitly states `change_tier: standard` and `hotfix_disposition: rejected`. |
-| `require_prd_trd_alignment` | PASS | With_skill output identifies PRD/TRD and related product/test expectations as pending, requests the missing context and confirmation, and sets `execution_boundary` to prohibit direct planning, implementation, or testing before alignment. |
-| `request_type_existing_update` | PASS | With_skill output explicitly sets `request_type: existing_update` and explains that the request changes an existing refund-approval business rule. |
+| `classify_standard` | PASS | With_skill explicitly classifies the change as standard and rejects hotfix treatment. |
+| `request_type_existing_update` | PASS | With_skill explicitly identifies the request as existing_update and explains that it changes existing refund-approval behavior. |
+| `require_prd_trd_alignment` | NOT_EXERCISED | With_skill requires PM clarification and PRD/DECISIONS alignment, and forbids downstream implementation; the later downstream handoff is not exercised because user confirmation and project context are missing. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2c9f63eba393d7546f89112ce3f1659145dc2f6ca60bdba6ba71df10258a35a4; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=8fd0af405e240b4cd1092713a10e10f7d2c6275b40c4ba7d35cae7fd9c0c3d2a; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly classified the request as an existing update with standard change tier, rejected hotfix handling, and gated downstream work on missing product and technical context.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2c9f63eba393d7546f89112ce3f1659145dc2f6ca60bdba6ba71df10258a35a4; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=15a17615ddad1b6fb98b191cc36ceae894a413e228c5fd6f1fda67b7871b4db2; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly routes the request as an existing standard business-rule update, gates implementation on product/document alignment, and requests the missing project context.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2c9f63eba393d7546f89112ce3f1659145dc2f6ca60bdba6ba71df10258a35a4; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=bd6375fa04132cecdd9ad7f7520c89831a5f10feb0094cd0d61ba395d5fdfcb5; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Fresh baseline treated the empty workspace as the primary issue and did not classify the request or establish the required product-alignment gate.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2c9f63eba393d7546f89112ce3f1659145dc2f6ca60bdba6ba71df10258a35a4; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=7e332979d44ac05f36590316dc111549cb03b3a5482f6229066705e8d9e7781d; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline only reports that the workspace is empty and does not classify or route the request.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: None.
+- Next: Obtain the target product/codebase and confirm the refund workflow and approval boundaries, then complete the PRD/TRD or equivalent alignment before any downstream implementation handoff.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-12-change-tier-hotfix-abuse-blocked/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-12-change-tier-hotfix-abuse-blocked/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-12-change-tier-hotfix-abuse-blocked`.
-- Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
+- Identity schema: `2`
+- target_skill_sha256: `6f8f132bc1f6eba3f9eb10727126ee30960b503351486b4fb6204e20571ffb35`
+- eval_definition_sha256: `757872d7dabcbeb5f63781cd39c51a0fbd55c644aaecd2a814401a4e784d4603`
+- metadata_sha256: `5be95630fc657c3ddfcd1eee211fb45bdc7cc20a37cf20c50f58a72635d4712c`
+- fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `05754bc7141a9de585a1127391112d0da97f3c7138eba96f4377a8a50be63d7c`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `fd21822d29f9f59daea200bd14c26fadf30442cbe2bd48489976827d9b597907`
-- Repository HEAD: `8813f864e743f7c83dc2e51e0b5add79f312e870`
+- Repository HEAD: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7`
-- Skill overlay SHA-256: `4d4a580c5e7c36b9199abb80221829f90c900c96463581d7f87c6d7ccc538bd7`
-- Judge schema SHA-256: `05754bc7141a9de585a1127391112d0da97f3c7138eba96f4377a8a50be63d7c`
-- Eval definition SHA-256: `757872d7dabcbeb5f63781cd39c51a0fbd55c644aaecd2a814401a4e784d4603`
-- Metadata SHA-256: `5be95630fc657c3ddfcd1eee211fb45bdc7cc20a37cf20c50f58a72635d4712c`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
+- Skill overlay SHA-256: `6c6b79d36b8b3a1bf132fd82bfece3cf6e7b256e3a9a58a0cdb78f4a09e26e69`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -31,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `reject_hotfix_abuse` | PASS | with_skill 输出明确包含 `hotfix_disposition: rejected`，并说明禁止直接改代码、测试、提交或合并。 |
-| `expectation_change_standard` | PASS | with_skill 输出明确包含 `change_tier: standard`，并将其描述为业务预期变更。 |
-| `block_or_return_pm` | PASS | with_skill 输出将下一步设为 PM 对齐，并明确 `execution_boundary` 禁止直接实现，要求补齐产品与工程依据。 |
+| `reject_hotfix_abuse` | PASS | with_skill 输出明确写出 `hotfix_disposition: rejected`，并说明该变更不能按 hotfix 处理。 |
+| `expectation_change_standard` | PASS | with_skill 输出明确写出 `change_tier: standard`，并将 7 天改 30 天归类为业务预期变更。 |
+| `block_or_return_pm` | PASS | with_skill 输出明确禁止 downstream Engineer 执行实现、测试或合并，并要求 PM 先确认批准状态、受影响用户和生效规则，同时向用户询问产品/业务批准情况。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=fd21822d29f9f59daea200bd14c26fadf30442cbe2bd48489976827d9b597907; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=c779153a6142ee151aa57f5f9e6eb775d4146f7f5eb2c0700bb554ddef662139; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 正确拒绝 hotfix 滥用，按 standard 处理业务规则变化，并阻止直接进入实现，返回 PM 范围确认。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=fd21822d29f9f59daea200bd14c26fadf30442cbe2bd48489976827d9b597907; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=ad4c4a4dab42d4e1405b83a5457bc0baa982cbde7c386fa03fd27d176dfcbd40; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 正确将请求路由为 standard、拒绝 hotfix，并阻止直接实现/合并，返回 PM 确认。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=fd21822d29f9f59daea200bd14c26fadf30442cbe2bd48489976827d9b597907; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=40ef85412278167e9e59de44ddd2503dc1a23999430a15c8230b88ac32a0018f; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 仅报告工作区为空并请求重新挂载，未处理 hotfix、standard 或 PM 流程要求。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=fd21822d29f9f59daea200bd14c26fadf30442cbe2bd48489976827d9b597907; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=52d8d2e61f3c02ad6b3c55fac88e4299f85496b993df45ff1beb9e3bcd64cfcf; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 仅报告空仓库并请求重新挂载，未完成业务规则分类或 PM 阻断。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-13-change-tier-hotfix-e2e-direct-path/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-13-change-tier-hotfix-e2e-direct-path/comparison.md
@@ -12,46 +12,47 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-13-change-tier-hotfix-e2e-direct-path`.
-- Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
+- Identity schema: `2`
+- target_skill_sha256: `6f8f132bc1f6eba3f9eb10727126ee30960b503351486b4fb6204e20571ffb35`
+- eval_definition_sha256: `0e4e9687500855bbb8cac580183d47bafa14e53a69d5477185a5ceacddfe1857`
+- metadata_sha256: `385a2edb2c46d9f3ce571c34b812bf357f9247b71af061faebaf0764c87334a2`
+- fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `6a4c53f4d8ac913c9f4214c0dc35c3bf4c2a1bd9745f539a3879966e5d7f9011`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `4b716f413649b163f4dd5dcd45dc5b4214bafbb5cb059afb757fef3a77b94653`
-- Repository HEAD: `8813f864e743f7c83dc2e51e0b5add79f312e870`
+- Repository HEAD: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7`
-- Skill overlay SHA-256: `4d4a580c5e7c36b9199abb80221829f90c900c96463581d7f87c6d7ccc538bd7`
-- Judge schema SHA-256: `6a4c53f4d8ac913c9f4214c0dc35c3bf4c2a1bd9745f539a3879966e5d7f9011`
-- Eval definition SHA-256: `0e4e9687500855bbb8cac580183d47bafa14e53a69d5477185a5ceacddfe1857`
-- Metadata SHA-256: `385a2edb2c46d9f3ce571c34b812bf357f9247b71af061faebaf0764c87334a2`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
-- Behavior result: **FAIL**
-- Coverage result: **FULL**
-Overall result: FAIL
+- Skill overlay SHA-256: `6c6b79d36b8b3a1bf132fd82bfece3cf6e7b256e3a9a58a0cdb78f4a09e26e69`
+- Behavior result: **PASS**
+- Coverage result: **PARTIAL**
+Overall result: PASS (partial coverage)
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `hotfix_direct_path_only` | FAIL | with_skill 输出只包含 `change_tier: standard` 和 `hotfix_disposition: rejected`，未说明 hotfix QA/E2E 可限制到 directly affected path。 |
-| `evidence_still_required` | FAIL | with_skill 输出列出了 blockers_risks，但未要求记录 verification evidence、验证结果及 blocked checks。 |
-| `no_full_suite_required` | FAIL | with_skill 输出未说明无需完整 E2E suite，或仅在升级到 `standard` / `major` 时例外。 |
+| `hotfix_direct_path_only` | NOT_EXERCISED | With-skill lane stopped at missing implementation and approved expectation evidence; no QA/E2E scope was exercised. |
+| `evidence_still_required` | NOT_EXERCISED | No verification run occurred because the fixture contains no project files or implementation context. |
+| `no_full_suite_required` | NOT_EXERCISED | No QA/E2E suite decision was reached because execution was blocked before implementation and verification. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4b716f413649b163f4dd5dcd45dc5b4214bafbb5cb059afb757fef3a77b94653; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=f2d1a8bc68d88ebf5dbd6ebdb7139515de40fbdffac81beefb8a2832878bb637; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 诚实识别空仓库并停止修改，记录了路由与阻塞项，但遗漏断言要求的 hotfix QA 范围和验证证据政策。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4b716f413649b163f4dd5dcd45dc5b4214bafbb5cb059afb757fef3a77b94653; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=ae3f7c9154fc0a2a3dc0f18b058be6d9654d4bb97ddd6f778dfdc361278c3806; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly classified the request as a standard existing update, rejected the hotfix path, preserved a read-only boundary, and requested missing project evidence before implementation.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4b716f413649b163f4dd5dcd45dc5b4214bafbb5cb059afb757fef3a77b94653; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=d2c6e5abf62abcb3af02d58e983e0a1a594514edab0386c9a1736d583fedc869; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 识别为空仓库后直接报告无法修改或验证，未提供断言相关策略说明。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4b716f413649b163f4dd5dcd45dc5b4214bafbb5cb059afb757fef3a77b94653; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=924678b27a5b7132acb779392e2c8d33a2375886f8bcc3a4590ce06bc4651081; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Inspected the empty repository and reported that the requested change and verification could not be performed.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- with_skill 未交付三个断言要求的用户可见 QA/验证策略说明。
-- Next: 补充应用源码、预期文案和测试上下文后重新执行。
-- Next: 在交付说明中明确直接影响路径 QA/E2E 范围、verification evidence/结果/blocked checks，以及完整 E2E suite 的适用条件。
+- None.
+- Next: Provide the login-page implementation and approved expected wording or handoff evidence, then perform the minimal change and targeted verification with evidence and blocked checks recorded.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-14-route-site-notes-and-github-release/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-14-route-site-notes-and-github-release/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-14-route-site-notes-and-github-release`.
-- Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
+- Identity schema: `2`
+- target_skill_sha256: `6f8f132bc1f6eba3f9eb10727126ee30960b503351486b4fb6204e20571ffb35`
+- eval_definition_sha256: `ae4335c3ea7ab2052d5988d1cbe329b872d3570826da6174d95ecdee75a8f11e`
+- metadata_sha256: `7b48bd11ada861ee54366c474d903263630fabf2c5e0d3a66c9f38056e80908e`
+- fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `0e6be21ab02e72aa076a9b774d5cc60139434feba550f781574340027908427d`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `aeb9d94911e2f21a05aec636eb7871f30e1f918271687f3e921766aab4cdc3f2`
-- Repository HEAD: `8813f864e743f7c83dc2e51e0b5add79f312e870`
+- Repository HEAD: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7`
-- Skill overlay SHA-256: `4d4a580c5e7c36b9199abb80221829f90c900c96463581d7f87c6d7ccc538bd7`
-- Judge schema SHA-256: `0e6be21ab02e72aa076a9b774d5cc60139434feba550f781574340027908427d`
-- Eval definition SHA-256: `ae4335c3ea7ab2052d5988d1cbe329b872d3570826da6174d95ecdee75a8f11e`
-- Metadata SHA-256: `7b48bd11ada861ee54366c474d903263630fabf2c5e0d3a66c9f38056e80908e`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
+- Skill overlay SHA-256: `6c6b79d36b8b3a1bf132fd82bfece3cf6e7b256e3a9a58a0cdb78f4a09e26e69`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -31,27 +33,27 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `routes_site_notes_to_docs_specialist` | PASS | With-skill routing decision explicitly selects `docs-agent:release-notes-gen` for the requested site release notes. |
-| `routes_github_release_to_pm_specialist` | NOT_EXERCISED | The PM GitHub Release stage is blocked by missing runtime capability, so this later routing step is not exercised. |
-| `preserves_release_sequence` | NOT_EXERCISED | The output records site-first sequencing as required, but no ready handoff, Docs gates, or release audit evidence is produced because execution is blocked. |
-| `does_not_use_old_pm_skill_name` | PASS | The PM owner is not named `release-notes-gen`; the output names `docs-agent:release-notes-gen` as the downstream Docs specialist. |
+| `routes_site_notes_to_docs_specialist` | NOT_EXERCISED | The with_skill lane was blocked before an actual specialist handoff; locked raw evidence does not independently prove execution of this route. |
+| `routes_github_release_to_pm_specialist` | NOT_EXERCISED | The with_skill lane was blocked before GitHub Release specialist execution; locked raw evidence does not independently prove execution of this route. |
+| `preserves_release_sequence` | NOT_EXERCISED | The candidate states the intended site-notes → Docs audit → GitHub Release sequence, but missing version evidence and unavailable downstream capability prevented exercising the later handoff and audit-consumption stages. |
+| `does_not_use_old_pm_skill_name` | PASS | The visible with_skill output names github-release-gen separately from docs-agent and does not assign the old release-notes-gen name to PM, but the underlying routing process is not independently proven. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=aeb9d94911e2f21a05aec636eb7871f30e1f918271687f3e921766aab4cdc3f2; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=58d552206fb5af95533dd73acf539a6765f12dc72957ab878e1ffdd43b4ebb6b; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly selects the Docs specialist and preserves the site-first boundary, but stops before the PM Release stage because required capabilities and source evidence are unavailable.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=aeb9d94911e2f21a05aec636eb7871f30e1f918271687f3e921766aab4cdc3f2; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=7c23ac02cb955f7e8d06a6a81e6e74d82caf10d812914d83bed4c1dc30fbb235; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly stopped at the evidence and capability gate, reported the intended release sequence, and did not generate or publish unsupported release materials.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=aeb9d94911e2f21a05aec636eb7871f30e1f918271687f3e921766aab4cdc3f2; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=8bb3305a2db29083491536bf68c3ebe1ea686642c60ccbcdd74acd58a27d25fa; snapshot_sha256=ec43c795f403cdaedc59295e8d12ec4da8d823d501a4ed41186e262cf97a5fa1
-- Behavior: Creates site notes and a GitHub Release preview without routing or specialist handoff, using unconfirmed placeholders.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=aeb9d94911e2f21a05aec636eb7871f30e1f918271687f3e921766aab4cdc3f2; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=68fc360a30992da1680fd300f2f4188984166f1aa7d471b344f071d127978b1e; snapshot_sha256=3a1a2adec4a9ddc7ef831b16863a11f8beefaec42b4b85105b2d51b7d33f08ac
+- Behavior: Generated local in-app and GitHub Release drafts without specialist routing or the required site-first handoff sequence.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Provide the missing release-source evidence and enable the Docs and PM GitHub Release capabilities to exercise the remaining stages.
+- Next: Provide confirmed v1.0.0 release evidence and make the required Docs and PM specialists available, then rerun the workflow.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-17-scope-guard-unenabled-general/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-17-scope-guard-unenabled-general/comparison.md
@@ -1,38 +1,58 @@
-# Eval Result: PENDING
+# Issue #246 Evaluation Result
 
 ## Evaluation Target
 
 - Agent: `product_manager`
 - Skill: `pm-agent`
-- Eval: `PENDING`
+- Eval: `eval-017-scope-guard-unenabled-general`
 
-## Latest Result
+## Current Result
 
-- Evidence status: **PENDING**
-- Preflight status: **PENDING**
+- Evidence status: **FRESH**
+- Preflight status: **PASS**
+- Judge: third independent fresh judge completed after both candidates were locked.
+- Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-17-scope-guard-unenabled-general`.
+- Identity schema: `2`
+- target_skill_sha256: `6f8f132bc1f6eba3f9eb10727126ee30960b503351486b4fb6204e20571ffb35`
+- eval_definition_sha256: `2b26ec5b13cba548fe19b4f508977afc54ba26189b14fbc48be376e4d57b8178`
+- metadata_sha256: `05ea9f60607f11132b0f5ec8ca00cda463398f718c44648a9e2be81e39b17991`
+- fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `c5629d3608d1f142562d32ed4b435e3d2c557d9aa8b1c8b5f72fce35ca63e9a2`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
+- Prompt SHA-256: `0d80b9dec86a17116de51354d4b9cf60c96709a915b3655bf693ad2757979eb9`
+- Repository HEAD: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Repository worktree state: **DIRTY**
+- Skill overlay SHA-256: `637830d1287a617a207310e2740f1a3d3e1e42266df7b99ca4de0e57c2a0c6d6`
+- Behavior result: **PASS**
+- Coverage result: **FULL**
+Overall result: PASS
 
-## Test Set / Fixture Version
+## Assertion Results
 
-PENDING
+| Assertion | Result | Evidence |
+| --- | --- | --- |
+| `scope_guard_stops_general_request` | PASS | with_skill 输出明确说明“当前目录未启用”并停止；锁定 trace 显示其检查了当前目录及父级的 dev-agent-skills 标记，且未输出 request_type、change_tier、selected_owner 或下游文档/handoff。 |
 
-## With Skill
+## With-Skill Behavior
 
-PENDING
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=0d80b9dec86a17116de51354d4b9cf60c96709a915b3655bf693ad2757979eb9; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=6d50e13d8821bc4fc003b4f0506e1421f60c8653847cef87c025aadb5cc64e49; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 检查目录启用状态，判定未启用后以一句简短说明停止。
+- The with-skill context was created only after the baseline evidence was locked and destroyed.
 
-## Without Skill / Baseline
+## Fresh Without-Skill Baseline
 
-PENDING
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=0d80b9dec86a17116de51354d4b9cf60c96709a915b3655bf693ad2757979eb9; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=a435c8569a3cb0612f9f6281fa6220f33bfcb5c7ccf9b31ff815e3bba9677fca; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 尝试访问 ~/Downloads，因路径/权限问题未执行整理；未体现目录启用状态检查。
+- The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
-## Failures
+## Failures and Next Steps
 
-PENDING
+- None.
+- Next: None.
 
-## Next Steps
+## Runtime Artifact Policy
 
-PENDING
-
-## Runtime Artifacts Policy
-
-PENDING
-
-Overall result: PENDING
+- Candidate outputs, snapshots, judge packages, verdict payloads, timing, diagnostics, and other runtime files are deleted before the runner exits, including after FAIL, BLOCKED, or exceptions.
+- This durable comparison retains only the latest reviewable conclusion; Git history preserves earlier revisions.

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-18-scope-guard-explicit-invocation/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-18-scope-guard-explicit-invocation/comparison.md
@@ -1,38 +1,59 @@
-# Eval Result: PENDING
+# Issue #246 Evaluation Result
 
 ## Evaluation Target
 
 - Agent: `product_manager`
 - Skill: `pm-agent`
-- Eval: `PENDING`
+- Eval: `eval-018-scope-guard-explicit-invocation`
 
-## Latest Result
+## Current Result
 
-- Evidence status: **PENDING**
-- Preflight status: **PENDING**
+- Evidence status: **FRESH**
+- Preflight status: **PASS**
+- Judge: third independent fresh judge completed after both candidates were locked.
+- Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-18-scope-guard-explicit-invocation`.
+- Identity schema: `2`
+- target_skill_sha256: `6f8f132bc1f6eba3f9eb10727126ee30960b503351486b4fb6204e20571ffb35`
+- eval_definition_sha256: `c9288fa3642ba9620547b9cef097cb305dbbd76229e2d8a01a3398cb410b16ae`
+- metadata_sha256: `9bbacd8d1d30aecb1b4dd5b9add9750bc75aa04b90825b7bca13141ac06f87e8`
+- fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `3a5175573f5c12faf8ef17031068ea4a3554be3c63ea98a9f0e35a5de2fe7ef6`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
+- Prompt SHA-256: `495fc0f825d65d1e7057e4dc84ea777d069a48dcb665a6ab231607b5f4f53d34`
+- Repository HEAD: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Repository worktree state: **DIRTY**
+- Skill overlay SHA-256: `6c6b79d36b8b3a1bf132fd82bfece3cf6e7b256e3a9a58a0cdb78f4a09e26e69`
+- Behavior result: **PASS**
+- Coverage result: **FULL**
+Overall result: PASS
 
-## Test Set / Fixture Version
+## Assertion Results
 
-PENDING
+| Assertion | Result | Evidence |
+| --- | --- | --- |
+| `explicit_invocation_proceeds` | PASS | With_skill output explicitly states classification ran, identifies the request as local file organization, says no PM category or downstream role matched, and keeps the task in PM without claiming the unenabled-directory guard blocked it. |
+| `classifies_general_request` | PASS | With_skill output provides the required semantic classification: local file organization, no matching PM category or downstream role, task remains in PM; it does not skip classification or invent an incompatible owner. |
 
-## With Skill
+## With-Skill Behavior
 
-PENDING
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=495fc0f825d65d1e7057e4dc84ea777d069a48dcb665a6ab231607b5f4f53d34; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=e12254e6c765f8d2adba89993a3a66ffa6b2ae7b62d32300602a6aa4eca12a52; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly proceeds through classification for the explicitly invoked pm-agent request and honestly keeps the unmatched general file operation in PM.
+- The with-skill context was created only after the baseline evidence was locked and destroyed.
 
-## Without Skill / Baseline
+## Fresh Without-Skill Baseline
 
-PENDING
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=495fc0f825d65d1e7057e4dc84ea777d069a48dcb665a6ab231607b5f4f53d34; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=adecfe5a25a28b305aacb6bed994480fbcd599fcdcb5e271305c0eec3f004740; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline stops because pm-agent is unavailable and the Downloads directory is missing, without performing the required classification.
+- The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
-## Failures
+## Failures and Next Steps
 
-PENDING
+- None.
+- Next: None.
 
-## Next Steps
+## Runtime Artifact Policy
 
-PENDING
-
-## Runtime Artifacts Policy
-
-PENDING
-
-Overall result: PENDING
+- Candidate outputs, snapshots, judge packages, verdict payloads, timing, diagnostics, and other runtime files are deleted before the runner exits, including after FAIL, BLOCKED, or exceptions.
+- This durable comparison retains only the latest reviewable conclusion; Git history preserves earlier revisions.

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-19-scope-guard-enabled-general/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-19-scope-guard-enabled-general/comparison.md
@@ -1,38 +1,59 @@
-# Eval Result: PENDING
+# Issue #246 Evaluation Result
 
 ## Evaluation Target
 
 - Agent: `product_manager`
 - Skill: `pm-agent`
-- Eval: `PENDING`
+- Eval: `eval-019-scope-guard-enabled-general`
 
-## Latest Result
+## Current Result
 
-- Evidence status: **PENDING**
-- Preflight status: **PENDING**
+- Evidence status: **FRESH**
+- Preflight status: **PASS**
+- Judge: third independent fresh judge completed after both candidates were locked.
+- Fixture version/source: canonical manifest `fe6bcb3f9a810e8ec07d6cd151b927dd0790270b275bdd2a0170bbc91573f2d5` from `agents/product_manager/test/pm-agent/evals/workspace/eval-19-scope-guard-enabled-general`.
+- Identity schema: `2`
+- target_skill_sha256: `6f8f132bc1f6eba3f9eb10727126ee30960b503351486b4fb6204e20571ffb35`
+- eval_definition_sha256: `2e41aaf2a9f1898027fcb4bd2dc0d8b314b161c3848369aeb0ccc8e3d7c16e07`
+- metadata_sha256: `f5c5f2a20d2b5185fc2f9a51b4985187997e135f3a377de786395157cfcdb827`
+- fixture_sha256: `fe6bcb3f9a810e8ec07d6cd151b927dd0790270b275bdd2a0170bbc91573f2d5`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `78fbc30f6ea00642b27e4bc9a167610aaa84574a08fb26567e68734e28c9ff68`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
+- Prompt SHA-256: `9d2abe6f2d9f34e08ce206e7be1d9f6dca54aa3a23552cb1626522bb6c0a068c`
+- Repository HEAD: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Repository worktree state: **DIRTY**
+- Skill overlay SHA-256: `6c6b79d36b8b3a1bf132fd82bfece3cf6e7b256e3a9a58a0cdb78f4a09e26e69`
+- Behavior result: **PASS**
+- Coverage result: **FULL**
+Overall result: PASS
 
-## Test Set / Fixture Version
+## Assertion Results
 
-PENDING
+| Assertion | Result | Evidence |
+| --- | --- | --- |
+| `enabled_marker_detected` | PASS | Trace confirms the current directory contains both AGENTS.md and .claude-plugin/marketplace.json, and identifies the marketplace name as dev-agent-skills. |
+| `general_request_proceeds` | PASS | With-skill output classifies the request as matching no PM category or downstream role, keeps it in PM, and does not claim the directory is disabled. |
 
-## With Skill
+## With-Skill Behavior
 
-PENDING
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9d2abe6f2d9f34e08ce206e7be1d9f6dca54aa3a23552cb1626522bb6c0a068c; fixture_sha256=fe6bcb3f9a810e8ec07d6cd151b927dd0790270b275bdd2a0170bbc91573f2d5; output_sha256=e9ad61ff6ffd6c4e9e4207c142cb4683bf67c12753997a18395761e88b3917ed; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Detected the enabled project markers and provided an honest PM-scope classification without the disabled-directory interception.
+- The with-skill context was created only after the baseline evidence was locked and destroyed.
 
-## Without Skill / Baseline
+## Fresh Without-Skill Baseline
 
-PENDING
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9d2abe6f2d9f34e08ce206e7be1d9f6dca54aa3a23552cb1626522bb6c0a068c; fixture_sha256=fe6bcb3f9a810e8ec07d6cd151b927dd0790270b275bdd2a0170bbc91573f2d5; output_sha256=284215fe1e4c0c8e4e8a2c0f74e640e858ab84b50f88cc9bd019b35b32103c9c; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline only reported inability to access ~/Downloads and requested an accessible path; it did not perform the required enabled-directory routing.
+- The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
-## Failures
+## Failures and Next Steps
 
-PENDING
+- None.
+- Next: None.
 
-## Next Steps
+## Runtime Artifact Policy
 
-PENDING
-
-## Runtime Artifacts Policy
-
-PENDING
-
-Overall result: PENDING
+- Candidate outputs, snapshots, judge packages, verdict payloads, timing, diagnostics, and other runtime files are deleted before the runner exits, including after FAIL, BLOCKED, or exceptions.
+- This durable comparison retains only the latest reviewable conclusion; Git history preserves earlier revisions.

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-2-route-bugfix-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-2-route-bugfix-request/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-2-route-bugfix-request`.
-- Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
+- Identity schema: `2`
+- target_skill_sha256: `6f8f132bc1f6eba3f9eb10727126ee30960b503351486b4fb6204e20571ffb35`
+- eval_definition_sha256: `fe6d213ce4edb254dae39c5fefca87002824c8356e6ca05dfa6b8b92c57d378d`
+- metadata_sha256: `163386e80d321ea48ddfd244853e278bc70ea13a08cdc68ac01f85bf3ba7240f`
+- fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `00a01c5f9432a18e723abe9a7b1a555e5a2a41dc2c36a101ed91497434d1c7f4`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `3622b3dfdb9bef50766ff22e70a5639483865b84fa39f8a64f027bc492debda1`
-- Repository HEAD: `8813f864e743f7c83dc2e51e0b5add79f312e870`
+- Repository HEAD: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7`
-- Skill overlay SHA-256: `4d4a580c5e7c36b9199abb80221829f90c900c96463581d7f87c6d7ccc538bd7`
-- Judge schema SHA-256: `00a01c5f9432a18e723abe9a7b1a555e5a2a41dc2c36a101ed91497434d1c7f4`
-- Eval definition SHA-256: `fe6d213ce4edb254dae39c5fefca87002824c8356e6ca05dfa6b8b92c57d378d`
-- Metadata SHA-256: `163386e80d321ea48ddfd244853e278bc70ea13a08cdc68ac01f85bf3ba7240f`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
+- Skill overlay SHA-256: `6c6b79d36b8b3a1bf132fd82bfece3cf6e7b256e3a9a58a0cdb78f4a09e26e69`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -32,25 +34,25 @@ Overall result: PASS (partial coverage)
 | Assertion | Result | Evidence |
 | --- | --- | --- |
 | `request_type_bug_report` | PASS | with_skill 输出明确包含 `request_type: bug_report`。 |
-| `expectation_first` | NOT_EXERCISED | 工作区没有 PRD/TRD 或等价预期文档；候选输出的 `source_documents` 为空，并将补充已批准预期行为列为后续缺口。 |
-| `debugger_handoff_after_confirmation` | NOT_EXERCISED | 未提供实际 debugger/Engineer handoff；且因预期文档缺失，入口被标记为 blocked/failed，执行边界禁止工程执行。 |
+| `expectation_first` | NOT_EXERCISED | 工作区没有 approved PRD/TRD 或等价预期文档；候选正确报告缺失该依据并停止，因此未能实际 exercise 对照预期步骤。 |
+| `debugger_handoff_after_confirmation` | NOT_EXERCISED | 未确认实现偏差，且输出明确禁止工程调试、代码修改和测试；后续 handoff 尚未发生。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3622b3dfdb9bef50766ff22e70a5639483865b84fa39f8a64f027bc492debda1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=692f05e9dcd45ff16e6d292af33d5b58995e552ae7ba4bbf6bc30b03616ea4cc; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 正确识别为 bug report，并在缺少项目与预期证据时阻止工程执行。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3622b3dfdb9bef50766ff22e70a5639483865b84fa39f8a64f027bc492debda1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=24b4b04abdada91c45454dccabd1353bff29f3e97ba65f465be82be060c49dd9; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 识别为 bug_report，发现缺少预期与实现证据后阻止 Engineer/debugger 执行，未发生越权修复或 handoff。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3622b3dfdb9bef50766ff22e70a5639483865b84fa39f8a64f027bc492debda1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=a4a226af3fc3ee5f66ee6128730b0ff561c0c5c0d8c85f652fa944a1a328720b; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 仅识别为空仓库并停止，未进行请求分类或预期确认流程。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3622b3dfdb9bef50766ff22e70a5639483865b84fa39f8a64f027bc492debda1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=fa8428a62b0a23f65218cc22b2930047d2cc9d775358386e949e523b694ba5d9; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 仅报告空仓库并请求补充源码，未进行请求分类或流程门控。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: 补充项目源码及已批准的 PRD/TRD 或等价产品预期后，再确认实现偏差并决定是否 handoff。
+- Next: 补充 approved PRD/TRD 或等价产品预期、源码及错误日志后，再确认实现偏差并决定是否 handoff。
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-3-route-test-writing-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-3-route-test-writing-request/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-3-route-test-writing-request`.
-- Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
+- Identity schema: `2`
+- target_skill_sha256: `6f8f132bc1f6eba3f9eb10727126ee30960b503351486b4fb6204e20571ffb35`
+- eval_definition_sha256: `4c0ee7c09752627d6057c1ccc0d45cb292b19c1428b51ca9513725150029cf5a`
+- metadata_sha256: `48e1e31078cfd6a23e5c1bdb5481d8f4c6428eb757f9b42750f6377a78297239`
+- fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `4bea92cb3e04f7ad6bcf4e0dcdb3aa7c06af7bec325a6bea731363f44bd4e944`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `3f7994fdecfb94451400a56972388597b7ae51d2d37508524058139c5273a4e3`
-- Repository HEAD: `8813f864e743f7c83dc2e51e0b5add79f312e870`
+- Repository HEAD: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7`
-- Skill overlay SHA-256: `4d4a580c5e7c36b9199abb80221829f90c900c96463581d7f87c6d7ccc538bd7`
-- Judge schema SHA-256: `4bea92cb3e04f7ad6bcf4e0dcdb3aa7c06af7bec325a6bea731363f44bd4e944`
-- Eval definition SHA-256: `4c0ee7c09752627d6057c1ccc0d45cb292b19c1428b51ca9513725150029cf5a`
-- Metadata SHA-256: `48e1e31078cfd6a23e5c1bdb5481d8f4c6428eb757f9b42750f6377a78297239`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
+- Skill overlay SHA-256: `6c6b79d36b8b3a1bf132fd82bfece3cf6e7b256e3a9a58a0cdb78f4a09e26e69`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -31,26 +33,27 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `request_type_validation` | PASS | With-skill output explicitly classifies the request as `validation` and routes it toward QA validation. |
-| `test_basis_first` | PASS | With-skill output records `entry_basis: missing`, lists no source documents, identifies the missing PRD/TRD/acceptance basis, and blocks downstream test work until the basis is provided. |
-| `qa_or_test_writer_handoff` | NOT_EXERCISED | No downstream handoff occurred because the required behavior basis was missing; the later handoff step therefore could not yet be exercised. |
+| `request_type_validation` | PASS | With-skill output explicitly classifies the request as `request_type: validation`. |
+| `test_basis_first` | NOT_EXERCISED | The candidate reports `entry_basis: missing`, an empty `source_documents` list, and missing PRD/TRD/acceptance evidence; no qualifying test basis could be confirmed from the fixture. |
+| `qa_or_test_writer_handoff` | NOT_EXERCISED | The candidate states that missing approved behavior evidence must be supplied before Engineer handoff, but the handoff cannot occur until that evidence and implementation context are provided. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3f7994fdecfb94451400a56972388597b7ae51d2d37508524058139c5273a4e3; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=4bd30343171c1f0aa74cb7413f84b26c3a7960397d1507fda68f87840a1e33a0; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly classifies the request, verifies that the required test basis is absent, and blocks downstream execution pending documentation and project code.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3f7994fdecfb94451400a56972388597b7ae51d2d37508524058139c5273a4e3; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=3a7fa444bae8a2b3d700d1883805fb5a3c112b1c6aadca220da0c23e53120182; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Classified the request as validation, identified missing testing basis and project context, and stopped without making unsupported test changes or handing off prematurely.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3f7994fdecfb94451400a56972388597b7ae51d2d37508524058139c5273a4e3; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=376e61527b2a34a5473b42945f94774826f681202e0fb21dec24067f9b4377d8; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Detects the empty repository and stops, but does not provide the structured validation classification or basis-gated routing behavior.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3f7994fdecfb94451400a56972388597b7ae51d2d37508524058139c5273a4e3; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=622f2f9d1657a93d6a59109b20b4f704d329f40fd0f160b3330904c390018143; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Only reported that the repository was empty and requested the project source; it did not classify the request or establish a testing-basis gate.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Provide the order/refund code and an approved PRD, TRD, implementation plan, or acceptance record, then perform the QA handoff.
+- Next: Provide the refund implementation, existing tests, and an approved PRD/TRD/implementation plan or acceptance record.
+- Next: After expectations are confirmed and stable, hand off to Engineer/test-writer or QA.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-4-route-ui-update-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-4-route-ui-update-request/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-4-route-ui-update-request`.
-- Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
+- Identity schema: `2`
+- target_skill_sha256: `6f8f132bc1f6eba3f9eb10727126ee30960b503351486b4fb6204e20571ffb35`
+- eval_definition_sha256: `601243bb221e4073b25a6eba61d2cbbc1d243cb0d11ebc88b60ef8187a2e86e1`
+- metadata_sha256: `aa0eca0938ef56711257694af52b821c5be5dbedc9b5982d77710814288d3115`
+- fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `afcbd1cd02daddf2a5de8000a17edb44c8f3338aa4214be0e836d3a78f54f541`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `cc5c00e0814501d7ed50a7f0170322a995f768ddcee0b14ac461aa95868c10b8`
-- Repository HEAD: `8813f864e743f7c83dc2e51e0b5add79f312e870`
+- Repository HEAD: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7`
-- Skill overlay SHA-256: `4d4a580c5e7c36b9199abb80221829f90c900c96463581d7f87c6d7ccc538bd7`
-- Judge schema SHA-256: `afcbd1cd02daddf2a5de8000a17edb44c8f3338aa4214be0e836d3a78f54f541`
-- Eval definition SHA-256: `601243bb221e4073b25a6eba61d2cbbc1d243cb0d11ebc88b60ef8187a2e86e1`
-- Metadata SHA-256: `aa0eca0938ef56711257694af52b821c5be5dbedc9b5982d77710814288d3115`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
+- Skill overlay SHA-256: `6c6b79d36b8b3a1bf132fd82bfece3cf6e7b256e3a9a58a0cdb78f4a09e26e69`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -31,26 +33,26 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `request_type_design_or_update` | PASS | With_skill explicitly classifies the request as `request_type: existing_update`, routes it through `pm-agent` and `idea-to-spec`, and does not implement code. |
-| `pm_designer_engineer_decision` | PASS | With_skill explicitly uses the PM route, identifies design and engineering impacts as pending, and keeps the work in discovery pending confirmation rather than handing off implementation. |
-| `implementation_waits_for_alignment` | NOT_EXERCISED | No Engineer handoff or implementation occurred. The workflow correctly pauses for user confirmation, so the later alignment gate is not exercised. |
+| `request_type_design_or_update` | PASS | with_skill 输出明确写出 `request_type: existing_update`，并将执行边界设为暂不进行设计交付、代码实现或测试。 |
+| `pm_designer_engineer_decision` | PASS | with_skill 将下一责任路径定为 `selected_owner: idea-to-spec`，要求继续由 PM 收敛现状与目标，并明确当前不进入 Designer 设计交付或 Engineer 代码实现。 |
+| `implementation_waits_for_alignment` | NOT_EXERCISED | with_skill 已完成 PM 收敛这一前置步骤，但后续设计/TRD 对齐及 Engineer handoff 尚未发生，且需要用户补充现状信息；该后续断言未被实际行使。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cc5c00e0814501d7ed50a7f0170322a995f768ddcee0b14ac461aa95868c10b8; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=aec9ff445a1a3d33daa44fc84e3315f05bc4208b868f1053675503a13636d1d5; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly classified the UI request as an existing update, routed it through PM and idea-to-spec discovery, and paused for confirmation before downstream work.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cc5c00e0814501d7ed50a7f0170322a995f768ddcee0b14ac461aa95868c10b8; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=fe38d8022626070aa7ccb500286ae24498146a1538241e1d5a904473a010cbe7; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 正确将请求路由为 existing_update，停留在 PM/idea-to-spec 需求收敛阶段，明确暂不设计或实现，并请求补充现状信息。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cc5c00e0814501d7ed50a7f0170322a995f768ddcee0b14ac461aa95868c10b8; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=99bc864a02bf778897890f2c80c945b8fc4a72312222783f784082eaafdabe5a; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Provided a generic UI proposal without explicit request classification or PM/Designer/Engineer routing, while making no code changes.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cc5c00e0814501d7ed50a7f0170322a995f768ddcee0b14ac461aa95868c10b8; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=ab74c019c10203c53b993282a25175839d9f3508b9d85a1ce22d02b1a7e0a220; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 直接产出设置页左右分栏方案并建议后续进入实现，未执行 PM/Designer/Engineer 的前置路由与对齐门控。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Confirm the preferred left-navigation pattern, then complete the applicable PM/design alignment before any Engineer implementation handoff.
+- Next: 等待用户提供设置页截图/录屏或现状结构，再继续 PM 收敛并决定 Designer 设计交付。
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-5-route-deployment-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-5-route-deployment-request/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-5-route-deployment-request`.
-- Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
+- Identity schema: `2`
+- target_skill_sha256: `6f8f132bc1f6eba3f9eb10727126ee30960b503351486b4fb6204e20571ffb35`
+- eval_definition_sha256: `73a2b58c1c65bf56a5f6d6f35f003c86e432caed7b530c34cf851322050e2633`
+- metadata_sha256: `d17a05b229136107ac1e50142856979a9ae9f563cdb19b940e4810dadda79e1c`
+- fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `42fd42dc7a350eab589db47b48a132e9f478c8e119c1fdbd30b4875075f9f0b5`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `df8dd8d18e0b79f0114ea9e750efb47af7d21bc05b6ea3666cff7d6bae4802fe`
-- Repository HEAD: `8813f864e743f7c83dc2e51e0b5add79f312e870`
+- Repository HEAD: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7`
-- Skill overlay SHA-256: `4d4a580c5e7c36b9199abb80221829f90c900c96463581d7f87c6d7ccc538bd7`
-- Judge schema SHA-256: `42fd42dc7a350eab589db47b48a132e9f478c8e119c1fdbd30b4875075f9f0b5`
-- Eval definition SHA-256: `73a2b58c1c65bf56a5f6d6f35f003c86e432caed7b530c34cf851322050e2633`
-- Metadata SHA-256: `d17a05b229136107ac1e50142856979a9ae9f563cdb19b940e4810dadda79e1c`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
+- Skill overlay SHA-256: `6c6b79d36b8b3a1bf132fd82bfece3cf6e7b256e3a9a58a0cdb78f4a09e26e69`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -31,26 +33,26 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `request_type_deployment` | PASS | With_skill explicitly states `request_type: deployment` in its Routing decision. |
-| `repo_wide_scope_allowed` | PASS | With_skill uses `feature_path: N/A`, `feature: N/A`, `parent_feature: N/A`, and `feature_path_evidence: []` for repository-wide work. |
-| `devops_handoff_packet` | NOT_EXERCISED | The DevOps handoff is explicitly blocked because the target agent and required release context are unavailable; the actual handoff cannot yet occur. |
+| `request_type_deployment` | PASS | with_skill 输出明确将 request_type 设为 deployment。 |
+| `repo_wide_scope_allowed` | PASS | with_skill 输出使用 feature_path: N/A、feature: N/A，并提供空的 feature_path_evidence。 |
+| `devops_handoff_packet` | NOT_EXERCISED | 已记录 summary、environment、release_target、rollback_expectation 和 blockers_risks；但因 devops-agent 未安装，实际 DevOps handoff 尚未发生。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=df8dd8d18e0b79f0114ea9e750efb47af7d21bc05b6ea3666cff7d6bae4802fe; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=259042ca0672c7b0cc9ca01dcd11fa18d6918cce2344e47e60d0cdb8db780016; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly classifies the request as deployment, permits repository-wide N/A scope, and stops before an unsupported DevOps handoff.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=df8dd8d18e0b79f0114ea9e750efb47af7d21bc05b6ea3666cff7d6bae4802fe; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=d0cd99d7847e3f6a06fbbcfd02bbd48832b5dfd036a996097f9c72b1f476a7a9; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 正确识别 deployment，允许仓库级 N/A scope，并在路由前补齐交接上下文；因缺少 devops-agent 停在 handoff 前。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=df8dd8d18e0b79f0114ea9e750efb47af7d21bc05b6ea3666cff7d6bae4802fe; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=3ea9ec3f666f17ed064514f2fafa4c925fc8f737b7904e6aa6d9c97d2b17679d; snapshot_sha256=df9e7182eb760cabfbd10b7e99ad05abcb8ad7436780a669611ff080265c733b
-- Behavior: Implemented repository-level CI artifacts but did not provide the required deployment classification or structured handoff context.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=df8dd8d18e0b79f0114ea9e750efb47af7d21bc05b6ea3666cff7d6bae4802fe; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=73045bd7b878e3145abd8737e46dd2b5e9146cb0cf1f4bef849b2cdb5a83ca28; snapshot_sha256=61a743f873c27f3ed1ffcc7f4e744d8baad77a06a48759f68dac0210d141bb3f
+- Behavior: 直接创建 CI 和上线清单，但未展示 deployment 路由、N/A scope 或 DevOps 交接上下文。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Confirm environment, release scope, rollback needs, and risks, then hand off to DevOps when the target is available.
+- Next: 安装 devops-agent 后继续执行 DevOps handoff。
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-6-route-security-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-6-route-security-request/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-6-route-security-request`.
-- Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
+- Identity schema: `2`
+- target_skill_sha256: `6f8f132bc1f6eba3f9eb10727126ee30960b503351486b4fb6204e20571ffb35`
+- eval_definition_sha256: `33054d35eb6adb9b2259eedec7e911d8545eb305cd711e4206483eea10d13a8f`
+- metadata_sha256: `b68604b9408ecd1ae4f680e8b6bea0f1c221e273dc6389c6b8150eff4b36f0d2`
+- fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `356a8438fe026d0b1352a3ef7467cbb1d1fa3bb6c089f0c3e64b4d4c5d3741fc`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `36e2dc52efc02bd4a536346d8f3cd5d27459a1a97e6287cf5969afca708442f1`
-- Repository HEAD: `8813f864e743f7c83dc2e51e0b5add79f312e870`
+- Repository HEAD: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7`
-- Skill overlay SHA-256: `4d4a580c5e7c36b9199abb80221829f90c900c96463581d7f87c6d7ccc538bd7`
-- Judge schema SHA-256: `356a8438fe026d0b1352a3ef7467cbb1d1fa3bb6c089f0c3e64b4d4c5d3741fc`
-- Eval definition SHA-256: `33054d35eb6adb9b2259eedec7e911d8545eb305cd711e4206483eea10d13a8f`
-- Metadata SHA-256: `b68604b9408ecd1ae4f680e8b6bea0f1c221e273dc6389c6b8150eff4b36f0d2`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
+- Skill overlay SHA-256: `6c6b79d36b8b3a1bf132fd82bfece3cf6e7b256e3a9a58a0cdb78f4a09e26e69`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -31,26 +33,26 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `request_type_security` | PASS | With-skill output explicitly sets `request_type: security`. |
-| `security_scope_first` | PASS | With-skill output records `risk_surface`, `assets`, `permissions`, `data_flow`, and `remediation_expectations` in its routing scope. |
-| `security_handoff` | NOT_EXERCISED | The output selects `security-agent` and includes scope plus `required_output`, but states the agent is unavailable; an actual handoff is not exercised or independently evidenced. |
+| `request_type_security` | PASS | with_skill 明确将请求分类为 `request_type: security`。 |
+| `security_scope_first` | PASS | with_skill 输出包含 risk_surface、assets、permissions、data_flow 和 remediation_expectations，且这些范围信息出现在交接所需信息中。 |
+| `security_handoff` | NOT_EXERCISED | with_skill 明确选择 security-agent，并携带 scope 与 required_output；但 security-agent 未安装，实际下游交接无法完成。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=36e2dc52efc02bd4a536346d8f3cd5d27459a1a97e6287cf5969afca708442f1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=02a5a0aea5339b63b966b6448904636c0b9200213b610ed5d5483739fb4175a6; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly classified the request and recorded the required security scope and output contract; handoff was blocked by the unavailable Security agent.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=36e2dc52efc02bd4a536346d8f3cd5d27459a1a97e6287cf5969afca708442f1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=80920f8af43e071fc0b8c0a9b0afe8800a39cdc05883bbc029c88641952d66ca; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 识别为 security 请求，记录完整安全范围并准备交接 Security；因下游代理缺失而阻塞。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=36e2dc52efc02bd4a536346d8f3cd5d27459a1a97e6287cf5969afca708442f1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=63cc93a8319ca7ed3365902c952b8349f24a71ebe3e3950b98ac649c6d0f457a; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Performed a factual empty-repository assessment but did not classify, scope, or route the request through a Security handoff.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=36e2dc52efc02bd4a536346d8f3cd5d27459a1a97e6287cf5969afca708442f1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=9aa9c6bcb913af3e6708867f937d732e1471e1e1a8f36077ef514d6c090e1025; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 仅进行空工作区的安全检查说明和上线前建议，未进行 security 分类、范围记录或 Security 交接。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Enable or install security-agent and perform the Security handoff using the recorded scope and required output.
+- Next: 安装或启用 security-agent 后重新执行安全审查。
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-7-direct-downstream-without-handoff/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-7-direct-downstream-without-handoff/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-7-direct-downstream-without-handoff`.
-- Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
+- Identity schema: `2`
+- target_skill_sha256: `6f8f132bc1f6eba3f9eb10727126ee30960b503351486b4fb6204e20571ffb35`
+- eval_definition_sha256: `13771c6d0b126a3ca1ee1723ee43dcbca8cef0bbfd3ed1a8c42651bbd42a7c19`
+- metadata_sha256: `70b36659756bbd4d7fc0e09d0fabc7ee5ba1a168323c148fa735110fb59ec768`
+- fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `6f1f540339fe5c4c310ca6aaedc38adff3d61e4268399a40149f44e3770ac25c`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `57e82609f413c88720ec90ed64877ede694585115e55bf0256d08e8274436d4f`
-- Repository HEAD: `8813f864e743f7c83dc2e51e0b5add79f312e870`
+- Repository HEAD: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7`
-- Skill overlay SHA-256: `4d4a580c5e7c36b9199abb80221829f90c900c96463581d7f87c6d7ccc538bd7`
-- Judge schema SHA-256: `6f1f540339fe5c4c310ca6aaedc38adff3d61e4268399a40149f44e3770ac25c`
-- Eval definition SHA-256: `13771c6d0b126a3ca1ee1723ee43dcbca8cef0bbfd3ed1a8c42651bbd42a7c19`
-- Metadata SHA-256: `70b36659756bbd4d7fc0e09d0fabc7ee5ba1a168323c148fa735110fb59ec768`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
+- Skill overlay SHA-256: `6c6b79d36b8b3a1bf132fd82bfece3cf6e7b256e3a9a58a0cdb78f4a09e26e69`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -31,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `routing_decision_present` | PASS | With-skill output provides an auditable routing decision with selected_owner `idea-to-spec`, blocked entry_basis, unresolved feature_path, and an explicit execution boundary. |
-| `stay_in_pm_alignment` | PASS | With-skill output keeps the request in PM/idea-to-spec discovery, states the project is empty and blocked, and does not claim an Engineer handoff or downstream execution. |
-| `blocks_engineering_without_basis` | PASS | With-skill output requires product scope, design materials, and existing implementation/code or layout basis before proceeding, and explicitly prohibits writing code. |
+| `routing_decision_present` | PASS | With_skill output provides an auditable route to idea-to-spec, identifies it as selected_owner, and records entry_basis, feature_path, and execution_boundary in the routing block. |
+| `stay_in_pm_alignment` | PASS | With_skill output keeps the request in the PM idea-to-spec path, states that product/design scope is unresolved, and explicitly prohibits Engineer handoff or downstream execution. |
+| `blocks_engineering_without_basis` | PASS | With_skill output identifies missing product, design, and technical evidence, requires confirmation before implementation, and explicitly prohibits direct code changes; git evidence confirms no changes. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=57e82609f413c88720ec90ed64877ede694585115e55bf0256d08e8274436d4f; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=a9b3dbe3e3cdc4bde676128a1cebfa75f23e59859424ed8dba8daae1037e0dc0; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly routed the request to PM discovery, identified missing basis, and blocked implementation without modifying code.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=57e82609f413c88720ec90ed64877ede694585115e55bf0256d08e8274436d4f; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=404f49526f6d15f29fc9631300853f820c741b83122368bbb21da3491c1d59e8; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly routed the request to PM/idea-to-spec, maintained the scope-alignment boundary, blocked implementation pending required evidence, and requested user confirmation for the next clarification step.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=57e82609f413c88720ec90ed64877ede694585115e55bf0256d08e8274436d4f; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=2b400a645dfce3cae65dfe0f7a27ab340cfa6f225a071ff27642c41f0cfd065a; snapshot_sha256=df30d332dc7c1cb669534c43b47f952e575933dc964041c74ce5db24956ada0f
-- Behavior: Fresh baseline directly implemented a static settings page despite missing product/design basis.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=57e82609f413c88720ec90ed64877ede694585115e55bf0256d08e8274436d4f; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=960b7470019352e91d31da7edc6269201bb79413a26afb843045e66346f8ebbc; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Recognized the empty repository and avoided mutation, but did not provide the required PM routing decision or scope-alignment gate.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-8-direct-specialist-bypass-gate/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-8-direct-specialist-bypass-gate/comparison.md
@@ -12,45 +12,47 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-8-direct-specialist-bypass-gate`.
-- Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
+- Identity schema: `2`
+- target_skill_sha256: `6f8f132bc1f6eba3f9eb10727126ee30960b503351486b4fb6204e20571ffb35`
+- eval_definition_sha256: `cd9751a8b092fc6d7d98d6022afbbb3ec1c871d784270dc60d0af08525fe28a3`
+- metadata_sha256: `484b4662019ef115d32bbdc63a4fe4cffc2cd503d4cd9fc5262185023225f4ca`
+- fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `d4acd94dda2c52416ad87fb2e12177cf797b75ea923eded4095dac24f71a6a61`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `827e1eab57730473669ffa6562263ebb5fcf35595b38ae224272aca2a629a167`
-- Repository HEAD: `8813f864e743f7c83dc2e51e0b5add79f312e870`
+- Repository HEAD: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7`
-- Skill overlay SHA-256: `4d4a580c5e7c36b9199abb80221829f90c900c96463581d7f87c6d7ccc538bd7`
-- Judge schema SHA-256: `d4acd94dda2c52416ad87fb2e12177cf797b75ea923eded4095dac24f71a6a61`
-- Eval definition SHA-256: `cd9751a8b092fc6d7d98d6022afbbb3ec1c871d784270dc60d0af08525fe28a3`
-- Metadata SHA-256: `484b4662019ef115d32bbdc63a4fe4cffc2cd503d4cd9fc5262185023225f4ca`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
+- Skill overlay SHA-256: `6c6b79d36b8b3a1bf132fd82bfece3cf6e7b256e3a9a58a0cdb78f4a09e26e69`
 - Behavior result: **PASS**
-- Coverage result: **PARTIAL**
-Overall result: PASS (partial coverage)
+- Coverage result: **FULL**
+Overall result: PASS
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `routing_decision_present` | PASS | With_skill output provides a Routing decision naming `selected_owner: idea-to-spec`, `entry_basis: missing`, unresolved scope, and an explicit execution boundary prohibiting planning, design, coding, and testing; it keeps the request in PM discovery. |
-| `requires_product_and_engineering_basis` | NOT_EXERCISED | The candidate correctly states that PRD, technical design, and confirmed scope are missing and refuses to produce a credible implementation plan, but the later confirmation and TRD stages cannot be exercised before user input. |
-| `blocks_implementation` | PASS | With_skill output explicitly prohibits implementation and the locked workspace evidence shows no delivered files, git changes, or implementation/testing actions. |
+| `routing_decision_present` | PASS | With-skill output routes the request to idea-to-spec, identifies it as a new feature with undefined scope, states PM discovery is required, and prohibits direct coding. |
+| `requires_product_and_engineering_basis` | PASS | With-skill output requires clarification of users, goals, MVP, non-goals, acceptance criteria, PRD/DECISIONS, then TRD before implementation. |
+| `blocks_implementation` | PASS | With-skill output explicitly says coding cannot begin; git evidence shows no workspace changes, and the workflow remains in discovery pending user confirmation. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=827e1eab57730473669ffa6562263ebb5fcf35595b38ae224272aca2a629a167; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=86560df66be1336515f9ab483dfbdd8e34e8b488fc0c61c0fd518fcacdafd8ae; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Routes the vague feature request to PM discovery, records missing entry basis and unresolved scope, asks one narrowing question, and blocks implementation.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=827e1eab57730473669ffa6562263ebb5fcf35595b38ae224272aca2a629a167; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=8e3e67cf0c0fcec0a2dfdf7cc399ff092d5f343250a639e417e4b669a1de4033; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly keeps the underspecified account-center feature in PM discovery, requires scope confirmation and downstream design artifacts, and makes no implementation changes.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=827e1eab57730473669ffa6562263ebb5fcf35595b38ae224272aca2a629a167; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=a743fdc5612fce5601d3a16cd313cfe99ba8c8f806e1b63716a20a56b0ccd2ee; snapshot_sha256=5af0294f1e38bb2b97f3261212ce12cfa1be58009dec51da143c1bb94a32edf8
-- Behavior: Fresh baseline immediately created and delivered an account-center code skeleton despite missing product and technical basis.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=827e1eab57730473669ffa6562263ebb5fcf35595b38ae224272aca2a629a167; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=905503a776021f94f9acf8e8f14f8e835dd404dcb322dd4efaa0b7a1760e017d; snapshot_sha256=19a9b234411aea174a80390915e0f03352dc260cbb6052d3437bfea6eab0432b
+- Behavior: Fresh baseline incorrectly created an implementation plan and code from the vague request; raw trace also shows the claimed tests failed due to a listen EPERM error.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: After the user confirms the feature direction, complete PM scope and PRD/decision artifacts, then obtain technical design and confirmed implementation scope before planning implementation.
+- Next: None.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-9-missing-handoff-target-unavailable/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-9-missing-handoff-target-unavailable/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-9-missing-handoff-target-unavailable`.
-- Fixture SHA-256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
+- Identity schema: `2`
+- target_skill_sha256: `6f8f132bc1f6eba3f9eb10727126ee30960b503351486b4fb6204e20571ffb35`
+- eval_definition_sha256: `ea4ff3ed92cd6df9743d23b747dc29d9087560d5cfa7f5f4525b8e146b0b7e97`
+- metadata_sha256: `f52777a03f0c132438bf125e153205560b01f6abb53fcb15add6a3552b96312b`
+- fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `45aa95828b353344675a6e62421acac466500932a42ce4d64f8f43969bd5bb6d`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `5230fc275f473a55b5d59c172358aff82cf42415f36da1a920c1b4fa1e1e3cc1`
-- Repository HEAD: `8813f864e743f7c83dc2e51e0b5add79f312e870`
+- Repository HEAD: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7`
-- Skill overlay SHA-256: `4d4a580c5e7c36b9199abb80221829f90c900c96463581d7f87c6d7ccc538bd7`
-- Judge schema SHA-256: `45aa95828b353344675a6e62421acac466500932a42ce4d64f8f43969bd5bb6d`
-- Eval definition SHA-256: `ea4ff3ed92cd6df9743d23b747dc29d9087560d5cfa7f5f4525b8e146b0b7e97`
-- Metadata SHA-256: `f52777a03f0c132438bf125e153205560b01f6abb53fcb15add6a3552b96312b`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
+- Skill overlay SHA-256: `6c6b79d36b8b3a1bf132fd82bfece3cf6e7b256e3a9a58a0cdb78f4a09e26e69`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -31,26 +33,26 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `detect_missing_target` | PASS | With_skill explicitly states that designer-agent or an equivalent design capability is unavailable. |
-| `mark_handoff_blocked` | PASS | With_skill explicitly marks the handoff as blocked and requests installing or enabling designer-agent. |
-| `do_not_perform_missing_role` | PASS | With_skill performs no design production; it keeps PM routing and states the execution boundary forbids substituting for Designer. |
+| `detect_missing_target` | PASS | With_skill output states current design capability is missing and specifically identifies that `designer-agent` is absent. |
+| `mark_handoff_blocked` | PASS | With_skill output sets `entry_basis: blocked`, states the design entry gate did not pass, and requests installing/enabling `designer-agent`. |
+| `do_not_perform_missing_role` | PASS | With_skill delivery_snapshot is empty; the output explicitly limits work to handoff information and prohibits replacing Designer work. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5230fc275f473a55b5d59c172358aff82cf42415f36da1a920c1b4fa1e1e3cc1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=bc563a308901ee513841e5193a3a1da7a5dbcf3fe077e8a724f5efb209491abd; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly identifies the missing designer-agent capability, marks the handoff blocked, specifies the required enablement, and does not perform the missing design role.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5230fc275f473a55b5d59c172358aff82cf42415f36da1a920c1b4fa1e1e3cc1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=2422833170388b6044416167ed0fe5f7130ff37d1a9c4e451035d59fb2e51163; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly identified the unavailable designer-agent, marked the handoff blocked, named the required capability, and preserved the Designer role boundary without producing design deliverables.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5230fc275f473a55b5d59c172358aff82cf42415f36da1a920c1b4fa1e1e3cc1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=f7ac53dcadcd6ca378adfe6923d6522cfaff58eb368615becaa983d793b1ae51; snapshot_sha256=eb74465208301e13b4e07b6b8b1acde0642e25d2d46d7a37f59400e1ce2e40f7
-- Behavior: Fresh baseline creates a generic design handoff template but does not identify the unavailable designer-agent or explicitly mark the handoff blocked.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5230fc275f473a55b5d59c172358aff82cf42415f36da1a920c1b4fa1e1e3cc1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=ba0acd0d773bdc275a1fabe7983ed779644e23e0aaa1031a3002ecbf28138be5; snapshot_sha256=0786e2f7d7f4bcee5d626f9c3f9e035f19e39cbff8ba02f08d765abe5e93b267
+- Behavior: Created a generic design handoff template because the workspace appeared empty, but did not identify designer-agent as unavailable or mark the handoff blocked.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Install or enable designer-agent before continuing the formal design handoff.
+- Next: None.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/roadmap-gen/workspace/eval-1-timeline/comparison.md
+++ b/agents/product_manager/test/roadmap-gen/workspace/eval-1-timeline/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `1114e9e115cfb91a2f09d56b7563aa8c7433df316dc5fe8c86e2dd3614f9d165` from `agents/product_manager/test/roadmap-gen/workspace/eval-1-timeline`.
-- Fixture SHA-256: `1114e9e115cfb91a2f09d56b7563aa8c7433df316dc5fe8c86e2dd3614f9d165`
-- Prompt SHA-256: `ccc64c80301839b5d15a311cba6ab8a69fb955dea99cdfd947a735556c9d9e63`
+- Identity schema: `2`
+- target_skill_sha256: `74b972ac8dbd7706448e20025f6995b87c544e99309b65961f70d0e86a7bd191`
+- eval_definition_sha256: `d6df04c011109b2d27a14aaefa7802d9d9c0af801e4acce9ed37afdc4c26a731`
+- metadata_sha256: `c374d15583cb501346d3285d30669c9dbaf58b19f95661d07d8aeac8332d8ba1`
+- fixture_sha256: `1114e9e115cfb91a2f09d56b7563aa8c7433df316dc5fe8c86e2dd3614f9d165`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `c9231138562bec2ed562cf0d8c1ec94b96debb390ee547b6815473c326c64b09`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `74b972ac8dbd7706448e20025f6995b87c544e99309b65961f70d0e86a7bd191`
-- Skill overlay SHA-256: `bddee41393bca0a60880eaa8d81044ec84f2c1d751e6af66c6178450b19850d3`
-- Judge schema SHA-256: `c9231138562bec2ed562cf0d8c1ec94b96debb390ee547b6815473c326c64b09`
-- Eval definition SHA-256: `d6df04c011109b2d27a14aaefa7802d9d9c0af801e4acce9ed37afdc4c26a731`
-- Metadata SHA-256: `c374d15583cb501346d3285d30669c9dbaf58b19f95661d07d8aeac8332d8ba1`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/product_manager/test/roadmap-gen/workspace/eval-2-phase-classification/comparison.md
+++ b/agents/product_manager/test/roadmap-gen/workspace/eval-2-phase-classification/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `a264a565b80cdab16388e48390a97336c870c675ea266e111b6f98276cf41192` from `agents/product_manager/test/roadmap-gen/workspace/eval-2-phase-classification`.
-- Fixture SHA-256: `a264a565b80cdab16388e48390a97336c870c675ea266e111b6f98276cf41192`
-- Prompt SHA-256: `129b1e07f1b508c4a87a365c1e9c5e8cf169856473baee027f1d68878bcd93f2`
+- Identity schema: `2`
+- target_skill_sha256: `74b972ac8dbd7706448e20025f6995b87c544e99309b65961f70d0e86a7bd191`
+- eval_definition_sha256: `9bebcff97f69229af9d2fc6b841c4826a4650eeb5ee2c6254e8400fa19d31afa`
+- metadata_sha256: `ae0af75c7768cc5a422a172a7778c85838314f028847e67a9b64a099fa24dc99`
+- fixture_sha256: `a264a565b80cdab16388e48390a97336c870c675ea266e111b6f98276cf41192`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `828832f79453e0784207e366cba87f24e08c6f3017321b257129f96f3076509d`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `74b972ac8dbd7706448e20025f6995b87c544e99309b65961f70d0e86a7bd191`
-- Skill overlay SHA-256: `bddee41393bca0a60880eaa8d81044ec84f2c1d751e6af66c6178450b19850d3`
-- Judge schema SHA-256: `828832f79453e0784207e366cba87f24e08c6f3017321b257129f96f3076509d`
-- Eval definition SHA-256: `9bebcff97f69229af9d2fc6b841c4826a4650eeb5ee2c6254e8400fa19d31afa`
-- Metadata SHA-256: `ae0af75c7768cc5a422a172a7778c85838314f028847e67a9b64a099fa24dc99`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/product_manager/test/roadmap-gen/workspace/eval-3-no-dates/comparison.md
+++ b/agents/product_manager/test/roadmap-gen/workspace/eval-3-no-dates/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `8ed1c517c0f0999b8177c14728f4f1837cf8c41c83a93a8766a4e6fd07e1d14f` from `agents/product_manager/test/roadmap-gen/workspace/eval-3-no-dates`.
-- Fixture SHA-256: `8ed1c517c0f0999b8177c14728f4f1837cf8c41c83a93a8766a4e6fd07e1d14f`
-- Prompt SHA-256: `4165caadd548c6b8d1d9df4c0aa9c054ed9c0f0a71e88ab4aefd0c18bb92400a`
+- Identity schema: `2`
+- target_skill_sha256: `74b972ac8dbd7706448e20025f6995b87c544e99309b65961f70d0e86a7bd191`
+- eval_definition_sha256: `fbd695e0a879758e25936e89babfefc9a6cba4a52e1572a61e1da7fea0b1364b`
+- metadata_sha256: `1dfb7bfbfed7613af8764f4385cade9d5822d1652d85a0cbb75853e0bcae7474`
+- fixture_sha256: `8ed1c517c0f0999b8177c14728f4f1837cf8c41c83a93a8766a4e6fd07e1d14f`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `f6a7dabb82746a0dc0f0c5965d8e78c276cdccf3d2da25bfbb1a77e91ffeca3f`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `74b972ac8dbd7706448e20025f6995b87c544e99309b65961f70d0e86a7bd191`
-- Skill overlay SHA-256: `bddee41393bca0a60880eaa8d81044ec84f2c1d751e6af66c6178450b19850d3`
-- Judge schema SHA-256: `f6a7dabb82746a0dc0f0c5965d8e78c276cdccf3d2da25bfbb1a77e91ffeca3f`
-- Eval definition SHA-256: `fbd695e0a879758e25936e89babfefc9a6cba4a52e1572a61e1da7fea0b1364b`
-- Metadata SHA-256: `1dfb7bfbfed7613af8764f4385cade9d5822d1652d85a0cbb75853e0bcae7474`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/qa/test/bug-analyzer/evals/workspace/eval-1-analyze-test-failure/comparison.md
+++ b/agents/qa/test/bug-analyzer/evals/workspace/eval-1-analyze-test-failure/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `e52dc183368f81bf8278941735b98c8f9da85437b60c6dd9736b019d7bf6c9ca` from `agents/qa/test/bug-analyzer/evals/workspace/eval-1-analyze-test-failure`.
-- Fixture SHA-256: `e52dc183368f81bf8278941735b98c8f9da85437b60c6dd9736b019d7bf6c9ca`
-- Prompt SHA-256: `382c8cd397f8f6526e011c90c1ba36354751b701fabc41ae3a4966bbcf764eb3`
+- Identity schema: `2`
+- target_skill_sha256: `0d6c4b717279e8edddeea8100d93e004d25b98b502e0ca114092a3f0c007a52f`
+- eval_definition_sha256: `35f2f99594df8382cdc242359c30a451a1bdaa89727c7071b5ec00d92699fbf8`
+- metadata_sha256: `e96ab79b6862e4b82cb2cc5b58266d1ce1ed35caa4271d16c371f2d1b6443e6f`
+- fixture_sha256: `e52dc183368f81bf8278941735b98c8f9da85437b60c6dd9736b019d7bf6c9ca`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `84f20ca3637061984a451201365104813c56f53ca0b37a9fb14c70d8de0d29b1`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `0d6c4b717279e8edddeea8100d93e004d25b98b502e0ca114092a3f0c007a52f`
-- Skill overlay SHA-256: `5d8913cc96e6041afa6b90281f60caea168e5627ffe4b68ca7f549b9b2e89e9b`
-- Judge schema SHA-256: `84f20ca3637061984a451201365104813c56f53ca0b37a9fb14c70d8de0d29b1`
-- Eval definition SHA-256: `35f2f99594df8382cdc242359c30a451a1bdaa89727c7071b5ec00d92699fbf8`
-- Metadata SHA-256: `e96ab79b6862e4b82cb2cc5b58266d1ce1ed35caa4271d16c371f2d1b6443e6f`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)

--- a/agents/qa/test/bug-analyzer/evals/workspace/eval-2-thin-evidence-suspected-bug/comparison.md
+++ b/agents/qa/test/bug-analyzer/evals/workspace/eval-2-thin-evidence-suspected-bug/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `bd09f8717eb7765700b65e2c38ca5c4dcc82c7aff0bee46b30335bbb10dcf266` from `agents/qa/test/bug-analyzer/evals/workspace/eval-2-thin-evidence-suspected-bug`.
-- Fixture SHA-256: `bd09f8717eb7765700b65e2c38ca5c4dcc82c7aff0bee46b30335bbb10dcf266`
-- Prompt SHA-256: `78696c84c936a27db0d476b9673a2b9f30099e53a98c303b4036832baf353eb7`
+- Identity schema: `2`
+- target_skill_sha256: `0d6c4b717279e8edddeea8100d93e004d25b98b502e0ca114092a3f0c007a52f`
+- eval_definition_sha256: `ee85b4030fea85acc8c079589b9268be5087962ef495cf3e3194580abf721432`
+- metadata_sha256: `8fd7c615ab5c3a7f7edc961336d40be79c05d55d0c11dd967998bbb2abd4e9d7`
+- fixture_sha256: `bd09f8717eb7765700b65e2c38ca5c4dcc82c7aff0bee46b30335bbb10dcf266`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `086365b086fd130d9ef17a34e69f11d6786884f09ea0525a080792033b47d5cb`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `0d6c4b717279e8edddeea8100d93e004d25b98b502e0ca114092a3f0c007a52f`
-- Skill overlay SHA-256: `5d8913cc96e6041afa6b90281f60caea168e5627ffe4b68ca7f549b9b2e89e9b`
-- Judge schema SHA-256: `086365b086fd130d9ef17a34e69f11d6786884f09ea0525a080792033b47d5cb`
-- Eval definition SHA-256: `ee85b4030fea85acc8c079589b9268be5087962ef495cf3e3194580abf721432`
-- Metadata SHA-256: `8fd7c615ab5c3a7f7edc961336d40be79c05d55d0c11dd967998bbb2abd4e9d7`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/qa/test/bug-analyzer/evals/workspace/eval-3-mapped-doc-bug-analysis/comparison.md
+++ b/agents/qa/test/bug-analyzer/evals/workspace/eval-3-mapped-doc-bug-analysis/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `7d279cf3b0905050d0b65ec93cd3a19c763df01dd02f4eaadd2d86c46d0a38cf` from `agents/qa/test/bug-analyzer/evals/workspace/eval-3-mapped-doc-bug-analysis`.
-- Fixture SHA-256: `7d279cf3b0905050d0b65ec93cd3a19c763df01dd02f4eaadd2d86c46d0a38cf`
-- Prompt SHA-256: `42efa66a3d947aa438db6985ea7344decf5267623091f1d47b29acd454584b1d`
+- Identity schema: `2`
+- target_skill_sha256: `0d6c4b717279e8edddeea8100d93e004d25b98b502e0ca114092a3f0c007a52f`
+- eval_definition_sha256: `5055f21aa292e91a955bc3aa635c808239336415cf083aba532e9d19a7985220`
+- metadata_sha256: `6e065f47b93dd01060b700c2c7836503fb5797f7c0c1bb375677811fe6fa6d5f`
+- fixture_sha256: `7d279cf3b0905050d0b65ec93cd3a19c763df01dd02f4eaadd2d86c46d0a38cf`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `0d6c4b717279e8edddeea8100d93e004d25b98b502e0ca114092a3f0c007a52f`
-- Skill overlay SHA-256: `5d8913cc96e6041afa6b90281f60caea168e5627ffe4b68ca7f549b9b2e89e9b`
-- Judge schema SHA-256: `6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda`
-- Eval definition SHA-256: `5055f21aa292e91a955bc3aa635c808239336415cf083aba532e9d19a7985220`
-- Metadata SHA-256: `6e065f47b93dd01060b700c2c7836503fb5797f7c0c1bb375677811fe6fa6d5f`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/qa/test/exploratory-tester/evals/workspace/eval-1-explore-web-app/comparison.md
+++ b/agents/qa/test/exploratory-tester/evals/workspace/eval-1-explore-web-app/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `ee088defa4a7bb2cbc3d091f8817eac9fb8cc7c128c92be34adf72ee4a79f3b7` from `agents/qa/test/exploratory-tester/evals/workspace/eval-1-explore-web-app`.
-- Fixture SHA-256: `ee088defa4a7bb2cbc3d091f8817eac9fb8cc7c128c92be34adf72ee4a79f3b7`
-- Prompt SHA-256: `b0dd5a79c80e2e161088bef46107d054902f47f9ef2205167f1eaadd760b99cd`
+- Identity schema: `2`
+- target_skill_sha256: `4e2073febaef7202820d7977feb83c73b7673e1200e4724a3f37b54a20923059`
+- eval_definition_sha256: `32b9d61e575fbee81406ffc68edbaec9418feec621754c8fca12fc2f2edd2c08`
+- metadata_sha256: `228751d86855b3dcdb583bdc4a44c4a493c28334ed74368c030ddad805b1f314`
+- fixture_sha256: `ee088defa4a7bb2cbc3d091f8817eac9fb8cc7c128c92be34adf72ee4a79f3b7`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `3783048bfb479d6e8907a0e84c4199cb646178dd63c9a58d60ddd654db2122dc`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `4e2073febaef7202820d7977feb83c73b7673e1200e4724a3f37b54a20923059`
-- Skill overlay SHA-256: `d5a8b4f617bd4daeb6e78fdb531d6c6e6ec5fb1b029628fdf35a46d483c79624`
-- Judge schema SHA-256: `3783048bfb479d6e8907a0e84c4199cb646178dd63c9a58d60ddd654db2122dc`
-- Eval definition SHA-256: `32b9d61e575fbee81406ffc68edbaec9418feec621754c8fca12fc2f2edd2c08`
-- Metadata SHA-256: `228751d86855b3dcdb583bdc4a44c4a493c28334ed74368c030ddad805b1f314`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/qa/test/exploratory-tester/evals/workspace/eval-2-explore-with-custom-duration/comparison.md
+++ b/agents/qa/test/exploratory-tester/evals/workspace/eval-2-explore-with-custom-duration/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `58e996bab34649b23e7bf5cc00be4fa65ff65a8e7b288cba77fc10a44d715cf3` from `agents/qa/test/exploratory-tester/evals/workspace/eval-2-explore-with-custom-duration`.
-- Fixture SHA-256: `58e996bab34649b23e7bf5cc00be4fa65ff65a8e7b288cba77fc10a44d715cf3`
-- Prompt SHA-256: `95b19585ae663cfe50fef5d8a922d75ec357803535a13bbb323cdf9b1845fa29`
+- Identity schema: `2`
+- target_skill_sha256: `4e2073febaef7202820d7977feb83c73b7673e1200e4724a3f37b54a20923059`
+- eval_definition_sha256: `234873760fb9d0649d16f54118fbf0383fa2955b9451730f9429892d78a6d7e0`
+- metadata_sha256: `4befffc2e8037477b9995f3ded3869d8476cd9a66637621d7f8e8d3fc8c6fed3`
+- fixture_sha256: `58e996bab34649b23e7bf5cc00be4fa65ff65a8e7b288cba77fc10a44d715cf3`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `795b13efa8aba1d005ca8e2bf3be74790d6a011a9b79e7e9c3ef0bb4863b7e5d`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `4e2073febaef7202820d7977feb83c73b7673e1200e4724a3f37b54a20923059`
-- Skill overlay SHA-256: `d5a8b4f617bd4daeb6e78fdb531d6c6e6ec5fb1b029628fdf35a46d483c79624`
-- Judge schema SHA-256: `795b13efa8aba1d005ca8e2bf3be74790d6a011a9b79e7e9c3ef0bb4863b7e5d`
-- Eval definition SHA-256: `234873760fb9d0649d16f54118fbf0383fa2955b9451730f9429892d78a6d7e0`
-- Metadata SHA-256: `4befffc2e8037477b9995f3ded3869d8476cd9a66637621d7f8e8d3fc8c6fed3`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)

--- a/agents/qa/test/exploratory-tester/evals/workspace/eval-3-mapped-doc-exploration/comparison.md
+++ b/agents/qa/test/exploratory-tester/evals/workspace/eval-3-mapped-doc-exploration/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `5b1017edbbf8a6df86fadbd205bf7416456f615f000264cc379e5e296b079421` from `agents/qa/test/exploratory-tester/evals/workspace/eval-3-mapped-doc-exploration`.
-- Fixture SHA-256: `5b1017edbbf8a6df86fadbd205bf7416456f615f000264cc379e5e296b079421`
-- Prompt SHA-256: `d280f60d4c43a5403f08df3395711e665a24f6defcf1e883ede2ed9c11e2a47f`
+- Identity schema: `2`
+- target_skill_sha256: `4e2073febaef7202820d7977feb83c73b7673e1200e4724a3f37b54a20923059`
+- eval_definition_sha256: `c4de00c65a5c492d58d182077c448786bbd54172790d4519f15e143439929064`
+- metadata_sha256: `66549bc6a4cd28361d4fb0c300ac0600f32823bbce01dba9736725e4b2d843dd`
+- fixture_sha256: `5b1017edbbf8a6df86fadbd205bf7416456f615f000264cc379e5e296b079421`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `4e2073febaef7202820d7977feb83c73b7673e1200e4724a3f37b54a20923059`
-- Skill overlay SHA-256: `d5a8b4f617bd4daeb6e78fdb531d6c6e6ec5fb1b029628fdf35a46d483c79624`
-- Judge schema SHA-256: `6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda`
-- Eval definition SHA-256: `c4de00c65a5c492d58d182077c448786bbd54172790d4519f15e143439929064`
-- Metadata SHA-256: `66549bc6a4cd28361d4fb0c300ac0600f32823bbce01dba9736725e4b2d843dd`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/qa/test/qa-agent/evals/workspace/eval-1-route-mixed-qa-request/comparison.md
+++ b/agents/qa/test/qa-agent/evals/workspace/eval-1-route-mixed-qa-request/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `c9268123afd7a11d5bd4ac6d14865261ea2db8883ff6a745cea96f843ec5dbd5` from `agents/qa/test/qa-agent/evals/workspace/eval-1-route-mixed-qa-request`.
-- Fixture SHA-256: `c9268123afd7a11d5bd4ac6d14865261ea2db8883ff6a745cea96f843ec5dbd5`
-- Prompt SHA-256: `d32b34f557a9af42827fae115c24f25ec47fe1e0fcda62e092dc3afa3789c767`
+- Identity schema: `2`
+- target_skill_sha256: `23a4457fc9bf10be6976d98ea55607b47c6c623db1e20d5c73160d9f386c2a36`
+- eval_definition_sha256: `2ad0a90eac7fca1f06d238ff5d3d06535381ddd810d8a9e8e9e423ce29483f2c`
+- metadata_sha256: `718fcc57ee1abd91d0d7551c46ebe8546481fa4f027452b86db232f30d15ab47`
+- fixture_sha256: `c9268123afd7a11d5bd4ac6d14865261ea2db8883ff6a745cea96f843ec5dbd5`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `f4aaec46995456a39da2b489696e387a78408415038edddd6412ca13bedbc20a`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `23a4457fc9bf10be6976d98ea55607b47c6c623db1e20d5c73160d9f386c2a36`
-- Skill overlay SHA-256: `aba4853023a6c2866bcd67ad1139982ac56eeacfec787957221635a36cab60ad`
-- Judge schema SHA-256: `f4aaec46995456a39da2b489696e387a78408415038edddd6412ca13bedbc20a`
-- Eval definition SHA-256: `2ad0a90eac7fca1f06d238ff5d3d06535381ddd810d8a9e8e9e423ce29483f2c`
-- Metadata SHA-256: `718fcc57ee1abd91d0d7551c46ebe8546481fa4f027452b86db232f30d15ab47`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/qa/test/qa-agent/evals/workspace/eval-2-empty-qa-directory-expands-cases/comparison.md
+++ b/agents/qa/test/qa-agent/evals/workspace/eval-2-empty-qa-directory-expands-cases/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `870f233236f82c3cf594816a5771878c8e388e11eeb3846cf269bf436f0fb100` from `agents/qa/test/qa-agent/evals/workspace/eval-2-empty-qa-directory-expands-cases`.
-- Fixture SHA-256: `870f233236f82c3cf594816a5771878c8e388e11eeb3846cf269bf436f0fb100`
-- Prompt SHA-256: `068467ca9228748a58aa1065f9a150e3f5b012d5ddc3cefa3e5b130984c9cc4a`
+- Identity schema: `2`
+- target_skill_sha256: `23a4457fc9bf10be6976d98ea55607b47c6c623db1e20d5c73160d9f386c2a36`
+- eval_definition_sha256: `1252f49c3e393535dba5cc481c5c3100fe9a709aa3de1773196b4edb5900ada3`
+- metadata_sha256: `bf12045623474ece32b13073fc8cb963c9b4f673ab0fe9f0cf0dc0ad649d4ef6`
+- fixture_sha256: `870f233236f82c3cf594816a5771878c8e388e11eeb3846cf269bf436f0fb100`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `d61853152f0f59bd847f0aa3394c1f282e4bb9275d56c9fb66462de58118346d`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `23a4457fc9bf10be6976d98ea55607b47c6c623db1e20d5c73160d9f386c2a36`
-- Skill overlay SHA-256: `b870079a44b17e5ac069ca43e0effc6b68174cce854ca15c2eecd29cce74cae0`
-- Judge schema SHA-256: `d61853152f0f59bd847f0aa3394c1f282e4bb9275d56c9fb66462de58118346d`
-- Eval definition SHA-256: `1252f49c3e393535dba5cc481c5c3100fe9a709aa3de1773196b4edb5900ada3`
-- Metadata SHA-256: `bf12045623474ece32b13073fc8cb963c9b4f673ab0fe9f0cf0dc0ad649d4ef6`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/qa/test/qa-agent/evals/workspace/eval-3-feature-path-missing-plan-blocked/comparison.md
+++ b/agents/qa/test/qa-agent/evals/workspace/eval-3-feature-path-missing-plan-blocked/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `39ecc1af9722a7aadd83ae04a9403edca1017d45bde6a98a57d2d87ccb7702dc` from `agents/qa/test/qa-agent/evals/workspace/eval-3-feature-path-missing-plan-blocked`.
-- Fixture SHA-256: `39ecc1af9722a7aadd83ae04a9403edca1017d45bde6a98a57d2d87ccb7702dc`
-- Prompt SHA-256: `094ec5b09f42125c7ea3b42f7f8365ddf4bd40bef6652060cfeb7ff368908608`
+- Identity schema: `2`
+- target_skill_sha256: `23a4457fc9bf10be6976d98ea55607b47c6c623db1e20d5c73160d9f386c2a36`
+- eval_definition_sha256: `ffa490cd1f58367914b109adc50e94706c92cbf66e7c95942ae329d3f9a191c7`
+- metadata_sha256: `aa798ca118679678c2fef882d4726badd357a387202dcb387aceaa4b86696bd0`
+- fixture_sha256: `39ecc1af9722a7aadd83ae04a9403edca1017d45bde6a98a57d2d87ccb7702dc`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `7c827cee8609863280607c031efdc95a92d32b851664d68126eccd9d66c1f27a`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `23a4457fc9bf10be6976d98ea55607b47c6c623db1e20d5c73160d9f386c2a36`
-- Skill overlay SHA-256: `5754523ab6dc67a27703c13629b577962774677f13b55627e2b1a056ffc0bc71`
-- Judge schema SHA-256: `7c827cee8609863280607c031efdc95a92d32b851664d68126eccd9d66c1f27a`
-- Eval definition SHA-256: `ffa490cd1f58367914b109adc50e94706c92cbf66e7c95942ae329d3f9a191c7`
-- Metadata SHA-256: `aa798ca118679678c2fef882d4726badd357a387202dcb387aceaa4b86696bd0`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/qa/test/regression-suite/evals/workspace/eval-1-verify-bug-fix/comparison.md
+++ b/agents/qa/test/regression-suite/evals/workspace/eval-1-verify-bug-fix/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `de9aee791f056463d193f05e53c9f483fe312d6ee3aeb7bb4d1f7b0eb008f308` from `agents/qa/test/regression-suite/evals/workspace/eval-1-verify-bug-fix`.
-- Fixture SHA-256: `de9aee791f056463d193f05e53c9f483fe312d6ee3aeb7bb4d1f7b0eb008f308`
-- Prompt SHA-256: `c6a22bd6a4c946877c350cf1e3485fb0daa745bafdccb74f798f1fdae43d71c0`
+- Identity schema: `2`
+- target_skill_sha256: `4e9403c0e6549024a79156a156c1294488d1a418598e88e3e9565298bc6bae6a`
+- eval_definition_sha256: `8ca6ea4c46c7a5a2c854d9ff5def7ea0ec612ddbf9888a829e50de270f1b84c4`
+- metadata_sha256: `732278c998a10f6e6333dc13e2fc4edfbaed96da1abb806d2dc29682a3a79f75`
+- fixture_sha256: `de9aee791f056463d193f05e53c9f483fe312d6ee3aeb7bb4d1f7b0eb008f308`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `2c18050b9a27d5dccf92b0604097b9078533d47105266364099eafbf3833aad8`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `4e9403c0e6549024a79156a156c1294488d1a418598e88e3e9565298bc6bae6a`
-- Skill overlay SHA-256: `1cec710f9ba01d04ab324671796616b09b6a6eae6465b286be839bfcc2fe92d7`
-- Judge schema SHA-256: `2c18050b9a27d5dccf92b0604097b9078533d47105266364099eafbf3833aad8`
-- Eval definition SHA-256: `8ca6ea4c46c7a5a2c854d9ff5def7ea0ec612ddbf9888a829e50de270f1b84c4`
-- Metadata SHA-256: `732278c998a10f6e6333dc13e2fc4edfbaed96da1abb806d2dc29682a3a79f75`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)

--- a/agents/qa/test/regression-suite/evals/workspace/eval-2-blocked-without-original-bug-context/comparison.md
+++ b/agents/qa/test/regression-suite/evals/workspace/eval-2-blocked-without-original-bug-context/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `811b93327e61a4a1610d2801bebd47a27e231fa7f4e1ec17fdfda144fdd986f5` from `agents/qa/test/regression-suite/evals/workspace/eval-2-blocked-without-original-bug-context`.
-- Fixture SHA-256: `811b93327e61a4a1610d2801bebd47a27e231fa7f4e1ec17fdfda144fdd986f5`
-- Prompt SHA-256: `261f550b35c9a4d84c8303c0abe4a7adbe04fbf62131aadd694155952d4db10d`
+- Identity schema: `2`
+- target_skill_sha256: `4e9403c0e6549024a79156a156c1294488d1a418598e88e3e9565298bc6bae6a`
+- eval_definition_sha256: `bde407cd9167fc95a8a68436fa7745a88790341ccffae265b6e1321da5b3938f`
+- metadata_sha256: `e69dc8ec803ebfc43eb2e4147f1b861f4b02e94afa256d86c039101ea44fff1b`
+- fixture_sha256: `811b93327e61a4a1610d2801bebd47a27e231fa7f4e1ec17fdfda144fdd986f5`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `2f3ed1bac6bd41e43ecbd585f5beb95db8464a7cf767e9c9a3ef20fae4f56429`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `4e9403c0e6549024a79156a156c1294488d1a418598e88e3e9565298bc6bae6a`
-- Skill overlay SHA-256: `1cec710f9ba01d04ab324671796616b09b6a6eae6465b286be839bfcc2fe92d7`
-- Judge schema SHA-256: `2f3ed1bac6bd41e43ecbd585f5beb95db8464a7cf767e9c9a3ef20fae4f56429`
-- Eval definition SHA-256: `bde407cd9167fc95a8a68436fa7745a88790341ccffae265b6e1321da5b3938f`
-- Metadata SHA-256: `e69dc8ec803ebfc43eb2e4147f1b861f4b02e94afa256d86c039101ea44fff1b`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/qa/test/regression-suite/evals/workspace/eval-3-mapped-doc-regression/comparison.md
+++ b/agents/qa/test/regression-suite/evals/workspace/eval-3-mapped-doc-regression/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `b09fa431bfb2ae442891b6d53441773dfe7d31b84ffb9e7738912c1ba9a50a94` from `agents/qa/test/regression-suite/evals/workspace/eval-3-mapped-doc-regression`.
-- Fixture SHA-256: `b09fa431bfb2ae442891b6d53441773dfe7d31b84ffb9e7738912c1ba9a50a94`
-- Prompt SHA-256: `ffcf3a2d7addddf903f6f7ab8491b7d6388aab8f8d43086a53d98c797d44a47b`
+- Identity schema: `2`
+- target_skill_sha256: `4e9403c0e6549024a79156a156c1294488d1a418598e88e3e9565298bc6bae6a`
+- eval_definition_sha256: `e133160262ed184852d28136da76d373bddc3830b084351e43f62baba3d14a43`
+- metadata_sha256: `8f1420b83ef9d543d57a760ebba7fc169b9c3d2172e7b3b1e191d47cfe76b856`
+- fixture_sha256: `b09fa431bfb2ae442891b6d53441773dfe7d31b84ffb9e7738912c1ba9a50a94`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `4e9403c0e6549024a79156a156c1294488d1a418598e88e3e9565298bc6bae6a`
-- Skill overlay SHA-256: `1cec710f9ba01d04ab324671796616b09b6a6eae6465b286be839bfcc2fe92d7`
-- Judge schema SHA-256: `6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda`
-- Eval definition SHA-256: `e133160262ed184852d28136da76d373bddc3830b084351e43f62baba3d14a43`
-- Metadata SHA-256: `8f1420b83ef9d543d57a760ebba7fc169b9c3d2172e7b3b1e191d47cfe76b856`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/qa/test/spec-based-tester/evals/workspace/eval-1-test-from-spec/comparison.md
+++ b/agents/qa/test/spec-based-tester/evals/workspace/eval-1-test-from-spec/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `a434f6abe187edb75db35d4f3fb8bb622d73bfabcbaa68935c4416b36759d838` from `agents/qa/test/spec-based-tester/evals/workspace/eval-1-test-from-spec`.
-- Fixture SHA-256: `a434f6abe187edb75db35d4f3fb8bb622d73bfabcbaa68935c4416b36759d838`
-- Prompt SHA-256: `9354357763da0add30a1325fbbb8939ec16a97d466c020a03be8548593c2f944`
+- Identity schema: `2`
+- target_skill_sha256: `8ceb46669357c2ad2e3984067ae0ce5c97b019da23d3a0f850d2bedd7e38ab17`
+- eval_definition_sha256: `1c095f56ebf8188b170d450f4a4c64b7797467faefd997d04a5961dc178ee24e`
+- metadata_sha256: `beabc33b6b3cb3b4fcbdd2cd76be881ee37dbed2c10afbbb6515f52def856618`
+- fixture_sha256: `a434f6abe187edb75db35d4f3fb8bb622d73bfabcbaa68935c4416b36759d838`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `af6defb3674eb2b870c7db7cceb8e07b1bc81b7056b91617749018c2cf4bddc5`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `8ceb46669357c2ad2e3984067ae0ce5c97b019da23d3a0f850d2bedd7e38ab17`
-- Skill overlay SHA-256: `5754523ab6dc67a27703c13629b577962774677f13b55627e2b1a056ffc0bc71`
-- Judge schema SHA-256: `af6defb3674eb2b870c7db7cceb8e07b1bc81b7056b91617749018c2cf4bddc5`
-- Eval definition SHA-256: `1c095f56ebf8188b170d450f4a4c64b7797467faefd997d04a5961dc178ee24e`
-- Metadata SHA-256: `beabc33b6b3cb3b4fcbdd2cd76be881ee37dbed2c10afbbb6515f52def856618`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/qa/test/spec-based-tester/evals/workspace/eval-2-boundary-test-generation/comparison.md
+++ b/agents/qa/test/spec-based-tester/evals/workspace/eval-2-boundary-test-generation/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `b4127bff8b3b1c32e35f1a58623703ca5f4eb13030dd5763812f9d858500fda1` from `agents/qa/test/spec-based-tester/evals/workspace/eval-2-boundary-test-generation`.
-- Fixture SHA-256: `b4127bff8b3b1c32e35f1a58623703ca5f4eb13030dd5763812f9d858500fda1`
-- Prompt SHA-256: `fca68fb7467bf000e3c38b2b867a8aeab7cf98cabe927e8e96f334144b3ecb51`
+- Identity schema: `2`
+- target_skill_sha256: `8ceb46669357c2ad2e3984067ae0ce5c97b019da23d3a0f850d2bedd7e38ab17`
+- eval_definition_sha256: `7be9a5847eaa9053c9f4277b2d57d5f5622208652decda6e30f3718fbfec04c5`
+- metadata_sha256: `9bd3793631be46705766421244d6899c275c646d5598b1a7e8c43c8bec82ad4f`
+- fixture_sha256: `b4127bff8b3b1c32e35f1a58623703ca5f4eb13030dd5763812f9d858500fda1`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `6d4a307e5ec256ec68d2524f856808da877ec9503f513dcb2032388906c98b67`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `8ceb46669357c2ad2e3984067ae0ce5c97b019da23d3a0f850d2bedd7e38ab17`
-- Skill overlay SHA-256: `5754523ab6dc67a27703c13629b577962774677f13b55627e2b1a056ffc0bc71`
-- Judge schema SHA-256: `6d4a307e5ec256ec68d2524f856808da877ec9503f513dcb2032388906c98b67`
-- Eval definition SHA-256: `7be9a5847eaa9053c9f4277b2d57d5f5622208652decda6e30f3718fbfec04c5`
-- Metadata SHA-256: `9bd3793631be46705766421244d6899c275c646d5598b1a7e8c43c8bec82ad4f`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)

--- a/agents/qa/test/spec-based-tester/evals/workspace/eval-3-mapped-doc-acceptance/comparison.md
+++ b/agents/qa/test/spec-based-tester/evals/workspace/eval-3-mapped-doc-acceptance/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `bfb7b9881699180197883abe46418a65cf0676dceb7443a1b2ac7db5c3b8ae9b` from `agents/qa/test/spec-based-tester/evals/workspace/eval-3-mapped-doc-acceptance`.
-- Fixture SHA-256: `bfb7b9881699180197883abe46418a65cf0676dceb7443a1b2ac7db5c3b8ae9b`
-- Prompt SHA-256: `b0800640829a83735e541e027ba4771a2f52dd5cf39982ebc89e3721cf0f1d96`
+- Identity schema: `2`
+- target_skill_sha256: `8ceb46669357c2ad2e3984067ae0ce5c97b019da23d3a0f850d2bedd7e38ab17`
+- eval_definition_sha256: `69ea284c249fd48ea67518dcbbbb4aff0b51c724f5aa24139bc9524759db6c7c`
+- metadata_sha256: `dbcf12ca577304c6eedeb3847e29d69b72d051700655cd6bd5000bc1d6f7a9d9`
+- fixture_sha256: `bfb7b9881699180197883abe46418a65cf0676dceb7443a1b2ac7db5c3b8ae9b`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `8ceb46669357c2ad2e3984067ae0ce5c97b019da23d3a0f850d2bedd7e38ab17`
-- Skill overlay SHA-256: `5754523ab6dc67a27703c13629b577962774677f13b55627e2b1a056ffc0bc71`
-- Judge schema SHA-256: `6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda`
-- Eval definition SHA-256: `69ea284c249fd48ea67518dcbbbb4aff0b51c724f5aa24139bc9524759db6c7c`
-- Metadata SHA-256: `dbcf12ca577304c6eedeb3847e29d69b72d051700655cd6bd5000bc1d6f7a9d9`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/security/test/appsec-checklist/evals/workspace/eval-001-sql-injection/comparison.md
+++ b/agents/security/test/appsec-checklist/evals/workspace/eval-001-sql-injection/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `ede96965e7d44efbe6d4a7e610af20046168e4331047764663820caf76860ea6` from `agents/security/test/appsec-checklist/evals/workspace/eval-001-sql-injection`.
-- Fixture SHA-256: `ede96965e7d44efbe6d4a7e610af20046168e4331047764663820caf76860ea6`
-- Prompt SHA-256: `bb6bd5dae7cb984c9a3912af15f420906d99ddbd232c9c6777c774fceb165a28`
+- Identity schema: `2`
+- target_skill_sha256: `812b371fc30792cb2b0cf8d96079b3244c95b93efab7638e085d4e955d6ea42c`
+- eval_definition_sha256: `8fc30622b3de679ebf38da0b0fc7b8032d774fb8a425496383ba9ed0da1fdbb0`
+- metadata_sha256: `c7304df99ba027e455b94ef86d8c2964c99813b4b7afb5bd532e0bf494b29d15`
+- fixture_sha256: `ede96965e7d44efbe6d4a7e610af20046168e4331047764663820caf76860ea6`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `01ca86a4951823e3b6c703072ce5be09764c747ae9938b66975b80e4d41e39dd`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `812b371fc30792cb2b0cf8d96079b3244c95b93efab7638e085d4e955d6ea42c`
-- Skill overlay SHA-256: `11d9f677e9ab3fadaeeab596575848debc7e1fb3f4f8054e9e5572a63ccf426b`
-- Judge schema SHA-256: `01ca86a4951823e3b6c703072ce5be09764c747ae9938b66975b80e4d41e39dd`
-- Eval definition SHA-256: `8fc30622b3de679ebf38da0b0fc7b8032d774fb8a425496383ba9ed0da1fdbb0`
-- Metadata SHA-256: `c7304df99ba027e455b94ef86d8c2964c99813b4b7afb5bd532e0bf494b29d15`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/security/test/appsec-checklist/evals/workspace/eval-002-auth-bypass/comparison.md
+++ b/agents/security/test/appsec-checklist/evals/workspace/eval-002-auth-bypass/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `cc5543f86ff4c8f3552e0e869f4690b7cabc4d7aa6f846231a547e3a3fb6e25c` from `agents/security/test/appsec-checklist/evals/workspace/eval-002-auth-bypass`.
-- Fixture SHA-256: `cc5543f86ff4c8f3552e0e869f4690b7cabc4d7aa6f846231a547e3a3fb6e25c`
-- Prompt SHA-256: `f088fb8b19565a837c87f47deb48148bf8a1f74fd9bf243974d4975068d68895`
+- Identity schema: `2`
+- target_skill_sha256: `812b371fc30792cb2b0cf8d96079b3244c95b93efab7638e085d4e955d6ea42c`
+- eval_definition_sha256: `6a82fe3c3414aca61cd232161a32adb38bf8c698919832011992c1d84f8965f5`
+- metadata_sha256: `3fcfb91e83a24f1f8a67c2d9edff9012dc72e220f47b3bfd6102b0d7601836a9`
+- fixture_sha256: `cc5543f86ff4c8f3552e0e869f4690b7cabc4d7aa6f846231a547e3a3fb6e25c`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `dd30fe689fbcc65952d80f9f7fb0f55e7cc2d55b9002a172d25f15b8b97c4288`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `812b371fc30792cb2b0cf8d96079b3244c95b93efab7638e085d4e955d6ea42c`
-- Skill overlay SHA-256: `11d9f677e9ab3fadaeeab596575848debc7e1fb3f4f8054e9e5572a63ccf426b`
-- Judge schema SHA-256: `dd30fe689fbcc65952d80f9f7fb0f55e7cc2d55b9002a172d25f15b8b97c4288`
-- Eval definition SHA-256: `6a82fe3c3414aca61cd232161a32adb38bf8c698919832011992c1d84f8965f5`
-- Metadata SHA-256: `3fcfb91e83a24f1f8a67c2d9edff9012dc72e220f47b3bfd6102b0d7601836a9`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/security/test/appsec-checklist/evals/workspace/eval-003-xss/comparison.md
+++ b/agents/security/test/appsec-checklist/evals/workspace/eval-003-xss/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `746acb9424bcff0e7d1cdbd84db8418dc8fed63831bb1cdba56197295fa9433e` from `agents/security/test/appsec-checklist/evals/workspace/eval-003-xss`.
-- Fixture SHA-256: `746acb9424bcff0e7d1cdbd84db8418dc8fed63831bb1cdba56197295fa9433e`
-- Prompt SHA-256: `4fbcbae96df725d2ae68317bce92f64188686abcfd62940b28a42e14a09de97f`
+- Identity schema: `2`
+- target_skill_sha256: `812b371fc30792cb2b0cf8d96079b3244c95b93efab7638e085d4e955d6ea42c`
+- eval_definition_sha256: `6b75287b771a74771292ff6a9a4b1d4288f8c6b58ea121782df92af92abb087a`
+- metadata_sha256: `8b9d5478f14d810cc31c023b6e6a4956d8afc5605aa60470f7733640de6334fb`
+- fixture_sha256: `746acb9424bcff0e7d1cdbd84db8418dc8fed63831bb1cdba56197295fa9433e`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `dd30fe689fbcc65952d80f9f7fb0f55e7cc2d55b9002a172d25f15b8b97c4288`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `812b371fc30792cb2b0cf8d96079b3244c95b93efab7638e085d4e955d6ea42c`
-- Skill overlay SHA-256: `11d9f677e9ab3fadaeeab596575848debc7e1fb3f4f8054e9e5572a63ccf426b`
-- Judge schema SHA-256: `dd30fe689fbcc65952d80f9f7fb0f55e7cc2d55b9002a172d25f15b8b97c4288`
-- Eval definition SHA-256: `6b75287b771a74771292ff6a9a4b1d4288f8c6b58ea121782df92af92abb087a`
-- Metadata SHA-256: `8b9d5478f14d810cc31c023b6e6a4956d8afc5605aa60470f7733640de6334fb`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/security/test/appsec-checklist/evals/workspace/eval-004-feature-path-report/comparison.md
+++ b/agents/security/test/appsec-checklist/evals/workspace/eval-004-feature-path-report/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `258d12e924889cdd6b9d64d5ae077ef75e65139845669b9a81854ba9fc13621c` from `agents/security/test/appsec-checklist/evals/workspace/eval-004-feature-path-report`.
-- Fixture SHA-256: `258d12e924889cdd6b9d64d5ae077ef75e65139845669b9a81854ba9fc13621c`
-- Prompt SHA-256: `05538871e356a1820db883bcff8e90f4208bc94ba8410156f5ef306f19d4ce21`
+- Identity schema: `2`
+- target_skill_sha256: `812b371fc30792cb2b0cf8d96079b3244c95b93efab7638e085d4e955d6ea42c`
+- eval_definition_sha256: `cea867306caa7c154c38a57a7085c1f3dc292e28eb28f571e99034334c62710c`
+- metadata_sha256: `8529cb6cbe6ab9523b4f7cf3b65440375e54cbaab5ce6a8376eb7a3bc4427f65`
+- fixture_sha256: `258d12e924889cdd6b9d64d5ae077ef75e65139845669b9a81854ba9fc13621c`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `a8797f637904fc863710b298fe2fad8220a05aa0d79e70ed8997096bddf38e6c`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `812b371fc30792cb2b0cf8d96079b3244c95b93efab7638e085d4e955d6ea42c`
-- Skill overlay SHA-256: `11d9f677e9ab3fadaeeab596575848debc7e1fb3f4f8054e9e5572a63ccf426b`
-- Judge schema SHA-256: `a8797f637904fc863710b298fe2fad8220a05aa0d79e70ed8997096bddf38e6c`
-- Eval definition SHA-256: `cea867306caa7c154c38a57a7085c1f3dc292e28eb28f571e99034334c62710c`
-- Metadata SHA-256: `8529cb6cbe6ab9523b4f7cf3b65440375e54cbaab5ce6a8376eb7a3bc4427f65`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)

--- a/agents/security/test/appsec-checklist/evals/workspace/eval-005-mapped-search-security/comparison.md
+++ b/agents/security/test/appsec-checklist/evals/workspace/eval-005-mapped-search-security/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `fc2995d30d3ccba9dfaf0358946382fa2b5ecd4e3e1f4b423d1635f72c325d7d` from `agents/security/test/appsec-checklist/evals/workspace/eval-005-mapped-search-security`.
-- Fixture SHA-256: `fc2995d30d3ccba9dfaf0358946382fa2b5ecd4e3e1f4b423d1635f72c325d7d`
-- Prompt SHA-256: `e2ae5e4d2822699f2cb15956131366187d45773423915faa9c9726d6be1fc4de`
+- Identity schema: `2`
+- target_skill_sha256: `812b371fc30792cb2b0cf8d96079b3244c95b93efab7638e085d4e955d6ea42c`
+- eval_definition_sha256: `d863b13d3e997477097b1a2de108729923e21619e10b2847114ea312db1c1bc8`
+- metadata_sha256: `44e3487a1b0a940b7bf23d73f980b7d71bd0be1a4d04a13c48606fd67383de8a`
+- fixture_sha256: `fc2995d30d3ccba9dfaf0358946382fa2b5ecd4e3e1f4b423d1635f72c325d7d`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `fe1f59786edfa4e3b7ee12601522d693ef12a42cdfce9b4a390ad6d7b95d03d2`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `812b371fc30792cb2b0cf8d96079b3244c95b93efab7638e085d4e955d6ea42c`
-- Skill overlay SHA-256: `11d9f677e9ab3fadaeeab596575848debc7e1fb3f4f8054e9e5572a63ccf426b`
-- Judge schema SHA-256: `fe1f59786edfa4e3b7ee12601522d693ef12a42cdfce9b4a390ad6d7b95d03d2`
-- Eval definition SHA-256: `d863b13d3e997477097b1a2de108729923e21619e10b2847114ea312db1c1bc8`
-- Metadata SHA-256: `44e3487a1b0a940b7bf23d73f980b7d71bd0be1a4d04a13c48606fd67383de8a`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)

--- a/agents/security/test/authz-reviewer/evals/workspace/eval-001-rbac/comparison.md
+++ b/agents/security/test/authz-reviewer/evals/workspace/eval-001-rbac/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `a079595e48d457c66e6bfba203a327a4dd2cee76937828205dc7d5ae1bf6d9ea` from `agents/security/test/authz-reviewer/evals/workspace/eval-001-rbac`.
-- Fixture SHA-256: `a079595e48d457c66e6bfba203a327a4dd2cee76937828205dc7d5ae1bf6d9ea`
-- Prompt SHA-256: `1a600a6512e0923d93e2001890b6b0e358c2e4b71aa4c63f0e217fc733bd66d6`
+- Identity schema: `2`
+- target_skill_sha256: `c5c4e1b3eeeb704a06966dee8397bc4f1df239be6ed5f5799f8d4bd382f23626`
+- eval_definition_sha256: `235137f94204f51e6c45d33016dc89d9789a6db39caeb6f905a7bece723a5a15`
+- metadata_sha256: `df9bade135aeb250331ea2ef878f13f4c9a4066b16cd28748dca8a45cce63fa2`
+- fixture_sha256: `a079595e48d457c66e6bfba203a327a4dd2cee76937828205dc7d5ae1bf6d9ea`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `b9195372d92f3bbea03af4fc8ee3a7b882c68284b96da53cdd8cef5cf57e70e9`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `c5c4e1b3eeeb704a06966dee8397bc4f1df239be6ed5f5799f8d4bd382f23626`
-- Skill overlay SHA-256: `5d963f35c675c3748a7ab8200aa22a681cf01b4c9046afa796b21dbaa5d298b4`
-- Judge schema SHA-256: `b9195372d92f3bbea03af4fc8ee3a7b882c68284b96da53cdd8cef5cf57e70e9`
-- Eval definition SHA-256: `235137f94204f51e6c45d33016dc89d9789a6db39caeb6f905a7bece723a5a15`
-- Metadata SHA-256: `df9bade135aeb250331ea2ef878f13f4c9a4066b16cd28748dca8a45cce63fa2`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/security/test/authz-reviewer/evals/workspace/eval-002-session/comparison.md
+++ b/agents/security/test/authz-reviewer/evals/workspace/eval-002-session/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `ef54897bb21af32853256277d12077e05ab3c6d281df76ae5f08944cb67d641a` from `agents/security/test/authz-reviewer/evals/workspace/eval-002-session`.
-- Fixture SHA-256: `ef54897bb21af32853256277d12077e05ab3c6d281df76ae5f08944cb67d641a`
-- Prompt SHA-256: `2d47191ee1ff1f15f350d3cf5e7d5d57f991913e4e2049f23f29264b335bfc56`
+- Identity schema: `2`
+- target_skill_sha256: `c5c4e1b3eeeb704a06966dee8397bc4f1df239be6ed5f5799f8d4bd382f23626`
+- eval_definition_sha256: `86d9727a0807549b3bf3936da079aa7238a2b14b16eed4306c9bda4eb6d7be43`
+- metadata_sha256: `f26166d912f73c7f118a1561bee3e62973123b274975fb4a17a869fba31f82a0`
+- fixture_sha256: `ef54897bb21af32853256277d12077e05ab3c6d281df76ae5f08944cb67d641a`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `a3c690bb602cdac9c05191ab0581fc35b8fd034dd27825093b3b51de5926404b`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `c5c4e1b3eeeb704a06966dee8397bc4f1df239be6ed5f5799f8d4bd382f23626`
-- Skill overlay SHA-256: `5d963f35c675c3748a7ab8200aa22a681cf01b4c9046afa796b21dbaa5d298b4`
-- Judge schema SHA-256: `a3c690bb602cdac9c05191ab0581fc35b8fd034dd27825093b3b51de5926404b`
-- Eval definition SHA-256: `86d9727a0807549b3bf3936da079aa7238a2b14b16eed4306c9bda4eb6d7be43`
-- Metadata SHA-256: `f26166d912f73c7f118a1561bee3e62973123b274975fb4a17a869fba31f82a0`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/security/test/authz-reviewer/evals/workspace/eval-003-jwt/comparison.md
+++ b/agents/security/test/authz-reviewer/evals/workspace/eval-003-jwt/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `b22eea37eaa1e0fa82c96957a5790898e68b0e138db6319e88a5574aee2cf1f4` from `agents/security/test/authz-reviewer/evals/workspace/eval-003-jwt`.
-- Fixture SHA-256: `b22eea37eaa1e0fa82c96957a5790898e68b0e138db6319e88a5574aee2cf1f4`
-- Prompt SHA-256: `da9ecfe298cdea573f5e2d687f97fd893a94d3dc4b95b345575f1d452f32a2ab`
+- Identity schema: `2`
+- target_skill_sha256: `c5c4e1b3eeeb704a06966dee8397bc4f1df239be6ed5f5799f8d4bd382f23626`
+- eval_definition_sha256: `8f6e801f8a45c6ec677bbcaa4a56de6b68c935402a27b9f24ca631ffe0af8504`
+- metadata_sha256: `2db8c4dc18a4712e7dcc4d2c4e3e9c1608e8526019fbff1c3fc3e6ded6f9d1c5`
+- fixture_sha256: `b22eea37eaa1e0fa82c96957a5790898e68b0e138db6319e88a5574aee2cf1f4`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `a3c690bb602cdac9c05191ab0581fc35b8fd034dd27825093b3b51de5926404b`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `c5c4e1b3eeeb704a06966dee8397bc4f1df239be6ed5f5799f8d4bd382f23626`
-- Skill overlay SHA-256: `5d963f35c675c3748a7ab8200aa22a681cf01b4c9046afa796b21dbaa5d298b4`
-- Judge schema SHA-256: `a3c690bb602cdac9c05191ab0581fc35b8fd034dd27825093b3b51de5926404b`
-- Eval definition SHA-256: `8f6e801f8a45c6ec677bbcaa4a56de6b68c935402a27b9f24ca631ffe0af8504`
-- Metadata SHA-256: `2db8c4dc18a4712e7dcc4d2c4e3e9c1608e8526019fbff1c3fc3e6ded6f9d1c5`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/security/test/authz-reviewer/evals/workspace/eval-004-mapped-report-export-authz/comparison.md
+++ b/agents/security/test/authz-reviewer/evals/workspace/eval-004-mapped-report-export-authz/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `6b2ecd7bb8b1ef79f098d4d11a3ca4f93d8ab0f7969ef301d999bac9f594dbd1` from `agents/security/test/authz-reviewer/evals/workspace/eval-004-mapped-report-export-authz`.
-- Fixture SHA-256: `6b2ecd7bb8b1ef79f098d4d11a3ca4f93d8ab0f7969ef301d999bac9f594dbd1`
-- Prompt SHA-256: `956153b2567d541c97d7a49956fee1365b2dd3779decf5baff92a40059a84ff2`
+- Identity schema: `2`
+- target_skill_sha256: `c5c4e1b3eeeb704a06966dee8397bc4f1df239be6ed5f5799f8d4bd382f23626`
+- eval_definition_sha256: `8fb5f1e36d08ae5ad3c1dfb46758101e4ce1413f28a63b591aee885fb67bbefb`
+- metadata_sha256: `04460ae4a10b7b6f92dfdd6cb899ffd1f5dfbcb4fb34b6242a7bc18e450e6ddd`
+- fixture_sha256: `6b2ecd7bb8b1ef79f098d4d11a3ca4f93d8ab0f7969ef301d999bac9f594dbd1`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `fe1f59786edfa4e3b7ee12601522d693ef12a42cdfce9b4a390ad6d7b95d03d2`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `c5c4e1b3eeeb704a06966dee8397bc4f1df239be6ed5f5799f8d4bd382f23626`
-- Skill overlay SHA-256: `5d963f35c675c3748a7ab8200aa22a681cf01b4c9046afa796b21dbaa5d298b4`
-- Judge schema SHA-256: `fe1f59786edfa4e3b7ee12601522d693ef12a42cdfce9b4a390ad6d7b95d03d2`
-- Eval definition SHA-256: `8fb5f1e36d08ae5ad3c1dfb46758101e4ce1413f28a63b591aee885fb67bbefb`
-- Metadata SHA-256: `04460ae4a10b7b6f92dfdd6cb899ffd1f5dfbcb4fb34b6242a7bc18e450e6ddd`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)

--- a/agents/security/test/dependency-risk-auditor/evals/workspace/eval-001-npm-audit/comparison.md
+++ b/agents/security/test/dependency-risk-auditor/evals/workspace/eval-001-npm-audit/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `5d978f8d24e5dad96aba91cd89101e33e9f1a0bda647abfca6c8a768de860caa` from `agents/security/test/dependency-risk-auditor/evals/workspace/eval-001-npm-audit`.
-- Fixture SHA-256: `5d978f8d24e5dad96aba91cd89101e33e9f1a0bda647abfca6c8a768de860caa`
-- Prompt SHA-256: `77f74479311f236d7bdd232169db921b777009b1ba418244e6f3905f8b530b3e`
+- Identity schema: `2`
+- target_skill_sha256: `0f253c18407bc188d3558e673dc587116dcb519a01d7ef15849f9e98e350e1c1`
+- eval_definition_sha256: `971feaa0f85d14f75fe45df2640551915965f181de289e0a977efb57d2391e3e`
+- metadata_sha256: `aee94fbc4f1b4c53f14bd2d88b010307b382e89dd9cc2398f8a45f7d41146704`
+- fixture_sha256: `5d978f8d24e5dad96aba91cd89101e33e9f1a0bda647abfca6c8a768de860caa`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `07345508cc5d326f024163cc8715111c4efeeb1bd80f16886d65b16eb2ef9292`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `0f253c18407bc188d3558e673dc587116dcb519a01d7ef15849f9e98e350e1c1`
-- Skill overlay SHA-256: `a20df761eb11be10e69d0c69c6cd83a1d8df72f5c18c6d851046ac906baa7ff4`
-- Judge schema SHA-256: `07345508cc5d326f024163cc8715111c4efeeb1bd80f16886d65b16eb2ef9292`
-- Eval definition SHA-256: `971feaa0f85d14f75fe45df2640551915965f181de289e0a977efb57d2391e3e`
-- Metadata SHA-256: `aee94fbc4f1b4c53f14bd2d88b010307b382e89dd9cc2398f8a45f7d41146704`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/security/test/dependency-risk-auditor/evals/workspace/eval-002-abandoned/comparison.md
+++ b/agents/security/test/dependency-risk-auditor/evals/workspace/eval-002-abandoned/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `4ef6c6ec20f409ae50ba76d9496bdabb654cdb81289a7a2eacee1dc6b802832f` from `agents/security/test/dependency-risk-auditor/evals/workspace/eval-002-abandoned`.
-- Fixture SHA-256: `4ef6c6ec20f409ae50ba76d9496bdabb654cdb81289a7a2eacee1dc6b802832f`
-- Prompt SHA-256: `89079b812ce4ce066ef86759ed6c1d41f09649e1cedce1ebb540e93d141b1137`
+- Identity schema: `2`
+- target_skill_sha256: `0f253c18407bc188d3558e673dc587116dcb519a01d7ef15849f9e98e350e1c1`
+- eval_definition_sha256: `88dd9b929d53963534f872d5c6b43117be6b35cb41fa6b99bd7d05175018ade8`
+- metadata_sha256: `6e01d4daa6b468e7c7a0ddfd1d17ad1116a727bf8d6709ea8ad0e5baec7fce48`
+- fixture_sha256: `4ef6c6ec20f409ae50ba76d9496bdabb654cdb81289a7a2eacee1dc6b802832f`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `07345508cc5d326f024163cc8715111c4efeeb1bd80f16886d65b16eb2ef9292`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `0f253c18407bc188d3558e673dc587116dcb519a01d7ef15849f9e98e350e1c1`
-- Skill overlay SHA-256: `a20df761eb11be10e69d0c69c6cd83a1d8df72f5c18c6d851046ac906baa7ff4`
-- Judge schema SHA-256: `07345508cc5d326f024163cc8715111c4efeeb1bd80f16886d65b16eb2ef9292`
-- Eval definition SHA-256: `88dd9b929d53963534f872d5c6b43117be6b35cb41fa6b99bd7d05175018ade8`
-- Metadata SHA-256: `6e01d4daa6b468e7c7a0ddfd1d17ad1116a727bf8d6709ea8ad0e5baec7fce48`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/security/test/dependency-risk-auditor/evals/workspace/eval-003-python/comparison.md
+++ b/agents/security/test/dependency-risk-auditor/evals/workspace/eval-003-python/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `8307ea1325de4c132e54824c9dd507ed174ce29fe901e9f04e5a56bc654490e3` from `agents/security/test/dependency-risk-auditor/evals/workspace/eval-003-python`.
-- Fixture SHA-256: `8307ea1325de4c132e54824c9dd507ed174ce29fe901e9f04e5a56bc654490e3`
-- Prompt SHA-256: `109b986b4018ed5121d20e83d0f03f39a0aaef687eb5dd7c1936ee4b3a089210`
+- Identity schema: `2`
+- target_skill_sha256: `0f253c18407bc188d3558e673dc587116dcb519a01d7ef15849f9e98e350e1c1`
+- eval_definition_sha256: `b851960b1dd4c6ab11f9c42f685034d6bd0e27ae3c26e4256af19942329ed614`
+- metadata_sha256: `86d72efa91ee3890167dbac2135eac8aaff379e02491ea01e89a3595936d759c`
+- fixture_sha256: `8307ea1325de4c132e54824c9dd507ed174ce29fe901e9f04e5a56bc654490e3`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `07345508cc5d326f024163cc8715111c4efeeb1bd80f16886d65b16eb2ef9292`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `0f253c18407bc188d3558e673dc587116dcb519a01d7ef15849f9e98e350e1c1`
-- Skill overlay SHA-256: `a20df761eb11be10e69d0c69c6cd83a1d8df72f5c18c6d851046ac906baa7ff4`
-- Judge schema SHA-256: `07345508cc5d326f024163cc8715111c4efeeb1bd80f16886d65b16eb2ef9292`
-- Eval definition SHA-256: `b851960b1dd4c6ab11f9c42f685034d6bd0e27ae3c26e4256af19942329ed614`
-- Metadata SHA-256: `86d72efa91ee3890167dbac2135eac8aaff379e02491ea01e89a3595936d759c`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/security/test/dependency-risk-auditor/evals/workspace/eval-004-mapped-client-dependency/comparison.md
+++ b/agents/security/test/dependency-risk-auditor/evals/workspace/eval-004-mapped-client-dependency/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `9287a8fa578b5447f010eec525225500d555d9e2f5c2758277bcae9488425fa5` from `agents/security/test/dependency-risk-auditor/evals/workspace/eval-004-mapped-client-dependency`.
-- Fixture SHA-256: `9287a8fa578b5447f010eec525225500d555d9e2f5c2758277bcae9488425fa5`
-- Prompt SHA-256: `7a3821e75530d0b15af01947cb71f52d6f838c90667f22241c35f06721254994`
+- Identity schema: `2`
+- target_skill_sha256: `0f253c18407bc188d3558e673dc587116dcb519a01d7ef15849f9e98e350e1c1`
+- eval_definition_sha256: `8b3afd523591d93b0ae2bfbea1c5709666ee81c09a14160679da5b53064efb14`
+- metadata_sha256: `72846a754080f41b7de9981348b71040115d4704d0a16f2aad7aa4b526a44443`
+- fixture_sha256: `9287a8fa578b5447f010eec525225500d555d9e2f5c2758277bcae9488425fa5`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `fe1f59786edfa4e3b7ee12601522d693ef12a42cdfce9b4a390ad6d7b95d03d2`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `0f253c18407bc188d3558e673dc587116dcb519a01d7ef15849f9e98e350e1c1`
-- Skill overlay SHA-256: `a20df761eb11be10e69d0c69c6cd83a1d8df72f5c18c6d851046ac906baa7ff4`
-- Judge schema SHA-256: `fe1f59786edfa4e3b7ee12601522d693ef12a42cdfce9b4a390ad6d7b95d03d2`
-- Eval definition SHA-256: `8b3afd523591d93b0ae2bfbea1c5709666ee81c09a14160679da5b53064efb14`
-- Metadata SHA-256: `72846a754080f41b7de9981348b71040115d4704d0a16f2aad7aa4b526a44443`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)

--- a/agents/security/test/privacy-surface-mapper/evals/workspace/eval-001-gdpr/comparison.md
+++ b/agents/security/test/privacy-surface-mapper/evals/workspace/eval-001-gdpr/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `fc7c85721e9b7bd81a9ba3e487c8f00f57880deb91ce00e1ae1258884cc231db` from `agents/security/test/privacy-surface-mapper/evals/workspace/eval-001-gdpr`.
-- Fixture SHA-256: `fc7c85721e9b7bd81a9ba3e487c8f00f57880deb91ce00e1ae1258884cc231db`
-- Prompt SHA-256: `da21f882704758587ca44f889b8ee407dbf02d8334de8546d9781960b0a34c12`
+- Identity schema: `2`
+- target_skill_sha256: `25bd4dbed66f3625883b2a2072dcd568eef569278521e1eac012e86f61347836`
+- eval_definition_sha256: `3e00fd5f68469b1dbad14f0a400fd8e41079d5a8aa0df077168fd2333bd41a39`
+- metadata_sha256: `93577771a8ef98b760a14a69ae743909ae6d46791d7ed929dd703a6fc9855b54`
+- fixture_sha256: `fc7c85721e9b7bd81a9ba3e487c8f00f57880deb91ce00e1ae1258884cc231db`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `46c6f10cb2ee094e0f2d9b8cf0d9d794ebc801a301eb97187a76e961b4e37fd0`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `25bd4dbed66f3625883b2a2072dcd568eef569278521e1eac012e86f61347836`
-- Skill overlay SHA-256: `4894e45a78f6999eae63835919f4d9ac1eddcf0e15978742e5f90f2ebd544560`
-- Judge schema SHA-256: `46c6f10cb2ee094e0f2d9b8cf0d9d794ebc801a301eb97187a76e961b4e37fd0`
-- Eval definition SHA-256: `3e00fd5f68469b1dbad14f0a400fd8e41079d5a8aa0df077168fd2333bd41a39`
-- Metadata SHA-256: `93577771a8ef98b760a14a69ae743909ae6d46791d7ed929dd703a6fc9855b54`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/security/test/privacy-surface-mapper/evals/workspace/eval-002-user-rights/comparison.md
+++ b/agents/security/test/privacy-surface-mapper/evals/workspace/eval-002-user-rights/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `2a160ab6ab1065aa7d10a9502c97feefe12d13d5af072b1075181fbf932723d8` from `agents/security/test/privacy-surface-mapper/evals/workspace/eval-002-user-rights`.
-- Fixture SHA-256: `2a160ab6ab1065aa7d10a9502c97feefe12d13d5af072b1075181fbf932723d8`
-- Prompt SHA-256: `f954f6fb2beee6f446fdaf1e7380f20a7139675884dad90e43a17db9c8bbe9d0`
+- Identity schema: `2`
+- target_skill_sha256: `25bd4dbed66f3625883b2a2072dcd568eef569278521e1eac012e86f61347836`
+- eval_definition_sha256: `ba5034d1b895bcb95cc9d848045b869189eec2c98d23c0a5d5ce381059a73047`
+- metadata_sha256: `b655e3698222cf189fb740616c1df41fb5ccc3d4bf71526ca29a7ecf05ef368a`
+- fixture_sha256: `2a160ab6ab1065aa7d10a9502c97feefe12d13d5af072b1075181fbf932723d8`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `46c6f10cb2ee094e0f2d9b8cf0d9d794ebc801a301eb97187a76e961b4e37fd0`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `25bd4dbed66f3625883b2a2072dcd568eef569278521e1eac012e86f61347836`
-- Skill overlay SHA-256: `4894e45a78f6999eae63835919f4d9ac1eddcf0e15978742e5f90f2ebd544560`
-- Judge schema SHA-256: `46c6f10cb2ee094e0f2d9b8cf0d9d794ebc801a301eb97187a76e961b4e37fd0`
-- Eval definition SHA-256: `ba5034d1b895bcb95cc9d848045b869189eec2c98d23c0a5d5ce381059a73047`
-- Metadata SHA-256: `b655e3698222cf189fb740616c1df41fb5ccc3d4bf71526ca29a7ecf05ef368a`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/security/test/privacy-surface-mapper/evals/workspace/eval-003-third-party/comparison.md
+++ b/agents/security/test/privacy-surface-mapper/evals/workspace/eval-003-third-party/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `a0f9b5ed56aa92319d126897928b2da5ef1b5b085fbe003f0b4425dde5805c73` from `agents/security/test/privacy-surface-mapper/evals/workspace/eval-003-third-party`.
-- Fixture SHA-256: `a0f9b5ed56aa92319d126897928b2da5ef1b5b085fbe003f0b4425dde5805c73`
-- Prompt SHA-256: `f08db36d8714dffcf75b41015d8dc4b37be4570b39ece9523f67238ebf8ed935`
+- Identity schema: `2`
+- target_skill_sha256: `25bd4dbed66f3625883b2a2072dcd568eef569278521e1eac012e86f61347836`
+- eval_definition_sha256: `fde37322a972618cf8b85d5463c8e7a856c7547f8c15123669fd15297f556852`
+- metadata_sha256: `1b358949b025cd13ff498cda0a21978c243d4781824a1ceab1947fe97db21069`
+- fixture_sha256: `a0f9b5ed56aa92319d126897928b2da5ef1b5b085fbe003f0b4425dde5805c73`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `46c6f10cb2ee094e0f2d9b8cf0d9d794ebc801a301eb97187a76e961b4e37fd0`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `25bd4dbed66f3625883b2a2072dcd568eef569278521e1eac012e86f61347836`
-- Skill overlay SHA-256: `4894e45a78f6999eae63835919f4d9ac1eddcf0e15978742e5f90f2ebd544560`
-- Judge schema SHA-256: `46c6f10cb2ee094e0f2d9b8cf0d9d794ebc801a301eb97187a76e961b4e37fd0`
-- Eval definition SHA-256: `fde37322a972618cf8b85d5463c8e7a856c7547f8c15123669fd15297f556852`
-- Metadata SHA-256: `1b358949b025cd13ff498cda0a21978c243d4781824a1ceab1947fe97db21069`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS

--- a/agents/security/test/privacy-surface-mapper/evals/workspace/eval-004-mapped-profile-retention/comparison.md
+++ b/agents/security/test/privacy-surface-mapper/evals/workspace/eval-004-mapped-profile-retention/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `770d05d85a5304099a8f9433d2be942409c59c2f8ece13f985350673cd6e1b76` from `agents/security/test/privacy-surface-mapper/evals/workspace/eval-004-mapped-profile-retention`.
-- Fixture SHA-256: `770d05d85a5304099a8f9433d2be942409c59c2f8ece13f985350673cd6e1b76`
-- Prompt SHA-256: `90526a6f11b7d07cc96154485f1093a95a1e0a80c1ca3d9a35272a8e6b6e737f`
+- Identity schema: `2`
+- target_skill_sha256: `25bd4dbed66f3625883b2a2072dcd568eef569278521e1eac012e86f61347836`
+- eval_definition_sha256: `4636a9753113bcd43710d7f9510814811413ce11cdc5e68daebdc570220f08a9`
+- metadata_sha256: `9a8afbbbec758d7a8301647fd089cbe8695096269334ba062d91dd1eead9320a`
+- fixture_sha256: `770d05d85a5304099a8f9433d2be942409c59c2f8ece13f985350673cd6e1b76`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `fe1f59786edfa4e3b7ee12601522d693ef12a42cdfce9b4a390ad6d7b95d03d2`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `25bd4dbed66f3625883b2a2072dcd568eef569278521e1eac012e86f61347836`
-- Skill overlay SHA-256: `4894e45a78f6999eae63835919f4d9ac1eddcf0e15978742e5f90f2ebd544560`
-- Judge schema SHA-256: `fe1f59786edfa4e3b7ee12601522d693ef12a42cdfce9b4a390ad6d7b95d03d2`
-- Eval definition SHA-256: `4636a9753113bcd43710d7f9510814811413ce11cdc5e68daebdc570220f08a9`
-- Metadata SHA-256: `9a8afbbbec758d7a8301647fd089cbe8695096269334ba062d91dd1eead9320a`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)

--- a/agents/security/test/security-agent/evals/workspace/eval-1-route-auth-release-risk/comparison.md
+++ b/agents/security/test/security-agent/evals/workspace/eval-1-route-auth-release-risk/comparison.md
@@ -12,17 +12,19 @@
 - Preflight status: **PASS**
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `6becbc324dd17ee4f5ba7cdf2d867ad58ae183800d34e6d3eb510323380d49a0` from `agents/security/test/security-agent/evals/workspace/eval-1-route-auth-release-risk`.
-- Fixture SHA-256: `6becbc324dd17ee4f5ba7cdf2d867ad58ae183800d34e6d3eb510323380d49a0`
-- Prompt SHA-256: `5a4bc456b36f0fe19e8d15843877f0c9ef8daed9d99b67bdcc85d65720c79c5b`
+- Identity schema: `2`
+- target_skill_sha256: `f9c706626daa220552f758703ae64d133ee8d82358801e24309850f00386ef65`
+- eval_definition_sha256: `86d9cf5b5d192be02693890eee51825a1b00e0750fd5f2d88fdcc91b3fe08ad7`
+- metadata_sha256: `10861a3430f4e9df517502c7dede98b52c06228662db21b0d8914dd6b558a77c`
+- fixture_sha256: `6becbc324dd17ee4f5ba7cdf2d867ad58ae183800d34e6d3eb510323380d49a0`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `d09f4cbeb933e811c934cf8e665fe7675560abe0fc34d7865e0c67a56b1f4b12`
+- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
+- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
+- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
 - Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
 - Repository worktree state: **DIRTY**
-- Target skill tree SHA-256: `f9c706626daa220552f758703ae64d133ee8d82358801e24309850f00386ef65`
-- Skill overlay SHA-256: `f60ca20c88dbcd89128c2e7274062ceecd615c5940f10126a82abf339cb3d52f`
-- Judge schema SHA-256: `d09f4cbeb933e811c934cf8e665fe7675560abe0fc34d7865e0c67a56b1f4b12`
-- Eval definition SHA-256: `86d9cf5b5d192be02693890eee51825a1b00e0750fd5f2d88fdcc91b3fe08ad7`
-- Metadata SHA-256: `10861a3430f4e9df517502c7dede98b52c06228662db21b0d8914dd6b558a77c`
-- Executor SHA-256: `321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54`
-- Runtime SHA-256: `9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)

--- a/agents/test_eval_contract.py
+++ b/agents/test_eval_contract.py
@@ -155,7 +155,14 @@ class EvalContractTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
-            self.write_eval_fixture(root, "# Comparison\n")
+            identity = "".join(
+                f"- {key}: `{'a' * 64}`\n" for key in checker.FRESHNESS_KEYS
+            )
+            self.write_eval_fixture(
+                root,
+                "## Current Result\n\n- Evidence status: **PENDING**\n"
+                "- Identity schema: `2`\n" + identity + "Overall result: BLOCKED\n",
+            )
             skill_doc = root / "agents/docs/skills/manual-gen/SKILL.md"
             result_doc = root / "agents/docs/test/manual-gen/comparison.md"
             skill_doc.parent.mkdir(parents=True)
@@ -864,6 +871,45 @@ class EvalContractTests(unittest.TestCase):
             "",
         )
 
+    def test_only_pending_frozen_eval_skips_strict_contract_checks(self):
+        checker = load_checker_module()
+        identity = ("engineer", "debugger", "eval-001-baseline-evidence")
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            evals_path = self.write_eval_fixture(root, "# Comparison\n")
+            payload = json.loads(evals_path.read_text())
+            del payload["evals"][0]["scenario"]
+            evals_path.write_text(json.dumps(payload, ensure_ascii=False))
+            workspace = evals_path.parent / "workspace/eval-001-baseline-evidence"
+            metadata = workspace / "eval_metadata.json"
+            metadata_payload = json.loads(metadata.read_text())
+            del metadata_payload["runtime_isolation"]
+            metadata.write_text(json.dumps(metadata_payload))
+            (workspace / "service").mkdir()
+            (workspace / "service/README.md").write_text(
+                "Expected behavior: dispatcher should return PASS."
+            )
+
+            post_freeze_errors = checker.validate_file(
+                root, evals_path, pending_identities=set(),
+            )
+            pending_frozen_errors = checker.validate_file(
+                root, evals_path, pending_identities={identity},
+            )
+
+        strict_messages = "\n".join(error.render(root) for error in post_freeze_errors)
+        compatibility_messages = "\n".join(
+            error.render(root) for error in pending_frozen_errors
+        )
+        for message in (
+            "scenario must be an object",
+            "runtime_isolation must be an object",
+            "README contains high-confidence answer guidance",
+        ):
+            self.assertIn(message, strict_messages)
+            self.assertNotIn(message, compatibility_messages)
+
     def test_inventory_recomputes_frozen_pointer_and_hashes_from_commit(self):
         checker = load_checker_module()
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -919,108 +965,60 @@ class EvalContractTests(unittest.TestCase):
         self.assertIn("frozen_from_git_commit must be a real 40-hex commit", rendered)
         self.assertIn("source_contract must exactly match the frozen scan contract", rendered)
 
-    def test_complete_fresh_comparison_tracks_target_inputs_not_dependency_content(self):
+    def test_fresh_comparison_requires_exact_v2_identity_without_legacy_fields(self):
         checker = load_checker_module()
-        sys.path.insert(0, str(CHECKER_PATH.parents[1]))
-        from scripts import run_skill_eval as runner
-
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             evals_path = self.write_eval_fixture(root, "placeholder")
             workspace = evals_path.parent / "workspace/eval-001-baseline-evidence"
-            fixture = workspace / "host-input.txt"
-            fixture.write_text("host v1\n", encoding="utf-8")
-            dependency = root / "agents/product_manager/skills/idea-to-spec/SKILL.md"
-            dependency.parent.mkdir(parents=True)
-            dependency.write_text("dependency v1\n", encoding="utf-8")
-            metadata = workspace / "eval_metadata.json"
-            metadata.write_bytes(metadata.read_bytes().replace(
-                b'"skill_dependencies": []',
-                b'"skill_dependencies": ["agents/product_manager/skills/idea-to-spec"]',
-            ))
-            scripts = root / "scripts"
-            scripts.mkdir()
-            executor = scripts / "run_skill_eval.py"
-            runtime = scripts / "eval_runtime.py"
-            schema = scripts / "eval_judge_result.schema.json"
-            executor.write_text("executor v1\n", encoding="utf-8")
-            runtime.write_text("runtime v1\n", encoding="utf-8")
-            schema.write_bytes(runner.JUDGE_SCHEMA.read_bytes())
-            old_file, old_schema = runner.__file__, runner.JUDGE_SCHEMA
-            runner.__file__, runner.JUDGE_SCHEMA = str(executor), schema
-            try:
-                definition = runner.load_eval_definition(
-                    root, "engineer", "debugger", "eval-001-baseline-evidence",
-                )
-                identity = runner.source_identity(definition)
-                labels = {
-                    "Fixture SHA-256": checker.current_fixture_hash(definition),
-                    "Prompt SHA-256": hashlib.sha256(definition.item["prompt"].encode()).hexdigest(),
-                    "Eval definition SHA-256": identity["eval_definition_sha256"],
-                    "Metadata SHA-256": identity["metadata_sha256"],
-                    "Target skill tree SHA-256": identity["target_skill_sha256"],
-                    "Skill overlay SHA-256": identity["skill_overlay_sha256"],
-                    "Judge schema SHA-256": identity["judge_schema_sha256"],
-                    "Executor SHA-256": identity["executor_sha256"],
-                    "Runtime SHA-256": identity["runtime_sha256"],
-                }
-                comparison = workspace / "comparison.md"
-                comparison.write_text(
-                    "## Current Result\n\n- Evidence status: **FRESH**\n"
-                    "- Preflight status: **PASS**\n- Judge: fresh judge completed.\n"
-                    + "".join(f"- {name}: `{value}`\n" for name, value in labels.items())
-                    + "- Behavior result: **PASS**\n- Coverage result: **FULL**\n"
-                    "Overall result: PASS\n",
-                    encoding="utf-8",
-                )
-                baseline_errors = []
-                checker.validate_fresh_comparison_identity(
-                    root, comparison, "engineer", "debugger",
-                    "eval-001-baseline-evidence", baseline_errors,
-                )
-                self.assertEqual(baseline_errors, [])
+            identity = {"identity_schema": 2, **{
+                key: hashlib.sha256(key.encode()).hexdigest()
+                for key in checker.FRESHNESS_KEYS
+            }}
+            checker.current_identity_v2 = lambda _definition, **_kwargs: identity
+            comparison = workspace / "comparison.md"
+            base = (
+                "## Current Result\n\n- Evidence status: **FRESH**\n"
+                "- Preflight status: **PASS**\n- Judge: fresh judge completed.\n"
+                "- Identity schema: `2`\n"
+                + "".join(f"- {key}: `{identity[key]}`\n" for key in checker.FRESHNESS_KEYS)
+                + "- Behavior result: **PASS**\n- Coverage result: **FULL**\n"
+                "Overall result: PASS\n"
+            )
+            comparison.write_text(base, encoding="utf-8")
+            errors = []
+            checker.validate_fresh_comparison_identity(
+                root, comparison, "engineer", "debugger",
+                "eval-001-baseline-evidence", errors,
+            )
+            self.assertEqual(errors, [])
 
-                skill = root / "agents/engineer/skills/debugger/SKILL.md"
-                mutations = {
-                    "eval assertion": (evals_path, lambda data: data.replace(
-                        b"Result is present", b"Changed assertion",
-                    )),
-                    "metadata dependency": (metadata, lambda data: data.replace(
-                        b'"skill_dependencies": ["agents/product_manager/skills/idea-to-spec"]',
-                        b'"skill_dependencies": []',
-                    )),
-                    "target skill": (skill, lambda data: data + b"dirty skill\n"),
-                    "executor": (executor, lambda data: data + b"dirty executor\n"),
-                    "runtime": (runtime, lambda data: data + b"dirty runtime\n"),
-                    "judge schema": (schema, lambda data: data.replace(
-                        b'"Skill eval judge result"', b'"Changed judge result"',
-                    )),
-                    "fixture": (fixture, lambda data: data + b"dirty fixture\n"),
-                }
-                for label, (path, mutate) in mutations.items():
-                    with self.subTest(label=label):
-                        original = path.read_bytes()
-                        path.write_bytes(mutate(original))
-                        errors = []
-                        checker.validate_fresh_comparison_identity(
-                            root, comparison, "engineer", "debugger",
-                            "eval-001-baseline-evidence", errors,
-                        )
-                        self.assertTrue(any(
-                            "fresh comparison input identity is stale" in error.message
-                            for error in errors
-                        ))
-                        path.write_bytes(original)
+            comparison.write_text(
+                base + f"- Prompt SHA-256: `{'p' * 64}`\n"
+                f"- Skill overlay SHA-256: `{'s' * 64}`\n",
+                encoding="utf-8",
+            )
+            audit_errors = []
+            checker.validate_fresh_comparison_identity(
+                root, comparison, "engineer", "debugger",
+                "eval-001-baseline-evidence", audit_errors,
+            )
+            self.assertEqual(audit_errors, [])
 
-                dependency.write_text("dependency v2\n", encoding="utf-8")
-                dependency_errors = []
-                checker.validate_fresh_comparison_identity(
-                    root, comparison, "engineer", "debugger",
-                    "eval-001-baseline-evidence", dependency_errors,
-                )
-                self.assertEqual(dependency_errors, [])
-            finally:
-                runner.__file__, runner.JUDGE_SCHEMA = old_file, old_schema
+            for label, altered in (
+                ("missing schema", base.replace("- Identity schema: `2`\n", "")),
+                ("wrong field", base.replace(identity[checker.FRESHNESS_KEYS[0]], "f" * 64)),
+                ("legacy field", base + f"- Executor SHA-256: `{'e' * 64}`\n"),
+            ):
+                with self.subTest(label=label):
+                    comparison.write_text(altered, encoding="utf-8")
+                    errors = []
+                    checker.validate_fresh_comparison_identity(
+                        root, comparison, "engineer", "debugger",
+                        "eval-001-baseline-evidence", errors,
+                    )
+                    self.assertTrue(any("fresh comparison input identity is stale" in error.message
+                                        for error in errors))
 
     def test_fresh_comparison_allows_stale_word_in_eval_slug(self):
         checker = load_checker_module()
@@ -1040,6 +1038,61 @@ class EvalContractTests(unittest.TestCase):
             )
 
             self.assertTrue(checker._comparison_has_fresh_evidence(comparison))
+
+    def test_v2_freshness_check_does_not_query_git(self):
+        checker = load_checker_module()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            evals_path = self.write_eval_fixture(root, "placeholder")
+            workspace = evals_path.parent / "workspace/eval-001-baseline-evidence"
+            identity = {"identity_schema": 2, **{
+                key: hashlib.sha256(key.encode()).hexdigest()
+                for key in checker.FRESHNESS_KEYS
+            }}
+            checker.current_identity_v2 = lambda _definition, **_kwargs: identity
+            comparison = workspace / "comparison.md"
+            comparison.write_text(
+                "## Current Result\n\n- Evidence status: **FRESH**\n"
+                "- Identity schema: `2`\n"
+                + "".join(f"- {key}: `{identity[key]}`\n" for key in checker.FRESHNESS_KEYS),
+                encoding="utf-8",
+            )
+            original_run = subprocess.run
+            subprocess.run = lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                AssertionError("freshness checker must not query Git")
+            )
+            try:
+                errors = []
+                checker.validate_fresh_comparison_identity(
+                    root, comparison, "engineer", "debugger",
+                    "eval-001-baseline-evidence", errors,
+                )
+            finally:
+                subprocess.run = original_run
+        self.assertEqual(errors, [])
+
+    def test_validate_all_rejects_post_freeze_fresh_stale_digest(self):
+        checker = load_checker_module()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            identity = {key: hashlib.sha256(key.encode()).hexdigest()
+                        for key in checker.FRESHNESS_KEYS}
+            comparison_text = (
+                "## Current Result\n\n- Evidence status: **FRESH**\n"
+                "- Preflight status: **PASS**\n- Judge: fresh judge completed.\n"
+                "- Identity schema: `2`\n"
+                + "".join(f"- {key}: `{value}`\n" for key, value in identity.items())
+                + "- Behavior result: **PASS**\n- Coverage result: **FULL**\nOverall result: PASS\n"
+            )
+            evals_path = self.write_eval_fixture(root, comparison_text)
+            current = {"identity_schema": 2, **identity}
+            current[checker.FRESHNESS_KEYS[0]] = "f" * 64
+            checker.current_identity_v2 = lambda _definition, **_kwargs: current
+
+            errors = checker.validate_all(root)
+
+        self.assertTrue(any("fresh comparison input identity is stale" in error.message
+                            for error in errors))
 
     def test_runner_audit_requires_all_nine_fields_per_surface(self):
         checker = load_checker_module()

--- a/docs/engineer/repository-governance/eval-scenario-isolation/IMPLEMENTATION_PLAN.md
+++ b/docs/engineer/repository-governance/eval-scenario-isolation/IMPLEMENTATION_PLAN.md
@@ -1,419 +1,225 @@
 ---
-title: "Eval 真实场景与 Lane 隔离重构实施计划"
+title: "Eval 既有缺陷清理实施计划"
 type: IMPLEMENTATION_PLAN
-version: "0.6.0"
+version: "0.5.0"
 status: "Implemented"
 author: "Neplich Codex"
-date: "2026-08-07"
-last_updated: "2026-08-09"
+date: "2026-08-12"
+last_updated: "2026-08-12"
 generated_by: "feature-implementor"
 feature: "eval-scenario-isolation"
 feature_path: "repository-governance/eval-scenario-isolation"
 parent_feature: "repository-governance"
 feature_level: "2"
-implementation_scope: "eval-scenario-isolation-refactor"
+implementation_scope: "eval-defect-cleanup"
 change_tier: "major"
-related_issue: "#246"
+related_issue: "#277"
 related_prd: "docs/pm/repository-governance/eval-scenario-isolation/PRD.md"
 related_trd: "docs/engineer/repository-governance/eval-scenario-isolation/TRD.md"
+previous_plan_archive: "docs/engineer/repository-governance/eval-scenario-isolation/archive/IMPLEMENTATION_PLAN-eval-scenario-isolation-refactor.md"
 changelog:
-  - version: "0.6.0"
-    date: "2026-08-09"
-    changes: "完成 10 worker 全量重跑与 closeout；按维护者要求将 193 份 durable comparison 压缩为仅保留最新结果，不重新执行模型 eval"
   - version: "0.5.0"
-    date: "2026-08-08"
-    changes: "按维护者追加范围重开 closeout：删除全部测试过程产物、加入 10 worker 跨角色并发、聚类修复首轮 FAIL 后再全量重跑"
+    date: "2026-08-12"
+    changes: "完成 identity schema v2、协议模块拆分、187 份机械迁移、runner/checker 与 skill 修复、25 条受影响 fresh eval 和独立验收；Issue #277 目标通过，保留无关 PM eval-016 FAIL 为后续缺陷"
   - version: "0.4.0"
-    date: "2026-08-08"
-    changes: "完成 193 条 eval 迁移、fresh paired 执行、独立 judge、durable comparison 与最终门禁，记录实际量级和剩余行为风险"
+    date: "2026-08-12"
+    changes: "维护者确认 v0.3.0 实施计划，解除 schema v2、模块拆分、迁移器、确定性测试与一次性 comparison 迁移门禁；模型 eval 仍未授权"
   - version: "0.3.0"
-    date: "2026-08-07"
-    changes: "按阶段 1 至 4 隔离实证改用 permission profile，并把代码与测试量级修正为实测口径"
+    date: "2026-08-12"
+    changes: "按维护者授权加入 identity schema v2、协议模块边界、196 份 comparison 一次性迁移与 9 条 fresh 回归；扩大后的计划等待再次确认"
   - version: "0.2.0"
-    date: "2026-08-07"
-    changes: "维护者确认按本计划实施，解除代码、测试、pilot 与批量迁移门禁"
+    date: "2026-08-12"
+    changes: "维护者确认按计划实施，解除代码、测试、skill、eval 定义与 lockfile 修改门禁；模型 eval 仍需单独授权"
   - version: "0.1.0"
-    date: "2026-08-07"
-    changes: "初始草案，定义 stale 冻结、统一隔离运行时、七角色 pilot、全量迁移与收尾验证"
+    date: "2026-08-12"
+    changes: "初始草案，定义冻结后 eval 持久化、严格检查与 trd-gen eval-006 混合缺陷"
 ---
 
-# Eval 真实场景与 Lane 隔离重构实施计划
+# Eval 既有缺陷清理实施计划
 
 ## 1. 实施上下文与门禁
 
-本计划承接 Issue #246，仅落实已批准的 eval 真实场景、lane 隔离、fresh paired
-执行、独立 judge 与 durable comparison 重构。维护者已于 2026-08-07 明确确认按本计划实施，
-代码、测试、pilot 与批量资产迁移门禁已解除。
+本计划承接 Issue #277，处理冻结后新增 PM scope-guard eval 的持久化缺陷、`trd-gen`
+eval-006 的混合缺陷，并按维护者确认的 schema v2 方案收敛 durable identity、协议模块边界
+与一次性 comparison 迁移。该范围改变仓库级 eval identity 和 checker 契约，按仓库分级为
+`major`。
 
-| 门禁 | 结论 | 证据 |
-| --- | --- | --- |
-| PRD 对齐 | `already_approved` | PRD `1.1.0` 为 Approved；DECISIONS `1.0.0` 无冲突 |
-| TRD 对齐 | 已通过 | TRD `1.2.0` 为 Approved，清理、并发与 FAIL 聚类范围已对齐 |
-| Feature path | 已通过 | PRD、TRD 与本计划的 `feature_path`、`parent_feature`、`feature_level` 一致，TRD `related_prd` 正确 |
-| 变更等级 | `major` | 覆盖七角色、38 个 skill、runner/checker 契约和 193 条 eval |
-| 实施确认 | 已通过 | 维护者于 2026-08-07 回复“确认按计划实施” |
-| Active plan / archive | 无 | 本路径此前无 `IMPLEMENTATION_PLAN.md`，也无 `implementation-plans/archive/` 历史；不写 `previous_plan_archive` |
-| UI 设计 | 不适用 | 本次只改 CLI、脚本、测试与 eval 资产，不改产品 UI、交互或视觉系统 |
+来源文档已经对齐：PRD `1.4.0`、DECISIONS `1.3.0` 与 TRD `1.5.0` 使用相同
+`feature_path`、`parent_feature`、`feature_level`，TRD `related_prd` 指向同路径 PRD。
+原 `eval-scenario-isolation-refactor` 计划已按维护者批准归档，新活动入口保持为本文路径。
 
-来源文档：
+维护者已于 2026-08-12 确认 v0.3.0 实施计划，schema v2、模块拆分、迁移器、确定性测试与
+一次性 comparison 迁移门禁已解除。模型 eval 消耗模型时间并改写 fresh comparison，仍未
+授权；本次计划确认不视为模型运行授权。QA E2E、创建 PR 和关闭 Issue #277 继续等待实施
+与验收完成。
 
-- `docs/pm/repository-governance/eval-scenario-isolation/PRD.md`
-- `docs/pm/repository-governance/eval-scenario-isolation/DECISIONS.md`
-- `docs/engineer/repository-governance/eval-scenario-isolation/TRD.md`
+### 1.1 Planning checkpoint
+
+| 字段 | 值 |
+| --- | --- |
+| `feature_path` | `repository-governance/eval-scenario-isolation` |
+| `parent_feature` | `repository-governance` |
+| `feature_level` | `2` |
+| `change_map_path` | `N/A`（仓库无 `docs/site/standards/change-map.yaml`） |
+| `matched_code_glob` | `N/A` |
+| `mapped_docs` | PRD `1.4.0`、DECISIONS `1.3.0`、TRD `1.5.0` |
+| `prd_alignment` | `already_approved`：Issue #277 的 inventory、混合缺陷与 identity v2 已写入 PRD/DECISIONS |
+| `prd_path` | `docs/pm/repository-governance/eval-scenario-isolation/PRD.md` |
+| `trd_alignment` | `already_approved`：TRD 已定义 0/1/>1、协议模块、v2-only checker 与一次性迁移 |
+| `trd_path` | `docs/engineer/repository-governance/eval-scenario-isolation/TRD.md` |
+| `active_plan_path` | `docs/engineer/repository-governance/eval-scenario-isolation/IMPLEMENTATION_PLAN.md` |
+| `active_plan_status` | `Draft` |
+| `active_plan_scope_before` | `eval-scenario-isolation-refactor` |
+| `replacement_plan_scope` | `eval-defect-cleanup` |
+| `archive_directory` | `docs/engineer/repository-governance/eval-scenario-isolation/archive/` |
+| `active_entry_rule` | 活动入口固定为 `IMPLEMENTATION_PLAN.md`；历史计划只在 `archive/` |
+| `archive_state` | 原计划已归档为 `IMPLEMENTATION_PLAN-eval-scenario-isolation-refactor.md` |
+| `decision` | 维护者选择“完成态归档后创建新计划” |
+| `receiving_owner` | `engineer-agent:feature-implementor` |
+| `gap_packet` | `N/A` |
+| `planned_files` | 第 3 节列出的协议/identity/persistence 模块、checker、迁移器、测试、audit、skill、eval、lockfile 与 196 份 comparison |
+| `verification_commands` | 第 5 节命令 |
+| `subagent_split` | 启用；实现与独立验收分离，主进程保留集成与交付判断 |
+| `blocked_downstream_actions` | 模型 eval、QA E2E、交付、PR 和 issue closeout 仍阻塞 |
+| `confirmation_required` | v0.3.0 已确认；模型 eval 另需明确授权且当前未授权 |
+| `qa_e2e_tc_create_or_update` | `blocked_until_plan_confirmed`；本变更预计无需新增 E2E TC |
+| `qa_e2e_source_after_confirmation` | 本文路径 |
+| `qa_e2e_handoff_package_after_implementation` | PRD/TRD/计划路径已知；changed files、测试结果与风险待实施后填写；建议目录 `docs/qa/e2e/repository-governance/eval-scenario-isolation/` |
 
 ## 2. 成功标准与收紧边界
 
-### 2.1 成功标准
+1. `migration-inventory.json` 保持 schema `1.0`、193 条冻结记录和 counts，无内容 diff。
+2. Durable writer 对 retained identity 实现零匹配只写 comparison、唯一匹配同步更新、
+   多匹配拒绝写入，并有确定性回归测试。
+3. `check_eval_contract.py` 对全部当前常规 eval 使用同一严格输入契约，不以 complete inventory
+   identity 决定 scenario、metadata、runtime isolation 或 fixture 的校验强度。
+4. `trd-gen` eval-006 允许完成 TRD 后在交付摘要中提示合法下一阶段，但要求 `trd-gen`
+   自己完成本轮 TRD，且 TRD 正文不写 routing；正文归一化、frontmatter changelog 与不进入
+   实现三项要求保持不变。
+5. `trd-gen` 交付前自检明确验证正文没有旧方案状态标注，删除记录位于 frontmatter
+   changelog；skill 职责、路由和 discovery 不改变。
+6. Schema v2 只包含七字段：`target_skill_sha256`、`eval_definition_sha256`、
+   `metadata_sha256`、`fixture_sha256`、`execution_protocol_sha256`、
+   `runtime_protocol_sha256`、`judge_schema_sha256`；完整源码 manifest 只锁同轮 drift。
+7. 一次性迁移将 196 份常规 comparison 分类为 187 机械迁移、trd-gen 6 stale、PM 3 PENDING；
+   manual-only 1 份不迁移。187 份 verdict/evidence 与 807 条 assertion 逐字保持。
+8. 四项静态 contract、受影响 pytest、summarizer、whitespace 检查通过；模型获授权后，
+   9 个目标 eval 各产生一份 fresh durable comparison，runtime artifact 为零。
 
-1. 冻结 38 个常规 skill、193 条旧 eval，迁移清单逐条记录旧 ID、角色、skill、
-   `retained` / `merged` / `deleted` 结论、理由、替代覆盖、pilot 标记、迁移状态和
-   durable comparison；三类结论之和必须为 193。
-2. 旧 comparison 在新契约重跑前统一为 stale / `BLOCKED`，汇总器不得把历史 PASS
-   计作当前 release 证据。
-3. 共享运行时从同一 canonical fixture 物化两个互相不可见的独立 Git 根、`HOME`、
-   `CODEX_HOME`；两条 lane 唯一变量为目标 skill 是否加载。
-4. Preflight 对 fixture、prompt、排除项、skill 可见性、源码边界、模型、六类 runtime
-   surface 和 judge freshness 全部给出确定结论；任一失败或未知均为 `BLOCKED`。
-5. 七角色 pilot 先达到 7/7；门禁通过后才迁移剩余 186 条旧 eval。
-6. 每个 retained eval 都使用本轮 fresh `without_skill`、fresh `with_skill`、第三个
-   fresh Luna medium judge，并更新 durable comparison；merged/deleted 记录理由和替代
-   evidence，不伪造 paired run。
-7. 193/193 有去向，全部 retained 为 complete，所有契约、确定性测试和 artifact 检查
-   通过，Git 跟踪的 runtime artifact 为 0。
-8. 每个 worker 无论 PASS、FAIL、BLOCKED 或异常都删除完整 runtime root；CI 不上传运行期
-   树，仓库和 `tmp/eval-runs/` 最终只保留 durable `comparison.md` 所表达的结论。
-9. 全部已确认 FAIL 根因先完成修改，随后以最多 10 个跨角色 worker 重跑；单条 eval 内的
-   fresh without、fresh with、fresh judge 顺序不变，最终无未解释 FAIL/BLOCKED。
+预计机械移动约 900 至 1100 行，手写净新增约 350 至 550 行；移动只用于形成确认的模块
+边界。模型运行另更新 9 份 comparison。不新增额外抽象层、永久兼容桥、重试、缓存、配置项、
+feature flag、hook、监控或日志层。实际量级明显超出时停止并重新确认范围。
 
-### 2.2 改动量级
+## 3. 文件范围
 
-- 最终生产执行面由 3,023 行增至 4,436 行，净增加 1,413 行；口径覆盖 workflow、薄
-  runner、共享 runtime/executor/schema、checker 与 summarizer。增量对应 OS permission
-  profile、单上下文顺序、可信 Git topology、离线依赖物化、原始 Git 证据、source input
-  锁定、双文件事务、冻结 inventory 与兼容门禁。
-- 最终确定性测试面由 4,562 行增至 5,189 行，净增加 627 行；六套旧 runner 重复测试已
-  删除，共享测试补齐隔离、Git/ref、依赖完整性、事务、source drift、output gate 和 checker
-  故障注入。
-- 相对冻结 commit 的工作树涉及 885 个路径条目，其中 705 个 tracked 变更、180 个新文件；
-  范围包含 38 份 `evals.json`、193 份 metadata、193 份 comparison、迁移 inventory、共享
-  基础设施、测试和经逐条审查的宿主 fixture。
-- 193 份常规 durable comparison 最终只保留最新一轮可审查结论；旧轮次由 Git 历史追溯，
-  不再把 superseded comparison 递归嵌入当前文件。
-- 实际量级高于阶段 1 至 4 的早期估算；最终范围未加入重试、缓存、feature flag、hook 或
-  与 Issue #246 无关的业务抽象，增量均由隔离与证据契约的验收缺口直接触发。
-
-### 2.3 禁止区
-
-- 不修改与 fresh FAIL 无关的 skill 行为；允许按 durable assertion evidence 最小补齐已有
-  仓库契约、路由、门禁、证据或产物要求，并逐项记录对应失败。
-- 不修改或迁移 `agents/docs/test/manual-gen/`；`manual-gen` 保持唯一 manual-only 例外。
-- 不提交 `with_skill/`、`without_skill/`、`baseline/`、`outputs/`、`diagnostics/`、
-  `snapshots/`、`preflight/`、transcript、candidate output、judge verdict、timing、run status
-  或 `comparison.auto.md`。
-- 不新增重试、缓存、降级、feature flag、通用 hook、额外配置层、监控或日志层。
-- DECISIONS 保持不变；PRD、TRD 与本计划只同步维护者明确追加的清理、并发和 FAIL 整改
-  范围，不顺手重构无关代码。
-- 不把模型 eval 设为 required status check，不新增 Release CI 或发布能力。
-
-## 3. 依赖顺序
-
-```mermaid
-flowchart TD
-    A["确认本计划"] --> B["阶段 0：冻结 193 条清单并标记 stale"]
-    B --> C["阶段 1：先写确定性失败测试"]
-    C --> D["阶段 2：统一 runtime、executor 与 judge schema"]
-    D --> E["阶段 3：checker、artifact 与 summarizer"]
-    E --> F["阶段 4：5 个 runner、run_all 与 workflow 收敛"]
-    F --> G["阶段 5：七角色 pilot"]
-    G --> H{"7/7 满足 P0?"}
-    H -->|否| I["只修 scenario、fixture、runtime 或 assertions 后重跑"]
-    I --> G
-    H -->|是| J["阶段 6：按角色迁移剩余 186 条"]
-    J --> K["阶段 7：首轮全量契约、测试与 fresh 诊断"]
-    K --> L["阶段 8：清理过程产物、10 worker、FAIL 聚类整改"]
-    L --> M["阶段 9：全量重跑、二次聚类与最终 closeout"]
-```
-
-后续阶段不得绕过前置门禁；pilot 失败或模型不可用时保留 stale / `BLOCKED`，不得复用历史
-baseline、降低 assertions 或静默更换模型。
-
-## 4. 文件与文件组
-
-| 文件或文件组 | 操作 | 计划内容 |
+| 路径 | 操作 | 计划内容 |
 | --- | --- | --- |
-| `docs/engineer/repository-governance/eval-scenario-isolation/migration-inventory.json` | 新增 | 冻结 193 条旧记录、七角色/38 skill 计数、disposition、替代覆盖、runner 审计和迁移状态 |
-| `scripts/test_eval_runtime.py` | 新增 | materializer、manifest/hash、目录/Git/HOME 隔离、skill overlay、preflight、cleanup 测试 |
-| `scripts/test_run_skill_eval.py` | 新增 | 同 prompt、candidate 顺序、BLOCKED、judge freshness/schema、Overall 重算、认证边界、10 worker 上限和全异常路径 cleanup 测试 |
-| `agents/test_eval_contract.py` | 修改 | scenario、自然 prompt、fixture 泄漏、metadata、inventory 193/193 与 fresh comparison 正反测试 |
-| `scripts/test_check_eval_artifacts.py` | 新增 | snapshot/preflight/judge 等新增 runtime 名称的 tracked-file 正反测试 |
-| `scripts/test_summarize_eval_results.py` | 修改 | stale/BLOCKED 不计 PASS、合法两维结果和旧格式兼容测试 |
-| 六个现有 runner 测试 | 修改 | 更新 designer、devops、docs、PM `run_eval` / `transcript_runner`、QA 的薄入口与泄漏回归断言 |
-| `scripts/eval_runtime.py` | 修改 | canonical fixture、排除、hash、独立临时根/Git/HOME/CODEX_HOME、skill overlay、preflight 和 cleanup 的唯一实现 |
-| `scripts/run_skill_eval.py` | 新增 | 读取自然 prompt；单 eval 串行 paired，批量最多 10 worker；durable 写锁后在 `finally` 删除完整 runtime root |
-| `scripts/eval_judge_result.schema.json` | 新增 | assertion verdict、Behavior、Coverage、Overall、blocker/failure/next step 的严格 schema |
-| `scripts/check_eval_contract.py` | 修改 | scenario、prompt/fixture 泄漏、metadata、inventory 和 fresh comparison 契约 |
-| `scripts/check_eval_artifacts.py` | 修改 | 覆盖统一 runtime 新产物、目录和文件名 |
-| `scripts/summarize_eval_results.py` | 修改 | 区分 stale/BLOCKED 与当前 fresh 结论，阻止旧 PASS 进入当前汇总 |
-| 五个角色 `run_eval.py` | 修改 | designer、devops、docs、product_manager、qa 仅保留兼容 CLI 或确定性 post-run 检查，转发统一 executor |
-| `agents/product_manager/test/idea-to-spec/transcript_runner.py` | 修改 | 删除全 `agents/` mirror、共享 HOME 和自有 paired 物化，改由 PM 兼容入口调用共享实现 |
-| 三个 `run_all_evals.py` | 修改 | designer、docs、qa 只枚举目标并逐条调用统一入口，不持有隔离规则 |
-| `.github/workflows/evals.yml` | 修改 | 目标扩展至七角色，支持 agent/skill/eval 精确选择，调用 `--jobs 10` 且不上传 runtime tree |
-| `agents/{role}/test/{skill}/evals/evals.json`（38 份） | 修改 | 增加 scenario，重写自然 prompt 与语义 assertions，保留旧 ID 到新 ID 映射 |
-| `agents/{role}/test/{skill}/**/eval_metadata.json`（193 份） | 修改 | 增加显式 skill dependencies、六类 runtime isolation；移除 prompt 和脚手架重复信息 |
-| 对应 `comparison.md`（193 份） | 修改 | 先冻结为 stale/BLOCKED；retained 完成 fresh run 后写 preflight、paired、judge 与两维结果 |
-| 对应 README/fixture（按审计，最多 193 组） | 修改/删除 | 只保留宿主原生事实；移除答案材料、脚手架、历史输出和 assertion 同义提示 |
+| `scripts/run_skill_eval.py` | 修改 | 收敛为薄 CLI、target selection 与 orchestration；保留单轮源码 manifest 锁入口。 |
+| `scripts/eval_execution.py`、`scripts/eval_judging.py` | 新增 | 分别承接 candidate/evidence 与 judge/schema/Overall，形成 execution protocol。 |
+| `scripts/eval_runtime.py` | 修改 | 保留 fixture、lane、Git/HOME/CODEX_HOME、preflight、cleanup，形成 runtime protocol。 |
+| `scripts/eval_persistence.py`、`scripts/eval_identity.py` | 新增 | 分离 durable comparison/inventory 与 schema v2 identity；persistence 不进入跨版本 freshness。 |
+| `scripts/check_eval_contract.py` | 修改 | 迁移后单轨严格校验 schema v2；正常路径不调用 Git、不兼容 v1。 |
+| `scripts/migrate_eval_identity_v2.py`、migration audit JSON | 新增 | 一次性核验来源、分类、逐字保持并原子迁移；audit 记录实际旧 hash/source commit。 |
+| 相关 4 至 5 份测试 | 新增/修改 | 覆盖协议 hash、0/1/>1、source drift、v2-only checker、原子迁移和逐字 evidence。 |
+| `agents/engineer/skills/trd-gen/SKILL.md` | 修改 | 强化 current-state TRD 交付前自检，不改变 handoff 和角色边界。 |
+| `agents/engineer/test/trd-gen/evals/evals.json` | 修改 | 收窄 eval-006 的 ownership/handoff 断言，保留其余三项要求。 |
+| `skills-lock.json` | 修改 | 刷新 `trd-gen` 的 `computedHash`。 |
+| 196 份常规 `comparison.md` | 迁移器/runner 更新 | 187 机械迁移、6 stale、3 PENDING；模型另授权后对后两组共9条 fresh。 |
+| 本活动计划 | closeout 更新 | 实施后记录 changed files、命令结果、残余风险和 runtime 清理。 |
 
-“六个现有 runner 测试”指
-`agents/designer/test/test_designer_run_eval.py`、
-`agents/devops/test/test_devops_run_eval.py`、
-`agents/docs/test/test_docs_run_eval.py`、
-`agents/product_manager/test/idea-to-spec/test_pm_run_eval.py`、
-`agents/product_manager/test/idea-to-spec/test_transcript_runner.py` 和
-`agents/qa/test/test_qa_run_eval.py`。
+禁止修改：
 
-## 5. 分阶段实施步骤
+- `docs/engineer/repository-governance/eval-scenario-isolation/migration-inventory.json` 的任何 bytes，以及 manual-only `manual-gen` evaluation result；
+- marketplace、plugin manifest、router、README、AGENTS.md 与 discovery 描述；
+- PM eval-017/018/019 的定义、metadata 和 fixture，除非 fresh 诊断证明其自身另有缺陷并重新确认；
+- 无关 FAIL、comparison、skill、测试和过程文档；
+- `tmp/eval-runs/` 或任何 transcript、output、snapshot、judge verdict、timing、diagnostics、
+  run status、`comparison.auto.md`。
 
-### 阶段 0：冻结基线与旧结论
+## 4. 实施顺序
 
-1. 从当前 38 份 `evals.json` 生成 193 条 immutable old-eval 基线，核对角色计数为
-   designer 11、devops 15、docs 46、engineer 38、product_manager 50、qa 15、security 18。
-2. 逐条给出初始 `retained` / `merged` / `deleted` 结论；merged/deleted 必须同时记录
-   reason 与 replacement refs，retained 在 fresh 证据完成前保持 pending。
-3. 把 193 份旧 comparison 的当前结论统一改为 stale / `BLOCKED`，保留历史正文；
-   inventory 与 comparison 路径必须一一可定位。
-4. 记录五个角色 runner、PM transcript runner、三个 run_all 和 workflow 的泄漏审计字段，
-   未审计项不得标记 complete。
+1. **先写持久化与 checker 回归测试**
+   - 验证零匹配时 comparison 更新且 inventory bytes 不变；唯一匹配保持现有事务更新；
+     多匹配不写 comparison 或 inventory。
+   - 验证冻结后 eval 缺少 scenario、runtime isolation 或合法 fixture 时仍被 checker 拒绝。
+2. **先写 schema v2 与模块边界回归测试**
+   - 验证七字段精确集合；execution/judging、runtime/isolation 变化只更新对应 protocol hash，
+     persistence/inventory/report format 变化不改变跨版本 identity。
+   - 验证同轮完整源码 manifest 任意 drift 均 `BLOCKED`，checker 只接受 v2 且不调用 Git。
+3. **拆分模块并修复 runner/checker**
+   - 实现 TRD 5.1 的 0/1/>1 语义，将 execution、judging、persistence、identity 从薄 runner
+     中按第 3 节边界移出，runtime 保持唯一隔离实现。
+4. **执行一次性迁移**
+   - 先 dry-run 核验可信旧源码、196 分类和 187 份 verdict/evidence；生成 audit 后原子迁移，
+     再次 dry-run 必须零 diff，inventory bytes 与 manual-only result 不变。
+5. **收敛 trd-gen 混合缺陷**
+   - 修改 eval-006 ownership 断言，允许交付摘要中的合法 handoff；强化 skill 的最终文档自检；
+     刷新 lockfile hash。
+6. **执行确定性验证**
+   - 四项 contract 与受影响 pytest 全部通过后，检查 inventory 零 diff和禁止区。
+7. **执行精确 fresh eval（已完成）**
+   - 单一 runner 进程运行 trd-gen 全部 6 条与 PM eval-017/018/019，最多 `--jobs 9`；保留每个
+     有效 PASS、PASS (partial coverage) 或 FAIL，只重试 BLOCKED、timeout 或 incomplete。
+8. **独立验收与 closeout**
+   - 核对来源文档、diff、确定性结果、9 份 comparison、inventory、runtime 清理和残余风险；
+     全部完成后把本文更新为 `Implemented`，不在本轮自动归档新计划。
 
-验证：inventory 总数、唯一 ID、角色/skill 计数和 comparison 路径人工复核为 193/193；
-阶段 3 的 checker 完成后用机器检查替代人工复核。
-
-### 阶段 1：先写确定性测试
-
-1. 新增 runtime 与 executor 测试，先覆盖相同 fixture/prompt、不同 Git/HOME/CODEX_HOME、
-   精确 skill overlay、source/sibling 不可见、runtime unknown 即 BLOCKED、candidate 完成后才
-   建 judge、schema 与 Overall 组合规则。
-2. 扩展 contract、artifact、summarizer 和六个 runner 测试，加入已知 QA prompt/cwd 泄漏、
-   PM 全 skill mirror/共享 HOME 泄漏、非法 README、合法宿主 README、虚假 inventory complete
-   与 stale PASS 误汇总的回归用例。
-3. 先运行新增/修改测试并记录预期失败原因；失败必须对应尚未实现的 TRD 行为，不能以删测试
-   或弱化断言消除。
-
-验证命令：
-
-```bash
-uv run --with pytest pytest scripts/test_eval_runtime.py scripts/test_run_skill_eval.py \
-  agents/test_eval_contract.py scripts/test_check_eval_artifacts.py \
-  scripts/test_summarize_eval_results.py \
-  agents/designer/test/test_designer_run_eval.py \
-  agents/devops/test/test_devops_run_eval.py \
-  agents/docs/test/test_docs_run_eval.py \
-  agents/product_manager/test/idea-to-spec/test_transcript_runner.py \
-  agents/product_manager/test/idea-to-spec/test_pm_run_eval.py \
-  agents/qa/test/test_qa_run_eval.py
-```
-
-### 阶段 2：实现统一运行时、executor 与 judge schema
-
-1. 扩展 `scripts/eval_runtime.py`，集中实现 canonical fixture exclusion、SHA-256 manifest、
-   独立顶层临时根、Git 初始化、隔离 HOME/CODEX_HOME、认证文件权限、skill overlay、preflight
-   和销毁；不提供任意 hook 或角色扩展框架。
-2. 新增 `scripts/run_skill_eval.py`，按 agent/skill/eval ID 精确解析同一条 prompt，先
-   `without_skill` 后 `with_skill` 串行执行；只在两条输出及 diff/manifest 锁定后创建第三个
-   只读 judge package。
-3. 新增 judge JSON Schema，由 executor 校验 assertion verdict 和 Behavior/Coverage，重算
-   Overall；preflight 失败直接返回 `BLOCKED`，不调用 candidate 或 judge 伪造 PASS。
-4. Candidate 调用固定使用全局 approval flag：
-
-```text
-codex --ask-for-approval never --strict-config exec -C <lane-root> \
-  --ephemeral --ignore-rules \
-  --model gpt-5.6-luna -c model_reasoning_effort="medium"
-```
-
-5. Candidate 的隔离 `CODEX_HOME/config.toml` 选择 `eval-candidate` permission profile，
-   只开放当前 workspace 与隔离 HOME 写入并拒绝源码、sibling 和认证读取；Judge 使用
-   `eval-judge` 只读 profile 与 `--output-schema scripts/eval_judge_result.schema.json`。
-   Candidate 与 judge 均不得静默换模型。
-
-验证：阶段 1 的 runtime/executor 测试全部从预期失败转为通过；源仓库、用户 home、另一条
-lane 与目标外 skill 不进入 candidate-visible tree。
-
-### 阶段 3：收紧 checker、artifact 与 summarizer
-
-1. `check_eval_contract.py` 校验 scenario 七字段、自然 prompt 硬禁用模式、candidate fixture、
-   `skill_dependencies`、六类 runtime isolation、inventory 193/193 与 fresh comparison。
-2. 静态规则只拦截高置信泄漏；合法业务词与宿主原生 README 必须有反例测试，语义“活人感”
-   保留人工 review，不用关键词伪装模型判分。
-3. `check_eval_artifacts.py` 覆盖新增 snapshot/preflight/judge 包及所有既有 runtime 名称。
-4. `summarize_eval_results.py` 只把具备 fresh preflight/judge 的当前结论计入 PASS；stale
-   comparison 继续可解析但只能汇总为 BLOCKED。
-
-验证：阶段 1 对应 checker/artifact/summarizer 测试通过，并运行：
-
-```bash
-uv run scripts/check_eval_contract.py
-uv run scripts/check_eval_artifacts.py
-uv run scripts/summarize_eval_results.py
-```
-
-### 阶段 4：收敛 runner、run_all 与 workflow
-
-1. 五个角色 `run_eval.py` 删除 prompt/judge 构造、fixture 复制、lane HOME 和判定重复实现；
-   保留兼容参数与确有 deterministic output 时的最小 post-run 检查。
-2. PM `transcript_runner.py` 删除全 skill mirror、共享 HOME/CODEX_HOME 和自有物化逻辑；
-   PM `run_eval.py` 统一转发 `scripts/run_skill_eval.py`。
-3. 三个 `run_all_evals.py` 只负责稳定枚举与传播退出码；Engineer/Security 直接使用统一入口，
-   不新增角色 runner。
-4. workflow 支持七角色及 agent/skill/eval 精确选择，安装并认证 Codex CLI 后调用统一入口
-   `--jobs 10`；不上传 runtime tree，每条结束即删除过程产物。
-5. 完成 runner 审计：消息来源、cwd、HOME/CODEX_HOME、skill overlay、fixture、assertion/expected
-   output 可见性、runtime reset、judge freshness、artifact 落点全部有结论。
-
-验证：六个 runner 回归测试通过；共享执行面按第 2.2 节的实测口径复核，无未说明的范围扩张。
-
-### 阶段 5：七角色 pilot
-
-按以下冻结旧 ID 各迁移一条：
-
-| 角色 | Pilot 种子 |
-| --- | --- |
-| designer | `ui-ux-design/eval-001-saas-dashboard` |
-| devops | `deployment-planner/eval-002-python-api-only` |
-| docs | `docs-agent/eval-001-route-formal-docs-sync` |
-| engineer | `codebase-analyzer/eval-003-mapped-search-architecture` |
-| product_manager | `idea-to-spec/eval-001-existing-project-feature-design` |
-| qa | `bug-analyzer/eval-002-thin-evidence-suspected-bug` |
-| security | `authz-reviewer/eval-001-rbac` |
-
-每个 pilot 依次完成 scenario review、fixture 清理、metadata、两条 fresh candidate、preflight、
-独立 judge 和 durable comparison。运行入口形式为：
-
-```bash
-uv run scripts/run_skill_eval.py --agent <role> --skill <skill> --eval <eval-id>
-```
-
-7/7 的 FR-002、FR-003、FR-005 至 FR-009 全部满足后才放行阶段 6。任一 pilot 失败只修正
-scenario、fixture、runtime 或 assertions 并重跑；发现业务 skill 缺陷时另行建项。
-
-### 阶段 6：按角色迁移剩余 186 条
-
-1. 批次固定为 designer → devops → qa → security → engineer → docs → product_manager；
-   每个角色形成独立可回滚提交边界。
-2. 对剩余 186 条逐条 review 并更新 inventory。每个 retained eval 单独执行 fresh Luna medium
-   `without_skill`、fresh Luna medium `with_skill`、第三个 fresh Luna medium judge，并更新对应
-   comparison 后才标记 complete。
-3. merged/deleted 不执行虚假的 paired run，但必须记录 reason、replacement refs 和对应 durable
-   evidence；没有替代覆盖时不得使用 merged/deleted。
-4. 每个角色批次结束即运行 eval contract、artifact checker、summarizer 和相关确定性测试；
-   任一失败停止下一角色，不跨批次掩盖失败。
-5. 模型、认证或 runtime isolation 不可用时对应项保持 stale / `BLOCKED`；不复用历史 baseline，
-   不把 transcript、verdict、diagnostics 或 workspace snapshot 纳入 Git。
-
-### 阶段 7：最终验证与 closeout
-
-按 CI 顺序执行：
+## 5. 验证命令
 
 ```bash
 uv run scripts/check_repository_contract.py
 uv run scripts/check_eval_contract.py
 uv run scripts/check_eval_artifacts.py
 uv run scripts/check_doc_contract.py
-uv run --with pytest pytest scripts/test_eval_runtime.py scripts/test_run_skill_eval.py \
-  agents/test_eval_contract.py scripts/test_check_eval_artifacts.py \
-  scripts/test_summarize_eval_results.py \
-  agents/designer/test/test_designer_run_eval.py \
-  agents/devops/test/test_devops_run_eval.py \
-  agents/docs/test/test_docs_run_eval.py \
-  agents/product_manager/test/idea-to-spec/test_transcript_runner.py \
-  agents/product_manager/test/idea-to-spec/test_pm_run_eval.py \
-  agents/qa/test/test_qa_run_eval.py
+uv run --with pytest pytest scripts/test_run_skill_eval.py scripts/test_eval_runtime.py \
+  scripts/test_eval_execution.py scripts/test_eval_persistence.py \
+  scripts/test_migrate_eval_identity_v2.py agents/test_eval_contract.py
 uv run scripts/summarize_eval_results.py
-git ls-files agents tmp/eval-runs | \
-  rg '(^|/)(with_skill|without_skill|baseline|outputs|diagnostics|snapshots|preflight)(/|$)|comparison\.auto\.md|transcript\.md|candidate-output\.md|subagent-verdict\.md|timing\.json|run_status\.json'
 git diff --check
 git status --short
 ```
 
-最后一个 `rg` 命令预期无输出；其退出码为 1 表示零命中。Closeout 前还须核对：inventory
-为 193/193、七角色 pilot 为 7/7、全部 retained complete、旧 stale PASS 未进入当前汇总、
-生产/测试/资产量级符合第 2.2 节、禁止区零 diff。完成后再把本计划状态更新为
-`Implemented`，记录实际文件、逐条命令结果、模型 eval comparison、剩余风险和 QA/下一责任人；
-归档仍需维护者另行批准。
+模型获得明确授权后使用一个 runner 进程：
 
-### 阶段 7 首轮诊断结果
+```bash
+uv run scripts/run_skill_eval.py --jobs 9 \
+  --select engineer/trd-gen/eval-001-prd-to-engineer-trd \
+  --select engineer/trd-gen/eval-002-resolve-trd-gap-packet \
+  --select engineer/trd-gen/eval-003-nested-prd-to-engineer-trd \
+  --select engineer/trd-gen/eval-004-api-adr-owned-by-engineer \
+  --select engineer/trd-gen/eval-005-mapped-upload-trd-evidence \
+  --select engineer/trd-gen/eval-006-delivery-polling-to-events \
+  --select product_manager/pm-agent/eval-017-scope-guard-unenabled-general \
+  --select product_manager/pm-agent/eval-018-scope-guard-explicit-invocation \
+  --select product_manager/pm-agent/eval-019-scope-guard-enabled-general
+```
 
-- Inventory 为 193 retained / 193 complete / 0 pending；38 个 skill 分组的 durable
-  comparison 均为本轮 fresh 证据，汇总为 59 PASS、9 PASS (partial coverage)、125 FAIL、
-  0 BLOCKED。
-- 每条 eval 均使用 `gpt-5.6-luna`、`model_reasoning_effort="medium"` 完成 fresh
-  `without_skill`、fresh `with_skill` 与第三个独立 judge；同一 eval 内严格按顺序执行。
-- `check_repository_contract.py`、`check_eval_contract.py`、`check_eval_artifacts.py` 与
-  `check_doc_contract.py` 全部通过；精确 CI 清单为 273 passed、10 subtests passed。
-- Workflow YAML、Python compile、tracked/untracked whitespace、禁止区和当时的 tracked
-  runtime artifact 检查通过；首轮结果随后作为 FAIL 聚类输入，不再代表最终 closeout。
-- 125 个 FAIL 重叠聚类为路由/handoff 43、gate/authority 56、证据核验 42、产物完整性 43，
-  另有少量网络不可用、空材料和 Git 初始状态不成立的 fixture 设计错误。
-- 维护者于 2026-08-08 明确要求继续处理全部 FAIL，并把过程产物清理与 10 并发加入同一
-  closeout；因此本计划由 `Implemented` 重开为 `Draft` 活动计划，不归档。
-
-### 阶段 8：过程产物、并发与 FAIL 整改
-
-1. 已删除 ignored 的 `tmp/eval-runs/` 历史运行树约 7.5 GB；`AGENTS.md`、runner 和 workflow
-   已统一为每条结束删除完整 runtime root，CI 不再上传过程树。
-2. `run_skill_eval.py` 已增加 1 至 10 worker 批量调度和 durable 写锁；20 个假目标验证峰值
-   为 10，单目标 paired 顺序保持不变。Runtime/runner/artifact 定向测试为 73 passed。
-3. 已按首轮 evidence 补齐七角色 router、门禁、mapped-doc evidence、durable artifact 和
-   closeout 要求；跨 skill 共享契约路径改为安装态依赖路径，避免 source repository OS deny。
-4. 已修正不可能 fixture：delivery 使用真实未提交 patch topology；计划生成用例获得真实
-   PRD/TRD；GitHub/changelog/roadmap/battlecard 使用用户提供的原始离线导出；成功的
-   docs-audit pre-tag 场景补齐 Release Notes owner handoff。
-5. skills-lock、全静态契约与确定性测试均已完成；此阶段完成后才启动模型 eval。
-
-### 阶段 9：10 worker 全量重跑与最终 closeout
-
-1. 静态门禁通过后以 10 worker 跨七角色完成 193 条 eval；每条内部严格执行 fresh without、
-   fresh with 与 fresh read-only judge，最终为 193/193 FRESH、0 BLOCKED。
-2. 最终分布为 91 PASS、55 PASS (partial coverage)、47 FAIL。47 个行为 FAIL 已按角色聚合为
-   GitHub Issue #249 至 #255，后续分别判断 eval 是否偏离 skill 设计、skill 是否存在执行缺陷，
-   或是否属于模型波动；它们不再作为 Issue #246 的基础设施或迁移阻塞。
-3. Inventory 为 193 retained / 193 complete / 0 pending；四类 contract、完整确定性测试、
-   whitespace、YAML、Python compile、禁止区和 runtime artifact 检查均通过。
-
-### 阶段 10：Durable comparison 最新结果归一化
-
-1. 先把共享 writer 回归改为要求每份 comparison 只有一个 `Overall result`，并确认旧实现因
-   递归保留 historical context 而失败；随后移除 writer 的历史正文拼接。
-2. 193 份常规 comparison 全部删除 `Historical Context (Superseded)`，只保留最新 FRESH
-   结论；结果分布保持 91 PASS、55 PASS (partial coverage)、47 FAIL，`manual-gen` 不变。
-3. 维护者明确要求本次不重新执行模型 eval。文件中的 normalization note 说明本次只做
-   durable 格式归一化；candidate、judge 与既有结果没有被伪装成新一轮运行。
-4. `scripts/test_run_skill_eval.py` 为 33 passed；完整确定性测试为 284 passed、10 subtests
-   passed；repository、eval、artifact、doc 四项 contract 与 summarizer 全部通过。
+完成后再次运行 eval contract、artifact checker、summarizer、`git diff --check` 与
+`git status --short`，并确认 `migration-inventory.json` 无 diff、`tmp/eval-runs/` 不存在。
 
 ## 6. Sub-Agent 分工
 
-本任务触发复杂分工：跨七角色、至少 425 个资产文件，且必须把实现与验证上下文分离。
-
 | 角色 | 范围 | 边界 |
 | --- | --- | --- |
-| 主进程 | 保留 PRD/TRD、inventory、阶段门禁、提交边界和 closeout 上下文 | 不把门禁判断外包，不允许多个 agent 同时修改同一文件组 |
-| 基础设施实现 sub-agent | 阶段 1 至 4 的 runtime、executor、schema、checker、runner 与测试 | 只按本计划文件组修改，不接触 eval 业务资产和 skill 协议 |
-| 角色迁移 sub-agent | Pilot 通过后按单一角色批次迁移 eval 资产 | 每条先读目标 skill 契约；只改该角色 test 资产、inventory 对应记录和 comparison |
-| 独立验收 sub-agent | 使用全新只读上下文核对来源文档、diff、测试结果、inventory、禁止区和残余风险 | 不实现修复、不接受被测 lane 自评；发现问题回交对应实现批次 |
+| 主进程 | 保留 PRD、DECISIONS、TRD、仓库规则、计划门禁、集成和最终交付判断 | 不把范围扩张、模型授权或 closeout 决策外包 |
+| 实现 sub-agent | schema v2、模块拆分、迁移器、runner/checker 测试、trd-gen skill/eval 与 lockfile | 只改第 3 节文件，不运行模型 eval，不改 inventory 或无关资产 |
+| 独立验收 sub-agent | 只读核对来源文档、最终 diff、确定性命令、comparison、inventory 与残余风险 | 不实现修复，不接受候选自评作为证据 |
 
-角色迁移可串行复用 sub-agent，但不得并发改 inventory；主进程在每批回收后统一写入 inventory
-和 closeout。Fresh candidate/judge 是 eval 证据链，不替代独立工程验收 sub-agent。
+## 7. Closeout 记录
 
-## 7. 阶段回滚点
-
-| 回滚点 | 触发条件 | 回滚动作 |
-| --- | --- | --- |
-| R0：冻结后 | inventory 计数或旧 comparison 映射错误 | 修正 inventory 与 stale 映射；不得恢复旧 PASS 的 release 有效性 |
-| R1：共享基础设施后 | 隔离测试或 checker 不能稳定通过 | 回滚 runtime/executor/checker 代码，但保留 inventory 与 stale 状态 |
-| R2：runner 收敛后 | 薄 runner 与共享 runtime 不兼容 | 在同一回滚中恢复全部受影响 runner 与共享入口，禁止新旧隔离语义并存 |
-| R3：pilot 后 | 任一角色未满足 P0 | 停止批量迁移，只重做失败 pilot；已完成 durable evidence 保留 |
-| R4：角色批次后 | 批次出现契约、模型或资产问题 | 仅回滚该角色批次的 eval 资产与 inventory 状态，前序已通过角色不重跑 |
-| R5：closeout 前 | 193/193、artifact 或禁止区检查失败 | 保持计划 Draft、未完成项 stale/BLOCKED，修正后重跑最终验证 |
-
-`tmp/eval-runs/` 可删除并重新生成，不用于恢复 durable comparison。所有回滚以 Git 提交边界
-恢复仓库事实，不从 runtime artifact 回填结果。
+- `changed_files`: schema v2 execution/judging/runtime/persistence/identity 模块、薄 runner、
+  v2-only checker、一次性迁移器与 audit、确定性测试、trd-gen/pm-agent skill 与 trd-gen
+  eval-006、lockfile、活动文档，以及 196 份常规 comparison 的 v2 identity；冻结
+  `migration-inventory.json` 与 manual-only result 未改。
+- `commands_and_results`: 四项 contract 全部 PASS；受影响 pytest `175 passed, 6 subtests
+  passed`；迁移后二次 dry-run `0 changes`；summarizer 共 196 份 comparison，132 PASS、
+  50 PASS (partial coverage)、14 FAIL；`git diff --check` PASS。
+- `fresh_eval_results`: 首批 9 条确认 trd-gen eval-006 与 pm-agent eval-018 为 skill defect；
+  最小 skill 修复后按维护者扩大授权运行 trd-gen 6 条与 pm-agent 19 条。trd-gen 6/6
+  通过，pm-agent 18/19 通过；超时 BLOCKED 仅按 runbook 单目标提高至 900 秒重试并通过。
+- `residual_risks`: pm-agent eval-016 保留 fresh FULL FAIL，实际只读结构治理、HTML 报告、
+  六角色覆盖和 major 确认均通过，仅缺用户可见的显式 `idea-to-spec:structure-governance`
+  主 route；该缺陷与 Issue #277 的 scope guard/冻结后持久化目标无关，后续单独处理。
+- `runtime_artifacts_removed`: `tmp/eval-runs/` 不存在，artifact checker PASS。
+- `next_owner`: 维护者审阅并决定是否提交/创建 PR，以及是否为 pm-agent eval-016 建立独立
+  issue；本计划不自动归档。

--- a/docs/engineer/repository-governance/eval-scenario-isolation/TRD.md
+++ b/docs/engineer/repository-governance/eval-scenario-isolation/TRD.md
@@ -1,7 +1,7 @@
 ---
 title: "Eval 真实场景与 Lane 隔离重构技术需求文档"
 type: TRD
-version: "1.3.0"
+version: "1.5.0"
 status: Approved
 author: "Neplich Codex"
 date: "2026-08-07"
@@ -16,11 +16,13 @@ related_docs:
   - "docs/pm/repository-governance/eval-scenario-isolation/DECISIONS.md"
   - "https://github.com/Neplich/dev-agent-skills/issues/246"
   - "https://github.com/Neplich/dev-agent-skills/issues/275"
+  - "https://github.com/Neplich/dev-agent-skills/issues/277"
   - "https://learn.chatgpt.com/docs/developer-commands?surface=cli"
   - "https://learn.chatgpt.com/docs/sandboxing"
   - "https://learn.chatgpt.com/docs/permissions"
 related_code:
   - "scripts/eval_runtime.py"
+  - "scripts/run_skill_eval.py"
   - "scripts/check_eval_contract.py"
   - "scripts/check_eval_artifacts.py"
   - "scripts/summarize_eval_results.py"
@@ -30,8 +32,16 @@ related_code:
   - "agents/*/test/*/evals/evals.json"
   - "agents/*/test/*/evals/workspace/**"
   - "agents/*/test/*/workspace/**"
+  - "agents/engineer/skills/trd-gen/SKILL.md"
+  - "agents/engineer/test/trd-gen/evals/evals.json"
   - ".github/workflows/evals.yml"
 changelog:
+  - version: "1.5.0"
+    date: "2026-08-12"
+    changes: "定义 identity schema v2 七字段、协议模块边界与 196 份常规 comparison 的一次性单轨迁移"
+  - version: "1.4.0"
+    date: "2026-08-12"
+    changes: "定义冻结后 eval 的零/一/多 inventory 匹配语义、统一严格检查，并收敛 trd-gen eval-006 混合缺陷"
   - version: "1.3.0"
     date: "2026-08-12"
     changes: "分离完整 skill overlay 的运行锁定身份与 durable comparison 的历史 freshness 身份"
@@ -68,6 +78,16 @@ feature flag、额外配置层、监控系统或通用插件框架。运行状�
 runner 退出前删除完整 runtime root，仓库长期只保留 scenario、fixture、迁移清单和 durable
 `comparison.md`。
 
+Issue #277 的后续修复不扩充 Issue #246 冻结的 193 条迁移账本。Durable writer 将历史迁移
+状态更新与当前 comparison 持久化解耦，静态 checker 则对所有当前常规 eval 使用同一严格
+输入契约。`trd-gen` eval-006 只修正与合法后续 handoff 冲突的断言，同时保留并强化正文
+归一化与 frontmatter changelog 的现行 skill 义务。
+
+维护者随后授权把 #277 小幅扩大到 identity schema v2。跨版本 freshness 只绑定目标 skill、
+eval definition、metadata、fixture、execution protocol、runtime protocol 与 judge schema；
+persistence、inventory、报告格式和薄 CLI 不参与跨版本身份。全部执行源码 manifest 仍在同轮
+开始时锁定并在持久化前复核，任何漂移都 `BLOCKED`。
+
 ### 1.1 来源与追踪
 
 | 来源 | 本 TRD 的技术落实 |
@@ -77,8 +97,11 @@ runner 退出前删除完整 runtime root，仓库长期只保留 scenario、fix
 | PRD US-003、FR-005 至 FR-008 | 统一 materializer、preflight、skill overlay、paired executor 和 fresh judge。 |
 | PRD US-004、FR-001、FR-009 | 维护 193 条冻结基线迁移清单并机械校验 193/193。 |
 | PRD US-005、FR-009 | 未按新契约重跑的 comparison 标记 `BLOCKED`/stale。 |
-| DECISIONS D-001 至 D-015 | 保留 major 级别、唯一变量、runtime artifact 零提交和不改业务协议边界。 |
+| PRD US-006、FR-011 | 冻结后 eval 不登记 inventory；定义零/一/多匹配持久化与统一严格检查。 |
+| PRD US-007、FR-012、FR-013 | Identity v2 七字段、协议模块边界、同轮完整源码锁与一次性单轨迁移。 |
+| DECISIONS D-001 至 D-026 | 保留隔离与证据边界，并落实冻结账本、持久化三态、trd-gen 混合缺陷与 identity v2 决策。 |
 | Issue #246 | 修复 QA 确定性泄漏，审计其余 runner，并重建全部常规 eval 证据。 |
+| Issue #277 | 修复 PM scope-guard eval 的持久化阻塞，并收敛 trd-gen eval-006 的断言与行为缺陷。 |
 | AGENTS.md eval 契约 | 固定 fresh paired lane、Luna medium、独立 judge、Behavior/Coverage/Overall 结果。 |
 
 ## 2. 冻结实现基线
@@ -250,6 +273,47 @@ Executor 校验组合规则，不信任模型自由计算 Overall：Behavior FAI
 PASS + FULL 为 PASS；Behavior PASS + PARTIAL 为 PASS (partial coverage)。Preflight
 失败由 executor 直接产生 BLOCKED，不调用 judge。
 
+### 3.6 Identity schema v2 与模块边界
+
+Durable comparison 的跨版本 freshness 只包含以下七个字段：
+
+1. `target_skill_sha256`
+2. `eval_definition_sha256`
+3. `metadata_sha256`
+4. `fixture_sha256`
+5. `execution_protocol_sha256`
+6. `runtime_protocol_sha256`
+7. `judge_schema_sha256`
+
+实现按职责分成四层：`eval_execution.py` 负责 candidate 执行和证据锁定，
+`eval_judging.py` 负责 judge package、schema 校验与 Overall 重算，两者共同形成 execution
+protocol；`eval_runtime.py` 只负责 fixture、lane、Git/HOME/CODEX_HOME、preflight 与 cleanup，
+形成 runtime protocol；`eval_persistence.py` 负责 comparison 格式、事务写入和 inventory
+0/1/>1 语义，不进入跨版本 freshness。`eval_identity.py` 计算七字段和完整源码 manifest；
+`run_skill_eval.py` 只保留薄 CLI、目标枚举和 orchestration。
+
+单轮执行锁定上述全部模块以及 checker、schema 和报告格式等实际参与路径的完整源码
+manifest，并在 durable persistence 前复核；任一 bytes 变化均为 source drift，结果
+`BLOCKED`。完整 manifest 不写入 schema v2 freshness，也不因后续 persistence、inventory、
+report format 或薄 CLI 变化使历史 comparison stale。
+
+### 3.7 一次性迁移与 checker 切换
+
+`migrate_eval_identity_v2.py` 是一次性迁移器。Dry-run 先核验旧 Executor/Runtime hash 对应
+可信 Git source commit，重算当前四项 eval 输入，并输出 migration audit JSON；实际旧 hash
+和 source commit 只记录在 audit，不硬编码进正常 writer/checker。
+
+196 份常规 comparison 按冻结分类处理：187 份 FRESH 机械替换 identity 块并保持 verdict、
+assertion evidence、Behavior、Coverage 与 Overall 逐字不变；其结果分布为 127 PASS/FULL、
+46 PASS/PARTIAL、12 FAIL/FULL、2 FAIL/PARTIAL，807 条 assertion 为 717 PASS、
+70 NOT_EXERCISED、20 FAIL。`trd-gen` 6 份因 skill/eval 输入变化保持 v2 stale，PM eval-017/018/019
+保持 v2 PENDING；1 份 manual-only evaluation result 原样不迁移。
+
+迁移先完成全量验证再原子写入；任一来源、输入、数量或逐字保持校验失败时不部分落盘。
+迁移完成后 `check_eval_contract.py` 只接受 schema v2，正常检查不调用 Git、不读取迁移 audit、
+不保留 v1/v2 双轨。冻结 `migration-inventory.json` 的 schema 1.0、193 条记录和 counts 保持
+逐字不变。
+
 ## 4. Runner 收敛方案
 
 | 文件或角色 | 目标状态 |
@@ -291,6 +355,29 @@ fixture 复制、assertion/expected output 可见性、runtime reset、judge fre
 - `migration_status: complete` 只允许在新 comparison 含 fresh preflight、judge 和合法
   Behavior/Coverage/Overall 时出现；
 - 全量完成条件为 193/193 有处理结论，且所有 retained 均 complete。
+
+### 5.1 冻结后 Eval 持久化与检查
+
+`migration-inventory.json` 的 schema 继续为 `1.0`，`old_evals`、角色/skill 计数、disposition
+与 migration status 总数保持 Issue #246 冻结值。后续新增、修改或删除的常规 eval 不回填
+这份历史清单。
+
+`scripts/run_skill_eval.py` 在持久化 fresh judge 结果时按 `(agent, skill, eval_id)` 查找
+`disposition: retained` 的记录：
+
+- 零匹配：判定为冻结后 eval，只事务替换其 `comparison.md`，inventory 文件不参与写入；
+- 唯一匹配：在同一 durable transaction 中替换 comparison，并把对应 migration status 与
+  汇总计数更新为 complete；
+- 多于一个匹配：判定 inventory 身份歧义，拒绝 durable 写入并返回契约错误，不选择任一记录。
+
+`check_eval_contract.py` 对仓库中的每个常规 eval 一律执行 scenario、自然 prompt、assertions、
+metadata、`skill_dependencies`、六类 runtime isolation、Git topology 和 candidate fixture
+检查。Inventory 只额外验证冻结记录与 fresh identity，不再决定普通 eval 的校验强度。
+
+`trd-gen` eval-006 的修复分两层：断言允许 skill 在完成目标 TRD 后于交付摘要中声明
+`feature-implementor` owner/path，但仍要求本轮 TRD 由 `trd-gen` 自己完成，且 routing 信息不写入
+TRD 正文；skill 的交付前自检明确检查旧方案状态注释已从正文删除、移除记录已进入 frontmatter
+changelog。`body_consolidation`、`removal_recorded_in_changelog` 与“不创建计划/代码”断言不弱化。
 
 迁移开始时先把 193 份旧 comparison 的 Latest result 统一标记为 `BLOCKED`，原因写明
 Issue #246 新契约尚未重跑；保留历史正文。之后严格按以下阶段放行：
@@ -337,12 +424,26 @@ fixture 可执行性聚类：skill 未落实既有仓库契约时最小修正 sk
 | 193 个 eval workspace | 更新 metadata、清理/重写 README 与 fixture、保留 durable comparison。 |
 | `migration-inventory.json` | 新增 193 条冻结映射与阶段状态。 |
 | `.github/workflows/evals.yml` | 七角色统一入口、固定 `--jobs 10`，移除 runtime artifact 上传。 |
+| `scripts/run_skill_eval.py`、`scripts/test_run_skill_eval.py` | 增加 inventory 零/一/多 retained match 的持久化语义与回归测试。 |
+| `scripts/check_eval_contract.py`、`agents/test_eval_contract.py` | 对所有当前常规 eval 统一启用严格输入校验，保留冻结 inventory 的独立校验。 |
+| `scripts/eval_execution.py`、`scripts/eval_judging.py` | 新增 execution/judging 协议模块；承接 candidate、judge 与结果重算逻辑。 |
+| `scripts/eval_persistence.py`、`scripts/eval_identity.py` | 新增 persistence/inventory 与 schema v2 identity 模块；前者不参与跨版本 freshness。 |
+| `scripts/migrate_eval_identity_v2.py`、migration audit JSON | 新增一次性迁移器与可复核分类/来源报告；正常 checker 不依赖该报告。 |
+| `scripts/run_skill_eval.py`、`scripts/eval_runtime.py` | 前者收敛为薄入口，后者保留 runtime/isolation；完整源码 manifest 只用于同轮 drift。 |
+| 相关 4 至 5 份测试 | 覆盖协议 hash、模块边界、source drift、原子迁移、逐字证据保持和 v2-only checker。 |
+| `agents/engineer/skills/trd-gen/SKILL.md`、`skills-lock.json` | 强化 current-state TRD 交付前自检，并刷新目标 skill hash；不改变职责边界或 discovery。 |
+| `agents/engineer/test/trd-gen/evals/evals.json` | 修正 eval-006 对合法后续 handoff 的误判，保留正文归一化、frontmatter changelog 和不进入实现的断言。 |
+| 9 份目标 `comparison.md` | 经用户明确授权后，精确重跑 trd-gen 全部 6 条与 PM eval-017/018/019 并由 runner 更新。 |
+| `migration-inventory.json` | 禁止修改；保持 schema 1.0、193 条冻结记录及其 counts。 |
 
 阶段 1 至 4 的早期实测为生产净增加 215 行、确定性测试净删除 386 行；完整隔离终审加入
 Git topology、离线依赖、source lock 与原始 Git evidence 后，以实施计划记录的首轮 closeout
 实测为准。本轮追加预计主要落在 runner 并发/清理回归、目标 skill 的既有契约补齐和少量
 原始 fixture，不新增重试、缓存、降级、feature flag、通用 hook、监控或额外日志层；最终
 closeout 必须重新按冻结 commit 统计生产、测试、skill 和 fixture 四类净行数。
+
+Issue #277 扩大后预计机械移动约 900 至 1100 行，手写净新增约 350 至 550 行；移动用于形成
+上述清晰职责边界，不计为新功能。除这些边界文件外不新增额外抽象、框架或兼容层。
 
 资产触达规模为：38 个 eval 定义文件、193 份 metadata、193 份 comparison、1 份迁移
 清单，以及按审计结果最多 193 个 README/fixture 集合；最少触达 425 个资产文件，最多
@@ -367,6 +468,10 @@ verdict、timing、diagnostics 和 workspace snapshot 只在执行期间存在�
 - 并发 durable transaction 不丢 comparison/inventory 更新；
 - migration inventory 精确覆盖 193/193，并拒绝缺失、重复和虚假 complete；
 - 合法宿主 README 与业务词不被 prompt/fixture 检查误报。
+- Schema v2 七字段完整且协议模块 mutation 只影响对应 protocol hash；persistence/inventory/
+  report format 变化不影响跨版本 freshness；
+- 同轮完整源码 manifest 任意 bytes 漂移均 `BLOCKED`；迁移 dry-run 验证 187/6/3、807 条
+  assertion 逐字保持与 manual-only 排除，迁移后 checker 拒绝 v1 且二次 dry-run 零 diff。
 
 ### 7.2 验证命令
 
@@ -416,6 +521,8 @@ git ls-files agents tmp/eval-runs | \
 | 批量运行成本诱发历史 baseline 复用 | Comparison 不再是同轮证据。 | Executor 不提供复用入口；失败保留 stale/BLOCKED。 |
 | 并发写 durable inventory 丢更新 | Comparison 与 migration 状态不一致。 | Comparison + inventory 事务在进程内写锁中读取、重算和替换，并做并发回归。 |
 | 异常路径残留大体积 runtime tree | 工作区或 CI 磁盘持续膨胀。 | Materialization 也放入受保护的 try/finally；worker 和 `MaterializedEvalRun.cleanup()` 都删除完整 root。 |
+| 协议模块边界遗漏真实执行行为 | 历史 comparison 被错误保留为 fresh。 | Candidate/judge 只在 execution/judging，隔离只在 runtime；跨边界调用与 protocol hash 做确定性测试。 |
+| 一次性迁移部分写入或篡改结论 | 仓库进入双轨或 evidence 失真。 | 全量 dry-run 先行、原子写入、逐字 verdict/evidence 校验，失败不落盘。 |
 
 ## 10. 回滚方案
 
@@ -432,10 +539,12 @@ comparison 和迁移记录通过 Git 恢复，不从 runtime artifact 回填。
 ### 11.1 假设
 
 - 当前冻结基线保持为 Issue #246 核验的 38 skill / 193 eval；后续新增 eval 不改变原
-  193 条逐项去向要求。
+  193 条逐项去向要求，也不登记进历史 inventory。
 - 本机与 CI 的 Codex CLI 支持 `--output-schema`、`--ephemeral`、`--ignore-rules`、
   permission profile 与 `codex sandbox -P`；能力 preflight 失败即 BLOCKED。
 - `gpt-5.6-luna` medium 可用于 candidate 与 judge；不可用时不替换模型。
+- 一次性 migration audit 能核验旧 Executor/Runtime 来源；无法验证来源的 comparison 不机械
+  迁移为 FRESH，而是保持 stale 等待重跑。
 
 ### 11.2 开放问题
 
@@ -444,26 +553,28 @@ comparison 和迁移记录通过 Git 恢复，不从 runtime artifact 回填。
 
 ### 11.3 L2b 拆分评估
 
-本 TRD 少于 500 行；PRD 共 5 条 US 与 10 条 FR，未达到 15 条门槛；方案虽覆盖七角色，
-但只包含“统一运行时/检查器”和“eval 资产迁移”两个相互依赖的技术域，没有独立子功能
-所有权。当前 `feature_path` 不拆分，所有产物继续镜像已确认的 PM L2 路径。
+本 TRD 因保留 #246 至 #277 的当前架构与追踪事实已超过 500 行，触发 L2b 拆分评估；PRD
+共 7 条 US 与 13 条 FR，未达到 15 条门槛。新增 identity v2 与既有 runner/checker 共用
+同一 source identity 和 comparison contract，不形成可独立发布、独立验收或独立所有权的
+子域；拆分会把同一持久化证据链分散到两个 feature path。当前不拆分，所有产物继续镜像
+已确认的 PM L2 路径。
 
 ## 12. Feature Implementor Handoff 条件
 
 `feature-implementor` 仅在以下条件同时满足后编写
 `docs/engineer/repository-governance/eval-scenario-isolation/IMPLEMENTATION_PLAN.md`：
 
-1. 同路径 PRD `1.1.0`、DECISIONS 与本 TRD `1.2.0` 均为 Approved，`change_tier` 保持 major。
-2. 实施计划在原“stale 冻结 → runtime/checker → 七 pilot → 角色批次 → 全量收尾”后追加
-   “过程产物清理 → 10 worker 并发 → fresh FAIL 聚类整改 → 全量重跑”。
-3. 实施计划保留首轮实测量级，并在最终 closeout 按冻结 commit 重算生产、测试、skill 和
-   fixture 四类净行数；不得为满足旧估算删除隔离或证据逻辑。
-4. 只允许 durable FAIL evidence 支持的最小 skill 契约修正，不新增重试、缓存、feature
-   flag、通用 hook、监控或日志层，也不修改无关 skill 行为。
-5. 七角色 pilot 与 193 条首轮 fresh 证据继续作为诊断基线；全部已确认根因修复前不启动
-   正式重跑。
-6. 最终完成定义包含每条 eval 的 fresh without、fresh with、独立 judge、更新后的
-   comparison、退出后 runtime artifact 为 0，以及不存在未解释的 FAIL/BLOCKED。
-
-维护者已明确授权按该追加范围继续实施；`feature-implementor` 使用同一路径活动计划记录
-执行、验证和 closeout，不另建第二份计划或从旧 Implemented 状态跳过新门禁。
+1. 同路径 PRD `1.4.0`、DECISIONS `1.3.0` 与本 TRD `1.5.0` 均为 Approved；Issue #277
+   分类为 `existing_update`、`change_tier: major`；schema v2、checker 单轨和 comparison
+   迁移属于仓库契约面变更。
+2. 原 `eval-scenario-isolation-refactor` 计划已按维护者批准归档；新活动计划固定使用同路径
+   `IMPLEMENTATION_PLAN.md`，并通过 `previous_plan_archive` 回链。
+3. 实施范围只包含 runner 0/1/>1 持久化、checker 统一严格校验、identity v2 模块拆分与
+   一次性迁移、trd-gen eval-006 混合缺陷、相关确定性测试与九条精确 fresh eval；inventory、
+   注册、路由、README 与无关 comparison 均为禁止区。
+4. 预计机械移动约 900 至 1100 行、手写净新增约 350 至 550 行；除确认的模块边界外不新增
+   抽象、兼容桥、重试、缓存、feature flag、通用 hook、监控或日志层；明显偏离时先确认。
+5. 模型 eval 必须在新活动计划获用户确认且模型调用得到明确授权后执行；有效 PASS、
+   PASS (partial coverage) 与 FAIL 均保留，仅重试 BLOCKED、timeout 或 incomplete。
+6. 最终完成定义包含四项静态 contract、受影响确定性测试、九份目标 comparison、
+   inventory 零 diff、runtime artifact 为 0，以及实施计划 closeout 与独立验收结论。

--- a/docs/engineer/repository-governance/eval-scenario-isolation/archive/IMPLEMENTATION_PLAN-eval-scenario-isolation-refactor.md
+++ b/docs/engineer/repository-governance/eval-scenario-isolation/archive/IMPLEMENTATION_PLAN-eval-scenario-isolation-refactor.md
@@ -1,0 +1,422 @@
+---
+title: "Eval 真实场景与 Lane 隔离重构实施计划"
+type: IMPLEMENTATION_PLAN
+version: "0.6.0"
+status: "Archived"
+author: "Neplich Codex"
+date: "2026-08-07"
+last_updated: "2026-08-09"
+generated_by: "feature-implementor"
+feature: "eval-scenario-isolation"
+feature_path: "repository-governance/eval-scenario-isolation"
+parent_feature: "repository-governance"
+feature_level: "2"
+implementation_scope: "eval-scenario-isolation-refactor"
+change_tier: "major"
+related_issue: "#246"
+related_prd: "docs/pm/repository-governance/eval-scenario-isolation/PRD.md"
+related_trd: "docs/engineer/repository-governance/eval-scenario-isolation/TRD.md"
+archived_at: "2026-08-12"
+archive_approved_by: "Neplich"
+source_plan: "docs/engineer/repository-governance/eval-scenario-isolation/IMPLEMENTATION_PLAN.md"
+changelog:
+  - version: "0.6.0"
+    date: "2026-08-09"
+    changes: "完成 10 worker 全量重跑与 closeout；按维护者要求将 193 份 durable comparison 压缩为仅保留最新结果，不重新执行模型 eval"
+  - version: "0.5.0"
+    date: "2026-08-08"
+    changes: "按维护者追加范围重开 closeout：删除全部测试过程产物、加入 10 worker 跨角色并发、聚类修复首轮 FAIL 后再全量重跑"
+  - version: "0.4.0"
+    date: "2026-08-08"
+    changes: "完成 193 条 eval 迁移、fresh paired 执行、独立 judge、durable comparison 与最终门禁，记录实际量级和剩余行为风险"
+  - version: "0.3.0"
+    date: "2026-08-07"
+    changes: "按阶段 1 至 4 隔离实证改用 permission profile，并把代码与测试量级修正为实测口径"
+  - version: "0.2.0"
+    date: "2026-08-07"
+    changes: "维护者确认按本计划实施，解除代码、测试、pilot 与批量迁移门禁"
+  - version: "0.1.0"
+    date: "2026-08-07"
+    changes: "初始草案，定义 stale 冻结、统一隔离运行时、七角色 pilot、全量迁移与收尾验证"
+---
+
+# Eval 真实场景与 Lane 隔离重构实施计划
+
+## 1. 实施上下文与门禁
+
+本计划承接 Issue #246，仅落实已批准的 eval 真实场景、lane 隔离、fresh paired
+执行、独立 judge 与 durable comparison 重构。维护者已于 2026-08-07 明确确认按本计划实施，
+代码、测试、pilot 与批量资产迁移门禁已解除。
+
+| 门禁 | 结论 | 证据 |
+| --- | --- | --- |
+| PRD 对齐 | `already_approved` | PRD `1.1.0` 为 Approved；DECISIONS `1.0.0` 无冲突 |
+| TRD 对齐 | 已通过 | TRD `1.2.0` 为 Approved，清理、并发与 FAIL 聚类范围已对齐 |
+| Feature path | 已通过 | PRD、TRD 与本计划的 `feature_path`、`parent_feature`、`feature_level` 一致，TRD `related_prd` 正确 |
+| 变更等级 | `major` | 覆盖七角色、38 个 skill、runner/checker 契约和 193 条 eval |
+| 实施确认 | 已通过 | 维护者于 2026-08-07 回复“确认按计划实施” |
+| Active plan / archive | 无 | 本路径此前无 `IMPLEMENTATION_PLAN.md`，也无 `implementation-plans/archive/` 历史；不写 `previous_plan_archive` |
+| UI 设计 | 不适用 | 本次只改 CLI、脚本、测试与 eval 资产，不改产品 UI、交互或视觉系统 |
+
+来源文档：
+
+- `docs/pm/repository-governance/eval-scenario-isolation/PRD.md`
+- `docs/pm/repository-governance/eval-scenario-isolation/DECISIONS.md`
+- `docs/engineer/repository-governance/eval-scenario-isolation/TRD.md`
+
+## 2. 成功标准与收紧边界
+
+### 2.1 成功标准
+
+1. 冻结 38 个常规 skill、193 条旧 eval，迁移清单逐条记录旧 ID、角色、skill、
+   `retained` / `merged` / `deleted` 结论、理由、替代覆盖、pilot 标记、迁移状态和
+   durable comparison；三类结论之和必须为 193。
+2. 旧 comparison 在新契约重跑前统一为 stale / `BLOCKED`，汇总器不得把历史 PASS
+   计作当前 release 证据。
+3. 共享运行时从同一 canonical fixture 物化两个互相不可见的独立 Git 根、`HOME`、
+   `CODEX_HOME`；两条 lane 唯一变量为目标 skill 是否加载。
+4. Preflight 对 fixture、prompt、排除项、skill 可见性、源码边界、模型、六类 runtime
+   surface 和 judge freshness 全部给出确定结论；任一失败或未知均为 `BLOCKED`。
+5. 七角色 pilot 先达到 7/7；门禁通过后才迁移剩余 186 条旧 eval。
+6. 每个 retained eval 都使用本轮 fresh `without_skill`、fresh `with_skill`、第三个
+   fresh Luna medium judge，并更新 durable comparison；merged/deleted 记录理由和替代
+   evidence，不伪造 paired run。
+7. 193/193 有去向，全部 retained 为 complete，所有契约、确定性测试和 artifact 检查
+   通过，Git 跟踪的 runtime artifact 为 0。
+8. 每个 worker 无论 PASS、FAIL、BLOCKED 或异常都删除完整 runtime root；CI 不上传运行期
+   树，仓库和 `tmp/eval-runs/` 最终只保留 durable `comparison.md` 所表达的结论。
+9. 全部已确认 FAIL 根因先完成修改，随后以最多 10 个跨角色 worker 重跑；单条 eval 内的
+   fresh without、fresh with、fresh judge 顺序不变，最终无未解释 FAIL/BLOCKED。
+
+### 2.2 改动量级
+
+- 最终生产执行面由 3,023 行增至 4,436 行，净增加 1,413 行；口径覆盖 workflow、薄
+  runner、共享 runtime/executor/schema、checker 与 summarizer。增量对应 OS permission
+  profile、单上下文顺序、可信 Git topology、离线依赖物化、原始 Git 证据、source input
+  锁定、双文件事务、冻结 inventory 与兼容门禁。
+- 最终确定性测试面由 4,562 行增至 5,189 行，净增加 627 行；六套旧 runner 重复测试已
+  删除，共享测试补齐隔离、Git/ref、依赖完整性、事务、source drift、output gate 和 checker
+  故障注入。
+- 相对冻结 commit 的工作树涉及 885 个路径条目，其中 705 个 tracked 变更、180 个新文件；
+  范围包含 38 份 `evals.json`、193 份 metadata、193 份 comparison、迁移 inventory、共享
+  基础设施、测试和经逐条审查的宿主 fixture。
+- 193 份常规 durable comparison 最终只保留最新一轮可审查结论；旧轮次由 Git 历史追溯，
+  不再把 superseded comparison 递归嵌入当前文件。
+- 实际量级高于阶段 1 至 4 的早期估算；最终范围未加入重试、缓存、feature flag、hook 或
+  与 Issue #246 无关的业务抽象，增量均由隔离与证据契约的验收缺口直接触发。
+
+### 2.3 禁止区
+
+- 不修改与 fresh FAIL 无关的 skill 行为；允许按 durable assertion evidence 最小补齐已有
+  仓库契约、路由、门禁、证据或产物要求，并逐项记录对应失败。
+- 不修改或迁移 `agents/docs/test/manual-gen/`；`manual-gen` 保持唯一 manual-only 例外。
+- 不提交 `with_skill/`、`without_skill/`、`baseline/`、`outputs/`、`diagnostics/`、
+  `snapshots/`、`preflight/`、transcript、candidate output、judge verdict、timing、run status
+  或 `comparison.auto.md`。
+- 不新增重试、缓存、降级、feature flag、通用 hook、额外配置层、监控或日志层。
+- DECISIONS 保持不变；PRD、TRD 与本计划只同步维护者明确追加的清理、并发和 FAIL 整改
+  范围，不顺手重构无关代码。
+- 不把模型 eval 设为 required status check，不新增 Release CI 或发布能力。
+
+## 3. 依赖顺序
+
+```mermaid
+flowchart TD
+    A["确认本计划"] --> B["阶段 0：冻结 193 条清单并标记 stale"]
+    B --> C["阶段 1：先写确定性失败测试"]
+    C --> D["阶段 2：统一 runtime、executor 与 judge schema"]
+    D --> E["阶段 3：checker、artifact 与 summarizer"]
+    E --> F["阶段 4：5 个 runner、run_all 与 workflow 收敛"]
+    F --> G["阶段 5：七角色 pilot"]
+    G --> H{"7/7 满足 P0?"}
+    H -->|否| I["只修 scenario、fixture、runtime 或 assertions 后重跑"]
+    I --> G
+    H -->|是| J["阶段 6：按角色迁移剩余 186 条"]
+    J --> K["阶段 7：首轮全量契约、测试与 fresh 诊断"]
+    K --> L["阶段 8：清理过程产物、10 worker、FAIL 聚类整改"]
+    L --> M["阶段 9：全量重跑、二次聚类与最终 closeout"]
+```
+
+后续阶段不得绕过前置门禁；pilot 失败或模型不可用时保留 stale / `BLOCKED`，不得复用历史
+baseline、降低 assertions 或静默更换模型。
+
+## 4. 文件与文件组
+
+| 文件或文件组 | 操作 | 计划内容 |
+| --- | --- | --- |
+| `docs/engineer/repository-governance/eval-scenario-isolation/migration-inventory.json` | 新增 | 冻结 193 条旧记录、七角色/38 skill 计数、disposition、替代覆盖、runner 审计和迁移状态 |
+| `scripts/test_eval_runtime.py` | 新增 | materializer、manifest/hash、目录/Git/HOME 隔离、skill overlay、preflight、cleanup 测试 |
+| `scripts/test_run_skill_eval.py` | 新增 | 同 prompt、candidate 顺序、BLOCKED、judge freshness/schema、Overall 重算、认证边界、10 worker 上限和全异常路径 cleanup 测试 |
+| `agents/test_eval_contract.py` | 修改 | scenario、自然 prompt、fixture 泄漏、metadata、inventory 193/193 与 fresh comparison 正反测试 |
+| `scripts/test_check_eval_artifacts.py` | 新增 | snapshot/preflight/judge 等新增 runtime 名称的 tracked-file 正反测试 |
+| `scripts/test_summarize_eval_results.py` | 修改 | stale/BLOCKED 不计 PASS、合法两维结果和旧格式兼容测试 |
+| 六个现有 runner 测试 | 修改 | 更新 designer、devops、docs、PM `run_eval` / `transcript_runner`、QA 的薄入口与泄漏回归断言 |
+| `scripts/eval_runtime.py` | 修改 | canonical fixture、排除、hash、独立临时根/Git/HOME/CODEX_HOME、skill overlay、preflight 和 cleanup 的唯一实现 |
+| `scripts/run_skill_eval.py` | 新增 | 读取自然 prompt；单 eval 串行 paired，批量最多 10 worker；durable 写锁后在 `finally` 删除完整 runtime root |
+| `scripts/eval_judge_result.schema.json` | 新增 | assertion verdict、Behavior、Coverage、Overall、blocker/failure/next step 的严格 schema |
+| `scripts/check_eval_contract.py` | 修改 | scenario、prompt/fixture 泄漏、metadata、inventory 和 fresh comparison 契约 |
+| `scripts/check_eval_artifacts.py` | 修改 | 覆盖统一 runtime 新产物、目录和文件名 |
+| `scripts/summarize_eval_results.py` | 修改 | 区分 stale/BLOCKED 与当前 fresh 结论，阻止旧 PASS 进入当前汇总 |
+| 五个角色 `run_eval.py` | 修改 | designer、devops、docs、product_manager、qa 仅保留兼容 CLI 或确定性 post-run 检查，转发统一 executor |
+| `agents/product_manager/test/idea-to-spec/transcript_runner.py` | 修改 | 删除全 `agents/` mirror、共享 HOME 和自有 paired 物化，改由 PM 兼容入口调用共享实现 |
+| 三个 `run_all_evals.py` | 修改 | designer、docs、qa 只枚举目标并逐条调用统一入口，不持有隔离规则 |
+| `.github/workflows/evals.yml` | 修改 | 目标扩展至七角色，支持 agent/skill/eval 精确选择，调用 `--jobs 10` 且不上传 runtime tree |
+| `agents/{role}/test/{skill}/evals/evals.json`（38 份） | 修改 | 增加 scenario，重写自然 prompt 与语义 assertions，保留旧 ID 到新 ID 映射 |
+| `agents/{role}/test/{skill}/**/eval_metadata.json`（193 份） | 修改 | 增加显式 skill dependencies、六类 runtime isolation；移除 prompt 和脚手架重复信息 |
+| 对应 `comparison.md`（193 份） | 修改 | 先冻结为 stale/BLOCKED；retained 完成 fresh run 后写 preflight、paired、judge 与两维结果 |
+| 对应 README/fixture（按审计，最多 193 组） | 修改/删除 | 只保留宿主原生事实；移除答案材料、脚手架、历史输出和 assertion 同义提示 |
+
+“六个现有 runner 测试”指
+`agents/designer/test/test_designer_run_eval.py`、
+`agents/devops/test/test_devops_run_eval.py`、
+`agents/docs/test/test_docs_run_eval.py`、
+`agents/product_manager/test/idea-to-spec/test_pm_run_eval.py`、
+`agents/product_manager/test/idea-to-spec/test_transcript_runner.py` 和
+`agents/qa/test/test_qa_run_eval.py`。
+
+## 5. 分阶段实施步骤
+
+### 阶段 0：冻结基线与旧结论
+
+1. 从当前 38 份 `evals.json` 生成 193 条 immutable old-eval 基线，核对角色计数为
+   designer 11、devops 15、docs 46、engineer 38、product_manager 50、qa 15、security 18。
+2. 逐条给出初始 `retained` / `merged` / `deleted` 结论；merged/deleted 必须同时记录
+   reason 与 replacement refs，retained 在 fresh 证据完成前保持 pending。
+3. 把 193 份旧 comparison 的当前结论统一改为 stale / `BLOCKED`，保留历史正文；
+   inventory 与 comparison 路径必须一一可定位。
+4. 记录五个角色 runner、PM transcript runner、三个 run_all 和 workflow 的泄漏审计字段，
+   未审计项不得标记 complete。
+
+验证：inventory 总数、唯一 ID、角色/skill 计数和 comparison 路径人工复核为 193/193；
+阶段 3 的 checker 完成后用机器检查替代人工复核。
+
+### 阶段 1：先写确定性测试
+
+1. 新增 runtime 与 executor 测试，先覆盖相同 fixture/prompt、不同 Git/HOME/CODEX_HOME、
+   精确 skill overlay、source/sibling 不可见、runtime unknown 即 BLOCKED、candidate 完成后才
+   建 judge、schema 与 Overall 组合规则。
+2. 扩展 contract、artifact、summarizer 和六个 runner 测试，加入已知 QA prompt/cwd 泄漏、
+   PM 全 skill mirror/共享 HOME 泄漏、非法 README、合法宿主 README、虚假 inventory complete
+   与 stale PASS 误汇总的回归用例。
+3. 先运行新增/修改测试并记录预期失败原因；失败必须对应尚未实现的 TRD 行为，不能以删测试
+   或弱化断言消除。
+
+验证命令：
+
+```bash
+uv run --with pytest pytest scripts/test_eval_runtime.py scripts/test_run_skill_eval.py \
+  agents/test_eval_contract.py scripts/test_check_eval_artifacts.py \
+  scripts/test_summarize_eval_results.py \
+  agents/designer/test/test_designer_run_eval.py \
+  agents/devops/test/test_devops_run_eval.py \
+  agents/docs/test/test_docs_run_eval.py \
+  agents/product_manager/test/idea-to-spec/test_transcript_runner.py \
+  agents/product_manager/test/idea-to-spec/test_pm_run_eval.py \
+  agents/qa/test/test_qa_run_eval.py
+```
+
+### 阶段 2：实现统一运行时、executor 与 judge schema
+
+1. 扩展 `scripts/eval_runtime.py`，集中实现 canonical fixture exclusion、SHA-256 manifest、
+   独立顶层临时根、Git 初始化、隔离 HOME/CODEX_HOME、认证文件权限、skill overlay、preflight
+   和销毁；不提供任意 hook 或角色扩展框架。
+2. 新增 `scripts/run_skill_eval.py`，按 agent/skill/eval ID 精确解析同一条 prompt，先
+   `without_skill` 后 `with_skill` 串行执行；只在两条输出及 diff/manifest 锁定后创建第三个
+   只读 judge package。
+3. 新增 judge JSON Schema，由 executor 校验 assertion verdict 和 Behavior/Coverage，重算
+   Overall；preflight 失败直接返回 `BLOCKED`，不调用 candidate 或 judge 伪造 PASS。
+4. Candidate 调用固定使用全局 approval flag：
+
+```text
+codex --ask-for-approval never --strict-config exec -C <lane-root> \
+  --ephemeral --ignore-rules \
+  --model gpt-5.6-luna -c model_reasoning_effort="medium"
+```
+
+5. Candidate 的隔离 `CODEX_HOME/config.toml` 选择 `eval-candidate` permission profile，
+   只开放当前 workspace 与隔离 HOME 写入并拒绝源码、sibling 和认证读取；Judge 使用
+   `eval-judge` 只读 profile 与 `--output-schema scripts/eval_judge_result.schema.json`。
+   Candidate 与 judge 均不得静默换模型。
+
+验证：阶段 1 的 runtime/executor 测试全部从预期失败转为通过；源仓库、用户 home、另一条
+lane 与目标外 skill 不进入 candidate-visible tree。
+
+### 阶段 3：收紧 checker、artifact 与 summarizer
+
+1. `check_eval_contract.py` 校验 scenario 七字段、自然 prompt 硬禁用模式、candidate fixture、
+   `skill_dependencies`、六类 runtime isolation、inventory 193/193 与 fresh comparison。
+2. 静态规则只拦截高置信泄漏；合法业务词与宿主原生 README 必须有反例测试，语义“活人感”
+   保留人工 review，不用关键词伪装模型判分。
+3. `check_eval_artifacts.py` 覆盖新增 snapshot/preflight/judge 包及所有既有 runtime 名称。
+4. `summarize_eval_results.py` 只把具备 fresh preflight/judge 的当前结论计入 PASS；stale
+   comparison 继续可解析但只能汇总为 BLOCKED。
+
+验证：阶段 1 对应 checker/artifact/summarizer 测试通过，并运行：
+
+```bash
+uv run scripts/check_eval_contract.py
+uv run scripts/check_eval_artifacts.py
+uv run scripts/summarize_eval_results.py
+```
+
+### 阶段 4：收敛 runner、run_all 与 workflow
+
+1. 五个角色 `run_eval.py` 删除 prompt/judge 构造、fixture 复制、lane HOME 和判定重复实现；
+   保留兼容参数与确有 deterministic output 时的最小 post-run 检查。
+2. PM `transcript_runner.py` 删除全 skill mirror、共享 HOME/CODEX_HOME 和自有物化逻辑；
+   PM `run_eval.py` 统一转发 `scripts/run_skill_eval.py`。
+3. 三个 `run_all_evals.py` 只负责稳定枚举与传播退出码；Engineer/Security 直接使用统一入口，
+   不新增角色 runner。
+4. workflow 支持七角色及 agent/skill/eval 精确选择，安装并认证 Codex CLI 后调用统一入口
+   `--jobs 10`；不上传 runtime tree，每条结束即删除过程产物。
+5. 完成 runner 审计：消息来源、cwd、HOME/CODEX_HOME、skill overlay、fixture、assertion/expected
+   output 可见性、runtime reset、judge freshness、artifact 落点全部有结论。
+
+验证：六个 runner 回归测试通过；共享执行面按第 2.2 节的实测口径复核，无未说明的范围扩张。
+
+### 阶段 5：七角色 pilot
+
+按以下冻结旧 ID 各迁移一条：
+
+| 角色 | Pilot 种子 |
+| --- | --- |
+| designer | `ui-ux-design/eval-001-saas-dashboard` |
+| devops | `deployment-planner/eval-002-python-api-only` |
+| docs | `docs-agent/eval-001-route-formal-docs-sync` |
+| engineer | `codebase-analyzer/eval-003-mapped-search-architecture` |
+| product_manager | `idea-to-spec/eval-001-existing-project-feature-design` |
+| qa | `bug-analyzer/eval-002-thin-evidence-suspected-bug` |
+| security | `authz-reviewer/eval-001-rbac` |
+
+每个 pilot 依次完成 scenario review、fixture 清理、metadata、两条 fresh candidate、preflight、
+独立 judge 和 durable comparison。运行入口形式为：
+
+```bash
+uv run scripts/run_skill_eval.py --agent <role> --skill <skill> --eval <eval-id>
+```
+
+7/7 的 FR-002、FR-003、FR-005 至 FR-009 全部满足后才放行阶段 6。任一 pilot 失败只修正
+scenario、fixture、runtime 或 assertions 并重跑；发现业务 skill 缺陷时另行建项。
+
+### 阶段 6：按角色迁移剩余 186 条
+
+1. 批次固定为 designer → devops → qa → security → engineer → docs → product_manager；
+   每个角色形成独立可回滚提交边界。
+2. 对剩余 186 条逐条 review 并更新 inventory。每个 retained eval 单独执行 fresh Luna medium
+   `without_skill`、fresh Luna medium `with_skill`、第三个 fresh Luna medium judge，并更新对应
+   comparison 后才标记 complete。
+3. merged/deleted 不执行虚假的 paired run，但必须记录 reason、replacement refs 和对应 durable
+   evidence；没有替代覆盖时不得使用 merged/deleted。
+4. 每个角色批次结束即运行 eval contract、artifact checker、summarizer 和相关确定性测试；
+   任一失败停止下一角色，不跨批次掩盖失败。
+5. 模型、认证或 runtime isolation 不可用时对应项保持 stale / `BLOCKED`；不复用历史 baseline，
+   不把 transcript、verdict、diagnostics 或 workspace snapshot 纳入 Git。
+
+### 阶段 7：最终验证与 closeout
+
+按 CI 顺序执行：
+
+```bash
+uv run scripts/check_repository_contract.py
+uv run scripts/check_eval_contract.py
+uv run scripts/check_eval_artifacts.py
+uv run scripts/check_doc_contract.py
+uv run --with pytest pytest scripts/test_eval_runtime.py scripts/test_run_skill_eval.py \
+  agents/test_eval_contract.py scripts/test_check_eval_artifacts.py \
+  scripts/test_summarize_eval_results.py \
+  agents/designer/test/test_designer_run_eval.py \
+  agents/devops/test/test_devops_run_eval.py \
+  agents/docs/test/test_docs_run_eval.py \
+  agents/product_manager/test/idea-to-spec/test_transcript_runner.py \
+  agents/product_manager/test/idea-to-spec/test_pm_run_eval.py \
+  agents/qa/test/test_qa_run_eval.py
+uv run scripts/summarize_eval_results.py
+git ls-files agents tmp/eval-runs | \
+  rg '(^|/)(with_skill|without_skill|baseline|outputs|diagnostics|snapshots|preflight)(/|$)|comparison\.auto\.md|transcript\.md|candidate-output\.md|subagent-verdict\.md|timing\.json|run_status\.json'
+git diff --check
+git status --short
+```
+
+最后一个 `rg` 命令预期无输出；其退出码为 1 表示零命中。Closeout 前还须核对：inventory
+为 193/193、七角色 pilot 为 7/7、全部 retained complete、旧 stale PASS 未进入当前汇总、
+生产/测试/资产量级符合第 2.2 节、禁止区零 diff。完成后再把本计划状态更新为
+`Implemented`，记录实际文件、逐条命令结果、模型 eval comparison、剩余风险和 QA/下一责任人；
+归档仍需维护者另行批准。
+
+### 阶段 7 首轮诊断结果
+
+- Inventory 为 193 retained / 193 complete / 0 pending；38 个 skill 分组的 durable
+  comparison 均为本轮 fresh 证据，汇总为 59 PASS、9 PASS (partial coverage)、125 FAIL、
+  0 BLOCKED。
+- 每条 eval 均使用 `gpt-5.6-luna`、`model_reasoning_effort="medium"` 完成 fresh
+  `without_skill`、fresh `with_skill` 与第三个独立 judge；同一 eval 内严格按顺序执行。
+- `check_repository_contract.py`、`check_eval_contract.py`、`check_eval_artifacts.py` 与
+  `check_doc_contract.py` 全部通过；精确 CI 清单为 273 passed、10 subtests passed。
+- Workflow YAML、Python compile、tracked/untracked whitespace、禁止区和当时的 tracked
+  runtime artifact 检查通过；首轮结果随后作为 FAIL 聚类输入，不再代表最终 closeout。
+- 125 个 FAIL 重叠聚类为路由/handoff 43、gate/authority 56、证据核验 42、产物完整性 43，
+  另有少量网络不可用、空材料和 Git 初始状态不成立的 fixture 设计错误。
+- 维护者于 2026-08-08 明确要求继续处理全部 FAIL，并把过程产物清理与 10 并发加入同一
+  closeout；因此本计划由 `Implemented` 重开为 `Draft` 活动计划，不归档。
+
+### 阶段 8：过程产物、并发与 FAIL 整改
+
+1. 已删除 ignored 的 `tmp/eval-runs/` 历史运行树约 7.5 GB；`AGENTS.md`、runner 和 workflow
+   已统一为每条结束删除完整 runtime root，CI 不再上传过程树。
+2. `run_skill_eval.py` 已增加 1 至 10 worker 批量调度和 durable 写锁；20 个假目标验证峰值
+   为 10，单目标 paired 顺序保持不变。Runtime/runner/artifact 定向测试为 73 passed。
+3. 已按首轮 evidence 补齐七角色 router、门禁、mapped-doc evidence、durable artifact 和
+   closeout 要求；跨 skill 共享契约路径改为安装态依赖路径，避免 source repository OS deny。
+4. 已修正不可能 fixture：delivery 使用真实未提交 patch topology；计划生成用例获得真实
+   PRD/TRD；GitHub/changelog/roadmap/battlecard 使用用户提供的原始离线导出；成功的
+   docs-audit pre-tag 场景补齐 Release Notes owner handoff。
+5. skills-lock、全静态契约与确定性测试均已完成；此阶段完成后才启动模型 eval。
+
+### 阶段 9：10 worker 全量重跑与最终 closeout
+
+1. 静态门禁通过后以 10 worker 跨七角色完成 193 条 eval；每条内部严格执行 fresh without、
+   fresh with 与 fresh read-only judge，最终为 193/193 FRESH、0 BLOCKED。
+2. 最终分布为 91 PASS、55 PASS (partial coverage)、47 FAIL。47 个行为 FAIL 已按角色聚合为
+   GitHub Issue #249 至 #255，后续分别判断 eval 是否偏离 skill 设计、skill 是否存在执行缺陷，
+   或是否属于模型波动；它们不再作为 Issue #246 的基础设施或迁移阻塞。
+3. Inventory 为 193 retained / 193 complete / 0 pending；四类 contract、完整确定性测试、
+   whitespace、YAML、Python compile、禁止区和 runtime artifact 检查均通过。
+
+### 阶段 10：Durable comparison 最新结果归一化
+
+1. 先把共享 writer 回归改为要求每份 comparison 只有一个 `Overall result`，并确认旧实现因
+   递归保留 historical context 而失败；随后移除 writer 的历史正文拼接。
+2. 193 份常规 comparison 全部删除 `Historical Context (Superseded)`，只保留最新 FRESH
+   结论；结果分布保持 91 PASS、55 PASS (partial coverage)、47 FAIL，`manual-gen` 不变。
+3. 维护者明确要求本次不重新执行模型 eval。文件中的 normalization note 说明本次只做
+   durable 格式归一化；candidate、judge 与既有结果没有被伪装成新一轮运行。
+4. `scripts/test_run_skill_eval.py` 为 33 passed；完整确定性测试为 284 passed、10 subtests
+   passed；repository、eval、artifact、doc 四项 contract 与 summarizer 全部通过。
+
+## 6. Sub-Agent 分工
+
+本任务触发复杂分工：跨七角色、至少 425 个资产文件，且必须把实现与验证上下文分离。
+
+| 角色 | 范围 | 边界 |
+| --- | --- | --- |
+| 主进程 | 保留 PRD/TRD、inventory、阶段门禁、提交边界和 closeout 上下文 | 不把门禁判断外包，不允许多个 agent 同时修改同一文件组 |
+| 基础设施实现 sub-agent | 阶段 1 至 4 的 runtime、executor、schema、checker、runner 与测试 | 只按本计划文件组修改，不接触 eval 业务资产和 skill 协议 |
+| 角色迁移 sub-agent | Pilot 通过后按单一角色批次迁移 eval 资产 | 每条先读目标 skill 契约；只改该角色 test 资产、inventory 对应记录和 comparison |
+| 独立验收 sub-agent | 使用全新只读上下文核对来源文档、diff、测试结果、inventory、禁止区和残余风险 | 不实现修复、不接受被测 lane 自评；发现问题回交对应实现批次 |
+
+角色迁移可串行复用 sub-agent，但不得并发改 inventory；主进程在每批回收后统一写入 inventory
+和 closeout。Fresh candidate/judge 是 eval 证据链，不替代独立工程验收 sub-agent。
+
+## 7. 阶段回滚点
+
+| 回滚点 | 触发条件 | 回滚动作 |
+| --- | --- | --- |
+| R0：冻结后 | inventory 计数或旧 comparison 映射错误 | 修正 inventory 与 stale 映射；不得恢复旧 PASS 的 release 有效性 |
+| R1：共享基础设施后 | 隔离测试或 checker 不能稳定通过 | 回滚 runtime/executor/checker 代码，但保留 inventory 与 stale 状态 |
+| R2：runner 收敛后 | 薄 runner 与共享 runtime 不兼容 | 在同一回滚中恢复全部受影响 runner 与共享入口，禁止新旧隔离语义并存 |
+| R3：pilot 后 | 任一角色未满足 P0 | 停止批量迁移，只重做失败 pilot；已完成 durable evidence 保留 |
+| R4：角色批次后 | 批次出现契约、模型或资产问题 | 仅回滚该角色批次的 eval 资产与 inventory 状态，前序已通过角色不重跑 |
+| R5：closeout 前 | 193/193、artifact 或禁止区检查失败 | 保持计划 Draft、未完成项 stale/BLOCKED，修正后重跑最终验证 |
+
+`tmp/eval-runs/` 可删除并重新生成，不用于恢复 durable comparison。所有回滚以 Git 提交边界
+恢复仓库事实，不从 runtime artifact 回填结果。

--- a/docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json
+++ b/docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json
@@ -1,0 +1,7060 @@
+{
+  "schema_version": "2.0",
+  "migration": "eval-identity-v2",
+  "mode": "applied",
+  "source_attestation": {
+    "source_ref": "4cca644d64c599531542e66ba5a9210c5c6bf40c",
+    "source_commit": "4cca644d64c599531542e66ba5a9210c5c6bf40c",
+    "executor_sha256": "321fdc8a67ccc7fd6265fadebaa8db97593c38dcd8d7842f8aea59909966bd54",
+    "runtime_sha256": "9ed43d4c2c0e4dbf09b289476d4fe9240c9ba0e61bc3ba75633ffd6e514d710d"
+  },
+  "audit_path": "docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json",
+  "verification_contract": [
+    "uv run --with pytest pytest scripts/test_migrate_eval_identity_v2.py agents/test_eval_contract.py",
+    "uv run scripts/check_eval_contract.py",
+    "uv run scripts/check_eval_artifacts.py",
+    "git diff --check"
+  ],
+  "counts": {
+    "mechanical": 187,
+    "stale": 6,
+    "pending": 3,
+    "manual_excluded": 1
+  },
+  "mechanical_assertion_rows": {
+    "total": 807,
+    "PASS": 717,
+    "NOT_EXERCISED": 70,
+    "FAIL": 20
+  },
+  "inventory_sha256_before": "74556990293e9e01c602e2d8102b33ba060f5f1302a0a5793f24a9a071f2e3ce",
+  "inventory_sha256_after": "74556990293e9e01c602e2d8102b33ba060f5f1302a0a5793f24a9a071f2e3ce",
+  "entries": [
+    {
+      "agent": "designer",
+      "skill": "designer-agent",
+      "eval_id": "eval-001-route-design-handoff",
+      "comparison_path": "agents/designer/test/designer-agent/evals/workspace/eval-1-route-design-handoff/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "e8c75de1d6f9996313bad1fce4ede6ed7cde9c08fd07355edd02169db57e8e68",
+        "eval_definition_sha256": "22532d649002dfa1851fec27c554d610e1ed3e70ab860965c5b4914f96d4ccce",
+        "metadata_sha256": "b228adbda9579c0023d949fdd52d3bd090b6ff85b7c6c2610e5202c6900dbe10",
+        "fixture_sha256": "318a6ed6ff151cee086f75e2b1924aa867c873c059722194e1d201fc514c9d89",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "463caa76fbf321564869d8651cfcd73afe8721c939c5039c5cfd81c4ab25d935"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "b075bae8db5970f283731eb01a18e33edbcb25674621e018eac885079a4bc094"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "b075bae8db5970f283731eb01a18e33edbcb25674621e018eac885079a4bc094"
+      },
+      "before_sha256": "99175b56f2f053be2715bc4cd3add0ad022c7d69e56a007b9b079f8163d961c4",
+      "after_sha256": "b432798e829e632ed8ea3b00291f0144daee4f087f8301d93d3e57637c793709"
+    },
+    {
+      "agent": "designer",
+      "skill": "designer-agent",
+      "eval_id": "eval-002-feature-path-design-handoff",
+      "comparison_path": "agents/designer/test/designer-agent/evals/workspace/eval-2-feature-path-design-handoff/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "e8c75de1d6f9996313bad1fce4ede6ed7cde9c08fd07355edd02169db57e8e68",
+        "eval_definition_sha256": "53f91ea5792318b5883984b62004cc098b15b6389da8f0c2233bdab77fbf2aa6",
+        "metadata_sha256": "e6f9e581a9240bd876422c7ab0f1f1ca860fda8f563a8f02f87555323c8c7b30",
+        "fixture_sha256": "f51ab76601713bed8d87e8e33016aaf394374041676e06644b8b383a6a3f1ef6",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "173af1b9ec0e079651ca3a9820c63dda3723644385c5a202331578e8f1a93950"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "f3a77e2c2c6b8f9fb030f30a818524f7c9b8c5f0b24138e0b1979a9da54e56fb"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "f3a77e2c2c6b8f9fb030f30a818524f7c9b8c5f0b24138e0b1979a9da54e56fb"
+      },
+      "before_sha256": "6175a3e4fa2d7de8b50075d2a5dc0c42df72defbee6fcbcb5c625d53ba82e2f1",
+      "after_sha256": "69e199ba5f2ec644e5b6856753346853733e093c285551ca7b915f470e1c5949"
+    },
+    {
+      "agent": "designer",
+      "skill": "designer-agent",
+      "eval_id": "eval-003-engineer-ui-maintenance-handoff",
+      "comparison_path": "agents/designer/test/designer-agent/evals/workspace/eval-003-engineer-ui-maintenance-handoff/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "e8c75de1d6f9996313bad1fce4ede6ed7cde9c08fd07355edd02169db57e8e68",
+        "eval_definition_sha256": "138aebdae4a1049db8b791a6754cc321fff06d447fcae99b0206d1d5aa26e929",
+        "metadata_sha256": "f547a888a015d9e9862374a63fae63a3c03679e1e0f3c3c280b9cf0370c3b020",
+        "fixture_sha256": "821c99c85df4188cff291d55bb3f776ec720f8cbbd3f93df4bf7a03b6520bf3a",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "642d6c7ee5330dc1af39bc9648e9c1bffdb74e1229fc98a9c317e40e13baaebf"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "1608d00eaca9e45be7017c7d2fe8c3ecf1d9d180fabe1180d4743ee3a59ea02c"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "1608d00eaca9e45be7017c7d2fe8c3ecf1d9d180fabe1180d4743ee3a59ea02c"
+      },
+      "before_sha256": "9f2c6ec42d672e6c2eb8e99a64cd0936e271d1c2538a48281911df1e61700c5d",
+      "after_sha256": "8a100f2632cea42dc7884cf91f32ba936ec329b8e25b0c446214e9abca5c122e"
+    },
+    {
+      "agent": "designer",
+      "skill": "ui-ux-design",
+      "eval_id": "eval-001-saas-dashboard",
+      "comparison_path": "agents/designer/test/ui-ux-design/workspace/eval-1-saas-dashboard/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "a26ada6a2ba843cfb4e657c89ce7c3b76b2095d2b006f263e49042916f04185f",
+        "eval_definition_sha256": "9dfc3c0232e65b50d6964b6b208307eca95842562a8965fcb0999b7dc0293b57",
+        "metadata_sha256": "4806c6c3fd6574e59fbeca624e1db80b0abef304792432263a972f95ebcfa4e8",
+        "fixture_sha256": "0c6e97834bbed6c2319a5e523ec66e524f7cbbe181557cf3e6af4ae38b100532",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "8d2763ec3401350181ee644de1028a6695d69fa18b5430a0edd7593fdf2e890a"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "e56ad49c7598b084d600666f6e5b97fe819ef5382dd324f9d4eed66ae1c0f28b"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "e56ad49c7598b084d600666f6e5b97fe819ef5382dd324f9d4eed66ae1c0f28b"
+      },
+      "before_sha256": "944d159ce4d153ce4ffcf69846911e6891338ba7acde2f316349c9c06896e598",
+      "after_sha256": "13dc31089a0573f6382b7cfdf76e0d2fbc51b231ae2bc4fe0746293811d14a1c"
+    },
+    {
+      "agent": "designer",
+      "skill": "ui-ux-design",
+      "eval_id": "eval-002-ecommerce",
+      "comparison_path": "agents/designer/test/ui-ux-design/evals/workspace/eval-002-ecommerce/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "a26ada6a2ba843cfb4e657c89ce7c3b76b2095d2b006f263e49042916f04185f",
+        "eval_definition_sha256": "ca70808ebe45c256ed44d9380fa1c8f3bd3f78623591e611656fc168a26d9c94",
+        "metadata_sha256": "40409fe16f5c840772ed9dc96d9a9bf18f86662171fdae939c0a1ec6acbc3c28",
+        "fixture_sha256": "066b89d2cc1dd835345cd6d39e99316bc4d1c11f89b8739eb2d1941c8791d32f",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "5ac69cf52c4833a0e74ebe39318957376e1be2b4d8142bcff9072bdd02569746"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "28ff63801c8ddfba05d788f6080d5ed86a2735d2d93b87a583ecb1a03ebdfcc9"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "28ff63801c8ddfba05d788f6080d5ed86a2735d2d93b87a583ecb1a03ebdfcc9"
+      },
+      "before_sha256": "3926a1b957758e760c72956838c0d6fc0a372bee7256845620de81e5933fa003",
+      "after_sha256": "b0d704e9f623c0a32034ee12434618e9696fa678fbbb948cc9a757af8e34fc3b"
+    },
+    {
+      "agent": "designer",
+      "skill": "ui-ux-design",
+      "eval_id": "eval-003-with-reference",
+      "comparison_path": "agents/designer/test/ui-ux-design/evals/workspace/eval-003-with-reference/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "a26ada6a2ba843cfb4e657c89ce7c3b76b2095d2b006f263e49042916f04185f",
+        "eval_definition_sha256": "36f115852952f11f54a62c4ef547a3782cf81881da967b1b9e5b272fbfbef0f5",
+        "metadata_sha256": "1297d3b18067ef541e85c715177821c621d61aa5e828ddc8a5fd239236e4a6ab",
+        "fixture_sha256": "816b980f73797aa0bb179996356d70da27810eb91a7ac7c665a793e71da22e00",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "5ac69cf52c4833a0e74ebe39318957376e1be2b4d8142bcff9072bdd02569746"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "168d2c81e43c10d0d85fa0f6bef810c4621dab22f8d1ce5577fc70c700358731"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "168d2c81e43c10d0d85fa0f6bef810c4621dab22f8d1ce5577fc70c700358731"
+      },
+      "before_sha256": "677402742b377c12d5f2090bebef2dfd01631eb93ead88ea026a2057f10260de",
+      "after_sha256": "b8af07e5e3ff28284eda9e3f51dab856cc3134498793f977a19d3ef8c1a42684"
+    },
+    {
+      "agent": "designer",
+      "skill": "ui-ux-design",
+      "eval_id": "eval-004-pm-spec-handoff",
+      "comparison_path": "agents/designer/test/ui-ux-design/workspace/eval-4-pm-spec-handoff/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "a26ada6a2ba843cfb4e657c89ce7c3b76b2095d2b006f263e49042916f04185f",
+        "eval_definition_sha256": "f5e031cd559d08b9cd37fee2f571fc541cf110879ad665b05952cb915a09fe63",
+        "metadata_sha256": "a2b7d997dbacd7584fcef225254185f8826f79c87e7c30c69a40f24691946c86",
+        "fixture_sha256": "0791241d90c35458117ad7afc41087d198e776e1bb0d176e05c3732f6be148a6",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "2f242e255f292a4598cb48c2bfc21dd7b56a2d6cda47e6a68b75b5c3321a2e98"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "37031027d19f89a5770bc625422e94338e3c756d6e4012ebe2261a513ddbae6c"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "37031027d19f89a5770bc625422e94338e3c756d6e4012ebe2261a513ddbae6c"
+      },
+      "before_sha256": "b64243da91d8fb788d34e770792011975bb2da011d6d7e80b788bf39d7a9ed9f",
+      "after_sha256": "29a817007c6b030355a25e6d8dc9a34c6564455542e704f7fe6b5fff41b3b6a6"
+    },
+    {
+      "agent": "designer",
+      "skill": "ui-ux-design",
+      "eval_id": "eval-005-mapped-notification-ui",
+      "comparison_path": "agents/designer/test/ui-ux-design/evals/workspace/eval-005-mapped-notification-ui/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "a26ada6a2ba843cfb4e657c89ce7c3b76b2095d2b006f263e49042916f04185f",
+        "eval_definition_sha256": "25a9beaf5037d128f11073d7bdad29e775b60a170f80ba9b4b2cd556e1ef1469",
+        "metadata_sha256": "10998afd499537d318b7152b7f04f522887c53c432e959ff9a023e23e13617cb",
+        "fixture_sha256": "cc899f673f7067e0f23d4e43273fcee59ea0d49ecc2127d06d0f6831a3eb4d0a",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "a4d0fee3aeb96dea9f51551a71038d83ea267c18cdc093d554b99c949e660468"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "a4d0fee3aeb96dea9f51551a71038d83ea267c18cdc093d554b99c949e660468"
+      },
+      "before_sha256": "8a411977609dd2d9fc17cff35b395833bb9a3a12baea77cfb9ca3bbafb70a4e3",
+      "after_sha256": "ed67fad615c2874bbea908bd8b04f3cffddac5d2543bd9dc856d7af2cc4c7913"
+    },
+    {
+      "agent": "designer",
+      "skill": "visual-design",
+      "eval_id": "eval-001-minimalist",
+      "comparison_path": "agents/designer/test/visual-design/workspace/eval-1-minimalist/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "7b149b6fe06b79fc3d427a1960513a2a422e6be13b6ef797018ec31a49be8d0b",
+        "eval_definition_sha256": "2ec4f897729f0820b0a7830a10f3f0348db98fac1c3a94d29404427ccb404465",
+        "metadata_sha256": "a8c3886c0203449f24edc77c5c3e77a82c91f7ce462169d6c62325194a234222",
+        "fixture_sha256": "89d144dafb490a68dbf1ec05d2336c43c874c81e51496b945ac9140ca757080a",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "e8bf769ac89a10c9a014e6b2e125d2d95f024ce8d37a4e4481c16c75936c71a8"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "2b4361c421c8332da06cdcd764fd6236ef67a591437cd9fdcb793c23f8651a23"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "2b4361c421c8332da06cdcd764fd6236ef67a591437cd9fdcb793c23f8651a23"
+      },
+      "before_sha256": "4f5df3ef9d30392802f90ff4e9f2ad043c1eac2be95163a734e1f3b656edaaa3",
+      "after_sha256": "8f5e93999bb69ef6182bdc442ff2933420ecc3ad8448e840728722fa6972fd8f"
+    },
+    {
+      "agent": "designer",
+      "skill": "visual-design",
+      "eval_id": "eval-002-playful",
+      "comparison_path": "agents/designer/test/visual-design/workspace/eval-2-reference-design-system/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "7b149b6fe06b79fc3d427a1960513a2a422e6be13b6ef797018ec31a49be8d0b",
+        "eval_definition_sha256": "1e9739265f0721cb69546820ef87da3e0b8045e92accd200c449d4a7c5bab7c5",
+        "metadata_sha256": "dea024aad09482b4b51327a960ae6e8c89fbc9764107a299297b588df52b9aa7",
+        "fixture_sha256": "42400da86be636a5c48d6ced7acfe1114f7f3fc84e29109517e26b5a0856067c",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "b207ccfef6c29a46ee4c39ebd7d39f4af35c494d6c841b0789899fe237e9584b"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "e27e89f7569b48caf8e4377a0e0cca062258a6663111d6f1b63afc0d98849e2c"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "e27e89f7569b48caf8e4377a0e0cca062258a6663111d6f1b63afc0d98849e2c"
+      },
+      "before_sha256": "5ee54c23074966b79056861fbd12ff04a87634abf3b50a02e78e4bd976d2385e",
+      "after_sha256": "3820a9963aaeeb50322f3efc9a950e9994080eff352eebe092859dcac13dab8a"
+    },
+    {
+      "agent": "designer",
+      "skill": "visual-design",
+      "eval_id": "eval-003-professional",
+      "comparison_path": "agents/designer/test/visual-design/evals/workspace/eval-003-professional/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "7b149b6fe06b79fc3d427a1960513a2a422e6be13b6ef797018ec31a49be8d0b",
+        "eval_definition_sha256": "730e4eb8de3e03b346a013a3d5577a175072336c34214d71e41ce4685c2c2ee1",
+        "metadata_sha256": "0f7ee2304f9494f523bf0e9ffeed979b5af06eb7930b9cda8b5ec89883762703",
+        "fixture_sha256": "567d74ee90d360991ab613f98d8049d53202d95a2bc7caeb2b7d46b23846a5f0",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "5ac69cf52c4833a0e74ebe39318957376e1be2b4d8142bcff9072bdd02569746"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "b51122c74ec9ea0ad6da74b60f9a11bacc1701ef5960d1c68c711ff55216e213"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "b51122c74ec9ea0ad6da74b60f9a11bacc1701ef5960d1c68c711ff55216e213"
+      },
+      "before_sha256": "1b5060cf02d2af096e7fe1c5a97c2cebba40489b2f5188e4033b3ee8843e66aa",
+      "after_sha256": "e87d96be6252a748814bdf266e698cde2cd50b3f3440217aea405837dad5fd80"
+    },
+    {
+      "agent": "devops",
+      "skill": "cicd-bootstrap",
+      "eval_id": "eval-001-github-actions-docker",
+      "comparison_path": "agents/devops/test/cicd-bootstrap/evals/workspace/eval-001-github-actions-docker/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "86f7228d11d9f7ad3ec145d83be1c28f8a4bb93afea61016f55ed2860069bc68",
+        "eval_definition_sha256": "e302fa46977944ed026b10f7f1ded4b3717a6c85f19be1f78da9c42d4b0c0b8d",
+        "metadata_sha256": "9e986f54be95fd6454e99ce66dc884d4d84134a4b07d49e0942d5d6169d042bf",
+        "fixture_sha256": "343bcb839e30c78715e11895db5ff7bd71039ec73fe31429c1bbda5b9e3e2a90",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "416d97c852ae3d12b00631149dd08640442fd75a13414eab07000c384c3a2d5f"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "4e775b7226a8d5c9e696284c9bd4dc27a7b9c7ee157b3fa062054f37f765ab33"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "4e775b7226a8d5c9e696284c9bd4dc27a7b9c7ee157b3fa062054f37f765ab33"
+      },
+      "before_sha256": "ab893550603044e551a53616a6236141ba29be153e8821415d66d2cfb60e2985",
+      "after_sha256": "ffa7e371c13c183e3381a2c2a9f6708046ebd83297dbdfdb241097e1c5d9023a"
+    },
+    {
+      "agent": "devops",
+      "skill": "cicd-bootstrap",
+      "eval_id": "eval-002-mapped-doc-cicd",
+      "comparison_path": "agents/devops/test/cicd-bootstrap/evals/workspace/eval-002-mapped-doc-cicd/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "86f7228d11d9f7ad3ec145d83be1c28f8a4bb93afea61016f55ed2860069bc68",
+        "eval_definition_sha256": "68a87fb5d229c5c451c4b7081adb9e28c9c2e68f2832958c12f8d53464b0ae13",
+        "metadata_sha256": "a6802835ad6096782cd89b2c4280b4422a56ff9be96ac885a939daae8583297c",
+        "fixture_sha256": "b0f5ab103062d754c225176fd1995f4f428e9f29340584ac86077ed978dc1482",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "b5defa0f9eea26f869a21177491f6cd66726570a3255aabd91997be6978cbc01"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "b5defa0f9eea26f869a21177491f6cd66726570a3255aabd91997be6978cbc01"
+      },
+      "before_sha256": "40aa08082b2e2dbd3ddec962e1c22dc3d1ce3936c666abf7af08d408b44b20f1",
+      "after_sha256": "019cffe5316b463b4879d6850a91eb5a2477dd03c300dbabcbde16f6cea7c20a"
+    },
+    {
+      "agent": "devops",
+      "skill": "cicd-bootstrap",
+      "eval_id": "eval-003-docs-image-release-rules",
+      "comparison_path": "agents/devops/test/cicd-bootstrap/evals/workspace/eval-003-docs-image-release-rules/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "86f7228d11d9f7ad3ec145d83be1c28f8a4bb93afea61016f55ed2860069bc68",
+        "eval_definition_sha256": "90a9cf04ee14bffff8a2eaca0298de327ed551cee77903fd69a219a57495281e",
+        "metadata_sha256": "3fa9951d25624dea3daa1a46647a39c6e45e551d897c4684f13850f3c7afbfd4",
+        "fixture_sha256": "3676f277a876b41e1703c92d57107677efc45689334ecbdddc74bf8f7e7cb8bf",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "8eaf2480ee518c77bc5e1ae8a7f25c0acfc010e7317cc45d7143e8591e25551c"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "097444e2cd32bce6f4571d29ed3b7f62471fbcbabb9e3961f09a875dd6389b48"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "097444e2cd32bce6f4571d29ed3b7f62471fbcbabb9e3961f09a875dd6389b48"
+      },
+      "before_sha256": "1fd9e14a7788ad5274aeac860aa2e41e07381c0bc6b94e26fdd532ec133ec0f9",
+      "after_sha256": "a3c97c4046004369f35f12e1ff5d6593471ff46204cfe4ddadaf439d5ecf6670"
+    },
+    {
+      "agent": "devops",
+      "skill": "deployment-planner",
+      "eval_id": "eval-001-nextjs-web-app",
+      "comparison_path": "agents/devops/test/deployment-planner/evals/workspace/eval-001-nextjs-web-app/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "e850d2052b73e431758456627cb816e0d9a45db383146d1349cf24ca05b2aec1",
+        "eval_definition_sha256": "4ab6f3577023497f11197efb5117e95119ab70a437c95770925330f5be6aa5f2",
+        "metadata_sha256": "be29fd9ddbc554b7d8ca7f9912c9d54f61470e99abd7c2e138b60022c4086794",
+        "fixture_sha256": "06f8a5807d1130b7a91a700b2074192e6dfed0933a071ce16642b27aa050360d",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "8fdd554bf7008e1addc7b92301444335139887034f2813ab539445a1df4b82d6"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "32d0834bdd3832adcd49598b04591cb3ac3b1e698c2d1469936cf7a9478926c8"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "32d0834bdd3832adcd49598b04591cb3ac3b1e698c2d1469936cf7a9478926c8"
+      },
+      "before_sha256": "0679360ff51d1fbfa36ff677b7bff3dcd6301aa1968ef6b1115510cbe0444dec",
+      "after_sha256": "63d6cb3ee1d93301b8f98efe3551d013446b1bf912f962d84fbc358e27706549"
+    },
+    {
+      "agent": "devops",
+      "skill": "deployment-planner",
+      "eval_id": "eval-002-python-api-only",
+      "comparison_path": "agents/devops/test/deployment-planner/evals/workspace/eval-002-python-api-only/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "e850d2052b73e431758456627cb816e0d9a45db383146d1349cf24ca05b2aec1",
+        "eval_definition_sha256": "f6bee599168504aabc5841db04bc20810e822fd2af8545bc98e19f6298c38285",
+        "metadata_sha256": "cd34fc596ce17b79112511df2244a7b68d45546111925715157c8598360bb097",
+        "fixture_sha256": "259dab4dbfe64941c0c3fdd5c97b56c6b90abb97168eeb7461bd9a7bf8e30888",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "6d6cb805f86354c5ca7fe62a901b9a052b0e2f5bc53f163da17451ac99ca29a5"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "b492affa251beb87984b30c37c8a191cc6e959965a667143e78f7cecbf3dd990"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "b492affa251beb87984b30c37c8a191cc6e959965a667143e78f7cecbf3dd990"
+      },
+      "before_sha256": "953dc0169485d55755783a796b5094faa3566067b3476a70fb276199912dce3d",
+      "after_sha256": "1ee96d98960481629495914915acdd664565fe14a89260956dafe8df264879da"
+    },
+    {
+      "agent": "devops",
+      "skill": "deployment-planner",
+      "eval_id": "eval-003-mapped-doc-deployment",
+      "comparison_path": "agents/devops/test/deployment-planner/evals/workspace/eval-003-mapped-doc-deployment/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "e850d2052b73e431758456627cb816e0d9a45db383146d1349cf24ca05b2aec1",
+        "eval_definition_sha256": "3a6f0e2dac2acec4b2146c1f3b14a82dc89e2d78da9249fb55fda45906586c82",
+        "metadata_sha256": "d4f866ac92cff8803e8f120ce38631fed1d054cce30a482192275834ed6880bf",
+        "fixture_sha256": "beceb4834aab461ec20117458ef66d8ba65e677ecbef5e80a9e59909d2fe5471",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "3fd213f6de3f610cad1c014e643471913a0678af0ef96531f1f973bd669f4005"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "311a5e6133c9b4b92c031d12af377668b530cafd7f3936109fd4b05a87fe4464"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "311a5e6133c9b4b92c031d12af377668b530cafd7f3936109fd4b05a87fe4464"
+      },
+      "before_sha256": "4831d1140af08368df700639bc93705f055dfa1ceaa17e6c9bd99a740d45db01",
+      "after_sha256": "5cc155f5f2921e1b413774106000551c80a921113805b69c32d034fd457c7d4c"
+    },
+    {
+      "agent": "devops",
+      "skill": "deployment-planner",
+      "eval_id": "eval-004-docs-build-variant-matrix",
+      "comparison_path": "agents/devops/test/deployment-planner/evals/workspace/eval-004-docs-build-variant-matrix/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "e850d2052b73e431758456627cb816e0d9a45db383146d1349cf24ca05b2aec1",
+        "eval_definition_sha256": "4c14837e1c149db8fdda5fa172eb35b4e3c167d223226adbc87832c6a7126d6f",
+        "metadata_sha256": "ae56541ba154741dfb7ef84587ce065786aeb8ae82c4a282fa656aa8884b399e",
+        "fixture_sha256": "1133bdf01ec9b2682fe921196914971ab2c40caac0f63afd22f66198e7edede5",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "cfb4e9daef57a9f8f8f71bd53e7b9c04b3f443f035ca06014209a131297ec22b"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "fac9fb8a90a49d1d9fe980b24735b7202e801edf37ab10c2590955a83bb3e6b9"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "fac9fb8a90a49d1d9fe980b24735b7202e801edf37ab10c2590955a83bb3e6b9"
+      },
+      "before_sha256": "cab750fb0a75e1cb9478b682c074d404890501e4d6b1d9403374d9ad88ebfb53",
+      "after_sha256": "8da5ebaed3c2dec6bbb962a0a18ce605b110cacce90c1136edc7c76364a208de"
+    },
+    {
+      "agent": "devops",
+      "skill": "devops-agent",
+      "eval_id": "eval-001-route-ci-readiness",
+      "comparison_path": "agents/devops/test/devops-agent/evals/workspace/eval-1-route-ci-readiness/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "d688e19912770823b0aab741fb33c331e4eee7536315cf3080fbad81ca1e904f",
+        "eval_definition_sha256": "bf26d801d111c094ffb06e4f6cd89e1f8a4b7c9a1e7fc76f302a33c493a411f4",
+        "metadata_sha256": "7dd2e52b200852fa05d4eb58b51c5b9cc7af5f7c62ced61947f3e3d4b9b7a2c0",
+        "fixture_sha256": "01efe0f9d93680399a4e60a121c590987f01c7feeb295910c354e36c32f0a756",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "c7039dc2c9d829f51219a90df8027752cbbdaa32f7d8b6eb4b07c94a61b14320"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "3b0ebd81fae53c41ce1d90cf41a74b67d0ed5aecaead4524a1895b76e941de6d"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "3b0ebd81fae53c41ce1d90cf41a74b67d0ed5aecaead4524a1895b76e941de6d"
+      },
+      "before_sha256": "ac1f1e163463fa436416de0ab8ecc7f302961ce0035f73e02e6b42dc35b589e9",
+      "after_sha256": "621ed987a90d6120796697027b6ef6937b8f58fe6b83863c7e0d5039170f2b27"
+    },
+    {
+      "agent": "devops",
+      "skill": "devops-agent",
+      "eval_id": "eval-002-route-docs-site-completeness-chain",
+      "comparison_path": "agents/devops/test/devops-agent/evals/workspace/eval-002-route-docs-site-completeness-chain/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "d688e19912770823b0aab741fb33c331e4eee7536315cf3080fbad81ca1e904f",
+        "eval_definition_sha256": "dc1b04424607a1675278b8e310c3f7b0da94f3cf1e857f037b9a6a8dbbf9482f",
+        "metadata_sha256": "2718def12280e05b73752266e8d3b39d6929d0781f7ca1aa2088b55bd4e38e9c",
+        "fixture_sha256": "db76812ee462c1a8d89decf8e6fae581930c1406d7c6f72f3847172ed0bb02f3",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "fdb2fd9254bbcae4d1c5e9dd4a0df1a9be1ee48991c72d5d1ea96147641ed710"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "b87f0a77558ff425870fad32179ef07cdaa8e0ca9b27d157cc024051e208fe9a"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "b87f0a77558ff425870fad32179ef07cdaa8e0ca9b27d157cc024051e208fe9a"
+      },
+      "before_sha256": "8e1155d23db2aa20115299eac6edec503498d4be4966fc12d74820a879a6a7aa",
+      "after_sha256": "2261780b5320f8faf60be25561c6339466f254bb04a1127fa811fb52b683c380"
+    },
+    {
+      "agent": "devops",
+      "skill": "env-config-auditor",
+      "eval_id": "eval-001-missing-variables",
+      "comparison_path": "agents/devops/test/env-config-auditor/workspace/iteration-1/eval-1-missing-variables/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "11f5a69db2a4c2ab81d782a866d9a88090a8560b5e61462d8af4e66c4376601f",
+        "eval_definition_sha256": "5217a2bb49f0b8e0ba081e4029f81b07efd6b07af9fb34ce9773ecbde5d00a5b",
+        "metadata_sha256": "f2d1d6d11daf93046843d6cf276fdc2c30cd77fd3602aa38ebdb9fcc3d6c1a85",
+        "fixture_sha256": "4e6c22cd2abded0cbcf31007050064d16e8cb14c8ccdda445c9587853833ba57",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "7c0e897fa2e11e667f833a3bbf2e28e35b1c65790975d953ea93444f623ad66b"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "00bb8e620efce5738aba6728601b2f57d3bcb13a19802f4413a8c3bf0f7e932e"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "00bb8e620efce5738aba6728601b2f57d3bcb13a19802f4413a8c3bf0f7e932e"
+      },
+      "before_sha256": "b40276fe7783e740dac37971f16de81210707a706604ef531d919c296423222a",
+      "after_sha256": "bc978f319a1f031b85114da3e5b7aa6b21c494b70488702abf891f97f2518bb9"
+    },
+    {
+      "agent": "devops",
+      "skill": "env-config-auditor",
+      "eval_id": "eval-002-feature-path-audit",
+      "comparison_path": "agents/devops/test/env-config-auditor/workspace/eval-002-feature-path-audit/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "11f5a69db2a4c2ab81d782a866d9a88090a8560b5e61462d8af4e66c4376601f",
+        "eval_definition_sha256": "6efcde24d7900ac81923c70a8eb454a7b5687569fc19e166e7a2702223bf20b8",
+        "metadata_sha256": "ed9d0f761d7a235166a80b0e2724cd90628f15321561b77d0b2d2233a2c87014",
+        "fixture_sha256": "a481b5374544e745048b6d91a89eb4240f2b8d26afa6409ed21d0c822a29f8c9",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "542a3960b92dfab31d619dba36f1b4cd7435eaeb67ca74c65c1e8dc7cd584d0a"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "2edb042db2fd972c27c59e2a7414b596e3ea6ec504e1c4458e1e06608aa54060"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "2edb042db2fd972c27c59e2a7414b596e3ea6ec504e1c4458e1e06608aa54060"
+      },
+      "before_sha256": "bbf714699d5af3139dd860e7da732936ccc72967cca39c610db39a64d56f61d4",
+      "after_sha256": "0715efaea3ec3a663a6bcddf2750e0a7d8e5e317f5b50e5f5dcce3a8342df555"
+    },
+    {
+      "agent": "devops",
+      "skill": "env-config-auditor",
+      "eval_id": "eval-003-mapped-doc-config-audit",
+      "comparison_path": "agents/devops/test/env-config-auditor/evals/workspace/eval-003-mapped-doc-config-audit/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "11f5a69db2a4c2ab81d782a866d9a88090a8560b5e61462d8af4e66c4376601f",
+        "eval_definition_sha256": "745b306831066bee2a7ff3a7b48abf881c1196cfdb1e28206ff9239f069e955c",
+        "metadata_sha256": "c5eaf2656d7227ecd689bf4922af4f6c541bc3cb4d63375292c5b605d7e8380c",
+        "fixture_sha256": "d8b594c02acd54c63c782827a944b663d600d50c48ab45d0916be040dcdd3bf5",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "36cdc79485e5393c51c582d8374ada57ae700161e926a0b1cf1e58f60d91445d"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "36cdc79485e5393c51c582d8374ada57ae700161e926a0b1cf1e58f60d91445d"
+      },
+      "before_sha256": "bf85b41d568963f47c7b7c6f0b7198f76d490f76cc5175be0e36f05b8bb2b08b",
+      "after_sha256": "779bec83b74a3416c1ba35529dfdd807ea6dd23510b16a07e9d877afeb739aef"
+    },
+    {
+      "agent": "devops",
+      "skill": "env-config-auditor",
+      "eval_id": "eval-004-docs-entry-access-audit",
+      "comparison_path": "agents/devops/test/env-config-auditor/evals/workspace/eval-004-docs-entry-access-audit/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "11f5a69db2a4c2ab81d782a866d9a88090a8560b5e61462d8af4e66c4376601f",
+        "eval_definition_sha256": "7e8fed3827f899b24fa32a7e47350d1b61d93c36648369ee6fefd2624963c060",
+        "metadata_sha256": "3f77718e244c5e457dcf111e54d39609c8dbea3f2bea11e11380c41c91504669",
+        "fixture_sha256": "2af9780db4417e1c98550fa0f1ac701b6027949cee7ad798872f862a34631218",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "10734badb795d9dd2c7f522212860a120a71a582b6fdcf439619f31f19b4904f"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "c3b7d597b90acbc5cf2e7fdd66326463d30ade9ea4a9a5a2ad8174482842eaa2"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "c3b7d597b90acbc5cf2e7fdd66326463d30ade9ea4a9a5a2ad8174482842eaa2"
+      },
+      "before_sha256": "d45b82ea530c1e43c324d9dfe15ce2b24bd50605cda77351580dcb8867a1e838",
+      "after_sha256": "5c5a6385f02ea1131ea15ddf8633f65c0b8321ab485977645eeef72de59776b4"
+    },
+    {
+      "agent": "devops",
+      "skill": "incident-playbook-writer",
+      "eval_id": "eval-001-docker-rollback",
+      "comparison_path": "agents/devops/test/incident-playbook-writer/evals/workspace/eval-001-docker-rollback/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "500941dffb48347901d3283054321002e2a4be37cb509882170d999b6f27485f",
+        "eval_definition_sha256": "ef78ea6924e16ad4c29c668948468977eb007b3ff9fb4e26733caf7d332c338d",
+        "metadata_sha256": "aaf6d95692337cdac99edc2200f96e32a7dbdc444f3865d1a29464638703fbd4",
+        "fixture_sha256": "f3b605dee7b400a16cee380181367beb6aef0898c3081a8e6f89abd9e2c19e1a",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "82478d5bfcdfccbe67817c9bfae394096b57b2c317a4413eadf1808b946de6d0"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "a8b89e29d631022f92ebeea498388e2cc88c35820e9af105e2ec82ecda5cd76f"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "a8b89e29d631022f92ebeea498388e2cc88c35820e9af105e2ec82ecda5cd76f"
+      },
+      "before_sha256": "f535251dadc40076a6e63954649ae15acae2404c399400539af8c70331b4f4a3",
+      "after_sha256": "6576ee029ed157d42154cdafeef0d80c8bdb018dbb19d34fc7cc57580de623e6"
+    },
+    {
+      "agent": "devops",
+      "skill": "incident-playbook-writer",
+      "eval_id": "eval-002-mapped-doc-incident-playbook",
+      "comparison_path": "agents/devops/test/incident-playbook-writer/evals/workspace/eval-002-mapped-doc-incident-playbook/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "500941dffb48347901d3283054321002e2a4be37cb509882170d999b6f27485f",
+        "eval_definition_sha256": "56f66c660609712980bbe29e190d00dff6d36c67cb844c6b5e1aa3d336dcd314",
+        "metadata_sha256": "d30677e1d058f7ced7ac6b80a07136e834c175a519dc8964e75c167556348374",
+        "fixture_sha256": "cd9e0e84ed5447d0b5fbaab481b132d7d6de821290e56efdee5b00d1661c9bf7",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "463a96536b08f7016a6a683b9136683dbb295eda05786e95a82a1882703f91d1"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "463a96536b08f7016a6a683b9136683dbb295eda05786e95a82a1882703f91d1"
+      },
+      "before_sha256": "d34849fc6b3a199c8f1a721e9c416b3060d9a9cc069c1c2d1fa82723855c4e65",
+      "after_sha256": "357a48fbc4107ab2b5c75563fd346f09e0923ce69737b59758fc8c6bc8416cbd"
+    },
+    {
+      "agent": "docs",
+      "skill": "docs-agent",
+      "eval_id": "eval-001-route-formal-docs-sync",
+      "comparison_path": "agents/docs/test/docs-agent/evals/workspace/eval-001-route-formal-docs-sync/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "cf92649952a97be677cf5e900a4d9c793a6c0724813cf1fa3154f57e7d2c08f3",
+        "eval_definition_sha256": "4f62b001057b225d1029a6284046afacf46248ad92aa43b0c065e0a0456b7450",
+        "metadata_sha256": "320948f19ccb8c159c24fdc827ddc592aac02ee3f64236dd9e4896bae8e4979e",
+        "fixture_sha256": "5bfe584ec04ca9f6271a87eb0a6a94432a493cce40c865cd7e77c63d4d5a5991",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "d9120b553be3673816559c0b102ba0210980dbae3daaf9eeba42b66ee4308ec2"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "821771c4654bad272599f8492e357091732d523073dd99199e5565dc09122646"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "821771c4654bad272599f8492e357091732d523073dd99199e5565dc09122646"
+      },
+      "before_sha256": "826fce65324ee1c63f126e09795b7821531f19bd04a6fcf180243afd9764c3e3",
+      "after_sha256": "c9e8ea7d9f3a23f7c2d82c973dc83b582cd0dd153dd65bc35b456981a1a87a26"
+    },
+    {
+      "agent": "docs",
+      "skill": "docs-agent",
+      "eval_id": "eval-002-missing-entry-basis",
+      "comparison_path": "agents/docs/test/docs-agent/evals/workspace/eval-002-missing-entry-basis/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "cf92649952a97be677cf5e900a4d9c793a6c0724813cf1fa3154f57e7d2c08f3",
+        "eval_definition_sha256": "46e0e02295d606a359a2403ac234af592712f357041b544bb13a82efa1816296",
+        "metadata_sha256": "9e2c43ddcdebfd4398d2a8f32a222c29dd71f706e06b85ffb24ea4623239c500",
+        "fixture_sha256": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "da898e3ecfd0169570b22be7c73cd730ef2fd22e3bf1c5b559383dc76454ff0d"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "a08b38e0933afb280928fd27e589948c3fa84db37f8333ee26eb6b6a83d7a8af"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "a08b38e0933afb280928fd27e589948c3fa84db37f8333ee26eb6b6a83d7a8af"
+      },
+      "before_sha256": "be03e98841ec08bae41f1fe8fb705690df77295da10aa9188341662da12f3ee6",
+      "after_sha256": "d0748d9802686f32269ed2f542017fc5ab95a0087a102ed02ed68d1e242ab051"
+    },
+    {
+      "agent": "docs",
+      "skill": "docs-agent",
+      "eval_id": "eval-003-route-release-audit",
+      "comparison_path": "agents/docs/test/docs-agent/evals/workspace/eval-003-route-release-audit/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "cf92649952a97be677cf5e900a4d9c793a6c0724813cf1fa3154f57e7d2c08f3",
+        "eval_definition_sha256": "76669427412e6a3d2662bf813faa0ce4c31fa19c75739559cabe530efd5682a6",
+        "metadata_sha256": "d582bafa2b7d4e637ef2b4b71f14f435256d70c30e92f7097a43cd40dc9da750",
+        "fixture_sha256": "aea5c9e95cc3674c80708ee78ba0276fef121e6d5652789edf0421371d054bf6",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "f4f786bd56d6a5cbcee24193816a462566a8caafb4c223ef38759bdf64ee0486"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "b948b8323db48932d19e6fa8a34611e560be96e6cf55a2d2a7d68805b0b8e2ce",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "05a9efaec33b9cefe1b4a023686558c2b159d21bd5844cf8a0405c73ed620740",
+        "assertions": "e6abcfec57f72680a0951bcd37fc518cdb6f9cd19b84022c64a2c7bab94c21c9"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "b948b8323db48932d19e6fa8a34611e560be96e6cf55a2d2a7d68805b0b8e2ce",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "05a9efaec33b9cefe1b4a023686558c2b159d21bd5844cf8a0405c73ed620740",
+        "assertions": "e6abcfec57f72680a0951bcd37fc518cdb6f9cd19b84022c64a2c7bab94c21c9"
+      },
+      "before_sha256": "6402f4190f135338dfb65ae7b39e2ebfc28a5eac2211da427de2374613f6df40",
+      "after_sha256": "e171cd49c98c6fdc306f85f7af0f1107378bd412990dec53e9321d2c0f8bb65f"
+    },
+    {
+      "agent": "docs",
+      "skill": "docs-agent",
+      "eval_id": "eval-004-route-release-notes",
+      "comparison_path": "agents/docs/test/docs-agent/evals/workspace/eval-004-route-release-notes/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "cf92649952a97be677cf5e900a4d9c793a6c0724813cf1fa3154f57e7d2c08f3",
+        "eval_definition_sha256": "6d935c2fabb41ac4d322f49d33294bd64934555c17ee2ff70a64426da58d1b41",
+        "metadata_sha256": "5831b803b3b347d7fd4611f1c19958d707ffe3e9ced4a78ed755e71f76a2c9b8",
+        "fixture_sha256": "23d5701fab562491dfec3455fd6eabce7f6a6cba18940861023208d40f53fc3e",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "73f4addc59ec16b0f91c6a70a2a767ce7f6b4ad72612ca19a2131095a0722114"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "b948b8323db48932d19e6fa8a34611e560be96e6cf55a2d2a7d68805b0b8e2ce",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "05a9efaec33b9cefe1b4a023686558c2b159d21bd5844cf8a0405c73ed620740",
+        "assertions": "8f6d127e7f62ccd374a60c41129da6ce0be34a89e740d4dd5977bb3a08734ff9"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "b948b8323db48932d19e6fa8a34611e560be96e6cf55a2d2a7d68805b0b8e2ce",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "05a9efaec33b9cefe1b4a023686558c2b159d21bd5844cf8a0405c73ed620740",
+        "assertions": "8f6d127e7f62ccd374a60c41129da6ce0be34a89e740d4dd5977bb3a08734ff9"
+      },
+      "before_sha256": "fe9b96c5f3c8b28db303b9f4fbac069edfc2e211a53fdbc323c31dabe13fade2",
+      "after_sha256": "01da1cd4528204a11e6a46860affde96f345444d08fa3c08073b67ec4ee94633"
+    },
+    {
+      "agent": "docs",
+      "skill": "docs-agent",
+      "eval_id": "eval-005-integration-release-chain",
+      "comparison_path": "agents/docs/test/docs-agent/evals/workspace/eval-005-integration-release-chain/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "cf92649952a97be677cf5e900a4d9c793a6c0724813cf1fa3154f57e7d2c08f3",
+        "eval_definition_sha256": "05d8b9eb5ccf6bbc077dad850c79899562c5b4ed9bbb4187abffd82f21410ea3",
+        "metadata_sha256": "af301306a3e584e9c32987cd73e02ac298dcd98f38208af58ca0764e8b5a4154",
+        "fixture_sha256": "69659db940208abe97ba4ab195a49c736d9a7ba7e1e880c287d3bf12132c10a3",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "1f2ea17b811fce39b8e906ef0e0a70b6a6223a188a2f4a05f2f0a88c54c6aceb"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "b948b8323db48932d19e6fa8a34611e560be96e6cf55a2d2a7d68805b0b8e2ce",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "05a9efaec33b9cefe1b4a023686558c2b159d21bd5844cf8a0405c73ed620740",
+        "assertions": "cea09459c5f663d5329787a34b302589ff54d54b5ee9bffb0ee99c6b645e67c9"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "b948b8323db48932d19e6fa8a34611e560be96e6cf55a2d2a7d68805b0b8e2ce",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "05a9efaec33b9cefe1b4a023686558c2b159d21bd5844cf8a0405c73ed620740",
+        "assertions": "cea09459c5f663d5329787a34b302589ff54d54b5ee9bffb0ee99c6b645e67c9"
+      },
+      "before_sha256": "0535996a4634447c8e46fc1961f716e198d7a95e4c0c80d7d5baa01874ab4e09",
+      "after_sha256": "53c9f4e287845e942d5cdb5f37d22f506c080b5814a06beb6f00233898d65f1a"
+    },
+    {
+      "agent": "docs",
+      "skill": "docs-agent",
+      "eval_id": "eval-006-preserve-independent-hosting",
+      "comparison_path": "agents/docs/test/docs-agent/evals/workspace/eval-006-preserve-independent-hosting/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "cf92649952a97be677cf5e900a4d9c793a6c0724813cf1fa3154f57e7d2c08f3",
+        "eval_definition_sha256": "8a4360282a35d2ba7a52bbb24d703648e9f263e7fbfc9516063ba62f62b92b92",
+        "metadata_sha256": "62050136e2c1de0d65367ed4b1b1b706bb2211c3759fb54a832b8fd66233328b",
+        "fixture_sha256": "f6c421284ed0143d28fff161f0f4c1cd48b067505beae1d38677d871a066543f",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "787b3941ec90b819758a9894561fa37e2c0eff7eedddb4c4a4d863809f28587f"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "b948b8323db48932d19e6fa8a34611e560be96e6cf55a2d2a7d68805b0b8e2ce",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "05a9efaec33b9cefe1b4a023686558c2b159d21bd5844cf8a0405c73ed620740",
+        "assertions": "9c36fe162eb38229d40b0cf1ae8ad673ea06d3fb8fdc7cc30a0e322a8c70a22b"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "b948b8323db48932d19e6fa8a34611e560be96e6cf55a2d2a7d68805b0b8e2ce",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "05a9efaec33b9cefe1b4a023686558c2b159d21bd5844cf8a0405c73ed620740",
+        "assertions": "9c36fe162eb38229d40b0cf1ae8ad673ea06d3fb8fdc7cc30a0e322a8c70a22b"
+      },
+      "before_sha256": "cec7473deee4d96a81e7b3845a8abbf7eae4a284ebc4b10f6b61c90badea4906",
+      "after_sha256": "913d6b525c31f796fd8ea5ff07d72680be2d98bf2c9481b94424b5fe9a08afa5"
+    },
+    {
+      "agent": "docs",
+      "skill": "docs-agent",
+      "eval_id": "eval-007-route-manual-gen",
+      "comparison_path": "agents/docs/test/docs-agent/evals/workspace/eval-007-route-manual-gen/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "cf92649952a97be677cf5e900a4d9c793a6c0724813cf1fa3154f57e7d2c08f3",
+        "eval_definition_sha256": "11398fbb2de74bd454f6e9c88338b5fcf6dffb0fd21436f1f6c99eaff5b1117d",
+        "metadata_sha256": "31c2720a1114e612336c51527d7aae20dddb1f4e46b566ffffe4788d27952b8e",
+        "fixture_sha256": "7e690828debd990987ec359671232498f20061c2fa6e2bbd324f99b92a7c2fc8",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "dfbcad96e39d7a0ba2503c7d345d86b54a6c9e1188ff1c09f99476b24380e820"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "db0c6d20a49d9040df5baf511c659cf34d5636b3254b8e8345a82a2026caa53d"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "db0c6d20a49d9040df5baf511c659cf34d5636b3254b8e8345a82a2026caa53d"
+      },
+      "before_sha256": "c54f0871d8815ba9d19e6e6741682b68e1c947b60efd9ff81f0182d72aeed2d1",
+      "after_sha256": "dd91f9620e0fbae5ca1798bacc6cbe75929830fdfd76389cd48b774e356cac0b"
+    },
+    {
+      "agent": "docs",
+      "skill": "docs-audit",
+      "eval_id": "eval-001-audit-mismatch",
+      "comparison_path": "agents/docs/test/docs-audit/evals/workspace/eval-001-audit-mismatch/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "5b11b38c1c44c386fe19122dfb1ce5918b2bfbc4830ad32aa994d8a7e39f35e7",
+        "eval_definition_sha256": "fee749f35b3bf7110eb1c6f38c918db3407b1a46ffa3ff2613c15b835398219e",
+        "metadata_sha256": "23ce240f3f391bd560df8f9bbcf6e5d2ec76b8a3ffb73e38f416b3cdb2997a3a",
+        "fixture_sha256": "dc67ea3252d72d2cb1006bd586833469bce9e6071957244105d8c4e3b86358a2",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "218cecf9b4e5893cf80d7edfea7d7877463de8efad846bf62ba5cba015ad2ed5"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "2f063b7fdce20a3342102c620a4b82807d0732d763f9ab68d49c578eae519b02"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "2f063b7fdce20a3342102c620a4b82807d0732d763f9ab68d49c578eae519b02"
+      },
+      "before_sha256": "ad4e905a70648329cfe321798f7fb589e4db0c5dd023f4d8c128ee5e5c381478",
+      "after_sha256": "4065e4687d683787b30169a6a0eed3031feebb36652f73416f4c8f8e65f112b5"
+    },
+    {
+      "agent": "docs",
+      "skill": "docs-audit",
+      "eval_id": "eval-002-audit-stale-doc",
+      "comparison_path": "agents/docs/test/docs-audit/evals/workspace/eval-002-audit-stale-doc/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "5b11b38c1c44c386fe19122dfb1ce5918b2bfbc4830ad32aa994d8a7e39f35e7",
+        "eval_definition_sha256": "65171d2c00ad7205a3b92eb523639da0ae1b9b851f9b225fb39f151ac8a09d1b",
+        "metadata_sha256": "393d49433e1e9b818095a60378e27c82e27a5159f0878e57881a2872b5feee91",
+        "fixture_sha256": "7c0329b08b7d983c3fb25be26c421ff6963478e62486e2e0e75d22d246186583",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "6c436d29e1c4d967534d387d71455397c2a958eb0e9fdd8f24d404e3a4bfc7c7"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "5afa02638b4c351ae9597bf05c91ae8c06b7d56ad13bf409b0d93478176fbbb8"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "5afa02638b4c351ae9597bf05c91ae8c06b7d56ad13bf409b0d93478176fbbb8"
+      },
+      "before_sha256": "0c6f0d81971444d2bcacdcd487460296ca67e4f5987277a18b5fdf01c53734f4",
+      "after_sha256": "c5fe8068d31e836dc40f698c26b07a5c8fcb3c10a58a7f3be985868a322aafd3"
+    },
+    {
+      "agent": "docs",
+      "skill": "docs-audit",
+      "eval_id": "eval-003-audit-pure-refactor",
+      "comparison_path": "agents/docs/test/docs-audit/evals/workspace/eval-003-audit-pure-refactor/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "5b11b38c1c44c386fe19122dfb1ce5918b2bfbc4830ad32aa994d8a7e39f35e7",
+        "eval_definition_sha256": "a7212e3282f2eaaa660e0675fb965d5050f366a07c153f3821d78fdab8976de5",
+        "metadata_sha256": "1e20c97bb5ffc477023f6bbbd217e71d747297cb0b8f52652660b6b2d10adc7a",
+        "fixture_sha256": "a0071569c74867aaacfda16310f9f4a06e50a375aa0e6b62ee25e801db096677",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "3e58dae2a34edb25f9589f7bddb4e3282cd1f66e3b0c3f35187db4ed16fd5f23"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "a1153a0fe0a7e284caa72e7ff57a2b683c433b1ccefcc9fba53cf91a431c4385"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "a1153a0fe0a7e284caa72e7ff57a2b683c433b1ccefcc9fba53cf91a431c4385"
+      },
+      "before_sha256": "8f4702546852a15b7087e6cce914b511e89e0f5617a08d39a4855658ead0ba3d",
+      "after_sha256": "5169681d4bb9d4c6d42b254c738cf793a1294e1967b7e31698e32f3ea1c73846"
+    },
+    {
+      "agent": "docs",
+      "skill": "docs-audit",
+      "eval_id": "eval-004-audit-all-verified",
+      "comparison_path": "agents/docs/test/docs-audit/evals/workspace/eval-004-audit-all-verified/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "5b11b38c1c44c386fe19122dfb1ce5918b2bfbc4830ad32aa994d8a7e39f35e7",
+        "eval_definition_sha256": "9d29cd503dc3f38e1235bc8d674c667f9fc3bef38d94569b7888bb0dfed80506",
+        "metadata_sha256": "4c1ab6c77122f43adf1cbc9d6f05aea7b2b047fe1e69ba225e32d03f006dc954",
+        "fixture_sha256": "085a9df9c5171410b3af490aa0eb671dd955de6207e401089976f50095ed2897",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "a043187f1d82deb6ceb1f6f2a8dbb12db6dd01c71ced16d224de3ae50ca31c3b"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "659923748c5bcba5086c4d99187b38a9a1c92d5bfa272cce3c3ac026072a6391"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "659923748c5bcba5086c4d99187b38a9a1c92d5bfa272cce3c3ac026072a6391"
+      },
+      "before_sha256": "67238cefcfac55587f343e55087ad264ca91cfd7055ef13ebc5e098123e30cdd",
+      "after_sha256": "8598297d7f53ed3edd6ef7be6f6eff7f4ca5891e2220a41cbd725db5be2cb123"
+    },
+    {
+      "agent": "docs",
+      "skill": "docs-audit",
+      "eval_id": "eval-005-audit-doc-only-error",
+      "comparison_path": "agents/docs/test/docs-audit/evals/workspace/eval-005-audit-doc-only-error/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "5b11b38c1c44c386fe19122dfb1ce5918b2bfbc4830ad32aa994d8a7e39f35e7",
+        "eval_definition_sha256": "1f7d058864bf71ce0402d8ada31c06c85782a25b93779e842d80b5a98766c9d9",
+        "metadata_sha256": "63b77017b252b389a44397720be8380b6bee7f6a85225c5d210accca792fc487",
+        "fixture_sha256": "126b82b218c4429d9a8e50c428008903893e0b48fd89e0ee4186368ab968404a",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "d804d7eed6dff47b2c8744abfb057fce66d8fde2359e03e7f21e978c34808373"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "114f442bdb326a86fa831304b5c8c5e9bd42d8afb9f23b9f3eeeceb2c5d8967e"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "114f442bdb326a86fa831304b5c8c5e9bd42d8afb9f23b9f3eeeceb2c5d8967e"
+      },
+      "before_sha256": "d1fdfc76f2c633b201e8ec3f5ccc411e9c80a77f4f69b6e19e31a34b70143557",
+      "after_sha256": "97807510098b76d8c2f23661acf212d95e3fcb88c42121c179088fa219b48b09"
+    },
+    {
+      "agent": "docs",
+      "skill": "docs-audit",
+      "eval_id": "eval-006-audit-no-version-anchor",
+      "comparison_path": "agents/docs/test/docs-audit/evals/workspace/eval-006-audit-no-version-anchor/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "5b11b38c1c44c386fe19122dfb1ce5918b2bfbc4830ad32aa994d8a7e39f35e7",
+        "eval_definition_sha256": "405d79374055fe033af3883c346829478f3f76cf09e82f4870928a5901ad3a47",
+        "metadata_sha256": "953ef09fb5962b093fa646d68b6f137fe0b19f6ba0157a6c58aae94c9c50c930",
+        "fixture_sha256": "82b55bed70c9cef729375a3351448011b6841c9c9416854e0ef1fd304e6c48bb",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "7c0884fab11b08d46eb01de89abfa2125334493a96c7805f68a7161e9d7bff70"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "27d50a598393184936b3a4580c093f6a42f287fb04e8bd78eae3abfd620dfbf9"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "27d50a598393184936b3a4580c093f6a42f287fb04e8bd78eae3abfd620dfbf9"
+      },
+      "before_sha256": "8f2ae6e3204d438635105637361af9f18d66126503e31282e4cac9f358482d39",
+      "after_sha256": "c2b243b6ecea3a85f1ccb616370c5dad9cd212e331e27faab3506a6223e67407"
+    },
+    {
+      "agent": "docs",
+      "skill": "docs-audit",
+      "eval_id": "eval-007-frontmatter-contract-fixtures",
+      "comparison_path": "agents/docs/test/docs-audit/evals/workspace/eval-007-frontmatter-contract-fixtures/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "5b11b38c1c44c386fe19122dfb1ce5918b2bfbc4830ad32aa994d8a7e39f35e7",
+        "eval_definition_sha256": "6bde344495a08502946e81bb93f2ae1c40e1aff64c95e853b673dd5a307e9ade",
+        "metadata_sha256": "ac5c625c3b447eed92814a4915de66331bf3c2449cbef00676c3c687ad5d80de",
+        "fixture_sha256": "1219a80a8f97201ae3cdd929f2d631a2ba100cf6ab153bec6afe2b6d163ff59f",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "216827bc3e07bc68d228647a6fadcd479f48a986964f70c0c40f48052e42886f"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "2c274fc4085d5099b91101c7f4d3e0082df50dda7ca74f653dbda2cbb390974f"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "2c274fc4085d5099b91101c7f4d3e0082df50dda7ca74f653dbda2cbb390974f"
+      },
+      "before_sha256": "b1459e95f2e71474fb8afbd20004764e59345394fde5e9211331401ad89ea307",
+      "after_sha256": "ef3c865d5557a5172fd7155d3f8d1e280000b2324bb9d58b30b78d7f5a935dfe"
+    },
+    {
+      "agent": "docs",
+      "skill": "docs-audit",
+      "eval_id": "eval-008-pre-tag-success",
+      "comparison_path": "agents/docs/test/docs-audit/evals/workspace/eval-008-pre-tag-success/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "5b11b38c1c44c386fe19122dfb1ce5918b2bfbc4830ad32aa994d8a7e39f35e7",
+        "eval_definition_sha256": "4d1aa7f3a07c406f7e925f931c91ea28170bd7650629aa75bcd06b4f58bba0c7",
+        "metadata_sha256": "6adbc51a2dc07674edf9fca71addc72bccaccf75ae663c41fbf3725d8c48b107",
+        "fixture_sha256": "188f1d4d85d9c539fa3ce7acd636673ee316e8a8c7f692533cb806966484f84f",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "4cd14ef8cd033d31b5bb9ce50a786ad0b7d18c7ff4f682d88505eac53b634ecf"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "fc8fdb5f99e77b856da11104fdb7e7f54c494b97e8408339bca1c748568b2966"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "fc8fdb5f99e77b856da11104fdb7e7f54c494b97e8408339bca1c748568b2966"
+      },
+      "before_sha256": "23296d3de637c457b58730618d260d15f5b32bf5fa5ce618b45c45fc74a97181",
+      "after_sha256": "45e3805ae88e9ed5d71b1061b7c169e94a0d815611d0ded4cfee8b09e5f200c9"
+    },
+    {
+      "agent": "docs",
+      "skill": "docs-audit",
+      "eval_id": "eval-009-pre-tag-blocked",
+      "comparison_path": "agents/docs/test/docs-audit/evals/workspace/eval-009-pre-tag-blocked/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "5b11b38c1c44c386fe19122dfb1ce5918b2bfbc4830ad32aa994d8a7e39f35e7",
+        "eval_definition_sha256": "d573477cbe6d660b40a0fd1ef0416d1d407e28ca525b29d8ef8303b282fe7f56",
+        "metadata_sha256": "2fa243367a1e388253aea518818683b603664720294e82f2ffeeeebe3d5f82e8",
+        "fixture_sha256": "0c59dd74f98f557b12899cbca54adf5aa4fe8aa94d37037f8495e06f83e726c0",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "7dbaa3390632c779b209a0992154e3a2f393b139ccab7a74c59a949526e90023"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "1932a95b75951592f252b57fb17de25f6fa81f0ca58814bc552aa7fab9dcf707"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "1932a95b75951592f252b57fb17de25f6fa81f0ca58814bc552aa7fab9dcf707"
+      },
+      "before_sha256": "b1490cb6f22b0191587e2ccc4690f292a37f66b00e62db7eb3bc0d958701e403",
+      "after_sha256": "01e677bb9acdc2086bef6932d03a24172eed4ae625590a8680385b2a86b3c7c9"
+    },
+    {
+      "agent": "docs",
+      "skill": "docs-audit",
+      "eval_id": "eval-010-post-tag-match",
+      "comparison_path": "agents/docs/test/docs-audit/evals/workspace/eval-010-post-tag-match/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "5b11b38c1c44c386fe19122dfb1ce5918b2bfbc4830ad32aa994d8a7e39f35e7",
+        "eval_definition_sha256": "f4b575228474dd8bb2a93bb17a067f25252f9c293e1f78393d445c449385e8d2",
+        "metadata_sha256": "12f75879efa3cacf943ae19595239a747563947015e4033eed4ea7f4a51a5b47",
+        "fixture_sha256": "43a1d01505e6c9e0f71431fdaeb75fea6b1939424f6c22775d15a970f4b73518",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "f64d4542aa97d4b9bcd4bc655a5e70fec7d827a5ea9e9f63067fde8d7b819748"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "2dc85cee601babf76fab97b8bb9252dda2617beb22220189ad46f11bd4d47ae5"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "2dc85cee601babf76fab97b8bb9252dda2617beb22220189ad46f11bd4d47ae5"
+      },
+      "before_sha256": "a19f119877b365287780e17f0101f1df5d7dc91a0b7497394647432cd84be2b3",
+      "after_sha256": "6928c7da06a8b0b5648367340019197535bbd4e98fd54bdb7a1457e4b0408fa7"
+    },
+    {
+      "agent": "docs",
+      "skill": "docs-audit",
+      "eval_id": "eval-011-post-tag-mismatch",
+      "comparison_path": "agents/docs/test/docs-audit/evals/workspace/eval-011-post-tag-mismatch/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "5b11b38c1c44c386fe19122dfb1ce5918b2bfbc4830ad32aa994d8a7e39f35e7",
+        "eval_definition_sha256": "dd2f814bca5d9dce6fed31e09545467860903a50efd0252401f17372eb85d63c",
+        "metadata_sha256": "44f3e50cd86c78b14f58e8584dc26444f39390cb3ef1d6e88051fdaf94a2e89e",
+        "fixture_sha256": "580d96fbd8d2adf79b801381050e6b3b9bfc58b8f39d636b27ce9f575d873d86",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "87ef764041bed9ee9555b42ac224112964f5f9e1229cf61ab18c2da424e966e8"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "54246632f44827fb4e5a524c6bf067586f9cee67dcf5491d5c80b121271c1013"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "54246632f44827fb4e5a524c6bf067586f9cee67dcf5491d5c80b121271c1013"
+      },
+      "before_sha256": "7833af39a83ca985ecfd377f48e74e3a2df063935b9c3e545b6ce1ff7a9e5979",
+      "after_sha256": "e8bf88fc137f1cdfafcc4613f9485d322806efe5a53bb4989da6ff3b72cb823c"
+    },
+    {
+      "agent": "docs",
+      "skill": "docs-audit",
+      "eval_id": "eval-012-staged-metadata-rollback",
+      "comparison_path": "agents/docs/test/docs-audit/evals/workspace/eval-012-staged-metadata-rollback/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "5b11b38c1c44c386fe19122dfb1ce5918b2bfbc4830ad32aa994d8a7e39f35e7",
+        "eval_definition_sha256": "885108a0e0e9ce48751816455b91da0ec400a08bb7d3a722984a36e4221d1938",
+        "metadata_sha256": "86b2ab0ad4bcb3fb98728ca8ff1375ff58d1094876353cbeafc325bf7593eb63",
+        "fixture_sha256": "1013313f9177f2e4b64118a15325ba0a4da0ec26b6c32604368f1f754b57e620",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "73f9308006ffa877e1ed5f74c8eef2e3a2b3222e98dd5485cfd0ba5e210de92a"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "b948b8323db48932d19e6fa8a34611e560be96e6cf55a2d2a7d68805b0b8e2ce",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "05a9efaec33b9cefe1b4a023686558c2b159d21bd5844cf8a0405c73ed620740",
+        "assertions": "8578835c255aec5af6a905d65d4bdd9e6acd817c17abfc0f77b662c6e605c624"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "b948b8323db48932d19e6fa8a34611e560be96e6cf55a2d2a7d68805b0b8e2ce",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "05a9efaec33b9cefe1b4a023686558c2b159d21bd5844cf8a0405c73ed620740",
+        "assertions": "8578835c255aec5af6a905d65d4bdd9e6acd817c17abfc0f77b662c6e605c624"
+      },
+      "before_sha256": "ed1c9395df92f31de747e57368272441d42d9c806674db80461ce7c19633d3e9",
+      "after_sha256": "fb14306918db5fb2824272ea0214328a47d083bead8ddf5efeef84aa16813487"
+    },
+    {
+      "agent": "docs",
+      "skill": "docs-audit",
+      "eval_id": "eval-013-version-normalization-boundaries",
+      "comparison_path": "agents/docs/test/docs-audit/evals/workspace/eval-013-version-normalization-boundaries/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "5b11b38c1c44c386fe19122dfb1ce5918b2bfbc4830ad32aa994d8a7e39f35e7",
+        "eval_definition_sha256": "5705e506f62200b76867ebca90e47274aa68bc0ca81a7790a3ab2ac8baafd194",
+        "metadata_sha256": "de723686d571b59f10dc657eaf98d1d9ad27c06a9381fcb0dfee19364fb401ec",
+        "fixture_sha256": "1cee6041bd72db3f52d6c6c5a5cd2b2192f387347cccb99c7f5a1da1c4e1e970",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "3cb4db02fceb3a963ab35cfa46d9bd95146e58bed4f92e90064a4aa2fe2f0404"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "07f12cc1e1488883b55491a23367aeae67eae14eda06fca274b15758a7b097a8"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "07f12cc1e1488883b55491a23367aeae67eae14eda06fca274b15758a7b097a8"
+      },
+      "before_sha256": "2be26166a1c9f36a124b36ce97294952ebf63fedb286f977683c543ab8d4cfaf",
+      "after_sha256": "44b7cb4d8584caabf9391e7a33244f919f1f30e71b76a6a109849e78f40013a7"
+    },
+    {
+      "agent": "docs",
+      "skill": "docs-audit",
+      "eval_id": "eval-014-conditional-deployment-recheck",
+      "comparison_path": "agents/docs/test/docs-audit/evals/workspace/eval-014-conditional-deployment-recheck/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "5b11b38c1c44c386fe19122dfb1ce5918b2bfbc4830ad32aa994d8a7e39f35e7",
+        "eval_definition_sha256": "3b49ebce5564e2973a0e2404ae2204baef9f3926736e7959e09be720ea423b90",
+        "metadata_sha256": "2b29c083a590a4eda139a3861e29b83daf406cc100d9a6f0e884225e104c8734",
+        "fixture_sha256": "02024e6f0aaa0bcf6615062b3d8a31430a90f2e0a76edad7ce1044c04423eb52",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "b484eac80dd3c83d19d6e2564672bb72616ee37e54370c5c00059bfaaa781dcf"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "21bebf21de9204e64d3b45d7e8bb66e3135d5e08711e7f14004b38233b0a8edd"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "21bebf21de9204e64d3b45d7e8bb66e3135d5e08711e7f14004b38233b0a8edd"
+      },
+      "before_sha256": "3581b056c043b80447c8eaab520a0f7a00d9567359174e067b1fa946e7817c86",
+      "after_sha256": "33894831f7cec2ab15ad202b7efbe3b2b8fd8f9fd4c3cf8e0c6ca9143ad8de7d"
+    },
+    {
+      "agent": "docs",
+      "skill": "docs-audit",
+      "eval_id": "eval-015-manual-page-evidence",
+      "comparison_path": "agents/docs/test/docs-audit/evals/workspace/eval-015-manual-page-evidence/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "5b11b38c1c44c386fe19122dfb1ce5918b2bfbc4830ad32aa994d8a7e39f35e7",
+        "eval_definition_sha256": "aa707a4a153cd14f8630bcfdbc7593482bcfc1de05bf7582ac2eeb6f645afb7d",
+        "metadata_sha256": "2b093794d817fa1de245fdac944141cf26e940fab11bd3c871b66f71a9c40eac",
+        "fixture_sha256": "1c27cfa2f41ff48338bb4acbfdb7cd16614fdaed5b9fc59cbb0ed2df02c327ad",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "cde7d254babf29e4546bfe9e69c491c81147f2f6aec782f40fd9d10a9dc4b4fd"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "b948b8323db48932d19e6fa8a34611e560be96e6cf55a2d2a7d68805b0b8e2ce",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "05a9efaec33b9cefe1b4a023686558c2b159d21bd5844cf8a0405c73ed620740",
+        "assertions": "06917f7da61737a7c8c10db473a17a48c962d30594442c27cc4dc3a5a8182acd"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "b948b8323db48932d19e6fa8a34611e560be96e6cf55a2d2a7d68805b0b8e2ce",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "05a9efaec33b9cefe1b4a023686558c2b159d21bd5844cf8a0405c73ed620740",
+        "assertions": "06917f7da61737a7c8c10db473a17a48c962d30594442c27cc4dc3a5a8182acd"
+      },
+      "before_sha256": "92649ffc45a89e20fb5baeea5ef2d5b0f6d5fa221a063195f099b13623a305e6",
+      "after_sha256": "f5e222c4d9d4d130f83148f3269ab06b4652d2d7c66bb2135823e359c984961c"
+    },
+    {
+      "agent": "docs",
+      "skill": "docs-site-bootstrap",
+      "eval_id": "eval-001-bootstrap-empty-workspace",
+      "comparison_path": "agents/docs/test/docs-site-bootstrap/evals/workspace/eval-001-bootstrap-empty-workspace/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "f74a445a21eabfad3f25cc38a5190833cf5fc52294bb0054a41378fe894ddd82",
+        "eval_definition_sha256": "0028d93b645e269e09fc6f6345ad073b0c2386395ad858bbd7693d057a9eca5f",
+        "metadata_sha256": "72695cba8eaf9810a85aa17ba3cc9622de1dd39f4d06db93fe0728a19509d73b",
+        "fixture_sha256": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "373ba2965836f0cc6198ffb0151c12c61c34831fe45aaa5ef665fae7d893acbc"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "58826d60b3eedfdc9d2f1d362542122ded2e5567b6e7da6248467aadfb1502fd"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "58826d60b3eedfdc9d2f1d362542122ded2e5567b6e7da6248467aadfb1502fd"
+      },
+      "before_sha256": "3bf52099edcfe46edbed279b4e337aba0ef21917ed61cf0311b80a48c8e30e3a",
+      "after_sha256": "2d86b2af1bbfa74a6633bd6a6513b18857cf60948b48b2de889a36c4961a68e3"
+    },
+    {
+      "agent": "docs",
+      "skill": "docs-site-bootstrap",
+      "eval_id": "eval-002-repeat-bootstrap-idempotent",
+      "comparison_path": "agents/docs/test/docs-site-bootstrap/evals/workspace/eval-002-repeat-bootstrap-idempotent/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "f74a445a21eabfad3f25cc38a5190833cf5fc52294bb0054a41378fe894ddd82",
+        "eval_definition_sha256": "67789de316a1ba3d112d33eabc20baa992cdfc352bddac2855c6bcc9a3f93650",
+        "metadata_sha256": "421f80bf3da30d58b5b544d4c2e96b4cfdc1446ea641a3ffc3d654e2472f3421",
+        "fixture_sha256": "970626314f80eb97fc008436179e977f3b31875ef015d6a3dcce0205080e223e",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "08c04fe57b81475dd890de6778e0567d043b2de7ae5ceb0392b2f8c748e60f69"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "ba4508cc7be02a36b8f2f9afd511255404d9d0378193ab4b97c23d73d601d97b"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "ba4508cc7be02a36b8f2f9afd511255404d9d0378193ab4b97c23d73d601d97b"
+      },
+      "before_sha256": "66f1ca3f997475c6a55bd4d6f3f1a28548855ee15e943c1c6252a03299723bd7",
+      "after_sha256": "481fd736336cf6021bf0c827d09939039f999680506f3b1c53661cdf26550dda"
+    },
+    {
+      "agent": "docs",
+      "skill": "docs-site-bootstrap",
+      "eval_id": "eval-003-block-bootstrap-conflict",
+      "comparison_path": "agents/docs/test/docs-site-bootstrap/evals/workspace/eval-003-block-bootstrap-conflict/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "f74a445a21eabfad3f25cc38a5190833cf5fc52294bb0054a41378fe894ddd82",
+        "eval_definition_sha256": "ef71b65d8d90e0a7a85b11140f77333b6bccfac4b39b25f67875d33153f0ebea",
+        "metadata_sha256": "dd91ae0a6e0ac8c19ffeb9b16bf575dc1d6e559c0626e7027f9e04c671f270d0",
+        "fixture_sha256": "67d646aaa1407e943f08140487b646ac63c9406ed33f7972e7921d67116c9f4a",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "8fb0a4310aa73072ce3915bd9569df86e49409cfb5df2e41bfa626f79fa1e1ef"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "3ed0ac821e8f9c258d351bf6f1e388904081ff353a0e47770720806880be4c61"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "3ed0ac821e8f9c258d351bf6f1e388904081ff353a0e47770720806880be4c61"
+      },
+      "before_sha256": "047e8e565e3caf1faa6288a6bd19575c339a521d8ec632b8cfbe94ec0df5988c",
+      "after_sha256": "6ce27a0d823f1d2e341b8cedb9ab1cbc9c22ab7a680d65926a0f84087c707f29"
+    },
+    {
+      "agent": "docs",
+      "skill": "docs-site-bootstrap",
+      "eval_id": "eval-004-deployment-completeness-trigger",
+      "comparison_path": "agents/docs/test/docs-site-bootstrap/evals/workspace/eval-004-deployment-completeness-trigger/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "f74a445a21eabfad3f25cc38a5190833cf5fc52294bb0054a41378fe894ddd82",
+        "eval_definition_sha256": "f0a0699462419947dfa64649c390cf74a3d370111b9c3ea826e84a8d4dc9f735",
+        "metadata_sha256": "abed400d8529a0bd91cc069fda9057f38aa9e64b1a632698bb6d1e29c26ae6e8",
+        "fixture_sha256": "4e3ac8498634ec41445a5f746933f338a50d3c3d4cae8d2f058bd619e288d842",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "84cb88cc9e25dde2fbf0d2a0fb5349bfe630e32b333634cfdb918d30e60002a8"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "42a3d6d149dad9e821cce002649b9e708a319b5b11425fbe7d326d0b071621c2"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "42a3d6d149dad9e821cce002649b9e708a319b5b11425fbe7d326d0b071621c2"
+      },
+      "before_sha256": "05f6ff4293af32939738ba49354b7f1a108bc722cd05af774f4671fd2f72134e",
+      "after_sha256": "78c622bb7c1d079a5a5f75407c704f8a9044e02fa0b28c7f802a906d8067dcc0"
+    },
+    {
+      "agent": "docs",
+      "skill": "formal-docs-sync",
+      "eval_id": "eval-001-sync-feature-api",
+      "comparison_path": "agents/docs/test/formal-docs-sync/evals/workspace/eval-001-sync-feature-api/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "dd975083d3977d90b71b3396dff2498ef2b7e8d49c50fab50b5462a26f3248ee",
+        "eval_definition_sha256": "ce743547e06014367140716bb2c97c1db58eb733e797662e8b4bd6eca00be3ee",
+        "metadata_sha256": "f8156f035dafc132a200ab0fabf455e3a12e92c380c1e7265ae20e3e3df0c170",
+        "fixture_sha256": "19be975a76919e1880464ff6b63104dc042d768be1d80c006b73e28d58ffabfa",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "b75531387a8a9fcbe3680466e0062ed9ca0b3db6341639dbf81c051b7647e990"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "719de0958c207dc18fa4599486b0b0c821a071ddaf8747e1da06d06a08ad3a00"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "719de0958c207dc18fa4599486b0b0c821a071ddaf8747e1da06d06a08ad3a00"
+      },
+      "before_sha256": "d973c100927b989f462dcae0efcb9b1c7b19c767883e56e20425121ca30ac29d",
+      "after_sha256": "419c16742f6de8e384df174f91f74969e9ddc72d8fded32c59e5d52bf6877f3f"
+    },
+    {
+      "agent": "docs",
+      "skill": "formal-docs-sync",
+      "eval_id": "eval-002-plan-backfill-batches",
+      "comparison_path": "agents/docs/test/formal-docs-sync/evals/workspace/eval-002-plan-backfill-batches/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "dd975083d3977d90b71b3396dff2498ef2b7e8d49c50fab50b5462a26f3248ee",
+        "eval_definition_sha256": "ac42526e36e715108f7b75fd8273d1a27b06b53f2d88401d4e0acf869a7f27d9",
+        "metadata_sha256": "5fd28d9378e7eecda587e4671ac17460a0dd3663cff48d75fd068b1dc2cb5f0c",
+        "fixture_sha256": "d39e08e3921dea4ed3620111c7989cda61f1e85ab306939032821affe0218f45",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "9176713527a4959d0641a1feea488e487885b76c3aa23f11bb3b81f29825c3ae"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "dca3cc6869130daa7880e3e5c0567a5fc477df617a92c6d6a1b06c5322e66815"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "dca3cc6869130daa7880e3e5c0567a5fc477df617a92c6d6a1b06c5322e66815"
+      },
+      "before_sha256": "499cf398e79927f4f44956e8d1c23c74f71fd604560b8aea1db984b9495cee8b",
+      "after_sha256": "1f9ed7a73d471e18c93d8f44fd75f8f64eb843147005e0ac3637bd89d85f1efd"
+    },
+    {
+      "agent": "docs",
+      "skill": "formal-docs-sync",
+      "eval_id": "eval-003-design-gate-incomplete-scope",
+      "comparison_path": "agents/docs/test/formal-docs-sync/evals/workspace/eval-003-design-gate-incomplete-scope/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "dd975083d3977d90b71b3396dff2498ef2b7e8d49c50fab50b5462a26f3248ee",
+        "eval_definition_sha256": "b2bf4f8fb3d18226f8bc19c0ca91afcf8f927301ac6d8c89204f1fa6248c4f6b",
+        "metadata_sha256": "60fd8d12ce139674523c1a361254f5e8a91b8a162c74d8b2d6b08ca495888809",
+        "fixture_sha256": "8aa9df65b73215302e91c3f000b2e01777ac5c79a5e42d477647ee57db58af66",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "4b5a2072f392f239ebcef5483d2cd7f59525e9dddc22047a3017a3927cbc8008"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "b948b8323db48932d19e6fa8a34611e560be96e6cf55a2d2a7d68805b0b8e2ce",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "05a9efaec33b9cefe1b4a023686558c2b159d21bd5844cf8a0405c73ed620740",
+        "assertions": "50f9ad21c4d93fac9be007717bcd5abca4c1ec62f60b0adcd45303d755fe7bb3"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "b948b8323db48932d19e6fa8a34611e560be96e6cf55a2d2a7d68805b0b8e2ce",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "05a9efaec33b9cefe1b4a023686558c2b159d21bd5844cf8a0405c73ed620740",
+        "assertions": "50f9ad21c4d93fac9be007717bcd5abca4c1ec62f60b0adcd45303d755fe7bb3"
+      },
+      "before_sha256": "7191745fbd9440fb3873c018fbd499a153dde89c2d6685bdea7061154211cac0",
+      "after_sha256": "5af231212ede67319aea09febcb3ee2b61d62bd21af96125dc4676879fa51eac"
+    },
+    {
+      "agent": "docs",
+      "skill": "formal-docs-sync",
+      "eval_id": "eval-004-design-gate-failing-tests",
+      "comparison_path": "agents/docs/test/formal-docs-sync/evals/workspace/eval-004-design-gate-failing-tests/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "dd975083d3977d90b71b3396dff2498ef2b7e8d49c50fab50b5462a26f3248ee",
+        "eval_definition_sha256": "ba23dfdb0f9a8ca4993196db1cc72ad98dc4f1e2f6b1b9055f218642fc040702",
+        "metadata_sha256": "b892d7f11434df5d87e026ef6208862e030c7c37761a266263d03ebecbf3949f",
+        "fixture_sha256": "888ec3cd17fb382d54d3506afed12dac820d7455abc356bb02ec550713d0ad9f",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "0669292f176355ed06a0f6f5bb030af6a23cb5add4a747bfc08b3a96f60fa065"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "c192633d8f06a4a51b5b5e33e67e91ad9dfb273ff298bf55903e6239e498f1df"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "c192633d8f06a4a51b5b5e33e67e91ad9dfb273ff298bf55903e6239e498f1df"
+      },
+      "before_sha256": "58f3af3ac2aea404e3d99f428d8f4e7480b070f5a3b9f50f3c080ca59a510ba8",
+      "after_sha256": "6507d2fbe4c12940e0c5de489bf29a44ed659f4f49783ee21c84c36737331a8e"
+    },
+    {
+      "agent": "docs",
+      "skill": "formal-docs-sync",
+      "eval_id": "eval-005-design-gate-mismatched-evidence",
+      "comparison_path": "agents/docs/test/formal-docs-sync/evals/workspace/eval-005-design-gate-mismatched-evidence/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "dd975083d3977d90b71b3396dff2498ef2b7e8d49c50fab50b5462a26f3248ee",
+        "eval_definition_sha256": "9b46c27014c750c2c7c902ee9b735c340d6216e70bd1db10e9ac7cfe4ffa72b8",
+        "metadata_sha256": "8201495b57b213f9db3f5219d86222ff877b211b7bfe7d5c149fe15482812507",
+        "fixture_sha256": "9ee09a35ffbbce09e9a24f1afab930b7c3820a015f0b4c8a431f51638de5592f",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "c9b93b28ac72af6810f4752921bb72d418af8d9162ae5d66c15fe90f929562c8"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "b948b8323db48932d19e6fa8a34611e560be96e6cf55a2d2a7d68805b0b8e2ce",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "05a9efaec33b9cefe1b4a023686558c2b159d21bd5844cf8a0405c73ed620740",
+        "assertions": "aff98674785f5a4052c3837d9707aab2eea4719c3205786868731d36f1a210b1"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "b948b8323db48932d19e6fa8a34611e560be96e6cf55a2d2a7d68805b0b8e2ce",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "05a9efaec33b9cefe1b4a023686558c2b159d21bd5844cf8a0405c73ed620740",
+        "assertions": "aff98674785f5a4052c3837d9707aab2eea4719c3205786868731d36f1a210b1"
+      },
+      "before_sha256": "2bfcd70dda97804ae895f4764b421e59d6d0093df701409a453f36e3d4f6da93",
+      "after_sha256": "cb73812533c7142828776770e14ec9410f00b11b681c9dcbab5e309a8bc44a75"
+    },
+    {
+      "agent": "docs",
+      "skill": "formal-docs-sync",
+      "eval_id": "eval-006-design-gate-all-passed",
+      "comparison_path": "agents/docs/test/formal-docs-sync/evals/workspace/eval-006-design-gate-all-passed/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "dd975083d3977d90b71b3396dff2498ef2b7e8d49c50fab50b5462a26f3248ee",
+        "eval_definition_sha256": "409f0dff74eed97473da7310514056fa3150a1bcc243e245700365b8124e237d",
+        "metadata_sha256": "d850062d9ab19e577fb519798bc20c97592f06bfa16acdff382b6c2af72957e7",
+        "fixture_sha256": "98bf611a541c8fe0137472ae23a2bee304eb1dd895062850790d9e776e872e75",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "ebe36ab58d09b32dcb1d3a0e60e80a8c30163db5b3f4afa9ec0da402309c3c17"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "b0f4a0633f2eb0b6ee02b0126744896ff45fba3f2795ea160522f9acc49abd2a"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "b0f4a0633f2eb0b6ee02b0126744896ff45fba3f2795ea160522f9acc49abd2a"
+      },
+      "before_sha256": "b0162ba4f3f4ec9400fa9d4abda3f012409cc1e58dd2f881486f790580786853",
+      "after_sha256": "6a3b68151737f62e0c2ca74ff0cbdd14b3b85394519cc70b63670a539d514f83"
+    },
+    {
+      "agent": "docs",
+      "skill": "formal-docs-sync",
+      "eval_id": "eval-007-feature-database-design",
+      "comparison_path": "agents/docs/test/formal-docs-sync/evals/workspace/eval-007-feature-database-design/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "dd975083d3977d90b71b3396dff2498ef2b7e8d49c50fab50b5462a26f3248ee",
+        "eval_definition_sha256": "dd84eeaf9ea9452e584f740ec00a1edde6c8e5bfae2ef83da4e9e416f2e769fe",
+        "metadata_sha256": "23140221449282820c7da53fcdbe46ce5ee1169aff6e90986ef0dbd09c5f9120",
+        "fixture_sha256": "de57a3e2c20f574e81d3d9803c1ae3a7c2c6c83bbead7114e75685122bb01a81",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "289a3b63a3dcdcdc4cc6c4b994a40567f085f301732b94d5ab13b0e67247a316"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "ebd163d035031fa3a1db4c56a09c36d9ffe198fdd687906ebcf59e3462dff6d0"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "ebd163d035031fa3a1db4c56a09c36d9ffe198fdd687906ebcf59e3462dff6d0"
+      },
+      "before_sha256": "c9ff98cc400b1aa1becf2ee69a66a9ea40976c88e72bd3e56cbef6b842197d9f",
+      "after_sha256": "9ad7df1301679bf60c58c5bdcad15d86ccd448b7bf17fe6888a033b67dfb3359"
+    },
+    {
+      "agent": "docs",
+      "skill": "formal-docs-sync",
+      "eval_id": "eval-008-deployment-ops-upgrade",
+      "comparison_path": "agents/docs/test/formal-docs-sync/evals/workspace/eval-008-deployment-ops-upgrade/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "dd975083d3977d90b71b3396dff2498ef2b7e8d49c50fab50b5462a26f3248ee",
+        "eval_definition_sha256": "7fe3c7ecf4038349101f98fb6f2ef19330f01c150bee2276a165994129650157",
+        "metadata_sha256": "2f78367477eb99dc045585689bae85fd3302b30aa534650ea910cd64f9bdfbbe",
+        "fixture_sha256": "214f53e3513d921f93697a6af50dd22ab635d80910879e93ccbc5d847195e845",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "f5d562d8581b8e42e3d9fc6fee3e3cf82b682235e3b52ce9b9c4f91a22e1e752"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "b948b8323db48932d19e6fa8a34611e560be96e6cf55a2d2a7d68805b0b8e2ce",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "05a9efaec33b9cefe1b4a023686558c2b159d21bd5844cf8a0405c73ed620740",
+        "assertions": "988e6dfe04143cf9d5084dad7c008791ce052f22d33bcf663b31306f59ad4646"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "b948b8323db48932d19e6fa8a34611e560be96e6cf55a2d2a7d68805b0b8e2ce",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "05a9efaec33b9cefe1b4a023686558c2b159d21bd5844cf8a0405c73ed620740",
+        "assertions": "988e6dfe04143cf9d5084dad7c008791ce052f22d33bcf663b31306f59ad4646"
+      },
+      "before_sha256": "1870994a3a22842c91377183f7198884c815394c9e1fa8ae80ee5d43034a485a",
+      "after_sha256": "5558f62f0f2f6518f857f9c596317740f322c4079c8ae0a19c80deaddd2beedd"
+    },
+    {
+      "agent": "docs",
+      "skill": "formal-docs-sync",
+      "eval_id": "eval-009-release-product-ops",
+      "comparison_path": "agents/docs/test/formal-docs-sync/evals/workspace/eval-009-release-product-ops/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "dd975083d3977d90b71b3396dff2498ef2b7e8d49c50fab50b5462a26f3248ee",
+        "eval_definition_sha256": "c9bcafbf3ecc8c0e0ac28908b463b075e9d1371a95444953a8afc3d41757e192",
+        "metadata_sha256": "d04b92e9a3754ad51ae5d707b3601a2084dc53a6e309122269ca881bc88a10ef",
+        "fixture_sha256": "88db6a4117456e7d2f0e14115ea2a173ee0022fedba47576986e4b24262edb75",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "56b98af2f6fc5a04535db999157836236eb69830528cbecc99ca00f23b4d8d9e"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "8c5bd2968f590be0a07e8eb8fac17770e6bfb7938a44ccd287513382842ceb03"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "8c5bd2968f590be0a07e8eb8fac17770e6bfb7938a44ccd287513382842ceb03"
+      },
+      "before_sha256": "f2554815477576bae925dda7696d9a81a7b211f5565d6aa5907510e2bb56d74c",
+      "after_sha256": "277620c3f52c3274a8fb3b27649db56ba5bd9420fded44c151eb0c28ba73f80a"
+    },
+    {
+      "agent": "docs",
+      "skill": "formal-docs-sync",
+      "eval_id": "eval-010-release-notes-boundary",
+      "comparison_path": "agents/docs/test/formal-docs-sync/evals/workspace/eval-010-release-notes-boundary/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "dd975083d3977d90b71b3396dff2498ef2b7e8d49c50fab50b5462a26f3248ee",
+        "eval_definition_sha256": "73a1610671f9f97761837a796f3ae7908687bbe25fc17ad4582a0bb4ee5c7fae",
+        "metadata_sha256": "2352ae604513521c63a446b6d886e6c879f4a0cef5861b4ee1c9c3ee9f319eba",
+        "fixture_sha256": "f62e3d002a3d849e5b28b313abce4433afd4885459572da3c6552b50d7fc432c",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "b3a1a852c447e6e1ef51ed958da793390c6914ade2f68188c4962daac377d01b"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "7cfbbf05265f5621522c01df0aa57932c7b9e7e6ba87f3aa0bc5664f83c2bc3e"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "7cfbbf05265f5621522c01df0aa57932c7b9e7e6ba87f3aa0bc5664f83c2bc3e"
+      },
+      "before_sha256": "34c65892e4f4dcee985b10b045739bd77b6281a665dc967611774657d8165fc5",
+      "after_sha256": "457621913b009111fd3a952581b58f3567bf03eb129206b861bb970e80d199cd"
+    },
+    {
+      "agent": "docs",
+      "skill": "formal-docs-sync",
+      "eval_id": "eval-011-deployment-three-class-backfill",
+      "comparison_path": "agents/docs/test/formal-docs-sync/evals/workspace/eval-011-deployment-three-class-backfill/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "dd975083d3977d90b71b3396dff2498ef2b7e8d49c50fab50b5462a26f3248ee",
+        "eval_definition_sha256": "75d9816433885deaa537c3684a33cbf77a210bf3435c193880901b7467aafb6d",
+        "metadata_sha256": "e1dbc6626788bdd9110a7a2968862f7b97506d86b4133c4cf183a556eecf36ce",
+        "fixture_sha256": "4d8408c1113f0b188f486ff52a1805928dda107a5b4bcef41d15ff086a7d524c",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "2e68facf61317de81b206f59b17f3e724dc3951afae11b2a8c4aad6ddba91a26"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "b948b8323db48932d19e6fa8a34611e560be96e6cf55a2d2a7d68805b0b8e2ce",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "05a9efaec33b9cefe1b4a023686558c2b159d21bd5844cf8a0405c73ed620740",
+        "assertions": "496ab661e6feb93a8b60ce15d51270a1c7cd98964966010a29bb14ef64db5121"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "b948b8323db48932d19e6fa8a34611e560be96e6cf55a2d2a7d68805b0b8e2ce",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "05a9efaec33b9cefe1b4a023686558c2b159d21bd5844cf8a0405c73ed620740",
+        "assertions": "496ab661e6feb93a8b60ce15d51270a1c7cd98964966010a29bb14ef64db5121"
+      },
+      "before_sha256": "94f515fc6d25d3ef1ff1fd531e5cb99940a79ba502576ecb89a72a60ac92b0f4",
+      "after_sha256": "0469c39a86ff5d90aa64996cd6e5c85a4d72e59f2bcc571e9ac435828eced79a"
+    },
+    {
+      "agent": "docs",
+      "skill": "formal-docs-sync",
+      "eval_id": "eval-012-deployment-class-evidence-gap",
+      "comparison_path": "agents/docs/test/formal-docs-sync/evals/workspace/eval-012-deployment-class-evidence-gap/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "dd975083d3977d90b71b3396dff2498ef2b7e8d49c50fab50b5462a26f3248ee",
+        "eval_definition_sha256": "649fb22000e8030404ac6361df8372e15d8183baaa675df886e6c740c229829a",
+        "metadata_sha256": "9b6d976d4601ac0de151b2a46d4bd90f68a76a475f804b7878df438cf1dba8d6",
+        "fixture_sha256": "94a440475528b183f978a35b0a119247396e300b3f4d27c6c1d0f2046bc60924",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "e93bcd19b2a81fd498c0a0b76bf2788577403b4eb3f684a80f1adbb170c93ef8"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "83d40b06216e91de1198b495289a7a41c173f9b686e20c0959c153fae9cafe52"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "83d40b06216e91de1198b495289a7a41c173f9b686e20c0959c153fae9cafe52"
+      },
+      "before_sha256": "2057d1bbde96391d22bef9ea62b5d496033c0a46386493131d3ea8cbcf5e85b3",
+      "after_sha256": "ba6cf4feb88b23c17dedb736ea266d9d55780ed71455a1f1526a37b6474dd059"
+    },
+    {
+      "agent": "docs",
+      "skill": "formal-docs-sync",
+      "eval_id": "eval-013-deployment-aggregate-migration",
+      "comparison_path": "agents/docs/test/formal-docs-sync/evals/workspace/eval-013-deployment-aggregate-migration/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "dd975083d3977d90b71b3396dff2498ef2b7e8d49c50fab50b5462a26f3248ee",
+        "eval_definition_sha256": "2adf472912fe37066628cc2da23affed241d146a6c7c80728c7df93b4f2fccc7",
+        "metadata_sha256": "1730a36a001d532f328500208fe2ccb136183d8551b840ea714421749b8365ea",
+        "fixture_sha256": "b9cf5f02e5624842eefaa770fff8e84ccfc602f0eed28accf48a25400705d39e",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "cb68cc7396b4ed1007a2bd5b5970baa015053110168fade98a969dbebc84c1b1"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "b948b8323db48932d19e6fa8a34611e560be96e6cf55a2d2a7d68805b0b8e2ce",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "05a9efaec33b9cefe1b4a023686558c2b159d21bd5844cf8a0405c73ed620740",
+        "assertions": "788aabedc9ff1f1cbd84e2b08911dab36facea31724389a140a39a222addcd12"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "b948b8323db48932d19e6fa8a34611e560be96e6cf55a2d2a7d68805b0b8e2ce",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "05a9efaec33b9cefe1b4a023686558c2b159d21bd5844cf8a0405c73ed620740",
+        "assertions": "788aabedc9ff1f1cbd84e2b08911dab36facea31724389a140a39a222addcd12"
+      },
+      "before_sha256": "cb5e0581fb2f8a17c1145694f5bbbcd8f3c48ee78b7ab4bf41fefc25ced4a65a",
+      "after_sha256": "38f4ba5a34d0e9d97183f6e24013a589902b6e4a01113fa1dc08f8daf1509072"
+    },
+    {
+      "agent": "docs",
+      "skill": "formal-docs-sync",
+      "eval_id": "eval-014-existing-site-deployment-recheck",
+      "comparison_path": "agents/docs/test/formal-docs-sync/evals/workspace/eval-014-existing-site-deployment-recheck/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "dd975083d3977d90b71b3396dff2498ef2b7e8d49c50fab50b5462a26f3248ee",
+        "eval_definition_sha256": "db9d705a02de2df76d9e1b62334995eac21d110dc172ed350d92306793043708",
+        "metadata_sha256": "88632df23697500a0c7c41e94fb02d6159ef73b07b033169b66f45a2a56cdd01",
+        "fixture_sha256": "af01acec7b20eeddc434bb03589d582f709819c1284ea057c0edd1ee4d701107",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "4b8356273a26d14ecc55ebfe7a9a2e541bdc3539a06437a0f30fb3a0dc7cbd4b"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "b948b8323db48932d19e6fa8a34611e560be96e6cf55a2d2a7d68805b0b8e2ce",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "05a9efaec33b9cefe1b4a023686558c2b159d21bd5844cf8a0405c73ed620740",
+        "assertions": "0d920443b2616525dce28b8c4e952cc47a2bb9e85486070b57c4ad6f72f554d0"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "b948b8323db48932d19e6fa8a34611e560be96e6cf55a2d2a7d68805b0b8e2ce",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "05a9efaec33b9cefe1b4a023686558c2b159d21bd5844cf8a0405c73ed620740",
+        "assertions": "0d920443b2616525dce28b8c4e952cc47a2bb9e85486070b57c4ad6f72f554d0"
+      },
+      "before_sha256": "c947eae0a2ced780862a4847cd4ee8151ae622d39b55e198161e93354a4f07b7",
+      "after_sha256": "956d4d24e982b9910d70af29bff704cde1ed06319e851188b9b9682b2922d68d"
+    },
+    {
+      "agent": "docs",
+      "skill": "formal-docs-sync",
+      "eval_id": "eval-015-flat-hierarchy-migration-proposal",
+      "comparison_path": "agents/docs/test/formal-docs-sync/evals/workspace/eval-015-flat-hierarchy-migration-proposal/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "dd975083d3977d90b71b3396dff2498ef2b7e8d49c50fab50b5462a26f3248ee",
+        "eval_definition_sha256": "b33925735dcdc1c16e96ba8e543e331eebb29f1fb2575eb75afef7012c2934cd",
+        "metadata_sha256": "1745a4b411c4974d9b158bc811fac50658345383bc93cab2e1df286dcb1629d0",
+        "fixture_sha256": "687c8c162f66866c443380eff16dcacb1132beefea8bacd8446882557f88aaac",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "162b3544cbde876f526df1805303ea3ab78e34b2ebde819bbdbfe83bc8251b8c"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "41c9f6274b7db48c716656a8b4183751c4c350395cd5d1d920d40c21d88145b9"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "41c9f6274b7db48c716656a8b4183751c4c350395cd5d1d920d40c21d88145b9"
+      },
+      "before_sha256": "929e201afc7003a96d42479342a7e29e084e7bbe0db7e7bebc0cf0325ea3aace",
+      "after_sha256": "04c7612ef369468095316ab8d06b44288370cbe274ab7a33f1c7f2e1337095b5"
+    },
+    {
+      "agent": "docs",
+      "skill": "release-notes-gen",
+      "eval_id": "eval-001-generate-site-release-notes",
+      "comparison_path": "agents/docs/test/release-notes-gen/evals/workspace/eval-001-generate-site-release-notes/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "c8459f189e8d92d91e1c7ede8875090bfc1c2e1e04b8f18983b4339e6b65ba34",
+        "eval_definition_sha256": "65fbac4fd20096e04fd9044ef9811d00f14a304548ada95a65b3bc87c1320345",
+        "metadata_sha256": "f1489da43deb17946a7db1865ce4492ffcbc2d33d7073fbbdc572711b748a76c",
+        "fixture_sha256": "5f0f5b3062eae992b755cdc1ae78582ce41bb32058f8a49d6044db233c5966f5",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "37b31d01c6d97d7403db04c5a14501c9f7c823331bdaca410487353335744541"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "129c2cf084d649d917f07de8731669daf205c509c6bdea77bf8529b98b00e156"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "129c2cf084d649d917f07de8731669daf205c509c6bdea77bf8529b98b00e156"
+      },
+      "before_sha256": "4275cea9b29937325948d7c1238e2b9de337191b9f32787514f6030636627321",
+      "after_sha256": "369395280743fd4de2ff933762dc2f5412f16a3007af29bcee42a4a20c233e57"
+    },
+    {
+      "agent": "docs",
+      "skill": "release-notes-gen",
+      "eval_id": "eval-002-confirmation-gate",
+      "comparison_path": "agents/docs/test/release-notes-gen/evals/workspace/eval-002-confirmation-gate/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "c8459f189e8d92d91e1c7ede8875090bfc1c2e1e04b8f18983b4339e6b65ba34",
+        "eval_definition_sha256": "734d8912f6102b866e236fb845ac847f11fde3651b05c29ee143e730ba9a8ce3",
+        "metadata_sha256": "244623c4cb29666e66fbef86938647497dad20990909aac70827020a236484a7",
+        "fixture_sha256": "d8d3cd2bcfa848d5848a9287f747e035b721f3a64f1b4c03c2359e2a75f040bc",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "f52a12716f836504537cf75e93c1e10d802a32eb7ad0a9945e2057c1a94c3f7c"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "8f6f3218fcf02910f8f8a4ba786fac9fb47dacc579ab930a65857f2c45b99d5f"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "8f6f3218fcf02910f8f8a4ba786fac9fb47dacc579ab930a65857f2c45b99d5f"
+      },
+      "before_sha256": "426c61a7d9a9de25dc26d6650011890ff73add491587cf98c352c2d8626ff92e",
+      "after_sha256": "b9bfab57f6e3a6fec20f63e70bf6b84b86c79f14cd8ac4976e4c4a8fae93162a"
+    },
+    {
+      "agent": "docs",
+      "skill": "release-notes-gen",
+      "eval_id": "eval-003-github-release-boundary",
+      "comparison_path": "agents/docs/test/release-notes-gen/evals/workspace/eval-003-github-release-boundary/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "c8459f189e8d92d91e1c7ede8875090bfc1c2e1e04b8f18983b4339e6b65ba34",
+        "eval_definition_sha256": "05f16fbca1905a6bf2d3e5279f6310a7d3001480023c03eb422e696627b86d5d",
+        "metadata_sha256": "79c5171e280a55a386cc65ee64ce2254d37bdb1b11edec578be748642efe98aa",
+        "fixture_sha256": "b6c1fa26768d6c9af6d59884eea70e6437cb9644150d6247f56b09929c6c2720",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "b3d43ca97793c6a0f8faf70ea92518e7709890635e7a921da0c1ddde071762ab"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "ed985f6f495b06e1a610c19fffc2be464a89031f9826e809450cc5e2e42acb66"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "ed985f6f495b06e1a610c19fffc2be464a89031f9826e809450cc5e2e42acb66"
+      },
+      "before_sha256": "0c4dfaf95b9fcc5823a0642fb5d1a474ae8fd48f5fa4721db5cac8f01a48e6de",
+      "after_sha256": "07a86e2ace7678ed5bf38f0468e9918c14e0a62eddac34efb15712e1f73b2f7c"
+    },
+    {
+      "agent": "docs",
+      "skill": "release-notes-gen",
+      "eval_id": "eval-004-conditional-deployment-recheck",
+      "comparison_path": "agents/docs/test/release-notes-gen/evals/workspace/eval-004-conditional-deployment-recheck/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "c8459f189e8d92d91e1c7ede8875090bfc1c2e1e04b8f18983b4339e6b65ba34",
+        "eval_definition_sha256": "34ab52326e403178b3c65c89903f9ce3ed937721059a083b8dcd35f212e12e18",
+        "metadata_sha256": "026d3644999635bf9397130063cb1f65e3467ff790b1fe892aa83df25be7904c",
+        "fixture_sha256": "1d05a5ef6eacf2734acacac9c7f138205eacee50a9bb44893b96aa9bb0d64d31",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "f6ca8293d29d78d2f2b85bd613e1f25b3aa93a647c64e21ca6731d5a228a1284"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "15ca91ee516da4ca109374ad6a550cd671392d2c6e99b7d5db373ed2f51537d7"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "15ca91ee516da4ca109374ad6a550cd671392d2c6e99b7d5db373ed2f51537d7"
+      },
+      "before_sha256": "69abbb343029c6b1d38f72f18d2d87c5d91f8364bf5a235ea29fdb2b7d566bdc",
+      "after_sha256": "58a6ba6c1ca0643ff1a17844d52d6f629c98061db528be285ffe449bcd68f4c0"
+    },
+    {
+      "agent": "docs",
+      "skill": "release-notes-gen",
+      "eval_id": "eval-004-confirmed-release-delivery",
+      "comparison_path": "agents/docs/test/release-notes-gen/evals/workspace/eval-004-confirmed-release-delivery/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "c8459f189e8d92d91e1c7ede8875090bfc1c2e1e04b8f18983b4339e6b65ba34",
+        "eval_definition_sha256": "6ba71c78dee7f69b879178b4307965fc8b664b773fca948482dc1711c289b5ad",
+        "metadata_sha256": "2e15aaf06f83170c681a449f442bd9946bbef263dbea552644182da638b4addc",
+        "fixture_sha256": "c11c4570536758cb911b613643632dd7b15e8b492fb6a5c6cb788342176462bf",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "5f19f02b941db43659fbfb03cc28f127d2b4bbc556ed59290b7811c966f30dc8"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "87f29e3ac589185c4861c77e5dbd18e0ca10baef64eaccb0d40044e64dd9e67e"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "87f29e3ac589185c4861c77e5dbd18e0ca10baef64eaccb0d40044e64dd9e67e"
+      },
+      "before_sha256": "12db1d50ad6a76081fd0a73965b17dff7322763adb4f4e5e486b113db4271e86",
+      "after_sha256": "971d2dddfca921eac0c634c6096ef32199214d5402476eee8501c69cbe92cb4b"
+    },
+    {
+      "agent": "engineer",
+      "skill": "codebase-analyzer",
+      "eval_id": "eval-001-analyze-nodejs-project",
+      "comparison_path": "agents/engineer/test/codebase-analyzer/evals/workspace/eval-001-analyze-nodejs-project/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "de6d27a82a6affa1d54b83f57c4eb1889c4977944cd8849112c1a97798fbfd77",
+        "eval_definition_sha256": "dad930e2f7ff239d93a7a9675b382ce2b702f6090d6d7cc66b26e7ea598351d6",
+        "metadata_sha256": "5ca1d6325e7d73a97605eeb110ddc4062765b77075b5da8df9a904201e44cb60",
+        "fixture_sha256": "70d2400afd3b1f84a7248de72cf04a9e4741bffe1ed6525d4f1cdd2942b2f522",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "4a44af8c4f43ac2a76bbdbb1c44519dabd549bb54a1dc48487259a1d80539946"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "89c4887c995c9b80d96ae99c7d71f81e1043afdba51d95aec0de72c6c753a8c2"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "89c4887c995c9b80d96ae99c7d71f81e1043afdba51d95aec0de72c6c753a8c2"
+      },
+      "before_sha256": "b6118570bf21c36286e3a8ba411df85f83546ce51bc1570ec3591dfe210369ad",
+      "after_sha256": "d2ad64ed3a40ff2a2f63d1f55af389e7b60ff8da52de9049c8a0a7be706fc0ae"
+    },
+    {
+      "agent": "engineer",
+      "skill": "codebase-analyzer",
+      "eval_id": "eval-002-detect-monorepo",
+      "comparison_path": "agents/engineer/test/codebase-analyzer/evals/workspace/eval-002-detect-monorepo/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "de6d27a82a6affa1d54b83f57c4eb1889c4977944cd8849112c1a97798fbfd77",
+        "eval_definition_sha256": "9a583203eacc9eba1f7a8bc21f635feb6ed3d4608d62de30920ed955c3d1edca",
+        "metadata_sha256": "c7ae12e62e0a39a4d07a2a609b69c812f1e0369799ab62ccf27310eb616d8c85",
+        "fixture_sha256": "f21b114551d8be3583bc722843216a52ebb44b2de4870be6c6e960ab6597a69f",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "34f896897fd86f962fdde3e8fbee4d88ed3d89310d32aa50bf9d05459ebc08b8"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "935205d6b2570acd02ed83d9158a98c52952b81cde1e208d95eab883187ac1e0"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "935205d6b2570acd02ed83d9158a98c52952b81cde1e208d95eab883187ac1e0"
+      },
+      "before_sha256": "81a76131432a563ead6d810b93cf940f9501c19acf9b7a91009001975d941b20",
+      "after_sha256": "06018b72e0782e69a498e8b27276ee123dee633aaa6a07a25bd19d6362cd576c"
+    },
+    {
+      "agent": "engineer",
+      "skill": "codebase-analyzer",
+      "eval_id": "eval-003-mapped-search-architecture",
+      "comparison_path": "agents/engineer/test/codebase-analyzer/evals/workspace/eval-003-mapped-search-architecture/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "de6d27a82a6affa1d54b83f57c4eb1889c4977944cd8849112c1a97798fbfd77",
+        "eval_definition_sha256": "df0ea3b9e16f84cfa3123784feaff62e9978d327069fdb7ff40819c75c9ebde1",
+        "metadata_sha256": "c79f8b60b8eda49d60383374b0b105b8c506dcb4b757a67593ed9721a0d169df",
+        "fixture_sha256": "a3ef5b9cc00c15c74b103c208a46d73ff5b53e17721ec0a79184a10c02b16859",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "953cf0ea99b9840a17c7b6706052165ac0b5ad2da8cf5b30696958f911637de4"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "8d0989f3ecc5979d4567bb9e015bbcce6992d1571f872c412b5d7bbba65ce316"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "8d0989f3ecc5979d4567bb9e015bbcce6992d1571f872c412b5d7bbba65ce316"
+      },
+      "before_sha256": "470ad2d024ad102844f59397debfe22ec6e26506b6fda4762d3d43ad15b9af38",
+      "after_sha256": "087d7c265a6cf7c9a67eed2927aca05f22380c70e05e8ae2f06954af983aff26"
+    },
+    {
+      "agent": "engineer",
+      "skill": "debugger",
+      "eval_id": "eval-001-fix-failing-test",
+      "comparison_path": "agents/engineer/test/debugger/evals/workspace/eval-001-fix-failing-test/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "acf0c5d2caeeb9edf300e1f0c7701e33bb6c45afbe3042c358a9c6ee00d796a7",
+        "eval_definition_sha256": "a64fd90ac10a25e027c288e912b74561949edde0e4324959b4f6359f344c4587",
+        "metadata_sha256": "b2ee79c4493432ae5076e82b907d6b1be7ab09583eef30c12a61c6ba0cd38123",
+        "fixture_sha256": "5c2aa809e84372707ac261c141dd4e1423c9e30cd9e6ea24a75c119a154d7dff",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "a8da760bc70af1b8443957d6d0e0908d94f04e37f7d5a4ff6aab844f06d89c5a"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "6133d8d4e0801fafb4b2235733bde1acaa8ac14dc78125cd326829077bf28273"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "6133d8d4e0801fafb4b2235733bde1acaa8ac14dc78125cd326829077bf28273"
+      },
+      "before_sha256": "631ff080c2cc6167c92239cdc5b2f138e3e67cf50f0244855e80f284105918ad",
+      "after_sha256": "298745184d4a21953f28f8ceab396961532b9a55d60e11de185d9646b7739865"
+    },
+    {
+      "agent": "engineer",
+      "skill": "debugger",
+      "eval_id": "eval-002-repair-plan-confirmation-gate",
+      "comparison_path": "agents/engineer/test/debugger/evals/workspace/eval-002-repair-plan-confirmation-gate/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "acf0c5d2caeeb9edf300e1f0c7701e33bb6c45afbe3042c358a9c6ee00d796a7",
+        "eval_definition_sha256": "024f4702e0fa8869af3d3c3109a71208ab006a57b0857bf3decfc75788b86ec1",
+        "metadata_sha256": "7d2fe0fce1e70425553acde36f203e00cc70ea5e32d8f50bf9a3232445ec4c62",
+        "fixture_sha256": "cb0f3c3b3299f6d7c5c59f8e23f6486f0ceb71f6128a3055fbac267527c0d07e",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "02d5b7800830ae12f2a9e99e570ad3aff880c5fd3790b18a9b48bd3dab3b6e8d"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "e0ac04fd8302ba35990d5f611ba343a3b85759e2188815bfc29076452cdac263"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "e0ac04fd8302ba35990d5f611ba343a3b85759e2188815bfc29076452cdac263"
+      },
+      "before_sha256": "ce48bedda933551c05afbda9bf5f8eec0e10adf5b2f078beae79f68777300746",
+      "after_sha256": "d369e9679360b66df97e10f11399091845275061b85e4ce5a814e48bf9ea894a"
+    },
+    {
+      "agent": "engineer",
+      "skill": "debugger",
+      "eval_id": "eval-003-bug-report-conflicts-with-prd",
+      "comparison_path": "agents/engineer/test/debugger/evals/workspace/eval-003-bug-report-conflicts-with-prd/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "acf0c5d2caeeb9edf300e1f0c7701e33bb6c45afbe3042c358a9c6ee00d796a7",
+        "eval_definition_sha256": "1b0128e389f23ce11fa7b4c38a0b662507e4f8c62e4b45bb6324446e6c6f6b76",
+        "metadata_sha256": "83547cd6afd667b78b8f3a62b333fd240958e2bcd69f2565824d154532321924",
+        "fixture_sha256": "b9cb551f52561a96ecca0df5c9b20f04fdacfc0ec8b6db0f67266ab529420ef6",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "a8bfc4df337c13eb13450fd2790a0adaaa6e985db2ba520873d18d41987ab63d"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "ed094a3cb655c3ed35948e3fd9c478d269f280deb4d920229c9b363e790832f1"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "ed094a3cb655c3ed35948e3fd9c478d269f280deb4d920229c9b363e790832f1"
+      },
+      "before_sha256": "c1cf4f38c7221d5804a258b70f336bf3446d7d07221cbf55ccfd020bbc5e1695",
+      "after_sha256": "4a390a919e7d3e40bb65ed75b2c0de65d99786645c24f2f6ee9d25fe5146d9f3"
+    },
+    {
+      "agent": "engineer",
+      "skill": "debugger",
+      "eval_id": "eval-004-nested-feature-path-bug-alignment",
+      "comparison_path": "agents/engineer/test/debugger/evals/workspace/eval-004-nested-feature-path-bug-alignment/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "acf0c5d2caeeb9edf300e1f0c7701e33bb6c45afbe3042c358a9c6ee00d796a7",
+        "eval_definition_sha256": "4ed41777f0081de6b22c8d5c1da9d06cff7a26fda1bb09b0b22361f263f5eaee",
+        "metadata_sha256": "92b34bddeb11ae5b3c6841a7115ad004679cbe8ce0c62b863a34d672cce43c83",
+        "fixture_sha256": "1e51e9c8d509d705021a998a8e3fa6c6c2d1f11f8d331f94d613c603fe3acfe0",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "8752855324ba03bc8e8e5d406c04e9f47ee4871f83be7779dbe93e460aa8eb03"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "680d993576741184be9828a0d28fae66444df804161030a98e4c6061512580c2"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "680d993576741184be9828a0d28fae66444df804161030a98e4c6061512580c2"
+      },
+      "before_sha256": "4698e868ec65171801ac829dbf74e2480f93578108264713d9484833fbf22743",
+      "after_sha256": "fedbfff04e386d38516a67b513fc5c6ed69a93e0d6d1f2428f479bcba0a65465"
+    },
+    {
+      "agent": "engineer",
+      "skill": "debugger",
+      "eval_id": "eval-005-mapped-cache-debug-evidence",
+      "comparison_path": "agents/engineer/test/debugger/evals/workspace/eval-005-mapped-cache-debug-evidence/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "acf0c5d2caeeb9edf300e1f0c7701e33bb6c45afbe3042c358a9c6ee00d796a7",
+        "eval_definition_sha256": "793c3f5cce4575964aaa387ece63f94a0f71e528641010e1ee2d932bd04007a8",
+        "metadata_sha256": "296cf62658138bf9e31e0fd2b92d8abed954cf84bd5c6bd08af68865f72fdfc1",
+        "fixture_sha256": "5265284c4bc9506c9aff21630151842110054255967ea23b3c9669fa67c6063d",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "337f700c72530a0e9753f3449cf14cfadf1a5110c2eed25a81a4aded823a50f1"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "337f700c72530a0e9753f3449cf14cfadf1a5110c2eed25a81a4aded823a50f1"
+      },
+      "before_sha256": "04d65d0fc6565a2c315fb7f59ce533953d99a74f57a06b6ce6abcde57fe05452",
+      "after_sha256": "dbb81fabc8ea117964a3a5dfd09207454ea39ebf54d50009933e89993598d468"
+    },
+    {
+      "agent": "engineer",
+      "skill": "delivery",
+      "eval_id": "eval-001-create-pr-with-commits",
+      "comparison_path": "agents/engineer/test/delivery/evals/workspace/eval-001-create-pr-with-commits/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "80143710c96793bf7a6f9a4804a3d60ffaac7dece4a2f7557d0f1f0713ea31bd",
+        "eval_definition_sha256": "7e02d3842aadb84c2bf63d29c927cc522ebed52b96eed1878122982c38563924",
+        "metadata_sha256": "ddad21037c097d13ee42c91b495c2c2326e53dc9044ae9a3b160a51decc6ffbb",
+        "fixture_sha256": "415df27ebd271a5c6f0949b6abe147a826b07a65acc211cf3185fa0d7f9c490e",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "eaac8d5ec4179daca7a6c1c98e4847ae0114d9d33168a84593f70ca6474abe10"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "1c92f6ed3cfcbc02704ffb9bce8004c340f0ac81239e7d6f07d46a230fbce9ca"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "1c92f6ed3cfcbc02704ffb9bce8004c340f0ac81239e7d6f07d46a230fbce9ca"
+      },
+      "before_sha256": "64c308ee3c59a158ae8b8edb07fd29c559b0f28430da49dced7a86e0d73d6cf3",
+      "after_sha256": "ae7bafd63fff1126f7a7cf58c181853a97ccac4c02dd94efa1194fe886ef6e44"
+    },
+    {
+      "agent": "engineer",
+      "skill": "engineer-agent",
+      "eval_id": "eval-001-route-implementation-chain",
+      "comparison_path": "agents/engineer/test/engineer-agent/evals/workspace/eval-1-route-implementation-chain/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "a0945f69a591a803cbdf998f521f63c8cd89a50d9611edf8290964f39919f246",
+        "eval_definition_sha256": "c64c3e656d8dd56f539b8d46bbf02d2891b999db368472657d75c526ab878d79",
+        "metadata_sha256": "8b67b33f30d9db399127d2f1e52b999931f8055d9c101157fccc82071f88b519",
+        "fixture_sha256": "6901f5611ca2fe3ad6e90465dd3d2fa7fe65487d3ee792571b1138447aa07b62",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "a1e6bf4e08477989b26fffa805de56b77288d345cfdf1b16c76dd2c7ddf824f4"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "817c8322e416776d8fc5a63d6068e7bc48463f0afd54e48f885a96be3485b2ba"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "817c8322e416776d8fc5a63d6068e7bc48463f0afd54e48f885a96be3485b2ba"
+      },
+      "before_sha256": "2e664c00add7fdad7a3db36d3f58ac2f2791306b54bebb70fd3b037f78b85c15",
+      "after_sha256": "89e7a9a77a7c00bede80e890f1c538364f6e4e90cb6d0fed47736ba18e87c0d5"
+    },
+    {
+      "agent": "engineer",
+      "skill": "engineer-agent",
+      "eval_id": "eval-002-existing-feature-alignment-gate",
+      "comparison_path": "agents/engineer/test/engineer-agent/evals/workspace/eval-002-existing-feature-alignment-gate/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "a0945f69a591a803cbdf998f521f63c8cd89a50d9611edf8290964f39919f246",
+        "eval_definition_sha256": "35bf0057341046be2b5db3cd90c99d825b61efaf315ed25428b5eda571894209",
+        "metadata_sha256": "43542dab517c382c8ae0bc3c7332df9e98a97a6229686bf334f88c000c1ef95a",
+        "fixture_sha256": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "fd74eb5f01d1266986de0e63d98b09a328266b3f4b3b37579328c75fc417b428"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "7b6b99454b8c94f934434475fea557e3c661fc2711cfaa3a4fbb9976e4c7b01b"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "7b6b99454b8c94f934434475fea557e3c661fc2711cfaa3a4fbb9976e4c7b01b"
+      },
+      "before_sha256": "82383de3d62708aad15800abf90539812d18345501f065c59581f5b675bce081",
+      "after_sha256": "ac40554510e53f05b63257da3073f2bfb9fd0019f54567713114d4a046fc58f3"
+    },
+    {
+      "agent": "engineer",
+      "skill": "engineer-agent",
+      "eval_id": "eval-003-nested-feature-alignment-routing",
+      "comparison_path": "agents/engineer/test/engineer-agent/evals/workspace/eval-003-nested-feature-alignment-routing/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "a0945f69a591a803cbdf998f521f63c8cd89a50d9611edf8290964f39919f246",
+        "eval_definition_sha256": "6c7cc377f055d604b202feb40d5d2142b855d0368cb0621fa60f17937cec9872",
+        "metadata_sha256": "cc9d0ea1f23672ef6b7d553053f01b0836b8fd341a707c6f88e853c6256fb3fb",
+        "fixture_sha256": "fce695dea6b3b91d6d3888c03505a121b7361b20c47f0ec1866020880becfe0b",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "2c28cd5019db4aa28a9d236d016e67174df115cef2180ca189d432ec28ba579c"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "3ac242948c74722246d3741583f3d17fa323c41c168d26628cd8be3cb4d60525"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "3ac242948c74722246d3741583f3d17fa323c41c168d26628cd8be3cb4d60525"
+      },
+      "before_sha256": "7b38957f628934ad0d3e96f0eff92bdbf07791b06ed4770dc721d006b6706c5e",
+      "after_sha256": "d498357779bf6edad33ee1a8160b3333e0b49925b2f6b0d078d0797500c167b3"
+    },
+    {
+      "agent": "engineer",
+      "skill": "engineer-agent",
+      "eval_id": "eval-004-frontend-ui-routing-contract",
+      "comparison_path": "agents/engineer/test/engineer-agent/evals/workspace/eval-004-frontend-ui-routing-contract/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "a0945f69a591a803cbdf998f521f63c8cd89a50d9611edf8290964f39919f246",
+        "eval_definition_sha256": "bfc10d83b8c5a5962987ac2605d966a1788bde7de31566b4d329601b6b214354",
+        "metadata_sha256": "4906971d417635b5c425ac490e57080c03cc4473b36cee23eaff89fa06fe26b0",
+        "fixture_sha256": "ec60268c3cba621e7690e34a6ae14bc9ac52429e90275b6d4c2fdedef202a8df",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "e2168c580c03f1c43acee8d4077b4a9553410b224e0542721c19d2cc8e09e39c"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "3a6511555f617e3d8db5eaec2c231409d33a3224bb6e65598c40ee5b0b3d7ad0"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "3a6511555f617e3d8db5eaec2c231409d33a3224bb6e65598c40ee5b0b3d7ad0"
+      },
+      "before_sha256": "ca17959d43d6e2bea6886c3a05e33a517dd2076b3528a2a58edb77927196b8ab",
+      "after_sha256": "695e11493c79afa5a7623972fb2e9e3eabfa384b3b9fee89cace19179fbce980"
+    },
+    {
+      "agent": "engineer",
+      "skill": "feature-implementor",
+      "eval_id": "eval-001-implement-from-prd-trd",
+      "comparison_path": "agents/engineer/test/feature-implementor/evals/workspace/eval-001-implement-from-prd-trd/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82",
+        "eval_definition_sha256": "fdd6ce4f4f12ff2cfeb67956eb31c203d7cf49aba2742edf2df400fcb4ed7d44",
+        "metadata_sha256": "5513e853bb936ee74aa78321c2888f8103020519d504b58c9b057a2fb3fd33ff",
+        "fixture_sha256": "6fefdc42c8b398b33bf8d36b081a2d2c404ba55841f19917d1bf8a129df36ca6",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "beede515c8e2f36efe8ae181f94762d96db69fb2e24a26068fcdd2ef262c1f48"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "1332f1f9f0dc4ca4c84705ce698ae2682d6c2c83878722ed0bbd6bc32b811c85"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "1332f1f9f0dc4ca4c84705ce698ae2682d6c2c83878722ed0bbd6bc32b811c85"
+      },
+      "before_sha256": "70a5840c6aefa314adc4b2ea0ed8b6babcf9a39a3cfd77cb18f723eb58488786",
+      "after_sha256": "481bda4d555d05b18802cf12aa8e419b888981c311b37d31464754b430fc9724"
+    },
+    {
+      "agent": "engineer",
+      "skill": "feature-implementor",
+      "eval_id": "eval-002-subagent-division-from-docs",
+      "comparison_path": "agents/engineer/test/feature-implementor/evals/workspace/eval-002-subagent-division-from-docs/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82",
+        "eval_definition_sha256": "5c62d2cc73fb2bf0752465157043f4f8dd87b392fc0487e4305ab334ca2facef",
+        "metadata_sha256": "0a81d92a9af555dbb300e83a7ff4d8024a21161273fe243a2bbb1dbd8da3747a",
+        "fixture_sha256": "65a99fdb8c4d1c46befd98fefb9960ee9aae1f97faab8a74ba30b0fffe3597a9",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "1e433f2d38239fdd1f4633433c706d2dafc7492741c63113035a8d0975b21d23"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "8e7ea66bac32f492ca5eb6cda3befee2f09060460bec79a8d68354d1198b5f21"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "8e7ea66bac32f492ca5eb6cda3befee2f09060460bec79a8d68354d1198b5f21"
+      },
+      "before_sha256": "8c44a4a2c1365a8be9319b27ff92ccfcea3c3aa0d0daa55312ade54873d8d4f7",
+      "after_sha256": "cf144bb8e79e39f6d3a9e626c5da2b0f5849afdcae8f38ffcb8fd4414080364c"
+    },
+    {
+      "agent": "engineer",
+      "skill": "feature-implementor",
+      "eval_id": "eval-003-missing-trd-handoff",
+      "comparison_path": "agents/engineer/test/feature-implementor/evals/workspace/eval-003-missing-trd-handoff/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82",
+        "eval_definition_sha256": "beeebfd4f2a4eb407e840ff01043296b9db4c0e70af2a9d7de790cf54280c082",
+        "metadata_sha256": "b646b97a67422c086871d592a86b4ef2968c69945b431fbbc93a36b8db79d701",
+        "fixture_sha256": "ab5acf9561757cd60998119f1643fd8622ced39a8046dbb107e9cf8100e1110f",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "e6ae86389c4cff0bdb9cc29f2e8bb068759de0c10b4021f42a0673c6cbfc39d1"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "44dc5f1fe50e1745884044aa8decb291471fa18a765d35d892dc67a978e7549a"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "44dc5f1fe50e1745884044aa8decb291471fa18a765d35d892dc67a978e7549a"
+      },
+      "before_sha256": "20d20dade74168dfd7184b1ec2888df69432ab96bac2cc1c3ff6591acebfb853",
+      "after_sha256": "200e17ab886df8c4b54b8b62fd9c747a7812ba63a0ac1c87d540cfaeb338d716"
+    },
+    {
+      "agent": "engineer",
+      "skill": "feature-implementor",
+      "eval_id": "eval-004-small-change-plan-gate",
+      "comparison_path": "agents/engineer/test/feature-implementor/evals/workspace/eval-004-small-change-plan-gate/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82",
+        "eval_definition_sha256": "7ad36e3dae8256ee32b41e326daa72d3992661ae3195905ab94c0de9d5bb4663",
+        "metadata_sha256": "62fa61590c7d39e5404273472c64cb54c1f2eedc4a5d8859470cb476742b524a",
+        "fixture_sha256": "08e37b0f6a888462b39d6fb25d39b0f94b11e631f275f2f0a4af2411345138b6",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "133a3fd5fa38d2737eb59228058522a6b1f1268ab7cae969d1962b0b8a3f990f"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "fb97454b0cc20f4420dff5b8e52b9031824c1546b30ca0c2ef51412893dc6f16"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "fb97454b0cc20f4420dff5b8e52b9031824c1546b30ca0c2ef51412893dc6f16"
+      },
+      "before_sha256": "796917bb6c7505f828428369cf40f3897b5c7322cdb471b96becc4c783868240",
+      "after_sha256": "c749f5c6f46341dba3dfeccbddfa9ae8940e9cded91753daa4faebffb1b5f8d8"
+    },
+    {
+      "agent": "engineer",
+      "skill": "feature-implementor",
+      "eval_id": "eval-005-existing-behavior-change-needs-pm",
+      "comparison_path": "agents/engineer/test/feature-implementor/evals/workspace/eval-005-existing-behavior-change-needs-pm/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82",
+        "eval_definition_sha256": "a4e07ef6b983fa7473b530066460795acade377b6663bfa81c7266e9bd35ec21",
+        "metadata_sha256": "4d7d33b92b764b2a122613cfa3d9e97d80ead9fb721df6a2df123d3fcb35534c",
+        "fixture_sha256": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "c708196a2509f10ac671d636aa20ae05a664bdf496710d323db28c9149713561"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "5180af123cf0675b859732fc61c50d973a7dc0c5fce05f6da5f8a8351ecdf3d5"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "5180af123cf0675b859732fc61c50d973a7dc0c5fce05f6da5f8a8351ecdf3d5"
+      },
+      "before_sha256": "8fc7ea4fcf36c6fefc033c16ef2eca54528103ad53e8d796760b5e85045b4bc4",
+      "after_sha256": "e936c99b4000cf2b11c10cb4f3a741e673de0ee3e2f8cfbf23d45d5ac43e5dd9"
+    },
+    {
+      "agent": "engineer",
+      "skill": "feature-implementor",
+      "eval_id": "eval-006-small-bug-fix-plan-gate",
+      "comparison_path": "agents/engineer/test/feature-implementor/evals/workspace/eval-006-small-bug-fix-plan-gate/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82",
+        "eval_definition_sha256": "eedd6f2658d30fa0d35d3b4c542f62bf462bc6c1940c310dab2dd6d4429a52b7",
+        "metadata_sha256": "e36d75fac31fda1c2cb2830fe86474e7378a0134e27ed358915e6d77bdb6c000",
+        "fixture_sha256": "189adddf12b53efb048e7c5d0b3605c9ce9d7f6b01023de7e418b715817c16f4",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "077d595387f9ef0925e654ba0704bfaf70b2ff427013d3059de96bcadac4157a"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "a9369f855de3a4a33d2a6b8ca18aa695e13cf78ea51c90dd2056fa7175e465f4"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "a9369f855de3a4a33d2a6b8ca18aa695e13cf78ea51c90dd2056fa7175e465f4"
+      },
+      "before_sha256": "7d925cfe285fcb591ff7ba9f926d5d381e59562bb7e4b758c36ce3e4e8fd12a5",
+      "after_sha256": "c08755e809420baa1639f5e5bb6356b253807a8d342b758ed60a2e09a00ce348"
+    },
+    {
+      "agent": "engineer",
+      "skill": "feature-implementor",
+      "eval_id": "eval-007-missing-nested-trd-handoff",
+      "comparison_path": "agents/engineer/test/feature-implementor/evals/workspace/eval-007-missing-nested-trd-handoff/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82",
+        "eval_definition_sha256": "b5bb3aa99b72ccf5e21dcb20544d88f2d186af2b99e158d4fcf19d8c4d0e753d",
+        "metadata_sha256": "bebe0f9634c14237118b72776255b4f9bb880a6d0204ec8383ca70e9eff7d678",
+        "fixture_sha256": "60bf457213c5027b1b635e439080d394ebbdbc0aadd1b41efc4678ffe172a846",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "80868b5a1dbdaaeaae58f1b6f4c234d150c4534f0ca9af8c7d89fa4350b459f6"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "7e7498b595ba7b334c5a156b88457a9711efeb07e4b5bf4bf748fd763bf9af9b"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "7e7498b595ba7b334c5a156b88457a9711efeb07e4b5bf4bf748fd763bf9af9b"
+      },
+      "before_sha256": "7fa68efe13b6543c5cd8d282aa91236b2f8709a3b8ff6c2bd5327ac5b97218b7",
+      "after_sha256": "547f1e4465bee3b84a43fef015d95f3aea83c451861bcd822b8fa761c3201786"
+    },
+    {
+      "agent": "engineer",
+      "skill": "feature-implementor",
+      "eval_id": "eval-008-feature-path-mismatch-blocked",
+      "comparison_path": "agents/engineer/test/feature-implementor/evals/workspace/eval-008-feature-path-mismatch-blocked/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82",
+        "eval_definition_sha256": "66c4bea185008e1b43202328d058ecaa9e2ff572bdfe8be7d346a358d1c56597",
+        "metadata_sha256": "3365bfe92db70d4ff5499652a29702f93ac57621aa93b249c4712559af86079a",
+        "fixture_sha256": "fa61fddb39b3b74bc77db4e82386f7b1f9cd3a070d4333160570607ea9172a8d",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "33864756672d39ea5d3d054f279e52d6c05b6ece12eef5c3a61c53de61073a90"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "3aaa2b255c19ac83cf0a98a66f6f84bb031107d3365320bfb440ca8efc8be8d6"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "3aaa2b255c19ac83cf0a98a66f6f84bb031107d3365320bfb440ca8efc8be8d6"
+      },
+      "before_sha256": "cbb1d16190100cd2154d10e13f7d7356e7d35e4d995921778bd21d0973c888db",
+      "after_sha256": "7e373af43551c8a5378dd5a8ccd5c9391d5f9c96ca292a547d88b03ea93492f7"
+    },
+    {
+      "agent": "engineer",
+      "skill": "feature-implementor",
+      "eval_id": "eval-009-ui-design-handoff-gate",
+      "comparison_path": "agents/engineer/test/feature-implementor/evals/workspace/eval-009-ui-design-handoff-gate/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82",
+        "eval_definition_sha256": "a313159478f71f3c53034d04181e6cf7f6ee092241472cdee4c99fbe2b9042fc",
+        "metadata_sha256": "5e7a0cec3496b476d745c2e2e1792aa7fe5d0f1912d30b7047f5ac770f4cdb1c",
+        "fixture_sha256": "e933472ac04a2cc28b54c89f863b1b89688bd67af1793cbac5f728cf5ae72984",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "2ecaa597e1be5d2c7100696a1bf5cce49ac2b021a5cc8ab7c690c99ac2883c0d"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "bd25a16821b76bfa701386a01355bf9483e76bda5c6dd77591e771991040f44f"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "bd25a16821b76bfa701386a01355bf9483e76bda5c6dd77591e771991040f44f"
+      },
+      "before_sha256": "26511f263e36ba8708fcb60aab1b5b93a080e47ec740bd3c110724f6d24d79c7",
+      "after_sha256": "289dee94b03fc76be784d3db6f79dfe88413e78ba3cae0c6ddda48c3079bac57"
+    },
+    {
+      "agent": "engineer",
+      "skill": "feature-implementor",
+      "eval_id": "eval-010-implementation-plan-closeout-sync",
+      "comparison_path": "agents/engineer/test/feature-implementor/evals/workspace/eval-010-implementation-plan-closeout-sync/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82",
+        "eval_definition_sha256": "20499e40a806229e21ef95ff8d5fbc24188637283192bc707a4d5fd2332a9e7d",
+        "metadata_sha256": "8cc2bbac5be951408272dda8df48e23d4c89655790723f30b56076864a8cfafc",
+        "fixture_sha256": "b472a02faf2f5e271bff5cfda7f77a99314d4a0e9e7388442ee7140ff824b071",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "fb8321bee2e5348476e997d826ae18ebe45fbbe3e17a6d49b5ba543f9a119c27"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "ce7473bdf892dbb1e1b98acb296206955a20225f9146b27258287f4b056f1e4f"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "ce7473bdf892dbb1e1b98acb296206955a20225f9146b27258287f4b056f1e4f"
+      },
+      "before_sha256": "f8cf9a392dd4d67e48226a8a043288b34767b8bc9eca30e3ee51287dc998f108",
+      "after_sha256": "494cb9348bc3979ee3db04f4f47cdfa793e7274fa1cf8ad436b8f94bdbd122ad"
+    },
+    {
+      "agent": "engineer",
+      "skill": "feature-implementor",
+      "eval_id": "eval-011-four-level-feature-path-plan-gate",
+      "comparison_path": "agents/engineer/test/feature-implementor/evals/workspace/eval-011-four-level-feature-path-plan-gate/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82",
+        "eval_definition_sha256": "7d6cafded24992611b95dfc908abe3d7611f7857dadb745152c30089566b43d2",
+        "metadata_sha256": "3668a072214fe6498899f002deadbb563dcff96e3a3df4bc0dd68e0b0df02057",
+        "fixture_sha256": "6c438d1edc9a89256655ae36e972b31a4929ddc7fe5b5f285e888975f24e8b68",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "daa05dfde11fd09221d4ad9b38d9b74b58a7b93050ec83c55293e7ca9eae6a7e"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "b38e0e1d09753c0548f4ce6a413e898d902eaa3f6833b350d24caf3c28995cb7"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "b38e0e1d09753c0548f4ce6a413e898d902eaa3f6833b350d24caf3c28995cb7"
+      },
+      "before_sha256": "07322a79e75caffe4095c2089f45bb3889f7c1097ae661f17f29f58e18b2361c",
+      "after_sha256": "73b6afe31fd21c6fa9c4d0c23e4ff3217a380df40f26fb2c704fbc04e0f12aa8"
+    },
+    {
+      "agent": "engineer",
+      "skill": "feature-implementor",
+      "eval_id": "eval-012-implementation-plan-archive-preflight",
+      "comparison_path": "agents/engineer/test/feature-implementor/evals/workspace/eval-012-implementation-plan-archive-preflight/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82",
+        "eval_definition_sha256": "7f61bff44513e544647aa068492b4fc39b7ba0f0b8a502c36472dbc74575e45e",
+        "metadata_sha256": "158f5bafaa3ad4ac6ba561642292db5794c29432044a423049518391aa4f0dbd",
+        "fixture_sha256": "681e197eb0a978ca201707a3d3b58dd8ed78255de8e5033ca94ef611ea90807e",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "097d311377d0abb4f2fcb1bfa46de1df83e6feccaa7b6f38bb1fb185a5118ab5"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "cf6f602fe0e6d37c218ca6601841b9297cbc26f14bd30036c1e500535f32cfbd"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "cf6f602fe0e6d37c218ca6601841b9297cbc26f14bd30036c1e500535f32cfbd"
+      },
+      "before_sha256": "92327a33831343c3f428cd2fe7a463afa503cbfa738e39dc851433d35d9ea484",
+      "after_sha256": "1847a3670d2ffb9301587c096c674c0ec2302d7296e773712595e118df673748"
+    },
+    {
+      "agent": "engineer",
+      "skill": "feature-implementor",
+      "eval_id": "eval-013-implementation-plan-archive-allows-next-plan",
+      "comparison_path": "agents/engineer/test/feature-implementor/evals/workspace/eval-013-implementation-plan-archive-allows-next-plan/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82",
+        "eval_definition_sha256": "e7ce63b1af29ecd94dfeb7909e7f066642dfdd9e9e7c1c834d32f01202820dcf",
+        "metadata_sha256": "09c697e47642eeb80d16370a2788d572a97cb4a1e71356745930b9203f62054c",
+        "fixture_sha256": "4ef8c6418e526050652f1a037736acaff4cffdb17b27acf4e8f94adbd8c3be96",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "92c95ee84208d5ddf7a774382e98fb939786b7da025643fcac881491d89921d5"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "486dad98045cfc54cbb11795c6937744982694c41aa2d44f0a3596c77c90c566"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "486dad98045cfc54cbb11795c6937744982694c41aa2d44f0a3596c77c90c566"
+      },
+      "before_sha256": "a1c24e28c44d8554a44c4cdfde538dd0eb40d36500c06bf06647dd2cda313b63",
+      "after_sha256": "960b4c341f50fa738fc4b06c7f5d3d051834dece03a497c799f65a423066c53c"
+    },
+    {
+      "agent": "engineer",
+      "skill": "feature-implementor",
+      "eval_id": "eval-015-implemented-status-detected-from-fixture",
+      "comparison_path": "agents/engineer/test/feature-implementor/evals/workspace/eval-015-implemented-status-detected-from-fixture/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82",
+        "eval_definition_sha256": "b2cb611a2eb526b32fe7d8233b7af41b5dc9690189d7d476ddf33384f3fb4855",
+        "metadata_sha256": "b8899bf7ae5f8fcc629e9bed966ceb9612aaea2fc7055363d1e8ea6b2efd4e30",
+        "fixture_sha256": "081f99f1748dae6b1e4b0b232ec7c1df3a484b0c63d868321dc8a1e16a817449",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "923a1c7b31287566dcbc7acd5bf79481560908bbcc5207920a4090de9501eef3"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "d08248c582489c1bdf5ad4fcc7d2ad3be26953a199cc4f48c4290826a8db88ed"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "d08248c582489c1bdf5ad4fcc7d2ad3be26953a199cc4f48c4290826a8db88ed"
+      },
+      "before_sha256": "341ee292b4cdec4ac580405feecda708ce05657e559e9ef06968b0ba8abdb944",
+      "after_sha256": "430a7c68d14a76883771c7a29488e383f7eb458e80368e4deaf193673ad47a56"
+    },
+    {
+      "agent": "engineer",
+      "skill": "feature-implementor",
+      "eval_id": "eval-016-draft-status-continues-current-plan",
+      "comparison_path": "agents/engineer/test/feature-implementor/evals/workspace/eval-016-draft-status-continues-current-plan/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82",
+        "eval_definition_sha256": "86c8e37f3b454c4b68e8a8e0d79eed844e522098807d679c66512f9c18daf3b3",
+        "metadata_sha256": "566e39d7363acab918c0b8b38f7cebac43ee4f4a9069dd6e8b635d61f1c29eb0",
+        "fixture_sha256": "20e27cdb155a076474a45e3e1e88d991a8bc4e1c3723a56f9fad5436bddd121e",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "b61097c2327e4512b0954be7440f9efb0288869d119e12aff21af89d2a1a48fa"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "246b46459bdc55556f79511c8ffdae2ae33489700f86b014ed23fc4df246f3b8"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "246b46459bdc55556f79511c8ffdae2ae33489700f86b014ed23fc4df246f3b8"
+      },
+      "before_sha256": "ab9e535a9ae3c421fb201b2b1bea3723c6a91dedbc359a483bfa41e809b61fbd",
+      "after_sha256": "abec12c8208cd587c82c02ce0bec6eaadab8f81a89eda40e2249d9deacbee8e9"
+    },
+    {
+      "agent": "engineer",
+      "skill": "feature-implementor",
+      "eval_id": "eval-017-abandoned-draft-can-be-superseded",
+      "comparison_path": "agents/engineer/test/feature-implementor/evals/workspace/eval-017-abandoned-draft-can-be-superseded/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82",
+        "eval_definition_sha256": "92bf4838a78758f537ca7650dd1be190ad947406f8ab40d6ace62d644c28dc37",
+        "metadata_sha256": "21a9c9ae11f8c9b8058a429c319a4f2a640a6b07fdf2d71e259bbc158caa4e24",
+        "fixture_sha256": "c0e7350515f9e8f3a166039b0e6d074b044f7918d0abfcaabf64ea0fd4ef53cb",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "a264d3282fcfebf29821ed24d8e702134594b3cc4be72cd72f03b0e03e92c160"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "2937f9307ca7d186960281ab381fe87748f5eebdea623d7d7ca99900a8ea667c"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "2937f9307ca7d186960281ab381fe87748f5eebdea623d7d7ca99900a8ea667c"
+      },
+      "before_sha256": "d78b6937d7200499d80edeb8f4ec964496fc49df006c6d83d7470c55579b53d6",
+      "after_sha256": "80765b1f9355a6734e6497ea0cfd3c15f82fde570692715f89e87f49f316328c"
+    },
+    {
+      "agent": "engineer",
+      "skill": "feature-implementor",
+      "eval_id": "eval-014-mapped-session-plan-evidence",
+      "comparison_path": "agents/engineer/test/feature-implementor/evals/workspace/eval-014-mapped-session-plan-evidence/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "2cef9a078b25940be2cd93c65c4193da4205d9703e5924079fcda5ac81b0dc82",
+        "eval_definition_sha256": "51a5d5a4f671b1df617b81a97fb84c601259cd9a8d3901d74d7d41b70d44d966",
+        "metadata_sha256": "85958a0c5140b007348a2041b6f7a9c97d73f65f93f4fafa12ba3e42d03d7a13",
+        "fixture_sha256": "ebf98490e96d51646bb08c2897d26dd073cad98267ddc69d86f17d77581f2927",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "10e66578ce9766b2b5d66168d3cd75d19add20c5f46a40329efb058c3d761f84"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "10e66578ce9766b2b5d66168d3cd75d19add20c5f46a40329efb058c3d761f84"
+      },
+      "before_sha256": "6336bb0b90ffc35d6b6c4440b1abceb06e3c2bcdcc853e4e35f903cc815f7827",
+      "after_sha256": "fbcda0244bdee77da3056bebb66f271ff542a67766b25c693d999fa7242630f7"
+    },
+    {
+      "agent": "engineer",
+      "skill": "test-writer",
+      "eval_id": "eval-001-write-tests-from-spec",
+      "comparison_path": "agents/engineer/test/test-writer/evals/workspace/eval-001-write-tests-from-spec/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "8676e9bdfb5dcb168ade64b20ca31fd5f471aaa2778319375ec606582ddd34da",
+        "eval_definition_sha256": "efd5ef5afb815bd08b4891a7e8121a2425c0d9fa58d54ab02bb52d9e0279793d",
+        "metadata_sha256": "f070f60ff223bb6ed508e78cdd69bdde29b46feeccf2713b0da03a7503f77d6f",
+        "fixture_sha256": "1fc33cc2cafe76721e09e39f06834f83330e227e59b4aed334bc003945dfdf3c",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "76acf51e56db3c0b81097f6bd3d6543ba266417fd8281a9ea540a61e66eb1dc7"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "8213b97b728fb84610af1fb773d3fe4f02f99c95023fdfbbf409bfceece9185f"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "8213b97b728fb84610af1fb773d3fe4f02f99c95023fdfbbf409bfceece9185f"
+      },
+      "before_sha256": "dbd49225b326ea626b67e2c41e578696322001a76b8f63f93f1d0c8aee5f082d",
+      "after_sha256": "5d60099bc894ed772b352f8da36d434656a6f100ed9afaf169e77bd16c5aca0f"
+    },
+    {
+      "agent": "engineer",
+      "skill": "test-writer",
+      "eval_id": "eval-002-mapped-pagination-tests",
+      "comparison_path": "agents/engineer/test/test-writer/evals/workspace/eval-002-mapped-pagination-tests/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "8676e9bdfb5dcb168ade64b20ca31fd5f471aaa2778319375ec606582ddd34da",
+        "eval_definition_sha256": "dffdc1de9650924aeba7f48471eac1b4c1592e52cef441419d14a463af648ff5",
+        "metadata_sha256": "6a60b69beab2bdd4c854670cd54e7749219cde65551c8e29d984d322f4c34c88",
+        "fixture_sha256": "866e2c4f7a812e0445a49d5de640bceae9b9dcd49ee9a3bd9c91db26e366238d",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "c54bc58422c757cec4c7b4e62659700d5fa9751ad9fb2e2a887150281b524730"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "c54bc58422c757cec4c7b4e62659700d5fa9751ad9fb2e2a887150281b524730"
+      },
+      "before_sha256": "435f9aa2ef8373abd3db923732a12f98c819e414dfac43b4a15023f619aee8a7",
+      "after_sha256": "8f8f28fdf1e507b9dfc7ca6df7175f2a77589f3726429b22bd8d506e92d939bf"
+    },
+    {
+      "agent": "engineer",
+      "skill": "trd-gen",
+      "eval_id": "eval-001-prd-to-engineer-trd",
+      "comparison_path": "agents/engineer/test/trd-gen/evals/workspace/eval-001-prd-to-engineer-trd/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "stale",
+      "reason_codes": [
+        "input_changed:execution_protocol_sha256"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "1a85a4d6a4264048f87f4cf1effe6b3b431c165a3ea2c34d652997a6a8e6a077",
+        "eval_definition_sha256": "541dd03d893d7d5a4e9f69c81d6344de365e55718cc67a40980e3cbdb34c6a30",
+        "metadata_sha256": "b33234ce56a0b715b632f392ff44ba7c27cad834dbc654110228254e610f01ec",
+        "fixture_sha256": "874c9a19c616d97ed625612e04c37ce561c010e8908c127503ea72d53817db55",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "4d4b8ebdf0eaf847b9097b848450fa85763a3e1f30bf1bb128228339ff87a28d"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "1dfd9775516473bd982190925262afc57f3d63333c72409b9c4bd2240cfe9b9e",
+        "assertions": "0b9c5dc55f2140f79ac7ac80103fe22e892e7c86866725ebb8d119ba947c8270"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "1dfd9775516473bd982190925262afc57f3d63333c72409b9c4bd2240cfe9b9e",
+        "assertions": "0b9c5dc55f2140f79ac7ac80103fe22e892e7c86866725ebb8d119ba947c8270"
+      },
+      "before_sha256": "abae3e9f835d3d9ed0ede9169d49237b42b0886a965b95717c4309cd8a896312",
+      "after_sha256": "c6206137f28418d55a2120412a1b3c1346a22ec70bedf31208496025188aa50f"
+    },
+    {
+      "agent": "engineer",
+      "skill": "trd-gen",
+      "eval_id": "eval-002-resolve-trd-gap-packet",
+      "comparison_path": "agents/engineer/test/trd-gen/evals/workspace/eval-002-resolve-trd-gap-packet/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "stale",
+      "reason_codes": [
+        "input_changed:execution_protocol_sha256"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "1a85a4d6a4264048f87f4cf1effe6b3b431c165a3ea2c34d652997a6a8e6a077",
+        "eval_definition_sha256": "96fd70658261e3a17be616b06efc13bb061ebd641ee5ed5f4b30d21e34984bf7",
+        "metadata_sha256": "4025e3b1dd282f00d05c7506655215876b7bcc3af8d7657c77ae8574687fce25",
+        "fixture_sha256": "d58240709fd95e80376991be4d5ae0d8785faa7c898ac347279a20ad514acd7a",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "3fb0bf5bc301ce78a33402f806b0b810ed122ae2263b6d9be14f49634de42f79"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "1dfd9775516473bd982190925262afc57f3d63333c72409b9c4bd2240cfe9b9e",
+        "assertions": "f672c09d25b7bc4e88a60004187532cbd795741f15a5f358cb8d32ba26bf39ec"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "1dfd9775516473bd982190925262afc57f3d63333c72409b9c4bd2240cfe9b9e",
+        "assertions": "f672c09d25b7bc4e88a60004187532cbd795741f15a5f358cb8d32ba26bf39ec"
+      },
+      "before_sha256": "c8dfbf70a80884046826708607b6d62ebd70b4355134cdda5187fc24ff437781",
+      "after_sha256": "2291047957a5f12c162c32a5ada63d78b7391dce48b7be7bab08f7e9e7dc085f"
+    },
+    {
+      "agent": "engineer",
+      "skill": "trd-gen",
+      "eval_id": "eval-003-nested-prd-to-engineer-trd",
+      "comparison_path": "agents/engineer/test/trd-gen/evals/workspace/eval-003-nested-prd-to-engineer-trd/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "stale",
+      "reason_codes": [
+        "input_changed:execution_protocol_sha256"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "1a85a4d6a4264048f87f4cf1effe6b3b431c165a3ea2c34d652997a6a8e6a077",
+        "eval_definition_sha256": "f3397b62fc4d049158e92b00f525e136ca990d6c804b1f211ce557bfaf30d03e",
+        "metadata_sha256": "de0335f1a182c8496f115f68dc77dc691a79abeae555386cc002141eada43865",
+        "fixture_sha256": "9c19cf5e49c59929ac5b070de11f3df7bfcbee1e79646cc4eec47c40b398a1bc",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "10a807298f91a20d6e9b68f75881e7ea6287d8afeff10727bea551d980d3535f"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "1dfd9775516473bd982190925262afc57f3d63333c72409b9c4bd2240cfe9b9e",
+        "assertions": "da97e1e1a0277448aaa7d1d56fcb54041906de9a86e47e071adda892cded875d"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "1dfd9775516473bd982190925262afc57f3d63333c72409b9c4bd2240cfe9b9e",
+        "assertions": "da97e1e1a0277448aaa7d1d56fcb54041906de9a86e47e071adda892cded875d"
+      },
+      "before_sha256": "6300a0936b88bc422e9ab5787b5e8f0d43d1909775ee798c239f183697c9949d",
+      "after_sha256": "916722efa44f3eb606227b87b7e6854a4c30a9eeb1a1b6e6d22459f775c2a046"
+    },
+    {
+      "agent": "engineer",
+      "skill": "trd-gen",
+      "eval_id": "eval-004-api-adr-owned-by-engineer",
+      "comparison_path": "agents/engineer/test/trd-gen/evals/workspace/eval-004-api-adr-owned-by-engineer/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "stale",
+      "reason_codes": [
+        "input_changed:execution_protocol_sha256"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "1a85a4d6a4264048f87f4cf1effe6b3b431c165a3ea2c34d652997a6a8e6a077",
+        "eval_definition_sha256": "c2e125b845f0cfd23a8b77d0953e79c0dfdb8a47bc09cbe45bf84d70fdf9a2db",
+        "metadata_sha256": "d32be481f3b029c028aa82a9a8adf92bda8ff5084062b1a65511dd3d764980a1",
+        "fixture_sha256": "7b6820d67dd73e9499a1ca84c463bfc82e890640eeaf8c3154b04834d8479116",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "2fb0119eb77903cfe9db053e59a3c85f9fb841609febdeb77953e7bac06ea0fe"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "1dfd9775516473bd982190925262afc57f3d63333c72409b9c4bd2240cfe9b9e",
+        "assertions": "06053cc69d6af97ee74d56bc41d65ab66bbf665be35cd69e61234845631d9cc8"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "1dfd9775516473bd982190925262afc57f3d63333c72409b9c4bd2240cfe9b9e",
+        "assertions": "06053cc69d6af97ee74d56bc41d65ab66bbf665be35cd69e61234845631d9cc8"
+      },
+      "before_sha256": "f8c152a7e75add942cabdaa97c0bc36f7a197d8fe97d020026bfae0f8dbf9db9",
+      "after_sha256": "101025da25b98d66eacfab56b6338138edc2d2067ae770735d2dfdf0335fcf1e"
+    },
+    {
+      "agent": "engineer",
+      "skill": "trd-gen",
+      "eval_id": "eval-005-mapped-upload-trd-evidence",
+      "comparison_path": "agents/engineer/test/trd-gen/evals/workspace/eval-005-mapped-upload-trd-evidence/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "stale",
+      "reason_codes": [
+        "input_changed:execution_protocol_sha256"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "1a85a4d6a4264048f87f4cf1effe6b3b431c165a3ea2c34d652997a6a8e6a077",
+        "eval_definition_sha256": "ed02404d14ffd40d542c29f44a74caf2fc5696740b01f75b11e50dfad6379f60",
+        "metadata_sha256": "cfc84017a2f6130d5f5d58c0d09338a6a3beaaf2ead3e34eb6d3229566da0300",
+        "fixture_sha256": "b9272be266caff6ac38d8060f5dbdbc6e981647729fe1530cfc53ca05b58b007",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "1dfd9775516473bd982190925262afc57f3d63333c72409b9c4bd2240cfe9b9e",
+        "assertions": "a36299da31fd64b0e1a56529d983ba29d2f7a26b07095d8a2bbb785530df66ba"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "1dfd9775516473bd982190925262afc57f3d63333c72409b9c4bd2240cfe9b9e",
+        "assertions": "a36299da31fd64b0e1a56529d983ba29d2f7a26b07095d8a2bbb785530df66ba"
+      },
+      "before_sha256": "247b2987f76b63b9d5f83aa85470da8ca74cd714430ea429cc5c196ed06f4a9e",
+      "after_sha256": "1566604f593263255f815154260bb2668e360919876509759bc52f0cc13fcc0b"
+    },
+    {
+      "agent": "engineer",
+      "skill": "trd-gen",
+      "eval_id": "eval-006-delivery-polling-to-events",
+      "comparison_path": "agents/engineer/test/trd-gen/evals/workspace/eval-006-delivery-polling-to-events/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "stale",
+      "reason_codes": [
+        "input_changed:execution_protocol_sha256"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "1a85a4d6a4264048f87f4cf1effe6b3b431c165a3ea2c34d652997a6a8e6a077",
+        "eval_definition_sha256": "3255bddbc0ba9d00273a741fab78b9e223454656c0b7cbcdb74a3b3b193952f9",
+        "metadata_sha256": "c58e464b2f51cbecc05208e0f4320ff2bade980227072a25840336ba048c489e",
+        "fixture_sha256": "26621a90d557560b63afa9dd1b1ebe2dbb9f05568b574efca78ec5babe092c74",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "58d5f8c73c18457a8d0864b8f5e21613dc914d57c8f96acc11ce98a78c601f05"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "b948b8323db48932d19e6fa8a34611e560be96e6cf55a2d2a7d68805b0b8e2ce",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "1dfd9775516473bd982190925262afc57f3d63333c72409b9c4bd2240cfe9b9e",
+        "assertions": "506c6543279d4eabb1c30964b30f43eda1210e2fdc0a93881dba66d4e89e79ee"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "b948b8323db48932d19e6fa8a34611e560be96e6cf55a2d2a7d68805b0b8e2ce",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "1dfd9775516473bd982190925262afc57f3d63333c72409b9c4bd2240cfe9b9e",
+        "assertions": "506c6543279d4eabb1c30964b30f43eda1210e2fdc0a93881dba66d4e89e79ee"
+      },
+      "before_sha256": "3ba1c806701bd788d303713529caabb709810702dbad604ef69456392ecf3f8b",
+      "after_sha256": "7457ef3764da3fa74d0e2b63b1b4fff49d6447bcd4f466fc2e30f3e83ae3582c"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "changelog-gen",
+      "eval_id": "eval-001-unreleased-mode",
+      "comparison_path": "agents/product_manager/test/changelog-gen/evals/workspace/eval-001-unreleased-mode/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "53f035563de038125d09b7a8997f87e900d099e00223f427a7c690e11ebbe449",
+        "eval_definition_sha256": "f643e5a44adc95dee4686543e115df7acb899ebc5dec146519d9991e82db553d",
+        "metadata_sha256": "95c0dae43621d97267d71f9000473df424f0f20875022c90f8a0826f1615ee52",
+        "fixture_sha256": "6c891edd0d2edaa974f9696bff7fd8bce1989edc225daec7356e08843c3ccf17",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "e87b7560e9b11fe6dfc954d0faa2696f04b98bb48f59af2eb521a8e8cfed4660"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "e805926f5a01fd0b188ae88740f2a6b806c96306046f6f838557efb0effcb760"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "e805926f5a01fd0b188ae88740f2a6b806c96306046f6f838557efb0effcb760"
+      },
+      "before_sha256": "394559210605b62d5c721fbf3bfc6c751bc780a166ea5a53f0673273bf0167c6",
+      "after_sha256": "c9e2c446a51cf6d8bfd3a230dfa9abf7d9958e21efcdff280a7568f5c181351c"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "changelog-gen",
+      "eval_id": "eval-002-single-version-mode",
+      "comparison_path": "agents/product_manager/test/changelog-gen/evals/workspace/eval-002-single-version-mode/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "53f035563de038125d09b7a8997f87e900d099e00223f427a7c690e11ebbe449",
+        "eval_definition_sha256": "8e1f2a2b7cff1dcc676c7dcd6956883a0a24ee6d97754afcf56bc59fdaf06a61",
+        "metadata_sha256": "814184c8bd7a959b3f0695c85bef4dd34c73bd316a08d00ccc354207f37fabc9",
+        "fixture_sha256": "835e6d91014bb254ac4027a75b2b94fcac8cc02efcf4ee8832fb73ee44824c88",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "609660421781976ec561327c947a31da6f7d421bc63e99d2f3f00692dcdf763a"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "cdda51920fb6daf3eaa9d04c122a01e06319ceaf572c1cda5092f3c6bbb47e30"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "cdda51920fb6daf3eaa9d04c122a01e06319ceaf572c1cda5092f3c6bbb47e30"
+      },
+      "before_sha256": "27ff21e197df74c90b1c1d29c8ec3f5da14f31cfe97c499caf17c6439e41e10d",
+      "after_sha256": "9ff9cc31232c0fee8fe1084a338ca2049bbfd857b13cb204975fb3f8a4779533"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "changelog-gen",
+      "eval_id": "eval-003-prefix-classification",
+      "comparison_path": "agents/product_manager/test/changelog-gen/evals/workspace/eval-003-prefix-classification/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "53f035563de038125d09b7a8997f87e900d099e00223f427a7c690e11ebbe449",
+        "eval_definition_sha256": "02c7a6bcc66679fa2f47687ffd7cdba26fff303adab62c4e3435b49f28878db8",
+        "metadata_sha256": "7c295252d061c5f27afb73a5d2bc7ec230ac3e0e3896f6109062c7b18ee9cf2e",
+        "fixture_sha256": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "cc05e28bb9aed099804431e1cee55bda0cec7614cc8c780d6f8ad4d50c137367"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "5834f3ebeabe536bf85d16a9ec7e9ee6150973374a72365c4ba0a138c555e7da"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "5834f3ebeabe536bf85d16a9ec7e9ee6150973374a72365c4ba0a138c555e7da"
+      },
+      "before_sha256": "5d7ef300cc2d90872d31fd35957eac837153ab537163b5ef9187a5604201cbfc",
+      "after_sha256": "0bfdb6853d54aae9370d7255ca839de5acd60a095c492f66ebc21de6ee7475e1"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "competitive-brief",
+      "eval_id": "eval-001-positioning-gap-brief",
+      "comparison_path": "agents/product_manager/test/competitive-brief/evals/workspace/eval-001-positioning-gap-brief/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "64a375a1a490fa251e9b252ef3a7787f55ca6a4fd08e5d401228a899b274ed39",
+        "eval_definition_sha256": "97a23b71b146f4c0d34488da4fd45ddfa63b73d91d16deb5d2e03fbe4f5d01f6",
+        "metadata_sha256": "253b7cd58ea1d83c5776d9de8bd0332f1de43ff8d162b4ae1c25de74c0394acf",
+        "fixture_sha256": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "9482baaf8c9e8ed2c6d5d65dd72ca668fb6cc639dacfe10c14d42e2f2d0f4c53"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "33c044dce7ccc39d2aef12eb7e3f0b333930efc83ad4afe8bb058aa9177121e5"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "33c044dce7ccc39d2aef12eb7e3f0b333930efc83ad4afe8bb058aa9177121e5"
+      },
+      "before_sha256": "94fe7567fa21156f59ad20acf1012fa166371865a845e43a8c0b62ff400a54f2",
+      "after_sha256": "851282f4018ea68fa32daf46d053a3a308e08eb54b3c029ad887fb9a2b6b83fe"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "competitive-brief",
+      "eval_id": "eval-002-battlecard-mode",
+      "comparison_path": "agents/product_manager/test/competitive-brief/evals/workspace/eval-002-battlecard-mode/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "64a375a1a490fa251e9b252ef3a7787f55ca6a4fd08e5d401228a899b274ed39",
+        "eval_definition_sha256": "a7454ae2eccc665064a08c31fc99de3b8f0a596f72811f2e5035b12f267e9fe8",
+        "metadata_sha256": "be38b1b419460352b11de0cc1468d57c031f7575d697be3bf617760a456d47f3",
+        "fixture_sha256": "580131b9961f88dece682fec7455c21af018b400a3742eb37ae40114374aeae0",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "e42897afb6931d7065c6aa9ac71e607d574f057396cd3a30a0419c210f3be3cb"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "b5d051c44a2009a5feff2e48a64cb0ffc94b6f83627f0e10022e903be60734bd"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "b5d051c44a2009a5feff2e48a64cb0ffc94b6f83627f0e10022e903be60734bd"
+      },
+      "before_sha256": "f007ecfb2da552b3c28bdf15acee95a9072eb76e91a66e5ac5dbd21fb8ae008d",
+      "after_sha256": "3373da2feb84496208770a791bf87b0bb2f0f18da284fa72e5ed360072cc95f7"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "feature-catalog",
+      "eval_id": "eval-001-legacy-project-catalog",
+      "comparison_path": "agents/product_manager/test/feature-catalog/evals/workspace/eval-001-legacy-project-catalog/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "272c84e241c5d52534922fccf2bc6732492a0d70c9f6e2ab8dc1eff2533f7b0c",
+        "eval_definition_sha256": "6316196cbc0024d8a369162c20842d191078adb23f3f59cfbc5541923081da5e",
+        "metadata_sha256": "aa9b419ec00ff2ce5f9c2775fc1e620cf1eb45a8d316e5adf573b14f5b74c3e2",
+        "fixture_sha256": "fa295db805350878180b0b5d2e6fc6d21188b2866a3c61c345e1f1875b201554",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "6731c51ff9f69981e5ade0a40fa5fb4f93b6c439e428212a1b46155c6fa123f1"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "349785f6bbf2f529d93076140fb2046684d8de6ce6201863af36ae2be96840ca"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "349785f6bbf2f529d93076140fb2046684d8de6ce6201863af36ae2be96840ca"
+      },
+      "before_sha256": "9180caf8e7e562926897dc0858b3447c92322383bb834ef161e15bd0e929ac62",
+      "after_sha256": "758ba08dc4522c980830c8cbd7e5698aa2d7c69af8743ababa197a23ce0d5991"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "feature-catalog",
+      "eval_id": "eval-002-child-feature-under-parent-prd",
+      "comparison_path": "agents/product_manager/test/feature-catalog/evals/workspace/eval-002-child-feature-under-parent-prd/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "272c84e241c5d52534922fccf2bc6732492a0d70c9f6e2ab8dc1eff2533f7b0c",
+        "eval_definition_sha256": "381b074083537f3d71cb0a28bd3dbbcbf80ece8371ca5fba3a891d822f995603",
+        "metadata_sha256": "9511751d671a5ae5883161ea664a79cdce7fc89cb2e17e607a976174a239c8f6",
+        "fixture_sha256": "e64d0dc500eb5720a57f43e64b9a52c75b87f674117c2e966a459db4cd412910",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "c03c0410b926db4903e624e0fe3e993a88d8b355caa51278c9f027aa7078ef66"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "49f8b314a2cffc0ebeb6fdebe397f3ede4d196a3151ae38f84ebc701592e73c2"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "49f8b314a2cffc0ebeb6fdebe397f3ede4d196a3151ae38f84ebc701592e73c2"
+      },
+      "before_sha256": "7fd6507751540117b0cb0bbe0345cfecf26c41811cdf730138d249e17e2e77bf",
+      "after_sha256": "361d1a750f343d0295b5494496a57b624358c2d225ce85bdd9763f3528fa059f"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "feature-catalog",
+      "eval_id": "eval-003-monorepo-scope-clarification",
+      "comparison_path": "agents/product_manager/test/feature-catalog/evals/workspace/eval-003-monorepo-scope-clarification/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "272c84e241c5d52534922fccf2bc6732492a0d70c9f6e2ab8dc1eff2533f7b0c",
+        "eval_definition_sha256": "221668759d9b3f1847f350986e591b6defbd71cd5f83a296b96e5736de8e7ceb",
+        "metadata_sha256": "8aa1f1f970ba708ba203aa964e23b048bfd278c5cd0d04094602a65c55ad9476",
+        "fixture_sha256": "c414562285f1c022777b6125d75fb56cbbd795475c5bf83bc97b862a14abc6d3",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "fe7ee6212a0514e053db6b490f2fd78c74a3e6115f5b789e3e3734a9d7b1be8b"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "4e8c6feebd292d4e460144e4e91957ab15ede9b14f1aab70f587af3abe61ea45"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "4e8c6feebd292d4e460144e4e91957ab15ede9b14f1aab70f587af3abe61ea45"
+      },
+      "before_sha256": "b1aee38e45af036ce135c53b90754a6f7c5dcf693793100eea31c17648b0d61f",
+      "after_sha256": "51ccdc1506dcc950b365ffc3cc5dc4e7b31ebe904bc1efa5177f057d02b674b3"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "feature-catalog",
+      "eval_id": "eval-004-catalog-mapped-billing-feature",
+      "comparison_path": "agents/product_manager/test/feature-catalog/evals/workspace/eval-004-catalog-mapped-billing-feature/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "272c84e241c5d52534922fccf2bc6732492a0d70c9f6e2ab8dc1eff2533f7b0c",
+        "eval_definition_sha256": "8d7030970f6fab5f1056baaa7f97792f12e093b11e3211055d5ae790cf0d3bc2",
+        "metadata_sha256": "b6e639db89ad7dc9c01b74ff5037844027a7f93b1a684864779b0328b14ee4bc",
+        "fixture_sha256": "dbc5593a346cec17c758e623e41d968d8b062bb60f1c6687047b79f186d5a5fa",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "b948b8323db48932d19e6fa8a34611e560be96e6cf55a2d2a7d68805b0b8e2ce",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "05a9efaec33b9cefe1b4a023686558c2b159d21bd5844cf8a0405c73ed620740",
+        "assertions": "4f0d424e67a6a1fcc663776ee355de9c136b3552a5bce509f14c9cd0d3a086bf"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "b948b8323db48932d19e6fa8a34611e560be96e6cf55a2d2a7d68805b0b8e2ce",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "05a9efaec33b9cefe1b4a023686558c2b159d21bd5844cf8a0405c73ed620740",
+        "assertions": "4f0d424e67a6a1fcc663776ee355de9c136b3552a5bce509f14c9cd0d3a086bf"
+      },
+      "before_sha256": "586262aa89ec6b2681b9c15b57d482d7a05323a22816c80e1d1921baf6bde5d8",
+      "after_sha256": "934cafdd739f706b612eb89ddae1444f3c51574470d18099b2d85d6febc27440"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "github-reader",
+      "eval_id": "eval-001-full-status",
+      "comparison_path": "agents/product_manager/test/github-reader/evals/workspace/eval-001-full-status/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "8b55857ad21cc937337dcf6bc1fa19fcc7f833c3e9c078d89a5db79725e98233",
+        "eval_definition_sha256": "a688cc91089931e5821e56e4470a0bc8844e7a9c13d1b4c5bcc8d2e3929da0ce",
+        "metadata_sha256": "94b279ac62424134e6355f46df23e4185fa4034dd04349372cf9178ca3c8c29f",
+        "fixture_sha256": "0519c739e4c8d28c0f994ae12773611385afed7d111bc3d263905cd5dd009c56",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "9f1a7ae2ae5e175ed8e057b35c400ea4c201e7779a64206f11bbe6bac585e282"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "bf16836b565b8228c1f405155fa4e241d946503837d82434d72f377e0cd63d47"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "bf16836b565b8228c1f405155fa4e241d946503837d82434d72f377e0cd63d47"
+      },
+      "before_sha256": "3eaf728065e87b29a3347ce8a379bb50f53503657137a417ce70e60aa1003203",
+      "after_sha256": "db63a48b0e2722871fb0d5d348b596bb6a7ec0ea536ed33cc2fb2beb14227eca"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "github-reader",
+      "eval_id": "eval-002-focused-pr-query",
+      "comparison_path": "agents/product_manager/test/github-reader/evals/workspace/eval-002-focused-pr-query/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "8b55857ad21cc937337dcf6bc1fa19fcc7f833c3e9c078d89a5db79725e98233",
+        "eval_definition_sha256": "f5bead0980a8f345220f5b383eac5991e933d1b98e28d8a0a232f76e705ff52b",
+        "metadata_sha256": "c5e584cdac5929bc66cbb7a8b1f6027ddae3cc40fe09b2afaf2c981fd146a7b2",
+        "fixture_sha256": "c47404a9f5ea07f17a4bfb2e97874d6684926d30ff0b484abac088755424ca88",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "ddb9410329ada83c41bd4e356f1396d4382d0277cddc70506d8c08ee4b2fa89f"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "025ba680bce3fb8e48655613839b01a2dec6616484bd16d61bdc2bf113c2372f"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "025ba680bce3fb8e48655613839b01a2dec6616484bd16d61bdc2bf113c2372f"
+      },
+      "before_sha256": "b48aabe974dad8142f4367e08d68681c7b624206381f400654b5c393a2cd4675",
+      "after_sha256": "2b24b362a470518583c75cf87b13d9e2c1065c4d9c487c49f6bd6e882dca7dd3"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "github-reader",
+      "eval_id": "eval-003-milestone-focused",
+      "comparison_path": "agents/product_manager/test/github-reader/evals/workspace/eval-003-milestone-focused/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "8b55857ad21cc937337dcf6bc1fa19fcc7f833c3e9c078d89a5db79725e98233",
+        "eval_definition_sha256": "42081b8248822116670301abef5c529a038e386c92ca99283441306b2d8ac307",
+        "metadata_sha256": "99e5bae99fd448ea8124895faf739aa4393a75e56feb8e7b78841ca027a5f393",
+        "fixture_sha256": "2ba90e4cae03b1fd07ce6567f8fe44587f4577228f679c498afbf0484b96f05c",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "e8bf769ac89a10c9a014e6b2e125d2d95f024ce8d37a4e4481c16c75936c71a8"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "5f2b3091d397eb4234f67f691f8afd56eb7d0dd45807d51017d299666d513ba1"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "5f2b3091d397eb4234f67f691f8afd56eb7d0dd45807d51017d299666d513ba1"
+      },
+      "before_sha256": "44b99b023b5f54031044b7d0513733ebe188469d9acbc273951d240962d20843",
+      "after_sha256": "7242a22b84ea5911ab334b2af65755426d7f9e28814393ab079035ad65398487"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "github-reader",
+      "eval_id": "eval-004-mapped-export-status-context",
+      "comparison_path": "agents/product_manager/test/github-reader/evals/workspace/eval-004-mapped-export-status-context/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "8b55857ad21cc937337dcf6bc1fa19fcc7f833c3e9c078d89a5db79725e98233",
+        "eval_definition_sha256": "c9320af546c098adb51ac45faa524e2216c221f13ecd2b33fb2f8f822f024522",
+        "metadata_sha256": "d12a4df00a2f5f04d2bf0e553078ba3dc62e403dd0f77a037fb5796abdce7123",
+        "fixture_sha256": "b91f8ca3f3681cf4c1a336f7748050f27d679c67ce39092970202362aab7af63",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "64b613036af9e29c86dc56ef6355a8c161fd52e8c4bc61c276e270054068afde"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "64b613036af9e29c86dc56ef6355a8c161fd52e8c4bc61c276e270054068afde"
+      },
+      "before_sha256": "9543e46f155e190b42823b1254627a66b0690dc5329d2dd3f8d4f92a87236f2c",
+      "after_sha256": "a9f6647f4c6fe8326fc5bb2b78b774ee8d52d61be7363c97d79672eea48d0bd5"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "github-reader",
+      "eval_id": "eval-005-feed-mode-completeness",
+      "comparison_path": "agents/product_manager/test/github-reader/evals/workspace/eval-005-feed-mode-completeness/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "8b55857ad21cc937337dcf6bc1fa19fcc7f833c3e9c078d89a5db79725e98233",
+        "eval_definition_sha256": "c049e8ab5f946f319bc21927957f6fda02a148471bd8950bd306a941a14167f6",
+        "metadata_sha256": "07ab98c6d1c3adcc9277e1cfe784f8d017e9650890973540f2c3871622f64ed2",
+        "fixture_sha256": "740d701b2570cd48dc39895eb6dad24e4e63318905be6af74ad27b07c8129f82",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "4f066e3762e89c228d67c784e34a35c0c16edf603d99427b4a0ebdaa56519646"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "ab8b0be99c0a3d1483e43c25736ec70bc8d41de00afbba35c067cb8f76e32c34"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "ab8b0be99c0a3d1483e43c25736ec70bc8d41de00afbba35c067cb8f76e32c34"
+      },
+      "before_sha256": "02a33cd4f7cbc791e6911600f1fc752585223f83c55b8eb784af99c2143bb158",
+      "after_sha256": "6accb530ba464aab1385579584cb38f2b22b5b553967d511ed56667929118e9f"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "github-release-gen",
+      "eval_id": "eval-001-block-without-ready-handoff",
+      "comparison_path": "agents/product_manager/test/github-release-gen/evals/workspace/eval-001-block-without-ready-handoff/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "0c9b1305da43afbfc22e6d563651831ce45be05793224d552c008cc393a37b1e",
+        "eval_definition_sha256": "f104e1c59d5fad76689ae01a26b19666b3049ba013ffcdc08c70032e1a95c629",
+        "metadata_sha256": "9990f4cbb2adede98186059b8ed7e0088b4cd2cc6d822272edf43193f350dfdf",
+        "fixture_sha256": "7971e90a4d24648a705271605d4ebb4560650bfee70305b5f8ad9d95d2e46900",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "00bb3d210a5b206a0ac9f62c0fe5d7e4f8787acdaa15b33827594f02c88b5a24"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "3e4a6cdf377ae3b9dfa0a69b9ecfd73e4b176d416c561e678643a8331a6a6126"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "3e4a6cdf377ae3b9dfa0a69b9ecfd73e4b176d416c561e678643a8331a6a6126"
+      },
+      "before_sha256": "2d4116ea8d59c8f702ff0e2d21c5b7bb33970d3c47512adb9d7ac842af7dc14d",
+      "after_sha256": "fc38ed03cce36fb0d0b53adec2ded9405710e2771c9627cd8b5856bd9c03648e"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "github-release-gen",
+      "eval_id": "eval-002-enforce-release-sequence-gates",
+      "comparison_path": "agents/product_manager/test/github-release-gen/evals/workspace/eval-002-enforce-release-sequence-gates/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "0c9b1305da43afbfc22e6d563651831ce45be05793224d552c008cc393a37b1e",
+        "eval_definition_sha256": "4ae771ce624f2d4218d5a0892756a08ab5deb5771e2156fa84d9cebf89f45e20",
+        "metadata_sha256": "6e1c66d9908de26eec5a81a59cb64d6d09ad4a2d9291406739a3d318995009f5",
+        "fixture_sha256": "d16b0aba9c42c15bb50cb2e6533059095747e0b241aeb84f42387b57f3c93839",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "7387039bc0ee52f805d2ca2d9e0306841c5745b2dec693f7be7ed2c655d6f462"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "5a38e01724b9a53fdbaac1bc5624280d1a2a6334069c249aad438df04325e2e8"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "5a38e01724b9a53fdbaac1bc5624280d1a2a6334069c249aad438df04325e2e8"
+      },
+      "before_sha256": "21c804be46d57f3fadb29311a303d93e1e83a6ec300b68b6bc826d50958dcff7",
+      "after_sha256": "0a00b63820a5810bc96b69c96af0d3a49a73fc581ca1341256947416a4ad2254"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "github-release-gen",
+      "eval_id": "eval-003-preserve-facts-and-add-traceability",
+      "comparison_path": "agents/product_manager/test/github-release-gen/evals/workspace/eval-003-preserve-facts-and-add-traceability/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "0c9b1305da43afbfc22e6d563651831ce45be05793224d552c008cc393a37b1e",
+        "eval_definition_sha256": "95f3370a6690706f871a83ed16fd2ea4af289f136e5af47351107d1ec6c06fc2",
+        "metadata_sha256": "9e52b1a05d9dc7bd3856fe83df9035077725f4a4387447107b2ae09c5bfbb539",
+        "fixture_sha256": "da29a479071012ab3bfa3af5ab47af8541f3b6d49a5ec8e88304fa50a27aed17",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "13218ab4a7abff52fb220f782ffa27173bde4d7c9a5b1ae26ef3115112e26b3d"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "47ab7481a016d903cbe7ad0c653e4d9edd5cb237585e7977eccc8a5dc4f7b22f"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "47ab7481a016d903cbe7ad0c653e4d9edd5cb237585e7977eccc8a5dc4f7b22f"
+      },
+      "before_sha256": "f097acf5d03bf6c8382030dbe46a32437ac613e7040ad7f045c1caf87c6c6639",
+      "after_sha256": "5addf39bbc22b11da6cb62536efda733f8d79bab7218a32e07f145ceb050f03e"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "github-release-gen",
+      "eval_id": "eval-004-zero-site-and-tag-writes",
+      "comparison_path": "agents/product_manager/test/github-release-gen/evals/workspace/eval-004-zero-site-and-tag-writes/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "0c9b1305da43afbfc22e6d563651831ce45be05793224d552c008cc393a37b1e",
+        "eval_definition_sha256": "266baf4d19e4ef318c97a6eab3bf8e029fbe8357edfa824c6d453c40e91b2d33",
+        "metadata_sha256": "12fc2cb8802eb1dba2db5f0429fdb4322d489582597f6f44ee10596dc46d8d26",
+        "fixture_sha256": "a74185c0f265c7463444aa160a9976a1ef120533a9280afc72706076cc5c1626",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "80b618e955757ddc076d881c72f5f8be648700b5dd3e7c6b222dd59ecfccd495"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "9c50d342177c04e33957a1a183ad2c3937ba30cfafbd9161e1f3a9cba5482a76"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "9c50d342177c04e33957a1a183ad2c3937ba30cfafbd9161e1f3a9cba5482a76"
+      },
+      "before_sha256": "128c16eda88909480e39b0fc667c37064a0bd8f213012d9d06b6164eaffda8b7",
+      "after_sha256": "55793da042bba138673dfdab555ae9cc51def02dc953b6fe00f1d908a71cf5c7"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "github-release-gen",
+      "eval_id": "eval-005-outline-sections-quality-exclusion",
+      "comparison_path": "agents/product_manager/test/github-release-gen/evals/workspace/eval-005-outline-sections-quality-exclusion/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "0c9b1305da43afbfc22e6d563651831ce45be05793224d552c008cc393a37b1e",
+        "eval_definition_sha256": "5768440d836f6d58f2492f6254c4eaae18fe913a310437aaee98134c39857a50",
+        "metadata_sha256": "a9879c47e38cec76a35a3ff0087c5b764086d8e7ca04745f8977bbd30db8f459",
+        "fixture_sha256": "f342d8ca65c8f77883288a82a7edf00ac90a64350a66217406a6bf2cc1477c79",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "f3cdc20a6c2d6d35b8761172794fe96e07166b0922a8d802a01f520259d39177"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "f19365141e34c267c97f701c42eb8dd1d20af405651cd4bd3f11bfa96e10617d"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "f19365141e34c267c97f701c42eb8dd1d20af405651cd4bd3f11bfa96e10617d"
+      },
+      "before_sha256": "e7e00fa9d03b834769cd2f7613cefde28936b6a503a3005d061b6f718e3f5454",
+      "after_sha256": "7132f0cd6c4ed7211de1b1066d8d91d9667f3d9f01fe9ab184c59e34d07b9598"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "github-release-gen",
+      "eval_id": "eval-006-site-less-degraded-gate",
+      "comparison_path": "agents/product_manager/test/github-release-gen/evals/workspace/eval-006-site-less-degraded-gate/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "0c9b1305da43afbfc22e6d563651831ce45be05793224d552c008cc393a37b1e",
+        "eval_definition_sha256": "ee0644452d121d4667c014aaf941ed770c3978ba415b0f3ee7cfc601dc801335",
+        "metadata_sha256": "d64e10da3608725d47dc87efed91ed453ddbf43cfa5350e92eb1e539cf16b5a4",
+        "fixture_sha256": "411862fab7a80dddacd42426a98282018153d50c9458b43edec6c0056c4dce20",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "b8169d6d4489fefe59aefe4458af6c4e8108513691e18f7c250f5d7f5c9b7ba5"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "41025b4af3b0b1d8032c9a8ded90a9a58d24d60b36061c23cd618591cb309ed7"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "41025b4af3b0b1d8032c9a8ded90a9a58d24d60b36061c23cd618591cb309ed7"
+      },
+      "before_sha256": "757be6a29ab4621b4be74d69ad9410d88e59b2d0feae905b6248b519b1ce2cb0",
+      "after_sha256": "4e0034bbad926731e63ffb7eab6e7575ff047560f9cf867af4d790da75190184"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "github-release-gen",
+      "eval_id": "eval-007-marketplace-full-capability-upgrade-note",
+      "comparison_path": "agents/product_manager/test/github-release-gen/evals/workspace/eval-007-marketplace-full-capability-upgrade-note/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "0c9b1305da43afbfc22e6d563651831ce45be05793224d552c008cc393a37b1e",
+        "eval_definition_sha256": "ddd9a7434f92d092aeb7262a95bca81739e99a684c38e41461345200798e8931",
+        "metadata_sha256": "b64763ea1d58b4c3c1d7a3e95d4a1d7bd5f4195151868d0276dd82eda387eb3e",
+        "fixture_sha256": "dc5fdc0f377589e2a17429105072ec9f0f122806b4874d8f07072dd9a6c6c26b",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "03a8fb59a79fd1eace9e70a8f76361828e062efb8e2ad27720ecf0844391b693"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "bf30499235888afc623c21496627130fd42ec6302b8f293113cdf43402262363"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "bf30499235888afc623c21496627130fd42ec6302b8f293113cdf43402262363"
+      },
+      "before_sha256": "c40c97cbb7055b7a0d9051548dfa74218f2cfbe91394913417790f121229da2f",
+      "after_sha256": "25aed3c9694698366243749d1565ce08bbed47ee673a9e3aa29cd276e5265ab6"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "github-release-gen",
+      "eval_id": "eval-008-marketplace-historical-tag-limit-upgrade-note",
+      "comparison_path": "agents/product_manager/test/github-release-gen/evals/workspace/eval-008-marketplace-historical-tag-limit-upgrade-note/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "0c9b1305da43afbfc22e6d563651831ce45be05793224d552c008cc393a37b1e",
+        "eval_definition_sha256": "ca7c0b18d751c17e3675256471abe2e22f05a84c6ec6d780c8a51c53156008f9",
+        "metadata_sha256": "a37c69100d8b09e8a32fd7ae07c266ac1aa0ef65dd08a89916726ecd29694ad7",
+        "fixture_sha256": "17e20791a9c9288907fb214989bbc6378e7d64a98732f68a5c493285ff25f933",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "df39efd24a07751331d3b8f08b12fab041cb7e732754feb1dfc8bc4a96c5fe1a"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "2a91de7efeaa60620a035a2167b79eb624e8a7ee34789cd9474c90a750f9efcb"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "2a91de7efeaa60620a035a2167b79eb624e8a7ee34789cd9474c90a750f9efcb"
+      },
+      "before_sha256": "bfd3db2c1b787ed4c9e994af6790b12ee52b1f838fe51e56ccf1d0a8160a3bc5",
+      "after_sha256": "075115f271ffd58b925a2c74c121f1df76aa6ec3d0f5a51229de2fd8a9c7bc48"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "idea-to-spec",
+      "eval_id": "eval-001-existing-project-feature-design",
+      "comparison_path": "agents/product_manager/test/idea-to-spec/workspace/iteration-1/eval-1-existing-project-feature/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "a5ef9beb8352f2c9b4cfde83ccd9caf0accd15d632ffa2d78214f3c51045041a",
+        "eval_definition_sha256": "fbb5377843587b9c6261e61b2a81e3a48d39c5e7814d8290865e02fe8eb5ec41",
+        "metadata_sha256": "ff56c9c4026c02d3f3b5f70e58cc2a2e628e1817de3ecbec4d01c2d2b3fe50bc",
+        "fixture_sha256": "2a0d3945e9442edd7c1ef55752552e4a49ef23e35e942cd87d1e31a4fa5138fc",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "dbe3f262003438ea2a4caaa2b38e4ab353ee29def3530b27abe04d98b19dfd03"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "ae06f2e9971554e7f3dd896e1a4b42a0fac511e7f63a4d857dcafc348dca4ec9"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "ae06f2e9971554e7f3dd896e1a4b42a0fac511e7f63a4d857dcafc348dca4ec9"
+      },
+      "before_sha256": "71edd45194bca04ca3b185e5b5788e22134ab1b45725b87421003dc96803ed15",
+      "after_sha256": "22704b2362ff3b8567f6724f3779f4906f0a1655d9178b5b194ae4c8f358cb2c"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "idea-to-spec",
+      "eval_id": "eval-002-existing-project-update",
+      "comparison_path": "agents/product_manager/test/idea-to-spec/workspace/iteration-1/eval-2-existing-project-update/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "a5ef9beb8352f2c9b4cfde83ccd9caf0accd15d632ffa2d78214f3c51045041a",
+        "eval_definition_sha256": "2eb26345c0320238f13795dd231ba4c205d452d230de64d35bcf4cc4acb002f8",
+        "metadata_sha256": "d7142d966569c4d32f40a170b0f92f6780789b8a982e6faeead586a238a9f649",
+        "fixture_sha256": "4a0c4f24287b030b034f66b2e9e0787c5b6e4b2e4a40435cb46ef2275f03923a",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "34ccc67474b5d5409e42b47f3e143e51f307a39f3959fa17d3be62715a379bc6"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "ccd17e8c178df7411093db16c798e210c397d2926bd7f878bde6d697665cd534"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "ccd17e8c178df7411093db16c798e210c397d2926bd7f878bde6d697665cd534"
+      },
+      "before_sha256": "c8590f44a4e68a8069abd443a2b1bb6e6cc1a422a5c287c60a9f53c13425331b",
+      "after_sha256": "3a5e156df5ca8ce24754b5beaa813a6c9aea99a4919c74f59c31dfcbb73177d3"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "idea-to-spec",
+      "eval_id": "eval-003-greenfield-discovery",
+      "comparison_path": "agents/product_manager/test/idea-to-spec/workspace/iteration-1/eval-3-greenfield-discovery/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "a5ef9beb8352f2c9b4cfde83ccd9caf0accd15d632ffa2d78214f3c51045041a",
+        "eval_definition_sha256": "c665f0cae1373d04b176b75bc723732674aeb9f3630f01eadac8f7310d65bdb7",
+        "metadata_sha256": "aa700f49d0f32cf47f3b535bd526e4ad2ade501da428e296936ddccef0bcdcbd",
+        "fixture_sha256": "a4faa6eb1bc545a0fcd2b0f3491c8b376050fe70e6b532b62cd5d45f16655b85",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "e8bf769ac89a10c9a014e6b2e125d2d95f024ce8d37a4e4481c16c75936c71a8"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "62069a0c32451e93506e1ba2b7b68565f74092e1d43e1aaeecd5110a21269988"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "62069a0c32451e93506e1ba2b7b68565f74092e1d43e1aaeecd5110a21269988"
+      },
+      "before_sha256": "00290d19c429d8e73dbba3c69a6b59b64aa5043c5532c1ff6bbdb85f603109c0",
+      "after_sha256": "fddea66872ab862d854f6df6899e0983af218d97b0fe740aa67f0d5a42a587d5"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "idea-to-spec",
+      "eval_id": "eval-004-greenfield-bootstrap-routing",
+      "comparison_path": "agents/product_manager/test/idea-to-spec/workspace/iteration-2/eval-4-greenfield-bootstrap-routing/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "a5ef9beb8352f2c9b4cfde83ccd9caf0accd15d632ffa2d78214f3c51045041a",
+        "eval_definition_sha256": "8e113c060d578c3d672e422d3214efcf8ef5f3dc4a4d591f825ce19450902064",
+        "metadata_sha256": "af73e5b9a9192eb83b6e3ca2d5cae73fe4fd2b14b49ac401fa1a5f606db4bd6c",
+        "fixture_sha256": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "333e583cf4bb11484925925c3c083e2f295eb8670599a3d04a51d2b749c8668a"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "c495a6b35b9f3160801a744949ead064b6a9d8762392be7d25ee3ed570a86e0f"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "c495a6b35b9f3160801a744949ead064b6a9d8762392be7d25ee3ed570a86e0f"
+      },
+      "before_sha256": "242394a2c9158f237f05487ecfbf59392c5fb57dbb84c728a5509f99b63b7ea3",
+      "after_sha256": "2930ccf16e4864a55791c5312e8a05e76e06e86d82bf7f6d7fb6e4fed2dd72dd"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "idea-to-spec",
+      "eval_id": "eval-005-pm-agent-direct-delegation",
+      "comparison_path": "agents/product_manager/test/idea-to-spec/workspace/iteration-2/eval-5-pm-agent-direct-delegation/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "a5ef9beb8352f2c9b4cfde83ccd9caf0accd15d632ffa2d78214f3c51045041a",
+        "eval_definition_sha256": "073eeac01923328bf5fb812c3ab5852d6edb01936d4f17fc20c69c0d80324b2c",
+        "metadata_sha256": "2ddab779806f9b6e5f9359612bd5cef16f9b4ffd4913ec9f35576d1c0f06be89",
+        "fixture_sha256": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "d5a49beb6f0959828703001ca6c478b09bfa703290aa048a42e8e1be6bc28cde"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "ab6a7745975ad0b6d9fe85d08f3ff56d015a7dfafeada0b42c868160f21bc696"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "ab6a7745975ad0b6d9fe85d08f3ff56d015a7dfafeada0b42c868160f21bc696"
+      },
+      "before_sha256": "bd7a50a135ee55f5b87ed2d7223ce22968b29b27b5db1dbcbc0924e5b7a4eb54",
+      "after_sha256": "e70e25839a305a31d4bcd8ee1aed5424d93b633b7c3acfb43b200b98512ebf14"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "idea-to-spec",
+      "eval_id": "eval-006-nested-feature-path",
+      "comparison_path": "agents/product_manager/test/idea-to-spec/workspace/iteration-3/eval-6-nested-feature-path/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "a5ef9beb8352f2c9b4cfde83ccd9caf0accd15d632ffa2d78214f3c51045041a",
+        "eval_definition_sha256": "0d6c5b2207f916945e44c4152d1df1a5456bcf63eecb7a912ef1fe1811598afa",
+        "metadata_sha256": "4835f86af8c88f61556ab924715c5dc8125d2c5616e22976f405e64c105bc13a",
+        "fixture_sha256": "7749eb192d7baaaa2204b646c198e25edb560363b060536f8cc66b5b6a90c8e7",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "4fbce5299edbfab7f3f9e314d3ad852d562878858c404b524820ab2f7613136e"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "9493c559b632c874b942e292c02b192ed8f5ee6049853fad40b4a43be42ab77d"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "9493c559b632c874b942e292c02b192ed8f5ee6049853fad40b4a43be42ab77d"
+      },
+      "before_sha256": "b273dd0e5a971abc9f84d521ce3a08e6c3b442f2e212c99cfed73ddfe8e653da",
+      "after_sha256": "2c65a790a71459f2c0044c3a0caa0282c7d03706a95ad333a41c6647b1a182f1"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "idea-to-spec",
+      "eval_id": "eval-007-api-adr-engineer-handoff",
+      "comparison_path": "agents/product_manager/test/idea-to-spec/workspace/iteration-3/eval-7-api-adr-engineer-handoff/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "a5ef9beb8352f2c9b4cfde83ccd9caf0accd15d632ffa2d78214f3c51045041a",
+        "eval_definition_sha256": "02e5d899a7687cd28d5b7fe3ed85f267cd9ce62f15d9844aa4281eff90859ac1",
+        "metadata_sha256": "6b28964c95e54c379988fdfd7c54f486a5c872824039a926ede4358e3117f378",
+        "fixture_sha256": "7b6820d67dd73e9499a1ca84c463bfc82e890640eeaf8c3154b04834d8479116",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "7d015813fae4cd945c52acc28425338fd81878adf050d1ecc956ba13abe7bc00"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "509f5889a291c9d718da9075f191750c2e211d4e3e155a3a5836ca8ac4b59dd5"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "509f5889a291c9d718da9075f191750c2e211d4e3e155a3a5836ca8ac4b59dd5"
+      },
+      "before_sha256": "2b778d9129e7ef28b8960dcef2b956631aed066bffaa275e2b550766b9bbcc22",
+      "after_sha256": "46323a50108dfa06e44559c87b2c8fe856c88245b37094b8694e6bf5b88aed95"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "idea-to-spec",
+      "eval_id": "eval-008-mapped-notification-update",
+      "comparison_path": "agents/product_manager/test/idea-to-spec/evals/workspace/eval-008-mapped-notification-update/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "a5ef9beb8352f2c9b4cfde83ccd9caf0accd15d632ffa2d78214f3c51045041a",
+        "eval_definition_sha256": "130498c1a4cc1643bdf013127365b28e5fdc8391203daf304f2cdc0ef5bc97d2",
+        "metadata_sha256": "071b1907c18a80afba8338dbc482c47ee9a6fa479b963c4fb7d1e4c62363e556",
+        "fixture_sha256": "177b1f9c445f127660775572bba7b23413067a88e77389cbdec983886f090960",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "f710875f76a80ed671ccf8efb8681012bf9b4a2e93e08246aaa135f3197672e9"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "f710875f76a80ed671ccf8efb8681012bf9b4a2e93e08246aaa135f3197672e9"
+      },
+      "before_sha256": "2a44bc2e2b23fb427decd3d53b5996c80e0ebac1446cb4988105dba32aa26779",
+      "after_sha256": "f0f7d259bfba33f8fc201052ed063eba689ce8e748b747ce0d48e1594bbb59f3"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "idea-to-spec",
+      "eval_id": "eval-009-prd-iteration-split-proposal",
+      "comparison_path": "agents/product_manager/test/idea-to-spec/workspace/eval-009-prd-iteration-split-proposal/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "a5ef9beb8352f2c9b4cfde83ccd9caf0accd15d632ffa2d78214f3c51045041a",
+        "eval_definition_sha256": "8ef466ccd13d937453c02f105817ced47839fb573011ea1ee300be62facb6b71",
+        "metadata_sha256": "ae189abbce9ec160b22d49ab4f79a0a7a8f521d1a6e2046930669caf75d7dab0",
+        "fixture_sha256": "cda1a0661ddb58fa697ce0a283dc50943986240370fdcd97782d5714af75a997",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "9c9a733fc3c46fd3cb1cdea794218e66a7a987137063c1a3c970e8e9386d1a58"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "8872ad0a50d28c240ab82c8f03a7b476549f0ed3018667e9ae37ea774fbe5ef4"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "8872ad0a50d28c240ab82c8f03a7b476549f0ed3018667e9ae37ea774fbe5ef4"
+      },
+      "before_sha256": "9f79f75df4cb2de0a1831d38d691ba16a5026caba6507ca256bbbeab9f4d05f2",
+      "after_sha256": "94b8d971db2112c90b6e35c5ad77b4f22e4c2d21b4181b2c1234b06aa29d2650"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "pm-agent",
+      "eval_id": "eval-001-route-greenfield-product-request",
+      "comparison_path": "agents/product_manager/test/pm-agent/evals/workspace/eval-1-route-greenfield-product-request/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7",
+        "eval_definition_sha256": "4e776e14ac2c8d3f3aa33718b92238355ee2d15eab3267a50cdada6bb3d4a1de",
+        "metadata_sha256": "98a5616a9f22e4ba7d6ed10c98a36b572ccd9f5c0bfcfaf868ea982ef672635f",
+        "fixture_sha256": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "8e99b873e976898a8a9714405f69dce2d81e6c553f7d4c2b0a99b8b832eee831"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "f6310bd5dd43a30e2335a9413559fcff83b3080c30373ec44a787fd44a168a9a"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "f6310bd5dd43a30e2335a9413559fcff83b3080c30373ec44a787fd44a168a9a"
+      },
+      "before_sha256": "3df7685175219bb30e1870510bc14cd3bf96e95e4e9962ec7a0345007d2c0d3e",
+      "after_sha256": "07c6c4c40069fdf10ca4b2970376194b9f4bcaaa4b761d349798013857389945"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "pm-agent",
+      "eval_id": "eval-002-route-bugfix-request",
+      "comparison_path": "agents/product_manager/test/pm-agent/evals/workspace/eval-2-route-bugfix-request/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7",
+        "eval_definition_sha256": "fe6d213ce4edb254dae39c5fefca87002824c8356e6ca05dfa6b8b92c57d378d",
+        "metadata_sha256": "163386e80d321ea48ddfd244853e278bc70ea13a08cdc68ac01f85bf3ba7240f",
+        "fixture_sha256": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "00a01c5f9432a18e723abe9a7b1a555e5a2a41dc2c36a101ed91497434d1c7f4"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "a0c7df56cf75d4d880a263034f9187a2565b6ae12bf16dcd9ad9ba3bf75f22e0"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "a0c7df56cf75d4d880a263034f9187a2565b6ae12bf16dcd9ad9ba3bf75f22e0"
+      },
+      "before_sha256": "30c77de970fe846bee953c214409168b819b2c0fdb0a03326b985afc13c92ec5",
+      "after_sha256": "97f62f55cc69fef558e18c1478073aeb6573e67e60ba886c6e97e1eccc2b7bb7"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "pm-agent",
+      "eval_id": "eval-003-route-test-writing-request",
+      "comparison_path": "agents/product_manager/test/pm-agent/evals/workspace/eval-3-route-test-writing-request/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7",
+        "eval_definition_sha256": "4c0ee7c09752627d6057c1ccc0d45cb292b19c1428b51ca9513725150029cf5a",
+        "metadata_sha256": "48e1e31078cfd6a23e5c1bdb5481d8f4c6428eb757f9b42750f6377a78297239",
+        "fixture_sha256": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "4bea92cb3e04f7ad6bcf4e0dcdb3aa7c06af7bec325a6bea731363f44bd4e944"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "68bf81d60540c52270128954e78a48b0427247fdc225710c3a1fe78a096bf696"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "68bf81d60540c52270128954e78a48b0427247fdc225710c3a1fe78a096bf696"
+      },
+      "before_sha256": "4408e8c71fe73624d9a7046ca22f7f53a0562e79419dcc79f81463c20ffbd571",
+      "after_sha256": "c59847f71d9afb5a12257623c41c30ef462f5062a8de35d14339e586ce8d7b4d"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "pm-agent",
+      "eval_id": "eval-004-route-ui-update-request",
+      "comparison_path": "agents/product_manager/test/pm-agent/evals/workspace/eval-4-route-ui-update-request/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7",
+        "eval_definition_sha256": "601243bb221e4073b25a6eba61d2cbbc1d243cb0d11ebc88b60ef8187a2e86e1",
+        "metadata_sha256": "aa0eca0938ef56711257694af52b821c5be5dbedc9b5982d77710814288d3115",
+        "fixture_sha256": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "afcbd1cd02daddf2a5de8000a17edb44c8f3338aa4214be0e836d3a78f54f541"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "1a50c21004cd847d0ffe5e2006ace8c7f9a6356be36a4c949781ab8572d962b0"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "1a50c21004cd847d0ffe5e2006ace8c7f9a6356be36a4c949781ab8572d962b0"
+      },
+      "before_sha256": "ab12afad182b5797557f313ecff7ac49231e67733103e0ce78ed6e5caebfc05a",
+      "after_sha256": "cc9708b58870aac559d8d87694612cca4777c7677383ef30eee522da03dddac1"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "pm-agent",
+      "eval_id": "eval-005-route-deployment-request",
+      "comparison_path": "agents/product_manager/test/pm-agent/evals/workspace/eval-5-route-deployment-request/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7",
+        "eval_definition_sha256": "73a2b58c1c65bf56a5f6d6f35f003c86e432caed7b530c34cf851322050e2633",
+        "metadata_sha256": "d17a05b229136107ac1e50142856979a9ae9f563cdb19b940e4810dadda79e1c",
+        "fixture_sha256": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "42fd42dc7a350eab589db47b48a132e9f478c8e119c1fdbd30b4875075f9f0b5"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "2ac667915ab4f855381927b82fbb59bb6a89c130b46cdb8f7ac30eed930b019d"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "2ac667915ab4f855381927b82fbb59bb6a89c130b46cdb8f7ac30eed930b019d"
+      },
+      "before_sha256": "56d99598de67d81b9139a2ff7a8285d0d98a132d265f87c6807c95c5ddc8a4e6",
+      "after_sha256": "c16166c26f81008071283f683b334febd9d05378b0b82c57fa376e4412821e45"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "pm-agent",
+      "eval_id": "eval-006-route-security-request",
+      "comparison_path": "agents/product_manager/test/pm-agent/evals/workspace/eval-6-route-security-request/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7",
+        "eval_definition_sha256": "33054d35eb6adb9b2259eedec7e911d8545eb305cd711e4206483eea10d13a8f",
+        "metadata_sha256": "b68604b9408ecd1ae4f680e8b6bea0f1c221e273dc6389c6b8150eff4b36f0d2",
+        "fixture_sha256": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "356a8438fe026d0b1352a3ef7467cbb1d1fa3bb6c089f0c3e64b4d4c5d3741fc"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "0b141bf070cdf5ee94482d3b737899acc1a38917a29ea5c884cf37fac9f74bc2"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "0b141bf070cdf5ee94482d3b737899acc1a38917a29ea5c884cf37fac9f74bc2"
+      },
+      "before_sha256": "315f25040f76bbbb344a7a2c49ee349180d013b611da1818480e5d21c24692b0",
+      "after_sha256": "ac9d3e19b273d2f07b44e54dbd6f33528d9b3d96ae3c9073a2a4a23b60d7a24b"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "pm-agent",
+      "eval_id": "eval-007-direct-downstream-without-handoff",
+      "comparison_path": "agents/product_manager/test/pm-agent/evals/workspace/eval-7-direct-downstream-without-handoff/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7",
+        "eval_definition_sha256": "13771c6d0b126a3ca1ee1723ee43dcbca8cef0bbfd3ed1a8c42651bbd42a7c19",
+        "metadata_sha256": "70b36659756bbd4d7fc0e09d0fabc7ee5ba1a168323c148fa735110fb59ec768",
+        "fixture_sha256": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "6f1f540339fe5c4c310ca6aaedc38adff3d61e4268399a40149f44e3770ac25c"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "bbfd83d8620306b81ce8caab34668d38c7a281137d54d7e950165bcaa74eceec"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "bbfd83d8620306b81ce8caab34668d38c7a281137d54d7e950165bcaa74eceec"
+      },
+      "before_sha256": "0aa7d472d4f6f15c8b1b826547bf445b8fae7b952b2681c82b08ac774f596ddc",
+      "after_sha256": "bf5d117d7a3e8cc8f7fdc17bbae3f9f70819f7235bca789a46539819334bb3d4"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "pm-agent",
+      "eval_id": "eval-008-direct-specialist-bypass-gate",
+      "comparison_path": "agents/product_manager/test/pm-agent/evals/workspace/eval-8-direct-specialist-bypass-gate/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7",
+        "eval_definition_sha256": "cd9751a8b092fc6d7d98d6022afbbb3ec1c871d784270dc60d0af08525fe28a3",
+        "metadata_sha256": "484b4662019ef115d32bbdc63a4fe4cffc2cd503d4cd9fc5262185023225f4ca",
+        "fixture_sha256": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "d4acd94dda2c52416ad87fb2e12177cf797b75ea923eded4095dac24f71a6a61"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "d44fac23649c2ee22cf9600b7d3cda5e0be594ab2e8b8f743679490e9c96e4bf"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "d44fac23649c2ee22cf9600b7d3cda5e0be594ab2e8b8f743679490e9c96e4bf"
+      },
+      "before_sha256": "8bb5ab66e79ff6b653b7e7162113562156b144a17c425669009d320c45da7e2d",
+      "after_sha256": "b139f4d7792ebaa3f7ae87b1f885d64048bab1b18eb7c9598728b32b7e92610f"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "pm-agent",
+      "eval_id": "eval-009-missing-handoff-target-unavailable",
+      "comparison_path": "agents/product_manager/test/pm-agent/evals/workspace/eval-9-missing-handoff-target-unavailable/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7",
+        "eval_definition_sha256": "ea4ff3ed92cd6df9743d23b747dc29d9087560d5cfa7f5f4525b8e146b0b7e97",
+        "metadata_sha256": "f52777a03f0c132438bf125e153205560b01f6abb53fcb15add6a3552b96312b",
+        "fixture_sha256": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "45aa95828b353344675a6e62421acac466500932a42ce4d64f8f43969bd5bb6d"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "8bcb98f324a02190abe384444bd75e77aa64120fe441b8a86e8151f6de9aefa4"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "8bcb98f324a02190abe384444bd75e77aa64120fe441b8a86e8151f6de9aefa4"
+      },
+      "before_sha256": "f1d309fd5ee2fb3ffcac13ddcd4151bccd50c7e0e95a1c79fb37de1491346bbc",
+      "after_sha256": "28c05adfebbf1f1425c585cbbcf08bd9b7cec2a1377ec7a26b50177c86580a01"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "pm-agent",
+      "eval_id": "eval-010-change-tier-hotfix-fast-lane",
+      "comparison_path": "agents/product_manager/test/pm-agent/evals/workspace/eval-10-change-tier-hotfix-fast-lane/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7",
+        "eval_definition_sha256": "47a19a6c15b443fba6827b5bff8e5f73b3367c26176898038b1822e6a445e0c6",
+        "metadata_sha256": "dd7edb355d66e4505d2039e9fe3eb4eb203c3d8b2cfcc299410f099efef7e166",
+        "fixture_sha256": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "bb0ee0282945f3d4f9dce339b9d8538e36a23ce40cb0cf92b33dc2be95234be0"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "05f77b5594dffab3307d3ffc09971ca927dda87c36daa1102b62320e1fb230b0"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "05f77b5594dffab3307d3ffc09971ca927dda87c36daa1102b62320e1fb230b0"
+      },
+      "before_sha256": "7de77c0806ba22e1e5ce349525d1fb0b3a4bda5757f94dfe1d1d735e67ccd154",
+      "after_sha256": "52caa264934eb51cf382a08be084aa49ac14d67f9618b02e6671a72f2004b81f"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "pm-agent",
+      "eval_id": "eval-011-change-tier-standard-full-gate",
+      "comparison_path": "agents/product_manager/test/pm-agent/evals/workspace/eval-11-change-tier-standard-full-gate/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7",
+        "eval_definition_sha256": "da85ba336c757be6c6ca84ef12c1d1a20655adb3e82559a2c2234b5462387973",
+        "metadata_sha256": "6652dce9ab8a85ed09b58d853b1bdac1fd0f6f3e5ccd74f38c1d4aa6171a8cf4",
+        "fixture_sha256": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "e0fce32f646911cc00fe0709c7d0e934a3657054c9fc5a2efda7653a3ac97ea6"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "6783d602f881b7c8ca19c875f22a06a1c10b1d86f0a6bd73bc7f850a11cfb78a"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "6783d602f881b7c8ca19c875f22a06a1c10b1d86f0a6bd73bc7f850a11cfb78a"
+      },
+      "before_sha256": "75149144759d2a14d5a61ae4b342e5e7e308905ebd58b054a1410e42fe0d67dc",
+      "after_sha256": "f9dc622e55e94fd10dcb194633e7c429eeccaf3884ba36613ebaed615f089a90"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "pm-agent",
+      "eval_id": "eval-012-change-tier-hotfix-abuse-blocked",
+      "comparison_path": "agents/product_manager/test/pm-agent/evals/workspace/eval-12-change-tier-hotfix-abuse-blocked/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7",
+        "eval_definition_sha256": "757872d7dabcbeb5f63781cd39c51a0fbd55c644aaecd2a814401a4e784d4603",
+        "metadata_sha256": "5be95630fc657c3ddfcd1eee211fb45bdc7cc20a37cf20c50f58a72635d4712c",
+        "fixture_sha256": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "05754bc7141a9de585a1127391112d0da97f3c7138eba96f4377a8a50be63d7c"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "8ad4723a5bb9f17ea114988053b59306b65e1d422e639359d6225053e74059b6"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "8ad4723a5bb9f17ea114988053b59306b65e1d422e639359d6225053e74059b6"
+      },
+      "before_sha256": "26d4d681053f96546d57219063c96530ca414f3cbea820f73f99b68367772c9c",
+      "after_sha256": "c012979565816ce8da8ebd4d1c2a21eb841860c90d9defbe70d3c42087881d17"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "pm-agent",
+      "eval_id": "eval-013-change-tier-hotfix-e2e-direct-path",
+      "comparison_path": "agents/product_manager/test/pm-agent/evals/workspace/eval-13-change-tier-hotfix-e2e-direct-path/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7",
+        "eval_definition_sha256": "0e4e9687500855bbb8cac580183d47bafa14e53a69d5477185a5ceacddfe1857",
+        "metadata_sha256": "385a2edb2c46d9f3ce571c34b812bf357f9247b71af061faebaf0764c87334a2",
+        "fixture_sha256": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "6a4c53f4d8ac913c9f4214c0dc35c3bf4c2a1bd9745f539a3879966e5d7f9011"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "b948b8323db48932d19e6fa8a34611e560be96e6cf55a2d2a7d68805b0b8e2ce",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "05a9efaec33b9cefe1b4a023686558c2b159d21bd5844cf8a0405c73ed620740",
+        "assertions": "155a5be81ca1b18167e2f602c49edd7ac5cc6a93e673aac4c2f62d0a01b9ee64"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "b948b8323db48932d19e6fa8a34611e560be96e6cf55a2d2a7d68805b0b8e2ce",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "05a9efaec33b9cefe1b4a023686558c2b159d21bd5844cf8a0405c73ed620740",
+        "assertions": "155a5be81ca1b18167e2f602c49edd7ac5cc6a93e673aac4c2f62d0a01b9ee64"
+      },
+      "before_sha256": "66d25984902c154ff469b42ed9b275b982a7f1d43fe34beeb266feaf1d84264a",
+      "after_sha256": "4400f98908e58224364367df716153e4502bd989c443cbbc2880af2053689174"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "pm-agent",
+      "eval_id": "eval-014-route-site-notes-and-github-release",
+      "comparison_path": "agents/product_manager/test/pm-agent/evals/workspace/eval-14-route-site-notes-and-github-release/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7",
+        "eval_definition_sha256": "ae4335c3ea7ab2052d5988d1cbe329b872d3570826da6174d95ecdee75a8f11e",
+        "metadata_sha256": "7b48bd11ada861ee54366c474d903263630fabf2c5e0d3a66c9f38056e80908e",
+        "fixture_sha256": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "0e6be21ab02e72aa076a9b774d5cc60139434feba550f781574340027908427d"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "896fea48467adf48c0b60efbfc818a3e1d44f5bf9fd93d4c3518c27b64e1159d"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "896fea48467adf48c0b60efbfc818a3e1d44f5bf9fd93d4c3518c27b64e1159d"
+      },
+      "before_sha256": "5578cf6eb6f794671b61c06ceea2b3572df9936666ececd4c4b8de8cdac0877d",
+      "after_sha256": "242af2bac98141cd4cab1b7b76831792534c665832f2e4b21049a79796c84bcc"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "pm-agent",
+      "eval_id": "eval-015-route-docs-site-deployment-gap",
+      "comparison_path": "agents/product_manager/test/pm-agent/evals/workspace/eval-015-route-docs-site-deployment-gap/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7",
+        "eval_definition_sha256": "8bc69d85fc3ff063d885b8a2c4d7a9ea83b6dca3de23a034dba15fb34f1ba98e",
+        "metadata_sha256": "e7a743e88e4c53094e4afe2903a87ebcc467ace2dc58c61ccb0a0dcf64ebf2fd",
+        "fixture_sha256": "16e3b6cbbbae6769ac6b5ead7bae34214b3dd90e3e6c4d5fad97cfd7d3784013",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "69f2798cad12b0dd0ca3c224e3cfd6cf611a315695684db1b07a23452b52a60e"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "7eddd14629d824c47ef3d808e0b1e5ab2d3d501f21ad2a11f75caa4acf9e92f5"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "7eddd14629d824c47ef3d808e0b1e5ab2d3d501f21ad2a11f75caa4acf9e92f5"
+      },
+      "before_sha256": "f94dd27830a7116e5fcabe1952251849f09df632e1efcb197beb26e583acc7bc",
+      "after_sha256": "bd7e98b0630a5700c576d0a27e3d9c905d4aeca6ef295f8988e76dec1e4c29f1"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "pm-agent",
+      "eval_id": "eval-016-route-document-structure-governance",
+      "comparison_path": "agents/product_manager/test/pm-agent/evals/workspace/eval-016-route-document-structure-governance/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7",
+        "eval_definition_sha256": "ba37454a106688e9f5f2e2586231a60f2093e364612eb14bfa53540c9e2d1589",
+        "metadata_sha256": "fe53b448dd4fd2693ceb179d875dd617b7b717601fc7d9d3214cab940b4cdef7",
+        "fixture_sha256": "1a6d7fa4c22a394f3c854eef7a25f4d0cf2e6b4ecd7c7a3d3bf15d295d6e43f8",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "c8400122a967de4e5b8b409bbe920fe16ec946724a3aa7d4b3077b3582a3f2f0"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "5466741a9f29a234a237f7bb0de98719c274fc7730882aa0dacf9cb3592b46d5"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "5466741a9f29a234a237f7bb0de98719c274fc7730882aa0dacf9cb3592b46d5"
+      },
+      "before_sha256": "3ed9fe077357d58ff4a529a875b7bc69a839ec090734a09724b9669f548b1b90",
+      "after_sha256": "57dc64766336bde8da6aa4207babe9e7a0da0095f4a70f81d4668f4390fc81fd"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "pm-agent",
+      "eval_id": "eval-017-scope-guard-unenabled-general",
+      "comparison_path": "agents/product_manager/test/pm-agent/evals/workspace/eval-17-scope-guard-unenabled-general/comparison.md",
+      "inventory_match_count": 0,
+      "classification": "pending",
+      "reason_codes": [
+        "no_fresh_evidence"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7",
+        "eval_definition_sha256": "2b26ec5b13cba548fe19b4f508977afc54ba26189b14fbc48be376e4d57b8178",
+        "metadata_sha256": "05ea9f60607f11132b0f5ec8ca00cda463398f718c44648a9e2be81e39b17991",
+        "fixture_sha256": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "c5629d3608d1f142562d32ed4b435e3d2c557d9aa8b1c8b5f72fce35ca63e9a2"
+      },
+      "preserved_raw_sha256_before": {},
+      "preserved_raw_sha256_after": {},
+      "before_sha256": "5aa5767efb7f05c4d59119871ac2b02656b2b5f984bfb661b433caba41abcdcb",
+      "after_sha256": "f243c765cc7073a57f6a939308754f5f8b026b1570255a93e47cb8bf735d58ac"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "pm-agent",
+      "eval_id": "eval-018-scope-guard-explicit-invocation",
+      "comparison_path": "agents/product_manager/test/pm-agent/evals/workspace/eval-18-scope-guard-explicit-invocation/comparison.md",
+      "inventory_match_count": 0,
+      "classification": "pending",
+      "reason_codes": [
+        "no_fresh_evidence"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7",
+        "eval_definition_sha256": "c9288fa3642ba9620547b9cef097cb305dbbd76229e2d8a01a3398cb410b16ae",
+        "metadata_sha256": "9bbacd8d1d30aecb1b4dd5b9add9750bc75aa04b90825b7bca13141ac06f87e8",
+        "fixture_sha256": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "3a5175573f5c12faf8ef17031068ea4a3554be3c63ea98a9f0e35a5de2fe7ef6"
+      },
+      "preserved_raw_sha256_before": {},
+      "preserved_raw_sha256_after": {},
+      "before_sha256": "9590dfbca1fbd39e9dcc8143463c7bed20758de37e9dfcbbb54cc5e2537fceae",
+      "after_sha256": "a9bfd7f89fab2f4a206363501fd57106cf0f6bb050e1f73454739f313228e114"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "pm-agent",
+      "eval_id": "eval-019-scope-guard-enabled-general",
+      "comparison_path": "agents/product_manager/test/pm-agent/evals/workspace/eval-19-scope-guard-enabled-general/comparison.md",
+      "inventory_match_count": 0,
+      "classification": "pending",
+      "reason_codes": [
+        "no_fresh_evidence"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "0616a11ea39f978cac34906ca01c79a336316825183bb1897d900f056d8544f7",
+        "eval_definition_sha256": "2e41aaf2a9f1898027fcb4bd2dc0d8b314b161c3848369aeb0ccc8e3d7c16e07",
+        "metadata_sha256": "f5c5f2a20d2b5185fc2f9a51b4985187997e135f3a377de786395157cfcdb827",
+        "fixture_sha256": "fe6bcb3f9a810e8ec07d6cd151b927dd0790270b275bdd2a0170bbc91573f2d5",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "78fbc30f6ea00642b27e4bc9a167610aaa84574a08fb26567e68734e28c9ff68"
+      },
+      "preserved_raw_sha256_before": {},
+      "preserved_raw_sha256_after": {},
+      "before_sha256": "c846b16b182dd89c5b37b6ac69d5ff4090e105fe910ae7f93b1d2b7dba162ba6",
+      "after_sha256": "fa561f727dbb5b22bf7941823dbffefdb41bc0b4add561f44398cad20d901e2f"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "roadmap-gen",
+      "eval_id": "eval-001-timeline",
+      "comparison_path": "agents/product_manager/test/roadmap-gen/workspace/eval-1-timeline/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "74b972ac8dbd7706448e20025f6995b87c544e99309b65961f70d0e86a7bd191",
+        "eval_definition_sha256": "d6df04c011109b2d27a14aaefa7802d9d9c0af801e4acce9ed37afdc4c26a731",
+        "metadata_sha256": "c374d15583cb501346d3285d30669c9dbaf58b19f95661d07d8aeac8332d8ba1",
+        "fixture_sha256": "1114e9e115cfb91a2f09d56b7563aa8c7433df316dc5fe8c86e2dd3614f9d165",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "c9231138562bec2ed562cf0d8c1ec94b96debb390ee547b6815473c326c64b09"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "fa7b89d0d248783a3a173693c1354595faac87a615b2f02e9894b606d087a49f"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "fa7b89d0d248783a3a173693c1354595faac87a615b2f02e9894b606d087a49f"
+      },
+      "before_sha256": "22fc00416a1bea0ffac94ee8c5491a9559dc20673cda9f1f7b55d87adf0dd3a5",
+      "after_sha256": "c0d108f114d8010f0829cb5fa497f3d01fa7e79d65fdfde503d9eb93cd8911ab"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "roadmap-gen",
+      "eval_id": "eval-002-phase-classification",
+      "comparison_path": "agents/product_manager/test/roadmap-gen/workspace/eval-2-phase-classification/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "74b972ac8dbd7706448e20025f6995b87c544e99309b65961f70d0e86a7bd191",
+        "eval_definition_sha256": "9bebcff97f69229af9d2fc6b841c4826a4650eeb5ee2c6254e8400fa19d31afa",
+        "metadata_sha256": "ae0af75c7768cc5a422a172a7778c85838314f028847e67a9b64a099fa24dc99",
+        "fixture_sha256": "a264a565b80cdab16388e48390a97336c870c675ea266e111b6f98276cf41192",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "828832f79453e0784207e366cba87f24e08c6f3017321b257129f96f3076509d"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "b26d30037fab3800011e61953d5ac213ad94485671b43984cb5dd236690bb0e7"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "b26d30037fab3800011e61953d5ac213ad94485671b43984cb5dd236690bb0e7"
+      },
+      "before_sha256": "84155953664c4cd9f3e2915d4dbc206e7f74760a46afefcef36f0ad28568cc38",
+      "after_sha256": "c3d7dfbacc2ec68749fadbb476eb12183e38688c8da32f8909992bb4dbd29fe0"
+    },
+    {
+      "agent": "product_manager",
+      "skill": "roadmap-gen",
+      "eval_id": "eval-003-no-dates",
+      "comparison_path": "agents/product_manager/test/roadmap-gen/workspace/eval-3-no-dates/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "74b972ac8dbd7706448e20025f6995b87c544e99309b65961f70d0e86a7bd191",
+        "eval_definition_sha256": "fbd695e0a879758e25936e89babfefc9a6cba4a52e1572a61e1da7fea0b1364b",
+        "metadata_sha256": "1dfb7bfbfed7613af8764f4385cade9d5822d1652d85a0cbb75853e0bcae7474",
+        "fixture_sha256": "8ed1c517c0f0999b8177c14728f4f1837cf8c41c83a93a8766a4e6fd07e1d14f",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "f6a7dabb82746a0dc0f0c5965d8e78c276cdccf3d2da25bfbb1a77e91ffeca3f"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "09752f52d827c3e3164cb4bbbd7d78cfd84529cb72b5ea575646f2d6de3c8237"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "09752f52d827c3e3164cb4bbbd7d78cfd84529cb72b5ea575646f2d6de3c8237"
+      },
+      "before_sha256": "e3ab3e71903711fdc1ff3ae47f9f34b540f6d462aa4f112c69d3d21d52ab9ea9",
+      "after_sha256": "b1af33bab0d50e50f511f06aa4112a953f13f0643a9e554ee013fa63c5d625b6"
+    },
+    {
+      "agent": "qa",
+      "skill": "bug-analyzer",
+      "eval_id": "eval-001-analyze-test-failure",
+      "comparison_path": "agents/qa/test/bug-analyzer/evals/workspace/eval-1-analyze-test-failure/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "0d6c4b717279e8edddeea8100d93e004d25b98b502e0ca114092a3f0c007a52f",
+        "eval_definition_sha256": "35f2f99594df8382cdc242359c30a451a1bdaa89727c7071b5ec00d92699fbf8",
+        "metadata_sha256": "e96ab79b6862e4b82cb2cc5b58266d1ce1ed35caa4271d16c371f2d1b6443e6f",
+        "fixture_sha256": "e52dc183368f81bf8278941735b98c8f9da85437b60c6dd9736b019d7bf6c9ca",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "84f20ca3637061984a451201365104813c56f53ca0b37a9fb14c70d8de0d29b1"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "b363b8018a5708be1bba4bb744d180298cd1527c66143bdb6e3951e245ddb366"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "b363b8018a5708be1bba4bb744d180298cd1527c66143bdb6e3951e245ddb366"
+      },
+      "before_sha256": "ae2dac9dcc2e1704f5dc8318082789aaf48ec91be5203b9313451606180a5745",
+      "after_sha256": "84ade24d3451530ea29382ec7901602875b89f46c20e1d264ae36e87a2e6b0e1"
+    },
+    {
+      "agent": "qa",
+      "skill": "bug-analyzer",
+      "eval_id": "eval-002-thin-evidence-suspected-bug",
+      "comparison_path": "agents/qa/test/bug-analyzer/evals/workspace/eval-2-thin-evidence-suspected-bug/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "0d6c4b717279e8edddeea8100d93e004d25b98b502e0ca114092a3f0c007a52f",
+        "eval_definition_sha256": "ee85b4030fea85acc8c079589b9268be5087962ef495cf3e3194580abf721432",
+        "metadata_sha256": "8fd7c615ab5c3a7f7edc961336d40be79c05d55d0c11dd967998bbb2abd4e9d7",
+        "fixture_sha256": "bd09f8717eb7765700b65e2c38ca5c4dcc82c7aff0bee46b30335bbb10dcf266",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "086365b086fd130d9ef17a34e69f11d6786884f09ea0525a080792033b47d5cb"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "23e241626b820ac57663cc46684748d9fc9994d17aa9fc44039ab3c2026abf2b"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "23e241626b820ac57663cc46684748d9fc9994d17aa9fc44039ab3c2026abf2b"
+      },
+      "before_sha256": "16596df319e4e2437ddc5541ad709616133e0baad82ae79ab53c3c897d63520f",
+      "after_sha256": "fd2506150e75421d7290f27872e379fb581a6d560de9c3b4c634ab62d434351c"
+    },
+    {
+      "agent": "qa",
+      "skill": "bug-analyzer",
+      "eval_id": "eval-003-mapped-doc-bug-analysis",
+      "comparison_path": "agents/qa/test/bug-analyzer/evals/workspace/eval-3-mapped-doc-bug-analysis/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "0d6c4b717279e8edddeea8100d93e004d25b98b502e0ca114092a3f0c007a52f",
+        "eval_definition_sha256": "5055f21aa292e91a955bc3aa635c808239336415cf083aba532e9d19a7985220",
+        "metadata_sha256": "6e065f47b93dd01060b700c2c7836503fb5797f7c0c1bb375677811fe6fa6d5f",
+        "fixture_sha256": "7d279cf3b0905050d0b65ec93cd3a19c763df01dd02f4eaadd2d86c46d0a38cf",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "b6687a75ef9bb699551db8e38999da79436ee46aeef4ad6375945c623f7d5f5d"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "b6687a75ef9bb699551db8e38999da79436ee46aeef4ad6375945c623f7d5f5d"
+      },
+      "before_sha256": "f48eacde34b23c4b5456d5ff029fc85c93cbf7aaf1629e3cd0fd63acd0cec4ef",
+      "after_sha256": "24eb2502adbc214f1045c57e06a4df8cd03590a2a74297812e34a4e26ed670cd"
+    },
+    {
+      "agent": "qa",
+      "skill": "exploratory-tester",
+      "eval_id": "eval-001-explore-web-app",
+      "comparison_path": "agents/qa/test/exploratory-tester/evals/workspace/eval-1-explore-web-app/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "4e2073febaef7202820d7977feb83c73b7673e1200e4724a3f37b54a20923059",
+        "eval_definition_sha256": "32b9d61e575fbee81406ffc68edbaec9418feec621754c8fca12fc2f2edd2c08",
+        "metadata_sha256": "228751d86855b3dcdb583bdc4a44c4a493c28334ed74368c030ddad805b1f314",
+        "fixture_sha256": "ee088defa4a7bb2cbc3d091f8817eac9fb8cc7c128c92be34adf72ee4a79f3b7",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "3783048bfb479d6e8907a0e84c4199cb646178dd63c9a58d60ddd654db2122dc"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "05b8f082d2be8686a39f5b4756e7237212420362593f89c7afb9ccf61532fe53"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "05b8f082d2be8686a39f5b4756e7237212420362593f89c7afb9ccf61532fe53"
+      },
+      "before_sha256": "72427c3d7797968a0ead640d7ae3528d1e28987661286f222e5ff1aa84bfb7dd",
+      "after_sha256": "a7cc0a8580cd2daa2d76c84d20a4bd62c8240d686fef4a2243fa00ce72e34ad7"
+    },
+    {
+      "agent": "qa",
+      "skill": "exploratory-tester",
+      "eval_id": "eval-002-explore-with-custom-duration",
+      "comparison_path": "agents/qa/test/exploratory-tester/evals/workspace/eval-2-explore-with-custom-duration/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "4e2073febaef7202820d7977feb83c73b7673e1200e4724a3f37b54a20923059",
+        "eval_definition_sha256": "234873760fb9d0649d16f54118fbf0383fa2955b9451730f9429892d78a6d7e0",
+        "metadata_sha256": "4befffc2e8037477b9995f3ded3869d8476cd9a66637621d7f8e8d3fc8c6fed3",
+        "fixture_sha256": "58e996bab34649b23e7bf5cc00be4fa65ff65a8e7b288cba77fc10a44d715cf3",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "795b13efa8aba1d005ca8e2bf3be74790d6a011a9b79e7e9c3ef0bb4863b7e5d"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "84e000fa31612d549cf087352fe1f39076b0022adfa45b6b9b85acbdbd451321"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "84e000fa31612d549cf087352fe1f39076b0022adfa45b6b9b85acbdbd451321"
+      },
+      "before_sha256": "bde65cc14d9205cd13583abec4bedebb17bc6e85f4eeca327f5b092a894d48b1",
+      "after_sha256": "bc6a4a0488e2eae527e8f8fac13b43550b1a9c1f3f23df01526a40b1bde8cb6c"
+    },
+    {
+      "agent": "qa",
+      "skill": "exploratory-tester",
+      "eval_id": "eval-003-mapped-doc-exploration",
+      "comparison_path": "agents/qa/test/exploratory-tester/evals/workspace/eval-3-mapped-doc-exploration/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "4e2073febaef7202820d7977feb83c73b7673e1200e4724a3f37b54a20923059",
+        "eval_definition_sha256": "c4de00c65a5c492d58d182077c448786bbd54172790d4519f15e143439929064",
+        "metadata_sha256": "66549bc6a4cd28361d4fb0c300ac0600f32823bbce01dba9736725e4b2d843dd",
+        "fixture_sha256": "5b1017edbbf8a6df86fadbd205bf7416456f615f000264cc379e5e296b079421",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "4c43daac86d8952305b7bb2678764b0601e00aab8c80c9bcb816f5f3c93c71d3"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "4c43daac86d8952305b7bb2678764b0601e00aab8c80c9bcb816f5f3c93c71d3"
+      },
+      "before_sha256": "4e6553ec52e075d28acadee13c14d3dba5b35700583dadb2beff9abcbce12337",
+      "after_sha256": "5a57ac05b2b62adf46af2ab2d38c3ed8a81fcb95bbc72860c4526eca9ca7cc81"
+    },
+    {
+      "agent": "qa",
+      "skill": "qa-agent",
+      "eval_id": "eval-001-route-mixed-qa-request",
+      "comparison_path": "agents/qa/test/qa-agent/evals/workspace/eval-1-route-mixed-qa-request/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "23a4457fc9bf10be6976d98ea55607b47c6c623db1e20d5c73160d9f386c2a36",
+        "eval_definition_sha256": "2ad0a90eac7fca1f06d238ff5d3d06535381ddd810d8a9e8e9e423ce29483f2c",
+        "metadata_sha256": "718fcc57ee1abd91d0d7551c46ebe8546481fa4f027452b86db232f30d15ab47",
+        "fixture_sha256": "c9268123afd7a11d5bd4ac6d14865261ea2db8883ff6a745cea96f843ec5dbd5",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "f4aaec46995456a39da2b489696e387a78408415038edddd6412ca13bedbc20a"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "c19c7f2648f5394dc28c150209c40ed887004329c6894dcb6990ef6859e1e178"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "c19c7f2648f5394dc28c150209c40ed887004329c6894dcb6990ef6859e1e178"
+      },
+      "before_sha256": "d6e834f5f9ce84339a8fa11fbd4abbd0e3cce62431b21f631ee106e3259fb54c",
+      "after_sha256": "17d0ba31c7ea2e604bae0d9575558941c390f7d831b17590c7dbb8f9eda43162"
+    },
+    {
+      "agent": "qa",
+      "skill": "qa-agent",
+      "eval_id": "eval-002-empty-qa-directory-expands-cases",
+      "comparison_path": "agents/qa/test/qa-agent/evals/workspace/eval-2-empty-qa-directory-expands-cases/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "23a4457fc9bf10be6976d98ea55607b47c6c623db1e20d5c73160d9f386c2a36",
+        "eval_definition_sha256": "1252f49c3e393535dba5cc481c5c3100fe9a709aa3de1773196b4edb5900ada3",
+        "metadata_sha256": "bf12045623474ece32b13073fc8cb963c9b4f673ab0fe9f0cf0dc0ad649d4ef6",
+        "fixture_sha256": "870f233236f82c3cf594816a5771878c8e388e11eeb3846cf269bf436f0fb100",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "d61853152f0f59bd847f0aa3394c1f282e4bb9275d56c9fb66462de58118346d"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "5156f759c3b517b9f8b3434f72bc38dce452c081c2cf167bd80aa8285539c69c"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "5156f759c3b517b9f8b3434f72bc38dce452c081c2cf167bd80aa8285539c69c"
+      },
+      "before_sha256": "7932ad98f949f9e777b8d52d96b56cf540a32df25ddb3c8c161bba07b278825c",
+      "after_sha256": "f7613034982d3e15d70addb2124d8b41a1f489ccbc52716317f3788c6845efda"
+    },
+    {
+      "agent": "qa",
+      "skill": "qa-agent",
+      "eval_id": "eval-003-feature-path-missing-plan-blocked",
+      "comparison_path": "agents/qa/test/qa-agent/evals/workspace/eval-3-feature-path-missing-plan-blocked/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "23a4457fc9bf10be6976d98ea55607b47c6c623db1e20d5c73160d9f386c2a36",
+        "eval_definition_sha256": "ffa490cd1f58367914b109adc50e94706c92cbf66e7c95942ae329d3f9a191c7",
+        "metadata_sha256": "aa798ca118679678c2fef882d4726badd357a387202dcb387aceaa4b86696bd0",
+        "fixture_sha256": "39ecc1af9722a7aadd83ae04a9403edca1017d45bde6a98a57d2d87ccb7702dc",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "7c827cee8609863280607c031efdc95a92d32b851664d68126eccd9d66c1f27a"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "c252b4592e1e41163d62776dc5894725be820a5c785f893478e40bffb8b55331"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "c252b4592e1e41163d62776dc5894725be820a5c785f893478e40bffb8b55331"
+      },
+      "before_sha256": "2c3140231c616cbbb8cc5b3d30bc3f77469db1c78cc83e7ee222f60a321a5a34",
+      "after_sha256": "726da8fb2ad4a9670e12c7da693723e6c4174cf3385a8712960f05563443f2eb"
+    },
+    {
+      "agent": "qa",
+      "skill": "regression-suite",
+      "eval_id": "eval-001-verify-bug-fix",
+      "comparison_path": "agents/qa/test/regression-suite/evals/workspace/eval-1-verify-bug-fix/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "4e9403c0e6549024a79156a156c1294488d1a418598e88e3e9565298bc6bae6a",
+        "eval_definition_sha256": "8ca6ea4c46c7a5a2c854d9ff5def7ea0ec612ddbf9888a829e50de270f1b84c4",
+        "metadata_sha256": "732278c998a10f6e6333dc13e2fc4edfbaed96da1abb806d2dc29682a3a79f75",
+        "fixture_sha256": "de9aee791f056463d193f05e53c9f483fe312d6ee3aeb7bb4d1f7b0eb008f308",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "2c18050b9a27d5dccf92b0604097b9078533d47105266364099eafbf3833aad8"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "b9860059cde85698fd357d56e0843e2360a523ac82b19330274246a0b51ef53e"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "b9860059cde85698fd357d56e0843e2360a523ac82b19330274246a0b51ef53e"
+      },
+      "before_sha256": "1043dcd1a35f33db3534ab10c2a4c2e6438ba4b301f2cdd23c064340da0787e9",
+      "after_sha256": "2ec396e566732c4d2e6695cbc9cf114a0c1fbcac9c8a5d99387aca801ae454e1"
+    },
+    {
+      "agent": "qa",
+      "skill": "regression-suite",
+      "eval_id": "eval-002-blocked-without-original-bug-context",
+      "comparison_path": "agents/qa/test/regression-suite/evals/workspace/eval-2-blocked-without-original-bug-context/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "4e9403c0e6549024a79156a156c1294488d1a418598e88e3e9565298bc6bae6a",
+        "eval_definition_sha256": "bde407cd9167fc95a8a68436fa7745a88790341ccffae265b6e1321da5b3938f",
+        "metadata_sha256": "e69dc8ec803ebfc43eb2e4147f1b861f4b02e94afa256d86c039101ea44fff1b",
+        "fixture_sha256": "811b93327e61a4a1610d2801bebd47a27e231fa7f4e1ec17fdfda144fdd986f5",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "2f3ed1bac6bd41e43ecbd585f5beb95db8464a7cf767e9c9a3ef20fae4f56429"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "a6270a3e1b845f653ee6947081c31546b458cb17cb0a7d794356c95e1108c953"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "a6270a3e1b845f653ee6947081c31546b458cb17cb0a7d794356c95e1108c953"
+      },
+      "before_sha256": "38f1e52ca57ecb35914a4d76a70a220810fee53f4f43939e73be4e9eca68f7a0",
+      "after_sha256": "c1ae832b6f0a1cc7318b5063dbdd5567ddde802dbeb2956d50d0eca3e3b993ce"
+    },
+    {
+      "agent": "qa",
+      "skill": "regression-suite",
+      "eval_id": "eval-003-mapped-doc-regression",
+      "comparison_path": "agents/qa/test/regression-suite/evals/workspace/eval-3-mapped-doc-regression/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "4e9403c0e6549024a79156a156c1294488d1a418598e88e3e9565298bc6bae6a",
+        "eval_definition_sha256": "e133160262ed184852d28136da76d373bddc3830b084351e43f62baba3d14a43",
+        "metadata_sha256": "8f1420b83ef9d543d57a760ebba7fc169b9c3d2172e7b3b1e191d47cfe76b856",
+        "fixture_sha256": "b09fa431bfb2ae442891b6d53441773dfe7d31b84ffb9e7738912c1ba9a50a94",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "71370c5d36fa6fdab5180ff34c8ffa193e202b45df9c393bdcd0331a4a95e616"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "71370c5d36fa6fdab5180ff34c8ffa193e202b45df9c393bdcd0331a4a95e616"
+      },
+      "before_sha256": "9992001a52ce4f639a29667e80af947198ea6f9fb1b6744be00add59747159e9",
+      "after_sha256": "35e313a45e20469ec202553e5a89a6cbbf3624fe9f88b1a4735dfe609f8bc6aa"
+    },
+    {
+      "agent": "qa",
+      "skill": "spec-based-tester",
+      "eval_id": "eval-001-test-from-spec",
+      "comparison_path": "agents/qa/test/spec-based-tester/evals/workspace/eval-1-test-from-spec/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "8ceb46669357c2ad2e3984067ae0ce5c97b019da23d3a0f850d2bedd7e38ab17",
+        "eval_definition_sha256": "1c095f56ebf8188b170d450f4a4c64b7797467faefd997d04a5961dc178ee24e",
+        "metadata_sha256": "beabc33b6b3cb3b4fcbdd2cd76be881ee37dbed2c10afbbb6515f52def856618",
+        "fixture_sha256": "a434f6abe187edb75db35d4f3fb8bb622d73bfabcbaa68935c4416b36759d838",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "af6defb3674eb2b870c7db7cceb8e07b1bc81b7056b91617749018c2cf4bddc5"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "5a4fff7cc4ee1eb62cbc3a5e1049e16e04d0351f5f0115b99fe728fc51345814"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "5a4fff7cc4ee1eb62cbc3a5e1049e16e04d0351f5f0115b99fe728fc51345814"
+      },
+      "before_sha256": "b6d7d4a349e90d60566b4e13e58fd84363a06263ec39842f04716f88eff0a67a",
+      "after_sha256": "d3f04da97291b98af06743cb7bb0d05fd4e1381fbfa87040b2f4f95aae9902e3"
+    },
+    {
+      "agent": "qa",
+      "skill": "spec-based-tester",
+      "eval_id": "eval-002-boundary-test-generation",
+      "comparison_path": "agents/qa/test/spec-based-tester/evals/workspace/eval-2-boundary-test-generation/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "8ceb46669357c2ad2e3984067ae0ce5c97b019da23d3a0f850d2bedd7e38ab17",
+        "eval_definition_sha256": "7be9a5847eaa9053c9f4277b2d57d5f5622208652decda6e30f3718fbfec04c5",
+        "metadata_sha256": "9bd3793631be46705766421244d6899c275c646d5598b1a7e8c43c8bec82ad4f",
+        "fixture_sha256": "b4127bff8b3b1c32e35f1a58623703ca5f4eb13030dd5763812f9d858500fda1",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "6d4a307e5ec256ec68d2524f856808da877ec9503f513dcb2032388906c98b67"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "dc08249c08761a6d90b039484d36a7d293c39394515f664c0b6bca5623e3a098"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "dc08249c08761a6d90b039484d36a7d293c39394515f664c0b6bca5623e3a098"
+      },
+      "before_sha256": "43b2234a1c289cfc0afcdb3c70639efaf1d4a91ff6be63d5ad9fe512a4d5a860",
+      "after_sha256": "088c05e2017328bf5061c8951a859eaf63b5c09a97540c8f66bd068ad1236ec9"
+    },
+    {
+      "agent": "qa",
+      "skill": "spec-based-tester",
+      "eval_id": "eval-003-mapped-doc-acceptance",
+      "comparison_path": "agents/qa/test/spec-based-tester/evals/workspace/eval-3-mapped-doc-acceptance/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "8ceb46669357c2ad2e3984067ae0ce5c97b019da23d3a0f850d2bedd7e38ab17",
+        "eval_definition_sha256": "69ea284c249fd48ea67518dcbbbb4aff0b51c724f5aa24139bc9524759db6c7c",
+        "metadata_sha256": "dbcf12ca577304c6eedeb3847e29d69b72d051700655cd6bd5000bc1d6f7a9d9",
+        "fixture_sha256": "bfb7b9881699180197883abe46418a65cf0676dceb7443a1b2ac7db5c3b8ae9b",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "a080f9679b7fd3cb3bbbb000b561ccd95f3725673471a728affaffcb4c93fe84"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "a080f9679b7fd3cb3bbbb000b561ccd95f3725673471a728affaffcb4c93fe84"
+      },
+      "before_sha256": "74e4faec5d016099cde0d846b61f45331666a7071245476782965dd9789a820e",
+      "after_sha256": "0d414c8f393c88f00a354ce65a3cfd2c8d95ceb8a8515a379174d993de325124"
+    },
+    {
+      "agent": "security",
+      "skill": "appsec-checklist",
+      "eval_id": "eval-001-sql-injection",
+      "comparison_path": "agents/security/test/appsec-checklist/evals/workspace/eval-001-sql-injection/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "812b371fc30792cb2b0cf8d96079b3244c95b93efab7638e085d4e955d6ea42c",
+        "eval_definition_sha256": "8fc30622b3de679ebf38da0b0fc7b8032d774fb8a425496383ba9ed0da1fdbb0",
+        "metadata_sha256": "c7304df99ba027e455b94ef86d8c2964c99813b4b7afb5bd532e0bf494b29d15",
+        "fixture_sha256": "ede96965e7d44efbe6d4a7e610af20046168e4331047764663820caf76860ea6",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "01ca86a4951823e3b6c703072ce5be09764c747ae9938b66975b80e4d41e39dd"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "ec94fb25182f119bc11a3791ea64879f13f1f48a87bf101b6c8bb6131a20aa42"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "ec94fb25182f119bc11a3791ea64879f13f1f48a87bf101b6c8bb6131a20aa42"
+      },
+      "before_sha256": "23b3af40f86dabcc92aa540d1210cdfba5adcf9d73f284e6d1dafb57dace642c",
+      "after_sha256": "340ec2613043f9f6d0ebec50a361bfd46305f4346209cde3181ace3e28330411"
+    },
+    {
+      "agent": "security",
+      "skill": "appsec-checklist",
+      "eval_id": "eval-002-auth-bypass",
+      "comparison_path": "agents/security/test/appsec-checklist/evals/workspace/eval-002-auth-bypass/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "812b371fc30792cb2b0cf8d96079b3244c95b93efab7638e085d4e955d6ea42c",
+        "eval_definition_sha256": "6a82fe3c3414aca61cd232161a32adb38bf8c698919832011992c1d84f8965f5",
+        "metadata_sha256": "3fcfb91e83a24f1f8a67c2d9edff9012dc72e220f47b3bfd6102b0d7601836a9",
+        "fixture_sha256": "cc5543f86ff4c8f3552e0e869f4690b7cabc4d7aa6f846231a547e3a3fb6e25c",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "dd30fe689fbcc65952d80f9f7fb0f55e7cc2d55b9002a172d25f15b8b97c4288"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "39068bcd2f4fd1c5da5aea4537e80a1ba4959d2639058d1906661462778fe66c"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "39068bcd2f4fd1c5da5aea4537e80a1ba4959d2639058d1906661462778fe66c"
+      },
+      "before_sha256": "2679f2fcab5b5ad67129931efbbc543c467159daad7545266de67ed4e320fcf8",
+      "after_sha256": "deac8ea0fcf702aa2f38ff680e952e18944597416946b7bc1ff1c85fb8884cd8"
+    },
+    {
+      "agent": "security",
+      "skill": "appsec-checklist",
+      "eval_id": "eval-003-xss",
+      "comparison_path": "agents/security/test/appsec-checklist/evals/workspace/eval-003-xss/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "812b371fc30792cb2b0cf8d96079b3244c95b93efab7638e085d4e955d6ea42c",
+        "eval_definition_sha256": "6b75287b771a74771292ff6a9a4b1d4288f8c6b58ea121782df92af92abb087a",
+        "metadata_sha256": "8b9d5478f14d810cc31c023b6e6a4956d8afc5605aa60470f7733640de6334fb",
+        "fixture_sha256": "746acb9424bcff0e7d1cdbd84db8418dc8fed63831bb1cdba56197295fa9433e",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "dd30fe689fbcc65952d80f9f7fb0f55e7cc2d55b9002a172d25f15b8b97c4288"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "fef261f24f87c637ff82795037171a833ce05b9760e9542b2bd45f5a5e5c9b2a"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "fef261f24f87c637ff82795037171a833ce05b9760e9542b2bd45f5a5e5c9b2a"
+      },
+      "before_sha256": "f77e6928e3b12aaf1ff66365a1c91d5c8f6e673badb55014256c1d7c27ff9a17",
+      "after_sha256": "033d6b9421e8881e060181b354f0a20bb56d3b6e0055d12c07b5a7f1e1da654f"
+    },
+    {
+      "agent": "security",
+      "skill": "appsec-checklist",
+      "eval_id": "eval-004-feature-path-report",
+      "comparison_path": "agents/security/test/appsec-checklist/evals/workspace/eval-004-feature-path-report/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "812b371fc30792cb2b0cf8d96079b3244c95b93efab7638e085d4e955d6ea42c",
+        "eval_definition_sha256": "cea867306caa7c154c38a57a7085c1f3dc292e28eb28f571e99034334c62710c",
+        "metadata_sha256": "8529cb6cbe6ab9523b4f7cf3b65440375e54cbaab5ce6a8376eb7a3bc4427f65",
+        "fixture_sha256": "258d12e924889cdd6b9d64d5ae077ef75e65139845669b9a81854ba9fc13621c",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "a8797f637904fc863710b298fe2fad8220a05aa0d79e70ed8997096bddf38e6c"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "f9fec8fc7592cffa6391eb2e907dcd276bfd750f4379c6a341db45b5b3334aba"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "f9fec8fc7592cffa6391eb2e907dcd276bfd750f4379c6a341db45b5b3334aba"
+      },
+      "before_sha256": "21d126cd22fa09931a5860ff5fb768f82468af4166bb29df38cb0b41871e3651",
+      "after_sha256": "5eaca0144c3bb6c48ca64307f457cf572d8b746f7adada4aae8269f7d39af785"
+    },
+    {
+      "agent": "security",
+      "skill": "appsec-checklist",
+      "eval_id": "eval-005-mapped-search-security",
+      "comparison_path": "agents/security/test/appsec-checklist/evals/workspace/eval-005-mapped-search-security/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "812b371fc30792cb2b0cf8d96079b3244c95b93efab7638e085d4e955d6ea42c",
+        "eval_definition_sha256": "d863b13d3e997477097b1a2de108729923e21619e10b2847114ea312db1c1bc8",
+        "metadata_sha256": "44e3487a1b0a940b7bf23d73f980b7d71bd0be1a4d04a13c48606fd67383de8a",
+        "fixture_sha256": "fc2995d30d3ccba9dfaf0358946382fa2b5ecd4e3e1f4b423d1635f72c325d7d",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "fe1f59786edfa4e3b7ee12601522d693ef12a42cdfce9b4a390ad6d7b95d03d2"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "8f60c64edbefe9182eab6b4bfbdb687778969a05dff0e42ba15fffb1be737778"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "8f60c64edbefe9182eab6b4bfbdb687778969a05dff0e42ba15fffb1be737778"
+      },
+      "before_sha256": "4257de3dfedb1139f276398fdb8c32718d64ecfad16b680028de531d976090f2",
+      "after_sha256": "90f7588138c0155beb491ad6a58fee9e7c05d13458067509fe3b8f422dc364cd"
+    },
+    {
+      "agent": "security",
+      "skill": "authz-reviewer",
+      "eval_id": "eval-001-rbac",
+      "comparison_path": "agents/security/test/authz-reviewer/evals/workspace/eval-001-rbac/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "c5c4e1b3eeeb704a06966dee8397bc4f1df239be6ed5f5799f8d4bd382f23626",
+        "eval_definition_sha256": "235137f94204f51e6c45d33016dc89d9789a6db39caeb6f905a7bece723a5a15",
+        "metadata_sha256": "df9bade135aeb250331ea2ef878f13f4c9a4066b16cd28748dca8a45cce63fa2",
+        "fixture_sha256": "a079595e48d457c66e6bfba203a327a4dd2cee76937828205dc7d5ae1bf6d9ea",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "b9195372d92f3bbea03af4fc8ee3a7b882c68284b96da53cdd8cef5cf57e70e9"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "78a80e10b02b02055c387754b92d0ce33b59ebdcab47991ee544558421d714f1"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "78a80e10b02b02055c387754b92d0ce33b59ebdcab47991ee544558421d714f1"
+      },
+      "before_sha256": "6304ff81c607008553f9c28da380c0fccd3124dfb0eeb2fb4eaf68b18152e755",
+      "after_sha256": "19b3433393f6eec9a504d81c985442a700825c0e9b8273447d1d6399a33799e6"
+    },
+    {
+      "agent": "security",
+      "skill": "authz-reviewer",
+      "eval_id": "eval-002-session",
+      "comparison_path": "agents/security/test/authz-reviewer/evals/workspace/eval-002-session/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "c5c4e1b3eeeb704a06966dee8397bc4f1df239be6ed5f5799f8d4bd382f23626",
+        "eval_definition_sha256": "86d9727a0807549b3bf3936da079aa7238a2b14b16eed4306c9bda4eb6d7be43",
+        "metadata_sha256": "f26166d912f73c7f118a1561bee3e62973123b274975fb4a17a869fba31f82a0",
+        "fixture_sha256": "ef54897bb21af32853256277d12077e05ab3c6d281df76ae5f08944cb67d641a",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "a3c690bb602cdac9c05191ab0581fc35b8fd034dd27825093b3b51de5926404b"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "df186dc8ca63b6b5e8516d7b9a292760bc12e767f4f4255c06cd02533cd5eeb4"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "df186dc8ca63b6b5e8516d7b9a292760bc12e767f4f4255c06cd02533cd5eeb4"
+      },
+      "before_sha256": "cade5bd613c561cac2f5eb4ba03bf80a28395603c8c54a048a3962e52615fbc7",
+      "after_sha256": "89fe829ce8633adea3f6ef0bd16df75d994fe22743e1119b72feb3acf84bee8b"
+    },
+    {
+      "agent": "security",
+      "skill": "authz-reviewer",
+      "eval_id": "eval-003-jwt",
+      "comparison_path": "agents/security/test/authz-reviewer/evals/workspace/eval-003-jwt/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "c5c4e1b3eeeb704a06966dee8397bc4f1df239be6ed5f5799f8d4bd382f23626",
+        "eval_definition_sha256": "8f6e801f8a45c6ec677bbcaa4a56de6b68c935402a27b9f24ca631ffe0af8504",
+        "metadata_sha256": "2db8c4dc18a4712e7dcc4d2c4e3e9c1608e8526019fbff1c3fc3e6ded6f9d1c5",
+        "fixture_sha256": "b22eea37eaa1e0fa82c96957a5790898e68b0e138db6319e88a5574aee2cf1f4",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "a3c690bb602cdac9c05191ab0581fc35b8fd034dd27825093b3b51de5926404b"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "e38a7404d3d58e5735d4e324479053eb8aedfa2ec839013967b445b07402ba18"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "e38a7404d3d58e5735d4e324479053eb8aedfa2ec839013967b445b07402ba18"
+      },
+      "before_sha256": "2196fe4ac26fb51af28899bdf092b3b7da9ea5d67d392c70f3fc57a0cb034664",
+      "after_sha256": "1af2a29a0a22b4985e56e196407e94db3aed11362d7600c56f02f2afacbe60de"
+    },
+    {
+      "agent": "security",
+      "skill": "authz-reviewer",
+      "eval_id": "eval-004-mapped-report-export-authz",
+      "comparison_path": "agents/security/test/authz-reviewer/evals/workspace/eval-004-mapped-report-export-authz/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "c5c4e1b3eeeb704a06966dee8397bc4f1df239be6ed5f5799f8d4bd382f23626",
+        "eval_definition_sha256": "8fb5f1e36d08ae5ad3c1dfb46758101e4ce1413f28a63b591aee885fb67bbefb",
+        "metadata_sha256": "04460ae4a10b7b6f92dfdd6cb899ffd1f5dfbcb4fb34b6242a7bc18e450e6ddd",
+        "fixture_sha256": "6b2ecd7bb8b1ef79f098d4d11a3ca4f93d8ab0f7969ef301d999bac9f594dbd1",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "fe1f59786edfa4e3b7ee12601522d693ef12a42cdfce9b4a390ad6d7b95d03d2"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "a53ae00751f8e226ec50aa134d63a57afd487f85af86facd95232b9c4b6af23d"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "a53ae00751f8e226ec50aa134d63a57afd487f85af86facd95232b9c4b6af23d"
+      },
+      "before_sha256": "78b79053a14badb8b1e025f876fcd297066946fbb41ae42c9144fdebcabad423",
+      "after_sha256": "aa0abde61a36798961246988d55ea06e1889281ef7f9dc5d446397691a1517cb"
+    },
+    {
+      "agent": "security",
+      "skill": "dependency-risk-auditor",
+      "eval_id": "eval-001-npm-audit",
+      "comparison_path": "agents/security/test/dependency-risk-auditor/evals/workspace/eval-001-npm-audit/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "0f253c18407bc188d3558e673dc587116dcb519a01d7ef15849f9e98e350e1c1",
+        "eval_definition_sha256": "971feaa0f85d14f75fe45df2640551915965f181de289e0a977efb57d2391e3e",
+        "metadata_sha256": "aee94fbc4f1b4c53f14bd2d88b010307b382e89dd9cc2398f8a45f7d41146704",
+        "fixture_sha256": "5d978f8d24e5dad96aba91cd89101e33e9f1a0bda647abfca6c8a768de860caa",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "07345508cc5d326f024163cc8715111c4efeeb1bd80f16886d65b16eb2ef9292"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "adb03f361761d7913f7611e84e3e50727043bb0c8fde60645015a16b8419baba"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "adb03f361761d7913f7611e84e3e50727043bb0c8fde60645015a16b8419baba"
+      },
+      "before_sha256": "b91b68bd140de96344f6479a998dd597797f74f85db7d4b97fc25314e7569fba",
+      "after_sha256": "81fa813c8496d986590b80ca67cc02a176c44bafc57405b601aa1d69b1c77966"
+    },
+    {
+      "agent": "security",
+      "skill": "dependency-risk-auditor",
+      "eval_id": "eval-002-abandoned",
+      "comparison_path": "agents/security/test/dependency-risk-auditor/evals/workspace/eval-002-abandoned/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "0f253c18407bc188d3558e673dc587116dcb519a01d7ef15849f9e98e350e1c1",
+        "eval_definition_sha256": "88dd9b929d53963534f872d5c6b43117be6b35cb41fa6b99bd7d05175018ade8",
+        "metadata_sha256": "6e01d4daa6b468e7c7a0ddfd1d17ad1116a727bf8d6709ea8ad0e5baec7fce48",
+        "fixture_sha256": "4ef6c6ec20f409ae50ba76d9496bdabb654cdb81289a7a2eacee1dc6b802832f",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "07345508cc5d326f024163cc8715111c4efeeb1bd80f16886d65b16eb2ef9292"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "0b4669fd053aaa0494b315bd20ddfcb4504a8e7b61ca3d7661bc47b2aa981092"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "0b4669fd053aaa0494b315bd20ddfcb4504a8e7b61ca3d7661bc47b2aa981092"
+      },
+      "before_sha256": "75d35c7f3a90da03737ca504ad4f98931bd3b93fb1da067e03d5559bc750e013",
+      "after_sha256": "ffdadbd44c2a35fc0aaa8d8e3aa5c3a9e9e9d3e83e15412b67c6089394b836a7"
+    },
+    {
+      "agent": "security",
+      "skill": "dependency-risk-auditor",
+      "eval_id": "eval-003-python",
+      "comparison_path": "agents/security/test/dependency-risk-auditor/evals/workspace/eval-003-python/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "0f253c18407bc188d3558e673dc587116dcb519a01d7ef15849f9e98e350e1c1",
+        "eval_definition_sha256": "b851960b1dd4c6ab11f9c42f685034d6bd0e27ae3c26e4256af19942329ed614",
+        "metadata_sha256": "86d72efa91ee3890167dbac2135eac8aaff379e02491ea01e89a3595936d759c",
+        "fixture_sha256": "8307ea1325de4c132e54824c9dd507ed174ce29fe901e9f04e5a56bc654490e3",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "07345508cc5d326f024163cc8715111c4efeeb1bd80f16886d65b16eb2ef9292"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "e6d76cfc588c12c274b4fd89409e00fe950b2bef49c9048449cf2c985778f663"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "e6d76cfc588c12c274b4fd89409e00fe950b2bef49c9048449cf2c985778f663"
+      },
+      "before_sha256": "251665a17905676cb0a98e010fa43d8b298e7a511b2bf77ac468763992e435c0",
+      "after_sha256": "34e1dcb82e4eccfd1badd223b3de594b4d78c9b0d8e8a1c3c18977face6fcbf1"
+    },
+    {
+      "agent": "security",
+      "skill": "dependency-risk-auditor",
+      "eval_id": "eval-004-mapped-client-dependency",
+      "comparison_path": "agents/security/test/dependency-risk-auditor/evals/workspace/eval-004-mapped-client-dependency/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "0f253c18407bc188d3558e673dc587116dcb519a01d7ef15849f9e98e350e1c1",
+        "eval_definition_sha256": "8b3afd523591d93b0ae2bfbea1c5709666ee81c09a14160679da5b53064efb14",
+        "metadata_sha256": "72846a754080f41b7de9981348b71040115d4704d0a16f2aad7aa4b526a44443",
+        "fixture_sha256": "9287a8fa578b5447f010eec525225500d555d9e2f5c2758277bcae9488425fa5",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "fe1f59786edfa4e3b7ee12601522d693ef12a42cdfce9b4a390ad6d7b95d03d2"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "bc08170d65597596613318b5d2c57c75fe822e317bc2eb3fa434be215c93be54"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "bc08170d65597596613318b5d2c57c75fe822e317bc2eb3fa434be215c93be54"
+      },
+      "before_sha256": "8cb6375d5d53853f99f8d486d41404b7c7208ed24393c17b5524f40912dbf3cd",
+      "after_sha256": "b880e3d9297b001828f08aa2f239c02c7849addb1cd2b1c98f801596a0e7b8cc"
+    },
+    {
+      "agent": "security",
+      "skill": "privacy-surface-mapper",
+      "eval_id": "eval-001-gdpr",
+      "comparison_path": "agents/security/test/privacy-surface-mapper/evals/workspace/eval-001-gdpr/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "25bd4dbed66f3625883b2a2072dcd568eef569278521e1eac012e86f61347836",
+        "eval_definition_sha256": "3e00fd5f68469b1dbad14f0a400fd8e41079d5a8aa0df077168fd2333bd41a39",
+        "metadata_sha256": "93577771a8ef98b760a14a69ae743909ae6d46791d7ed929dd703a6fc9855b54",
+        "fixture_sha256": "fc7c85721e9b7bd81a9ba3e487c8f00f57880deb91ce00e1ae1258884cc231db",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "46c6f10cb2ee094e0f2d9b8cf0d9d794ebc801a301eb97187a76e961b4e37fd0"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "830badecd99fbd014a7089269cf545bb880e0194deeac973461d0e34ff064a01"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "830badecd99fbd014a7089269cf545bb880e0194deeac973461d0e34ff064a01"
+      },
+      "before_sha256": "eeeca2c5bcc9eb38654d37db134c3f6ded94dc7c4b07c64b7ddf1482adab8435",
+      "after_sha256": "d59787c4e9284674999192607f7b58f10fb5c71c411920be27052572aef0e0fa"
+    },
+    {
+      "agent": "security",
+      "skill": "privacy-surface-mapper",
+      "eval_id": "eval-002-user-rights",
+      "comparison_path": "agents/security/test/privacy-surface-mapper/evals/workspace/eval-002-user-rights/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "25bd4dbed66f3625883b2a2072dcd568eef569278521e1eac012e86f61347836",
+        "eval_definition_sha256": "ba5034d1b895bcb95cc9d848045b869189eec2c98d23c0a5d5ce381059a73047",
+        "metadata_sha256": "b655e3698222cf189fb740616c1df41fb5ccc3d4bf71526ca29a7ecf05ef368a",
+        "fixture_sha256": "2a160ab6ab1065aa7d10a9502c97feefe12d13d5af072b1075181fbf932723d8",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "46c6f10cb2ee094e0f2d9b8cf0d9d794ebc801a301eb97187a76e961b4e37fd0"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "c0c7aabc3a5ef480854fb8344d86d30a42368c101f9472d1df12b1740113f787"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "c0c7aabc3a5ef480854fb8344d86d30a42368c101f9472d1df12b1740113f787"
+      },
+      "before_sha256": "d7a5dad2bbf27434bd55c4d2a1c3f81b407a2df5ed78879fb633209d21392f9c",
+      "after_sha256": "b992dc37af8478224ab253ee2cec82551effe445707c3433f5e510c9b0877cdb"
+    },
+    {
+      "agent": "security",
+      "skill": "privacy-surface-mapper",
+      "eval_id": "eval-003-third-party",
+      "comparison_path": "agents/security/test/privacy-surface-mapper/evals/workspace/eval-003-third-party/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "25bd4dbed66f3625883b2a2072dcd568eef569278521e1eac012e86f61347836",
+        "eval_definition_sha256": "fde37322a972618cf8b85d5463c8e7a856c7547f8c15123669fd15297f556852",
+        "metadata_sha256": "1b358949b025cd13ff498cda0a21978c243d4781824a1ceab1947fe97db21069",
+        "fixture_sha256": "a0f9b5ed56aa92319d126897928b2da5ef1b5b085fbe003f0b4425dde5805c73",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "46c6f10cb2ee094e0f2d9b8cf0d9d794ebc801a301eb97187a76e961b4e37fd0"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "8baee0dbc0ce3e484f700b4a38ae80d2ecd77136619efce4685242cf62272b2a"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "b26c7f085ad8e7483ebec9e732c8703c2b7137945072d5ebf2a708033a6bef24",
+        "overall": "8e6414098be9205eb7cf5c8164c1ff70e30acb6fde66ad43b0e4ee90762021e9",
+        "assertions": "8baee0dbc0ce3e484f700b4a38ae80d2ecd77136619efce4685242cf62272b2a"
+      },
+      "before_sha256": "e9ea28ea597022a741de99f0bfdc35d1ba0109ae5a3d5c34e03671460bcb1340",
+      "after_sha256": "e95dcdf5fe38a4e52ab0ef4a5e686153a4f48f4c0383535ae55831f1d0bb8068"
+    },
+    {
+      "agent": "security",
+      "skill": "privacy-surface-mapper",
+      "eval_id": "eval-004-mapped-profile-retention",
+      "comparison_path": "agents/security/test/privacy-surface-mapper/evals/workspace/eval-004-mapped-profile-retention/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "25bd4dbed66f3625883b2a2072dcd568eef569278521e1eac012e86f61347836",
+        "eval_definition_sha256": "4636a9753113bcd43710d7f9510814811413ce11cdc5e68daebdc570220f08a9",
+        "metadata_sha256": "9a8afbbbec758d7a8301647fd089cbe8695096269334ba062d91dd1eead9320a",
+        "fixture_sha256": "770d05d85a5304099a8f9433d2be942409c59c2f8ece13f985350673cd6e1b76",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "fe1f59786edfa4e3b7ee12601522d693ef12a42cdfce9b4a390ad6d7b95d03d2"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "76558b5641eb11c4bd998fa8e5530239babba57c3e44766e5a91de1732334200"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "76558b5641eb11c4bd998fa8e5530239babba57c3e44766e5a91de1732334200"
+      },
+      "before_sha256": "1a7771fe19a66d204279146921802e2fcb3856e513769bb34fa28aeb231f479f",
+      "after_sha256": "4b501dc9e5941d919050be3b963f5c3e4e84df4ffb0acb063a841b4a49544192"
+    },
+    {
+      "agent": "security",
+      "skill": "security-agent",
+      "eval_id": "eval-001-route-auth-release-risk",
+      "comparison_path": "agents/security/test/security-agent/evals/workspace/eval-1-route-auth-release-risk/comparison.md",
+      "inventory_match_count": 1,
+      "classification": "mechanical",
+      "reason_codes": [
+        "identity_v2_protocol_finalized"
+      ],
+      "legacy_executor_sha256": null,
+      "legacy_runtime_sha256": null,
+      "identity_v2": {
+        "target_skill_sha256": "f9c706626daa220552f758703ae64d133ee8d82358801e24309850f00386ef65",
+        "eval_definition_sha256": "86d9cf5b5d192be02693890eee51825a1b00e0750fd5f2d88fdcc91b3fe08ad7",
+        "metadata_sha256": "10861a3430f4e9df517502c7dede98b52c06228662db21b0d8914dd6b558a77c",
+        "fixture_sha256": "6becbc324dd17ee4f5ba7cdf2d867ad58ae183800d34e6d3eb510323380d49a0",
+        "execution_protocol_sha256": "200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede",
+        "runtime_protocol_sha256": "c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb",
+        "judge_schema_sha256": "d09f4cbeb933e811c934cf8e665fe7675560abe0fc34d7865e0c67a56b1f4b12"
+      },
+      "preserved_raw_sha256_before": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "01c0ae0defe57767d87a41945268f33002ea20ede38d74f18189b4f9538d9922"
+      },
+      "preserved_raw_sha256_after": {
+        "behavior": "a5ed481b4479960b6236aedbec0a97e516a231cbeb6aa268debe351251fae847",
+        "coverage": "04c8a45c7fe5ed62bda504656b2779a5b9e1dbc1dacffcb61e421cedbae661b2",
+        "overall": "f57ee754bef32ae17e33aeec46141d9d5b071037b9d8e67c93847efdc48e905f",
+        "assertions": "01c0ae0defe57767d87a41945268f33002ea20ede38d74f18189b4f9538d9922"
+      },
+      "before_sha256": "7a7ccf4ec154a7b272fafd2c7791ef0ded2752279aba9552144179e23f289291",
+      "after_sha256": "94e952b018bc534d8d98ab7be842b46427f270e200a80e2cc70e3cc419242ac3"
+    }
+  ]
+}

--- a/docs/pm/repository-governance/eval-scenario-isolation/DECISIONS.md
+++ b/docs/pm/repository-governance/eval-scenario-isolation/DECISIONS.md
@@ -1,7 +1,7 @@
 ---
 title: "Eval 真实场景与 Lane 隔离重构决策记录"
 type: DECISIONS
-version: "1.1.0"
+version: "1.3.0"
 status: Approved
 author: "Neplich Codex"
 date: "2026-08-07"
@@ -14,9 +14,16 @@ feature_level: "2"
 related_issue:
   - "https://github.com/Neplich/dev-agent-skills/issues/246"
   - "https://github.com/Neplich/dev-agent-skills/issues/275"
+  - "https://github.com/Neplich/dev-agent-skills/issues/277"
 related_docs:
   - "docs/pm/repository-governance/eval-scenario-isolation/PRD.md"
 changelog:
+  - version: "1.3.0"
+    date: "2026-08-12"
+    changes: "确认 identity schema v2 七字段、协议模块边界与 196 份常规 comparison 的一次性单轨迁移"
+  - version: "1.2.0"
+    date: "2026-08-12"
+    changes: "确认冻结后 eval 不登记迁移清单，并区分 trd-gen eval-006 的断言缺陷与 skill 执行缺陷"
   - version: "1.1.0"
     date: "2026-08-12"
     changes: "分离辅助 skill 的运行锁定证据与 comparison 历史重跑判定"
@@ -47,6 +54,16 @@ changelog:
 | D-014 | `manual-gen` 不进入本次常规 paired eval 重构。 | 它依赖真实登录环境、运行界面、源码和用户反馈，已由 manual-only 契约单独治理。 |
 | D-015 | 本 issue 不修改目标 skill 的业务协议，也不引入无关抽象或功能。 | 本轮只修复 eval 的用户代表性、lane 隔离与证据可信度；业务协议缺陷应另行分类。 |
 | D-016 | Eval 只对所属目标 skill 的设计结论负责；辅助 skill 的完整内容继续参与当次运行锁定和证据记录，但其后续内容变化不连带使其他目标 skill 的 comparison 失效。 | `skill_dependencies` 用于构建可信运行环境，不等同于跨 skill 回归依赖图；跨 skill 协作应由有明确归属的集成 eval 覆盖。 |
+| D-017 | `migration-inventory.json` 永久保持 Issue #246 冻结的 193 条历史迁移记录；冻结后新增 eval 不登记到该清单。 | 迁移清单用于证明旧基线的逐条去向，不是常规 eval 注册表；扩充清单会破坏冻结 commit、计数和 schema 语义。 |
+| D-018 | Durable writer 对 retained identity 使用三态规则：零匹配只写 comparison，唯一匹配同步更新 inventory，多匹配拒绝持久化。 | 新增 eval 必须能生成 fresh 证据，历史迁移记录仍需保持事务一致，多匹配代表不可接受的清单歧义。 |
+| D-019 | `trd-gen` eval-006 是混合缺陷：允许完成 TRD 后在交付摘要中提示合法的 `feature-implementor` 下一阶段，但不得转交本轮 TRD 更新职责；正文归一化和 frontmatter changelog 断言保持不变，并强化 skill 交付前自检。 | 原“不得把任务路由给别人”断言误伤了 `trd-gen` 的强制 handoff 契约；旧方案状态标注和正文 changelog 则确实违反现行 current-state 文档规则，不能通过弱化断言掩盖。 |
+| D-020 | 静态 eval checker 对所有当前常规 eval 使用同一严格输入契约，不再以是否存在 complete migration identity 决定校验强度。 | 冻结后新增 eval 也必须满足 scenario、自然 prompt、metadata、依赖、runtime isolation 和 fixture 规则；历史迁移身份不能成为质量降级开关。 |
+| D-021 | Durable comparison identity schema v2 的跨版本 freshness 只包含七字段：`target_skill_sha256`、`eval_definition_sha256`、`metadata_sha256`、`fixture_sha256`、`execution_protocol_sha256`、`runtime_protocol_sha256`、`judge_schema_sha256`。 | 这七项覆盖目标 skill、eval 自身输入、执行/判定协议和隔离协议；persistence、inventory 与报告格式变化不应连锁作废行为证据。 |
+| D-022 | 模块边界固定为 execution/judging、runtime/isolation、persistence/inventory；identity helper 单独计算七字段，`run_skill_eval.py` 只保留薄 CLI 与 orchestration。 | 协议 hash 必须来自清晰文件边界，不能用函数过滤或启发式排除推断哪些源码影响行为。 |
+| D-023 | 完整 runner、identity、execution、judging、runtime、persistence、inventory 和报告格式源码 manifest 只用于同轮 source-drift lock；持久化前任一 bytes 变化均 `BLOCKED`。 | 跨版本 freshness 与同轮输入稳定是不同安全属性；后者不能因 persistence 不参与历史 identity 而放松。 |
+| D-024 | V1 到 v2 只执行一次迁移；迁移前可以核验旧 Executor hash 的可信 Git 来源并把实际 hash/source commit 写入 audit JSON，但正常 writer/checker 不调用 Git、不硬编码旧 hash。迁移后 checker 只接受 v2。 | 永久兼容桥会形成双轨并把历史实现细节带入正常检查；来源核验属于一次性迁移证据。 |
+| D-025 | 196 份常规 comparison 分为 187 份机械迁移、6 份 `trd-gen` 保持 stale、3 份 PM scope-guard 保持 PENDING；1 份 manual-only 原样不迁移。187 份的 verdict/evidence 逐字保持。 | 审计分布为 127 PASS/FULL、46 PASS/PARTIAL、12 FAIL/FULL、2 FAIL/PARTIAL；807 assertions 为 717 PASS、70 NOT_EXERCISED、20 FAIL。`trd-gen` 输入已变化，不能继承 FRESH；PM 三条尚无 fresh 证据。 |
+| D-026 | #277 的模型回归范围为 `trd-gen` 全部 6 条加 PM eval-017/018/019，共 9 条；模型调用仍未授权。 | 文档与确定性实现授权不等同于模型成本授权；9 条必须在计划再次确认并单独授权后运行。 |
 
 ## 假设与约束
 
@@ -56,6 +73,8 @@ changelog:
 | A-002 | 保留、合并或删除是允许的迁移结论，最终 eval 数量不预设。 | 合并或删除必须记录理由、替代覆盖和对应 durable 证据。 |
 | A-003 | 指定模型和隔离运行环境可用于 fresh paired eval 与独立 judge。 | 能力不可用时标记 `BLOCKED` 并保留 stale 状态，不静默替换模型或复用历史结果。 |
 | A-004 | 宿主原生 README 或证据文件可能是合法 fixture。 | 仅在其描述真实产品或仓库事实且不承载评分答案时保留，并由正反测试防止静态检查误报。 |
+| A-005 | Issue #277 的三个 PM scope-guard eval 是冻结后新增资产。 | 它们按零匹配语义生成 fresh comparison，不改写 Issue #246 的 193 条 inventory。 |
+| A-006 | 一次性 migration audit 能定位旧 Executor hash 的可信 Git source commit。 | 无法验证来源的 comparison 不机械迁移为 FRESH，改为 stale 等待重跑。 |
 
 ## 已排除方案
 
@@ -67,6 +86,8 @@ changelog:
 | R-004 | 仅靠 prompt 告知 candidate 不要读取脚手架。 | Candidate 仍能访问文件、父上下文或源仓库，无法证明没有泄漏。 |
 | R-005 | 复用历史 baseline 或 comparison 以降低批量执行成本。 | 不同场景、fixture 或隔离条件下的结果不是同轮有效对照。 |
 | R-006 | 把所有旧 comparison 删除后再迁移。 | 会丢失历史结论和迁移追溯；stale 标记可以保留历史且阻止误用。 |
+| R-007 | 用源码结构过滤、函数排除表或完整 runner hash 作为跨版本行为身份。 | 前两者依赖启发式边界，后者继续让 persistence/report 机械变化批量作废证据；显式协议模块更直接。 |
+| R-008 | 在正常 checker 中保留 Git 历史查询或 v1/v2 双轨。 | 增加长期复杂度且让迁移永不结束；可信来源核验只属于一次性 migration audit。 |
 
 ## 待确认问题
 

--- a/docs/pm/repository-governance/eval-scenario-isolation/PRD.md
+++ b/docs/pm/repository-governance/eval-scenario-isolation/PRD.md
@@ -1,7 +1,7 @@
 ---
 title: "Eval 真实场景与 Lane 隔离重构 PRD"
 type: PRD
-version: "1.2.0"
+version: "1.4.0"
 status: Approved
 author: "Neplich Codex"
 date: "2026-08-07"
@@ -15,11 +15,18 @@ child_features: "N/A"
 related_issue:
   - "https://github.com/Neplich/dev-agent-skills/issues/246"
   - "https://github.com/Neplich/dev-agent-skills/issues/275"
+  - "https://github.com/Neplich/dev-agent-skills/issues/277"
 related_docs:
   - "docs/pm/repository-governance/eval-scenario-isolation/DECISIONS.md"
   - "docs/pm/repository-governance/eval-baseline-evidence-contract/PRD.md"
   - "docs/pm/repository-governance/eval-comparison-coverage/PRD.md"
 changelog:
+  - version: "1.4.0"
+    date: "2026-08-12"
+    changes: "定义 comparison identity schema v2、协议模块边界与 196 份常规 comparison 的一次性单轨迁移"
+  - version: "1.3.0"
+    date: "2026-08-12"
+    changes: "明确冻结迁移清单与后续新增 eval 解耦，并确认 trd-gen eval-006 同时包含断言缺陷和 skill 执行缺陷"
   - version: "1.2.0"
     date: "2026-08-12"
     changes: "明确 eval 只随目标 skill 与自身评测输入失效，辅助 skill 仅作为运行环境与当次证据"
@@ -56,6 +63,7 @@ changelog:
 | Lane 隔离 | 各角色自行处理，无法统一证明相同初始状态和唯一变量。 | 两条 lane 从同一 canonical fixture 物化到独立 scratch 目录和独立 Git 根，并完成统一 preflight。 |
 | 结果证据 | 旧 comparison 可能基于过时场景、旧 baseline 或不完整隔离。 | 每个保留 eval 都有 fresh paired 输出、独立 judge 结论和按新标准更新的 comparison。 |
 | 重跑范围 | 辅助 skill 的任意内容变化会连带使依赖它的 eval 失效。 | eval 只随目标 skill 或自身评测输入变化而失效；辅助 skill 内容变化不建立跨 skill 重跑关系。 |
+| 协议 freshness | 完整 runner、persistence 和报告格式源码变化会连带使全部历史 comparison stale。 | 跨版本只比较 execution、runtime、judge 与四项 eval 输入组成的 schema v2；所有源码 manifest 仅用于同轮 drift。 |
 
 ## 2. 目标与非目标
 
@@ -70,6 +78,8 @@ changelog:
 7. 批量入口最多使用 10 个跨角色 worker 并行处理不同 eval；每条 eval 内仍严格按 `without_skill → with_skill → judge` 顺序执行。
 8. 对 fresh FAIL 先聚类定位共享根因，修复 skill、fixture 或 assertions 的真实缺陷后再运行正式 eval；不得用弱化断言或伪造 fixture 制造 PASS。
 9. 将辅助 skill 限定为运行环境依赖：完整记录并锁定当次执行内容，但不因其后续内容变化连带使其他目标 skill 的 comparison 失效。
+10. 保持 Issue #246 的 193 条迁移清单为不可扩充的历史基线；冻结后新增 eval 独立接受完整静态契约与 fresh paired 执行，不依赖迁移清单登记才能持久化结果。
+11. 将 durable comparison 的跨版本身份固定为 schema v2 七字段，并把 execution/judging、runtime/isolation、persistence/inventory 分离；所有参与执行的源码 manifest 仍在同轮锁定，任何漂移均阻塞。
 
 ### 2.2 非目标
 
@@ -97,6 +107,8 @@ changelog:
 | US-003 | 作为 runner 维护者，我希望两条 lane 只有目标 skill 可见性不同，以便结果差异能归因于目标 skill。 | P0 | 两条 lane 使用逐字相同消息和内容 hash 一致的 fixture；目录、Git 根和运行时隔离可证明；`without_skill` 无法读取目标 skill 或另一条 lane。 |
 | US-004 | 作为审查者，我希望每条旧 eval 都有迁移去向且每个保留 eval 都有 fresh 证据，以便完整判断 193 条审计基线是否处理完。 | P0 | 迁移记录覆盖 193/193；每个保留 eval 都有本轮 fresh baseline、with-skill 输出、独立 judge 结论和更新后的 comparison。 |
 | US-005 | 作为 release 审查者，我希望旧结论在迁移期间明确失效，以免过时 comparison 被用作当前 release 依据。 | P0 | 未按新标准重跑的 comparison 被标记为 stale 或等效阻塞状态；静态检查、隔离测试和 artifact 检查全部通过后才可恢复为当前证据。 |
+| US-006 | 作为 eval 维护者，我希望迁移完成后新增的 eval 可以直接接受当前契约校验和 fresh 执行，以免历史迁移清单成为永久登记表或运行阻塞。 | P0 | 冻结后的 eval 不写入 193 条迁移清单；runner 在清单零匹配时仍可持久化 comparison，所有当前 eval 均接受严格 schema、scenario、metadata 和 fixture 校验。 |
+| US-007 | 作为评测审查者，我希望持久化、inventory 或报告格式调整不会批量作废历史证据，同时 execution、runtime 或 judge 协议变化仍会使 comparison stale。 | P0 | Schema v2 只使用七个明确身份字段；全部执行源码 manifest 在同轮开始与持久化前一致，否则 `BLOCKED`。 |
 
 ## 5. 功能需求
 
@@ -112,6 +124,9 @@ changelog:
 | FR-008 | Runner 泄漏修复 | 修复 QA runner 已知的 lane、metadata、expected output 和源仓库根泄漏，并审计其余专用 runner 的同类风险。 | P0 | QA runner 不再向 candidate 发送评测编排信息，也不从源仓库根启动 baseline；所有专用 runner 都有审计结论，发现的问题在迁移完成前修复并有回归测试。 |
 | FR-009 | Fresh 结果与治理检查 | 每轮重新生成 baseline，锁定两条输出后由独立 judge 判定，并更新 durable comparison；comparison 只随目标 skill、评测定义、metadata、fixture、judge 或 runner/runtime 输入变化而失效，辅助 skill 内容变化仅保留为当次执行证据；所有 runtime root、candidate 输出、snapshot、judge package/verdict、transcript、timing 和 diagnostics 在 runner 退出前删除。 | P0 | 每个保留 eval 的 comparison 记录本轮来源、完整 skill 环境、preflight、两条 lane、judge、Behavior/Coverage 与 Overall result；修改辅助 skill 内容不会连带使其他目标 skill 的 comparison 失效，修改依赖清单或目标 skill 仍会失效；成功、FAIL、BLOCKED 和异常路径均只留下 durable comparison；仓库、eval、artifact、doc contract 及相关确定性测试通过。 |
 | FR-010 | FAIL 聚类与并发重跑 | 首轮 fresh FAIL 按共享路径、路由/门禁、证据核验、产物完整性和 fixture 可执行性聚类；全部已确认根因整改完成后，统一入口以最多 10 个 worker 跨角色运行。 | P0 | 每个整改可追溯到 fresh assertion evidence；批量测试证明并发上限为 10、共享 inventory 写入安全、单 eval paired 顺序不变；最终不存在未解释的 FAIL/BLOCKED。 |
+| FR-011 | 冻结后 Eval 生命周期 | `migration-inventory.json` 只记录 Issue #246 冻结的 193 条旧 eval，不作为后续 eval 注册表；runner 持久化时按 retained identity 的匹配数量决定是否更新清单。 | P0 | 零匹配时只事务写入当前 comparison 且清单逐字不变；唯一匹配时同步更新 comparison 与迁移状态；多于一个匹配时拒绝持久化并报告契约错误。静态 checker 对所有当前常规 eval 执行同一严格输入契约，不因缺少迁移记录而降级。 |
+| FR-012 | Identity Schema v2 | 跨版本 freshness 精确使用 `target_skill_sha256`、`eval_definition_sha256`、`metadata_sha256`、`fixture_sha256`、`execution_protocol_sha256`、`runtime_protocol_sha256`、`judge_schema_sha256`。 | P0 | 新 writer 只写七字段；迁移后 checker 只接受 v2，不调用 Git、不保留 v1/v2 双轨。完整 runner、persistence、inventory、报告格式及其他执行源码 manifest 只用于同轮 source-drift，任一变化均 `BLOCKED`。 |
+| FR-013 | 一次性 V2 迁移 | 迁移器先核验旧 Executor 来源与当前真实输入，再把 196 份常规 comparison 收敛为单轨 v2；冻结 inventory 不参与迁移。 | P0 | 187 份 FRESH 机械迁移并逐字保持 verdict/evidence，分布为 127 PASS/FULL、46 PASS/PARTIAL、12 FAIL/FULL、2 FAIL/PARTIAL；807 assertions 保持 717 PASS、70 NOT_EXERCISED、20 FAIL。trd-gen 6 份保持 stale 待 fresh，PM 3 份保持 PENDING 待首次 fresh；1 份 manual-only 原样不迁移。迁移报告记录实际旧 hash、source commit、分类和逐字保持校验。 |
 
 ## 6. 非功能需求
 
@@ -162,7 +177,7 @@ flowchart TD
 
 | 对象 | 关键字段 | 关系与约束 |
 | --- | --- | --- |
-| 迁移记录 | old_eval_id、role、skill、disposition、new_eval_id、reason | 每条旧 eval 恰有一条处理结论。 |
+| 迁移记录 | old_eval_id、role、skill、disposition、new_eval_id、reason | 每条 Issue #246 冻结旧 eval 恰有一条处理结论；冻结后新增 eval 不进入该对象。 |
 | 真实场景 | persona、situation、trigger、goal、materials、constraints、success | 每个保留 eval 恰有一个场景定义。 |
 | Eval 定义 | id、prompt、expected_output、assertions、workspace | Prompt 不承载 expected output 或 assertions。 |
 | Canonical fixture | source_root、manifest、content_hash | 是两条 candidate lane 的唯一 fixture 来源。 |
@@ -170,6 +185,8 @@ flowchart TD
 | Preflight 结果 | fixture_match、excluded_files、skill_visibility、runtime_reset、judge_context | 任一必填项失败或未知即阻塞。 |
 | Judge 结论 | assertions、raw_evidence、behavior_result、coverage_result、overall_result | 在两条输出锁定后由第三个上下文生成。 |
 | Durable comparison | source_revision、preflight_summary、lane_summary、judge_summary、latest_result | 只记录可长期复核的结论，不承载 runtime artifact。 |
+| Comparison identity v2 | 七个 `*_sha256` 字段 | 四项 eval 输入与 execution/runtime/judge 三项协议共同决定跨版本 freshness。 |
+| 同轮源码锁 | 完整源码 manifest | 覆盖 CLI、identity、execution、judging、runtime、persistence、inventory、report format；只验证本轮无漂移，不进入历史 freshness。 |
 
 ## 10. 接口触点
 
@@ -181,12 +198,17 @@ flowchart TD
 | 统一 scratch materializer / preflight | 物化 lane 并验证隔离。 | 所有角色复用同一隔离语义，不各自复制不一致逻辑。 |
 | QA 与其他专用 runner | 执行角色特有 eval。 | 只接收 canonical fixture 和自然用户消息，不泄露评测信息。 |
 | Repository / eval / artifact / doc checkers | 校验结构、泄漏、产物和文档契约。 | 对已知违规稳定失败，对合法宿主事实不误报。 |
+| `migration-inventory.json` / durable writer | 保存历史迁移状态并事务持久化最新结果。 | 清单固定为 193 条；冻结后 eval 零匹配时仅写 comparison，唯一匹配才更新清单，多匹配阻塞。 |
+| Identity writer / checker | 写入并验证 schema v2 七字段。 | 迁移后 checker 只接受 v2；正常检查不读取 Git 历史。 |
+| 一次性 migration audit | 核验旧来源并记录 196 份分类。 | 可记录实际 hash 与 source commit，但这些值不硬编码进正常 writer/checker。 |
 
 ## 11. 假设与约束
 
 | 类型 | 描述 | 如果不成立的影响 |
 | --- | --- | --- |
-| 已知事实 | 审计基线为 38 个常规 skill、193 条 eval。 | 先记录仓库漂移并更新迁移清单基线，不得静默遗漏。 |
+| 已知事实 | Issue #246 的审计基线为 38 个常规 skill、193 条 eval。 | 后续仓库增减单独按当前 eval 契约处理，不改写冻结迁移清单。 |
+| 约束 | 193 条迁移清单是 Issue #246 的冻结历史账本，不是后续 eval 注册表。 | 新增 eval 不改变 schema 1.0、冻结计数或历史 counts；runner 和 checker 必须独立支持其严格校验与 fresh 结果。 |
+| 约束 | Schema v2 迁移是一次性切换。 | 迁移失败不部分写；成功后正常 checker 不提供 v1 兼容或 Git 历史回退。 |
 | 约束 | `manual-gen` 是唯一 manual-only 例外，不进入本次 paired eval。 | 不得用本次机制伪造其真实环境证据。 |
 | 约束 | Candidate 与 judge 使用的模型和 reasoning effort 遵循现行 eval 执行契约。 | 指定模型不可用时本轮 `BLOCKED`，不得静默替换。 |
 | 约束 | 两条 lane 的唯一变量是目标 skill 是否加载。 | 存在其他差异时，本轮输出不得作为比较证据。 |
@@ -195,7 +217,7 @@ flowchart TD
 
 ## 12. 依赖
 
-- Issue #246、#238 和 #234 提供审计范围与前置结论。
+- Issue #246、#238 和 #234 提供审计范围与前置结论；Issue #277 提供冻结后 eval 持久化和 trd-gen eval-006 缺陷证据。
 - `AGENTS.md` 提供 eval schema、paired lane、fresh judge、comparison 和 runtime artifact 契约。
 - 38 个目标 skill 的 `SKILL.md` 及其明确引用提供被测行为依据。
 - 七个角色现有 eval workspace、专用 runner 和 contract checker 提供迁移输入。
@@ -211,6 +233,8 @@ flowchart TD
 | 阶段 4 | 按角色批量迁移与 fresh paired eval。 | 193/193 有去向；所有保留 eval 完成新 comparison。 | 各角色维护者 / Engineer |
 | 阶段 5 | 仓库级收尾验证。 | Repository、eval、artifact、doc contract 与相关确定性测试通过。 | Engineer / Reviewer |
 | 阶段 6 | Fresh FAIL 聚类整改与并发重跑。 | 已确认根因全部修复；10 worker 重跑后不存在未解释的 FAIL/BLOCKED，过程产物为 0。 | Skill owner / Engineer |
+| 阶段 7 | 冻结后 eval 缺陷收敛。 | 193 条 inventory 不变；零/一/多匹配持久化测试通过；trd-gen eval-006 与 PM scope-guard 三条 eval 生成可复核 fresh 结果。 | Engineer / Skill owner |
+| 阶段 8 | Identity schema v2 单轨迁移。 | 187/6/3 分类与 807 条 assertion 审计通过，inventory 零改，checker 只接受 v2；授权后完成 trd-gen 6 条与 PM scope-guard 3 条 fresh eval。 | Engineer / Reviewer |
 
 本功能不以日期驱动放行。任一阶段未达到完成门槛时，后续 comparison 不作为 release 依据。
 
@@ -226,6 +250,8 @@ flowchart TD
 | 批量执行成本促使复用历史 baseline。 | 中 | Comparison 不再是同轮对照。 | 每轮强制 fresh baseline；无法完成时记录阻塞，不降级。 |
 | 并发 worker 竞争写 inventory 或残留大体积 scratch。 | 中 | Durable 状态损坏或磁盘膨胀。 | Durable transaction 使用进程内写锁；每个 worker 在 `finally` 删除完整 runtime root，并用并发与异常回归测试证明。 |
 | 把 skill 缺陷误判成 eval 缺陷。 | 高 | 通过弱化断言掩盖真实行为差距。 | 先核对 skill 契约、用户目标和 candidate 原始证据；只有不可能执行或材料事实不成立时才改 fixture/assertion。 |
+| 协议模块边界遗漏真实执行行为。 | 中 | 行为变化未使 comparison stale。 | Execution/judging 与 runtime/isolation 的文件集合显式固定并做 mutation 测试；persistence/inventory 不参与 candidate 或 judge 行为。 |
+| 一次性迁移部分写入或改动结论。 | 中 | 仓库出现双轨或证据失真。 | 先 dry-run 和完整审计，再原子写入；验证 187 份结论与 807 条 assertion 证据逐字保持，失败不落盘。 |
 
 ## 15. 待确认问题
 
@@ -242,3 +268,6 @@ flowchart TD
 | Runner 治理 | QA 已知泄漏修复，其他专用 runner 审计完成且问题清零。 | Runner 审计清单与回归测试。 |
 | 结论有效性 | 未迁移结论保持 stale 或 `BLOCKED`，完成项使用新 Behavior / Coverage / Overall 结果。 | Durable comparison 与静态检查。 |
 | 仓库质量 | Repository、eval、artifact、doc contract 和相关确定性测试全部通过。 | 最终验证命令输出；git 跟踪的 runtime artifact 为 0。 |
+| 冻结后 eval | 新增 eval 不依赖迁移登记即可通过严格校验并持久化 fresh 结果。 | 零/一/多匹配回归测试、清单无 diff、三份 PM scope-guard comparison。 |
+| Identity v2 | 跨版本只随七项真实输入/协议变化，同轮源码 drift 零容忍。 | v2 writer/checker、协议 mutation、完整 manifest drift 与单轨拒绝 v1 测试。 |
+| 一次性迁移 | 196 份常规 comparison 按 187 fresh、6 stale、3 pending 完成分类，manual-only 不动。 | Migration audit JSON、逐字证据校验、迁移后二次 dry-run 零 diff、inventory bytes 相同。 |

--- a/scripts/check_eval_contract.py
+++ b/scripts/check_eval_contract.py
@@ -18,6 +18,16 @@ if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from scripts.eval_runtime import git_topology_errors  # noqa: E402
+try:
+    from scripts.eval_identity import FRESHNESS_FIELDS as FRESHNESS_KEYS  # noqa: E402
+    from scripts.eval_identity import current_identity_v2  # noqa: E402
+except ImportError:  # The module is introduced in the same schema-v2 change.
+    FRESHNESS_KEYS = (
+        "target_skill_sha256", "eval_definition_sha256", "metadata_sha256",
+        "fixture_sha256", "execution_protocol_sha256", "runtime_protocol_sha256",
+        "judge_schema_sha256",
+    )
+    current_identity_v2 = None
 
 
 SCHEMA_VERSION = "1.0"
@@ -631,7 +641,7 @@ def validate_file(
     root: Path,
     path: Path,
     *,
-    complete_identities: set[tuple[str, str, str]] | None = None,
+    pending_identities: set[tuple[str, str, str]] | None = None,
 ) -> list[ContractError]:
     errors: list[ContractError] = []
     payload = load_json(path, errors)
@@ -667,11 +677,11 @@ def validate_file(
     seen_ids: set[str] = set()
     for eval_index, item in enumerate(evals):
         eval_id = item.get("id") if isinstance(item, dict) else None
-        strict_new_contract = complete_identities is None or (
+        strict_new_contract = pending_identities is None or (
             agent,
             skill_name,
             eval_id,
-        ) in complete_identities
+        ) not in pending_identities
         validate_eval_item(
             path,
             skill_test_dir,
@@ -760,19 +770,13 @@ def validate_fresh_comparison_identity(
 
     try:
         definition = runner.load_eval_definition(root, agent, skill, eval_id)
-        identity = runner.source_identity(definition)
-        # The full overlay is same-run evidence; dependency content is not a
-        # cross-skill historical freshness dependency.
-        expected = {
-            "Fixture SHA-256": current_fixture_hash(definition),
-            "Prompt SHA-256": hashlib.sha256(definition.item["prompt"].encode()).hexdigest(),
-            "Eval definition SHA-256": identity["eval_definition_sha256"],
-            "Metadata SHA-256": identity["metadata_sha256"],
-            "Target skill tree SHA-256": identity["target_skill_sha256"],
-            "Judge schema SHA-256": identity["judge_schema_sha256"],
-            "Executor SHA-256": identity["executor_sha256"],
-            "Runtime SHA-256": identity["runtime_sha256"],
-        }
+        if current_identity_v2 is None:
+            raise ValueError("scripts.eval_identity.current_identity_v2 is unavailable")
+        identity = current_identity_v2(
+            definition,
+            judge_schema_bytes=runner.build_judge_schema_bytes(definition.item["assertions"]),
+        )
+        expected = {key: identity[key] for key in FRESHNESS_KEYS}
     except (KeyError, OSError, ValueError) as exc:
         add_error(errors, comparison, f"fresh comparison input identity cannot be recomputed: {exc}")
         return
@@ -782,10 +786,18 @@ def validate_fresh_comparison_identity(
         text, re.M,
     )
     section = current.group(1) if current else text[:2000]
-    stale = [
-        label for label, digest in expected.items()
-        if not re.search(rf"^- {re.escape(label)}:\s*`{digest}`\s*$", section, re.M)
-    ]
+    schema = re.findall(r"^- Identity schema:\s*`([^`]+)`\s*$", section, re.M)
+    stale = [key for key, digest in expected.items() if not re.search(
+        rf"^- {re.escape(key)}:\s*`{digest}`\s*$", section, re.M,
+    )]
+    legacy = re.findall(
+        r"^- (?:Executor SHA-256|Runtime SHA-256):",
+        section, re.M,
+    )
+    if schema != ["2"]:
+        stale.insert(0, "Identity schema")
+    if legacy:
+        stale.append("legacy freshness fields")
     if stale:
         add_error(
             errors, comparison,
@@ -793,7 +805,32 @@ def validate_fresh_comparison_identity(
         )
 
 
-def _complete_inventory_identities(
+def validate_comparison_identity_v2_structure(
+    comparison: Path, errors: list[ContractError],
+) -> None:
+    text = comparison.read_text(encoding="utf-8")
+    current = re.search(
+        r"^##\s*(?:Latest|Current) (?:Result|result)\s*$([\s\S]*?)(?=^##\s|\Z)",
+        text, re.M,
+    )
+    section = current.group(1) if current else text[:2000]
+    invalid: list[str] = []
+    if re.findall(r"^- Identity schema:\s*`([^`]+)`\s*$", section, re.M) != ["2"]:
+        invalid.append("Identity schema")
+    for key in FRESHNESS_KEYS:
+        values = re.findall(rf"^- {re.escape(key)}:\s*`([^`]+)`\s*$", section, re.M)
+        if len(values) != 1 or not re.fullmatch(r"[0-9a-f]{64}", values[0]):
+            invalid.append(key)
+    if re.search(r"^- (?:Executor SHA-256|Runtime SHA-256):", section, re.M):
+        invalid.append("legacy freshness fields")
+    if invalid:
+        add_error(
+            errors, comparison,
+            f"comparison identity schema v2 is invalid: {', '.join(invalid)}",
+        )
+
+
+def _pending_inventory_identities(
     root: Path,
 ) -> set[tuple[str, str, str]] | None:
     path = root / MIGRATION_INVENTORY
@@ -806,9 +843,13 @@ def _complete_inventory_identities(
     records = payload.get("old_evals")
     if not isinstance(records, list):
         return None
-    complete: set[tuple[str, str, str]] = set()
+    pending: set[tuple[str, str, str]] = set()
     for record in records:
-        if not isinstance(record, dict) or record.get("migration_status") != "complete":
+        if (
+            not isinstance(record, dict)
+            or record.get("migration_status") != "pending"
+            or record.get("disposition") != "retained"
+        ):
             continue
         identity = (
             record.get("agent"),
@@ -816,8 +857,8 @@ def _complete_inventory_identities(
             record.get("new_eval_id"),
         )
         if all(isinstance(value, str) for value in identity):
-            complete.add(identity)
-    return complete
+            pending.add(identity)
+    return pending
 
 
 def _git_blob(
@@ -909,7 +950,12 @@ def validate_runner_audit(
     root = path.parents[len(MIGRATION_INVENTORY.parts) - 1]
     executor_text = "\n".join(
         candidate.read_text(encoding="utf-8")
-        for candidate in (root / "scripts/run_skill_eval.py", root / "scripts/eval_runtime.py")
+        for candidate in (
+            root / "scripts/run_skill_eval.py",
+            root / "scripts/eval_execution.py",
+            root / "scripts/eval_judging.py",
+            root / "scripts/eval_runtime.py",
+        )
         if candidate.is_file()
     )
     for index, surface in enumerate(surfaces):
@@ -1123,15 +1169,15 @@ def validate_migration_inventory(root: Path | None = None) -> list[ContractError
                 if metadata.get("eval_id") != new_eval_id:
                     add_error(errors, path, f"{prefix} metadata eval_id does not match new_eval_id")
             if migration_status == "complete" and comparison_file and comparison_file.is_file():
-                if not _comparison_has_fresh_evidence(comparison_file):
+                comparison_text = comparison_file.read_text(encoding="utf-8")
+                if _comparison_is_stale_blocked(comparison_file):
+                    if "- Identity schema: `2`" not in comparison_text:
+                        add_error(errors, path, f"{prefix} stale comparison lacks identity schema v2")
+                elif not _comparison_has_fresh_evidence(comparison_file):
                     add_error(
                         errors,
                         path,
                         f"{prefix} is complete but comparison lacks fresh preflight/judge evidence",
-                    )
-                else:
-                    validate_fresh_comparison_identity(
-                        root, comparison_file, agent, skill, new_eval_id, errors,
                     )
             elif migration_status == "pending" and comparison_file and comparison_file.is_file():
                 if not _comparison_is_stale_blocked(comparison_file):
@@ -1237,15 +1283,28 @@ def validate_all(root: Path | None = None) -> list[ContractError]:
                 )
             )
 
-    complete_identities = _complete_inventory_identities(root)
+    pending_identities = _pending_inventory_identities(root)
     for path in paths:
         errors.extend(
             validate_file(
                 root,
                 path,
-                complete_identities=complete_identities,
+                pending_identities=pending_identities,
             )
         )
+        payload = _load_json_unchecked(path)
+        skill_test_dir = path.parents[2]
+        for item in payload.get("evals", []):
+            workspace = item.get("workspace") if isinstance(item, dict) else None
+            if isinstance(workspace, str):
+                comparison = resolve_workspace_root(path, skill_test_dir, workspace) / "comparison.md"
+                if comparison.is_file():
+                    validate_comparison_identity_v2_structure(comparison, errors)
+                    if _comparison_has_fresh_evidence(comparison):
+                        validate_fresh_comparison_identity(
+                            root, comparison, payload.get("agent"), payload.get("skill_name"),
+                            item.get("id"), errors,
+                        )
 
     errors.extend(validate_migration_inventory(root))
 
@@ -1261,7 +1320,7 @@ def main() -> int:
             print(f"- {error.render(root)}", file=sys.stderr)
         return 1
 
-    print("PASS: all agent skill evals satisfy schema v1.0")
+    print("PASS: all agent skill evals satisfy the shared contract and identity schema v2")
     return 0
 
 

--- a/scripts/eval_execution.py
+++ b/scripts/eval_execution.py
@@ -1,0 +1,755 @@
+#!/usr/bin/env python3
+"""Run paired skill evals with one shared isolation and judging boundary."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.eval_runtime import (  # noqa: E402
+    IsolatedContext,
+    MaterializedEvalRun,
+    PermissionProbe,
+    close_context,
+    content_tree_hash,
+    copy_canonical_fixture,
+    evaluate_context_preflight,
+    fixture_manifest,
+    manifest_hash,
+    materialize_eval_run,
+    open_context,
+    record_preflight,
+    run_permission_probe,
+    skill_overlay_hash,
+    verify_context_dependencies,
+)
+from scripts import eval_identity, eval_judging, eval_persistence  # noqa: E402
+
+
+MODEL = "gpt-5.6-luna"
+REASONING_EFFORT = "medium"
+DEFAULT_TIMEOUT_SECONDS = 600
+MAX_CANDIDATE_TRACE_CHARS = 250_000
+JUDGE_SCHEMA = eval_judging.JUDGE_SCHEMA
+
+
+@dataclass(frozen=True)
+class EvalDefinition:
+    repository_root: Path
+    agent: str
+    skill: str
+    eval_id: str
+    workspace_root: Path
+    item: dict[str, Any]
+    metadata: dict[str, Any]
+    evals_bytes: bytes
+    metadata_bytes: bytes
+
+
+CommandRunner = Callable[..., dict[str, Any]]
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"JSON root must be an object: {path}")
+    return payload
+
+
+def build_judge_schema_bytes(assertions: list[dict[str, Any]]) -> bytes:
+    return eval_judging.build_judge_schema_bytes(assertions, schema_path=JUDGE_SCHEMA)
+
+
+def source_identity(
+    definition: EvalDefinition, *, judge_schema_bytes: bytes | None = None,
+) -> dict[str, Any]:
+    schema_bytes = judge_schema_bytes or build_judge_schema_bytes(definition.item["assertions"])
+    return eval_identity.source_identity(definition, judge_schema_bytes=schema_bytes)
+
+
+def _same_source_inputs(left: dict[str, Any], right: dict[str, Any]) -> bool:
+    return eval_identity.same_source_inputs(left, right)
+
+
+def _current_run_identity(definition: EvalDefinition) -> dict[str, Any]:
+    return source_identity(
+        definition,
+        judge_schema_bytes=build_judge_schema_bytes(definition.item["assertions"]),
+    )
+
+
+def _prune_runtime_parents(runtime_root: Path, repository_root: Path) -> None:
+    stop = (repository_root.resolve() / "tmp/eval-runs").resolve()
+    current = runtime_root.resolve().parent
+    if current != stop and stop not in current.parents:
+        return
+    while current == stop or stop in current.parents:
+        try:
+            current.rmdir()
+        except OSError:
+            return
+        if current == stop:
+            return
+        current = current.parent
+
+
+def _resolve_workspace(evals_path: Path, workspace: str) -> Path:
+    for candidate in (evals_path.parents[1] / workspace, evals_path.parent / workspace):
+        if candidate.exists():
+            return candidate.resolve()
+    raise ValueError(f"eval workspace does not exist: {workspace}")
+
+
+def load_eval_definition(
+    repository_root: Path,
+    agent: str,
+    skill: str,
+    eval_id: str,
+    *,
+    metadata_snapshot: tuple[dict[str, Any], bytes] | None = None,
+) -> EvalDefinition:
+    repository_root = repository_root.resolve()
+    evals_path = repository_root / f"agents/{agent}/test/{skill}/evals/evals.json"
+    evals_bytes = evals_path.read_bytes()
+    payload = json.loads(evals_bytes)
+    if not isinstance(payload, dict):
+        raise ValueError(f"JSON root must be an object: {evals_path}")
+    if payload.get("agent") != agent or payload.get("skill_name") != skill:
+        raise ValueError(f"eval suite identity does not match {agent}/{skill}")
+    item = next(
+        (candidate for candidate in payload.get("evals", []) if candidate.get("id") == eval_id),
+        None,
+    )
+    if item is None:
+        raise ValueError(f"eval {eval_id!r} not found in {evals_path}")
+    workspace = item.get("workspace")
+    if not isinstance(workspace, str):
+        raise ValueError(f"eval {eval_id!r} has no workspace")
+    workspace_root = _resolve_workspace(evals_path, workspace)
+    metadata_path = workspace_root / "eval_metadata.json"
+    if metadata_snapshot is None:
+        metadata_bytes = metadata_path.read_bytes()
+        metadata = json.loads(metadata_bytes)
+    else:
+        metadata, metadata_bytes = metadata_snapshot
+    if not isinstance(metadata, dict):
+        raise ValueError(f"JSON root must be an object: {metadata_path}")
+    if metadata.get("eval_id") != eval_id:
+        raise ValueError(f"metadata eval_id does not match {eval_id!r}")
+    return EvalDefinition(
+        repository_root, agent, skill, eval_id, workspace_root, item, metadata,
+        evals_bytes, metadata_bytes,
+    )
+
+
+def definition_from_metadata(
+    metadata_path: Path,
+    *,
+    repository_root: Path | None = None,
+) -> EvalDefinition:
+    metadata_path = metadata_path.resolve()
+    repository_root = (repository_root or Path(__file__).resolve().parents[1]).resolve()
+    relative = metadata_path.relative_to(repository_root)
+    parts = relative.parts
+    if len(parts) < 7 or parts[0] != "agents" or parts[2] != "test":
+        raise ValueError(f"metadata path is not in an agent eval workspace: {metadata_path}")
+    agent = parts[1]
+    skill = parts[3]
+    metadata_bytes = metadata_path.read_bytes()
+    metadata = json.loads(metadata_bytes)
+    if not isinstance(metadata, dict):
+        raise ValueError(f"JSON root must be an object: {metadata_path}")
+    eval_id = metadata.get("eval_id")
+    if not isinstance(eval_id, str):
+        raise ValueError(f"metadata is missing eval_id: {metadata_path}")
+    definition = load_eval_definition(
+        repository_root, agent, skill, eval_id,
+        metadata_snapshot=(metadata, metadata_bytes),
+    )
+    if definition.workspace_root / "eval_metadata.json" != metadata_path:
+        raise ValueError("metadata path does not match the eval definition workspace")
+    return definition
+
+
+def _codex_command(
+    workspace: Path,
+    output_path: Path,
+    *,
+    schema: Path | None = None,
+) -> list[str]:
+    command = [
+        "codex", "--ask-for-approval", "never", "--strict-config", "exec", "-C", str(workspace),
+        "--ephemeral", "--ignore-rules",
+        "--model", MODEL, "-c", f'model_reasoning_effort="{REASONING_EFFORT}"',
+    ]
+    if schema is not None:
+        command.extend(["--output-schema", str(schema)])
+    return [*command, "--output-last-message", str(output_path), "-"]
+
+
+def candidate_command(workspace: Path, output_path: Path) -> list[str]:
+    command = _codex_command(workspace, output_path)
+    command.insert(command.index("--output-last-message"), "--json")
+    return command
+
+
+def run_command(
+    command: list[str],
+    *,
+    prompt: str,
+    env: dict[str, str],
+    timeout_seconds: int,
+) -> dict[str, Any]:
+    try:
+        completed = subprocess.run(command, input=prompt, text=True, capture_output=True,
+                                   env=env, timeout=timeout_seconds)
+        return {
+            "returncode": completed.returncode,
+            "timed_out": False,
+            "stdout_tail": completed.stdout[-MAX_CANDIDATE_TRACE_CHARS:],
+            "stderr_tail": completed.stderr[-50_000:],
+        }
+    except subprocess.TimeoutExpired as exc:
+        stdout = exc.stdout.decode(errors="replace") if isinstance(exc.stdout, bytes) else exc.stdout or ""
+        stderr = exc.stderr.decode(errors="replace") if isinstance(exc.stderr, bytes) else exc.stderr or ""
+        return {
+            "returncode": 124,
+            "timed_out": True,
+            "stdout_tail": stdout[-MAX_CANDIDATE_TRACE_CHARS:],
+            "stderr_tail": stderr[-50_000:],
+        }
+
+
+def check_model_available(repository_root: Path) -> bool:
+    if shutil.which("codex") is None:
+        return False
+    try:
+        completed = subprocess.run(["codex", "debug", "models"], cwd=repository_root,
+                                   capture_output=True, text=True, timeout=30)
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return completed.returncode == 0 and MODEL in completed.stdout
+
+
+def _git(context: IsolatedContext, *args: str, check: bool = True) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=context.git_root, capture_output=True, text=True,
+    )
+    if check and result.returncode:
+        raise ValueError(f"git evidence command failed: git {' '.join(args)}")
+    return result.stdout
+
+
+def _git_ref_state(context: IsolatedContext) -> dict[str, dict[str, str | None]]:
+    refs: dict[str, dict[str, str | None]] = {}
+    for name in filter(None, _git(context, "for-each-ref", "--format=%(refname)").splitlines()):
+        commit = _git(context, "rev-parse", "--verify", f"{name}^{{commit}}", check=False).strip()
+        tree = _git(context, "rev-parse", "--verify", f"{name}^{{tree}}", check=False).strip()
+        refs[name] = {
+            "object": _git(context, "rev-parse", "--verify", name).strip(),
+            "commit": commit or None,
+            "tree": tree or None,
+        }
+    return refs
+
+
+def _git_reflog(context: IsolatedContext) -> list[dict[str, str]]:
+    entries: list[dict[str, str]] = []
+    output = _git(context, "reflog", "--all", "--format=%H%x00%gs", check=False)
+    for line in output.splitlines():
+        oid, separator, subject = line.partition("\0")
+        if separator and oid:
+            entries.append({"oid": oid, "subject": subject})
+    return entries
+
+
+def _capture_git_baseline(context: IsolatedContext) -> dict[str, Any]:
+    head = _git(context, "rev-parse", "--verify", "HEAD").strip()
+    untracked: list[dict[str, Any]] = []
+    for relative in filter(None, _git(
+        context, "ls-files", "--others", "--exclude-standard", "-z",
+    ).split("\0")):
+        path = context.workspace_root / relative
+        if path.is_file() and not path.is_symlink():
+            untracked.append(_render_snapshot(relative, "untracked", path.read_bytes()))
+    return {
+        "head": head,
+        "branch": _git(context, "symbolic-ref", "-q", "--short", "HEAD", check=False).strip() or None,
+        "refs": _git_ref_state(context),
+        "commits": sorted(filter(None, _git(
+            context, "rev-list", "--all", "--reflog", check=False,
+        ).splitlines())),
+        "reflog": _git_reflog(context),
+        "manifest": fixture_manifest(context.workspace_root),
+        "status_porcelain_v1": _git(
+            context, "status", "--porcelain=v1", "--untracked-files=all",
+        ),
+        "index_diff": _git(context, "diff", "--cached", "--no-ext-diff", "--binary"),
+        "worktree_diff": _git(context, "diff", "--no-ext-diff", "--binary"),
+        "untracked": untracked,
+        "worktrees": sorted(
+            line.removeprefix("worktree ") for line in _git(
+                context, "worktree", "list", "--porcelain",
+            ).splitlines() if line.startswith("worktree ")
+        ),
+    }
+
+
+def _render_snapshot(path: str, kind: str, content: bytes, **fields: Any) -> dict[str, Any]:
+    if len(content) > 2_000_000:
+        raise ValueError(f"candidate delivery exceeds 2 MB snapshot limit: {path}")
+    try:
+        rendered, encoding = content.decode("utf-8"), "utf-8"
+    except UnicodeDecodeError:
+        rendered, encoding = base64.b64encode(content).decode("ascii"), "base64"
+    return {
+        "path": path, "kind": kind, "encoding": encoding,
+        "sha256": hashlib.sha256(content).hexdigest(), "content": rendered, **fields,
+    }
+
+
+def _commit_blob(context: IsolatedContext, commit: str, path: str) -> bytes | None:
+    tree = subprocess.run(
+        ["git", "ls-tree", "-z", commit, "--", path], cwd=context.git_root,
+        capture_output=True,
+    )
+    if tree.returncode or not tree.stdout:
+        return None
+    header = tree.stdout.split(b"\t", 1)[0].decode("ascii")
+    oid = header.split()[2]
+    blob = subprocess.run(
+        ["git", "cat-file", "blob", oid], cwd=context.git_root, capture_output=True,
+    )
+    if blob.returncode:
+        raise ValueError(f"git evidence could not read changed blob: {path}")
+    return blob.stdout
+
+
+def _git_evidence(context: IsolatedContext, before: dict[str, Any]) -> dict[str, Any]:
+    after = _capture_git_baseline(context)
+    changed = {
+        relative for relative in set(before["manifest"]) | set(after["manifest"])
+        if before["manifest"].get(relative) != after["manifest"].get(relative)
+    }
+    snapshot: list[dict[str, Any]] = []
+    for relative in sorted(changed):
+        path = context.workspace_root / relative
+        if not path.exists() and not path.is_symlink():
+            snapshot.append({"path": relative, "kind": "deleted", "content": None})
+            continue
+        if path.is_symlink():
+            snapshot.append({"path": relative, "kind": "symlink", "content": os.readlink(path)})
+            continue
+        if not path.is_file():
+            continue
+        content = path.read_bytes()
+        snapshot.append(_render_snapshot(relative, "file", content))
+
+    ref_delta = {
+        name: {"before": before["refs"].get(name), "after": after["refs"].get(name)}
+        for name in sorted(set(before["refs"]) | set(after["refs"]))
+        if before["refs"].get(name) != after["refs"].get(name)
+    }
+    before_reflog = {(entry["oid"], entry["subject"]) for entry in before["reflog"]}
+    reflog_delta = [
+        entry for entry in after["reflog"]
+        if (entry["oid"], entry["subject"]) not in before_reflog
+    ]
+    new_commits = sorted(set(after["commits"]) - set(before["commits"]))
+    before_reachable = {
+        value["commit"] for value in before["refs"].values() if value["commit"]
+    } | {before["head"]}
+    after_reachable = {
+        value["commit"] for value in after["refs"].values() if value["commit"]
+    } | {after["head"]}
+    new_reachable = sorted(after_reachable - before_reachable)
+    changed_ref_commits = {
+        delta["after"]["commit"] for delta in ref_delta.values()
+        if delta["after"] and delta["after"]["commit"]
+    }
+    if before["head"] != after["head"]:
+        changed_ref_commits.add(after["head"])
+    result_commits = sorted(changed_ref_commits | set(new_commits))
+    result_diffs: list[dict[str, str]] = []
+    git_blob_keys: set[tuple[str, str, str]] = set()
+    evidence_bytes = 0
+    for commit in result_commits:
+        name_status = _git(context, "diff", "--name-status", before["head"], commit)
+        binary_diff = _git(context, "diff", "--no-ext-diff", "--binary", before["head"], commit)
+        evidence_bytes += len(name_status.encode()) + len(binary_diff.encode())
+        result_diffs.append({"commit": commit, "name_status": name_status, "binary_diff": binary_diff})
+        paths = filter(None, _git(
+            context, "diff", "--name-only", "-z", before["head"], commit,
+        ).split("\0"))
+        for relative in paths:
+            content = _commit_blob(context, commit, relative)
+            if content is None:
+                key = (relative, "deleted", commit)
+                if key not in git_blob_keys:
+                    snapshot.append({
+                        "path": relative, "kind": "git_blob", "content": None,
+                        "origin_commit": commit,
+                    })
+                    git_blob_keys.add(key)
+                continue
+            digest = hashlib.sha256(content).hexdigest()
+            key = (relative, digest, commit)
+            if key not in git_blob_keys:
+                snapshot.append(_render_snapshot(
+                    relative, "git_blob", content, origin_commit=commit,
+                    final_reachable=commit in after_reachable,
+                ))
+                git_blob_keys.add(key)
+                evidence_bytes += len(content)
+    if evidence_bytes > 32_000_000:
+        raise ValueError("candidate Git evidence exceeds 32 MB limit")
+
+    manifest = fixture_manifest(context.workspace_root)
+    return {
+        "git_status": _git(context, "status", "--short"),
+        "git_diff": _git(context, "diff", "--no-ext-diff", "--binary", "HEAD"),
+        "workspace_manifest": manifest,
+        "delivery_snapshot": snapshot,
+        "git_evidence": {
+            "head": {
+                "before": before["head"], "after": after["head"],
+                "changed": before["head"] != after["head"],
+            },
+            "branch": {
+                "before": before["branch"], "after": after["branch"],
+                "changed": before["branch"] != after["branch"],
+            },
+            "ref_delta": ref_delta,
+            "new_reachable_commits": new_reachable,
+            "new_commits": new_commits,
+            "reflog_delta": reflog_delta,
+            "result_diffs": result_diffs,
+            "initial_state": {
+                "status_porcelain_v1": before["status_porcelain_v1"],
+                "index_diff": before["index_diff"],
+                "worktree_diff": before["worktree_diff"],
+                "untracked": before["untracked"],
+            },
+            "status_porcelain_v1": _git(
+                context, "status", "--porcelain=v1", "--untracked-files=all",
+            ),
+            "index_diff": _git(context, "diff", "--cached", "--no-ext-diff", "--binary"),
+            "worktree_diff": _git(context, "diff", "--no-ext-diff", "--binary"),
+            "temporary_worktree_cleanup": {
+                "used": "unknown",
+                "before": before["worktrees"],
+                "after": after["worktrees"],
+                "residual_delta": sorted(set(after["worktrees"]) - set(before["worktrees"])),
+                "cleaned": not (set(after["worktrees"]) - set(before["worktrees"])),
+            },
+        },
+        "dependency_evidence": verify_context_dependencies(context),
+    }
+
+
+def _output_checks(
+    snapshot: list[dict[str, Any]], value: Any, mode: str,
+) -> list[dict[str, Any]]:
+    if value is None:
+        return []
+    specs = value if isinstance(value, list) else [value]
+    results: list[dict[str, Any]] = []
+    for spec in specs:
+        alternatives = spec if isinstance(spec, list) else [spec]
+        paths = [item for item in alternatives if isinstance(item, str)]
+        normalized: list[str] = []
+        for path in paths:
+            prefix = path.split("/", 1)[0]
+            if prefix in {"with_skill", "without_skill"}:
+                if prefix != mode:
+                    raise ValueError(f"declared output uses wrong lane prefix: {path}")
+                path = path.split("/", 1)[1] if "/" in path else ""
+            normalized.append(path)
+        delivered = {
+            item["path"] for item in snapshot
+            if (
+                item.get("kind") == "file"
+                or item.get("kind") == "git_blob" and item.get("final_reachable") is True
+            ) and bool(item.get("content"))
+        }
+        ok = bool(paths) and any(
+            changed == path.rstrip("/") or changed.startswith(path.rstrip("/") + "/")
+            for path in normalized for changed in delivered
+        )
+        results.append({"paths": paths, "semantics": "OR", "ok": ok})
+    return results
+
+
+def _candidate_run(
+    materialized: MaterializedEvalRun,
+    context: IsolatedContext,
+    *,
+    command_runner: CommandRunner,
+    timeout_seconds: int,
+) -> dict[str, Any]:
+    mode = context.mode.replace("-", "_")
+    output_path = materialized.runtime_root / f"outputs/{mode}/candidate-output.md"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    command = candidate_command(context.workspace_root, output_path)
+    git_before = _capture_git_baseline(context)
+    status = command_runner(
+        command,
+        prompt=materialized.prompt,
+        env=context.env,
+        timeout_seconds=timeout_seconds,
+    )
+    output = output_path.read_text(encoding="utf-8") if output_path.is_file() else ""
+    run = {
+        "mode": mode,
+        "command": command,
+        "output_exists": bool(output.strip()),
+        "output": output,
+        "output_sha256": hashlib.sha256(output.encode()).hexdigest(),
+        "status": status,
+        **_git_evidence(context, git_before),
+    }
+    return run
+
+
+def _lane_run_source(run: dict[str, Any], materialized: MaterializedEvalRun) -> str:
+    snapshot = json.dumps(
+        run["delivery_snapshot"], ensure_ascii=False, sort_keys=True, separators=(",", ":"),
+    ).encode()
+    status = run["status"]
+    return (
+        f"fresh {run['mode']} candidate; model={MODEL}; effort={REASONING_EFFORT}; "
+        f"returncode={status.get('returncode')}; timed_out={bool(status.get('timed_out'))}; "
+        f"prompt_sha256={materialized.prompt_hash}; fixture_sha256={materialized.canonical_hash}; "
+        f"output_sha256={run['output_sha256']}; "
+        f"snapshot_sha256={hashlib.sha256(snapshot).hexdigest()}"
+    )
+
+
+def _blocked_result(
+    definition: EvalDefinition,
+    materialized: MaterializedEvalRun,
+    blockers: list[str],
+    candidate_runs: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    result = {
+        "agent": definition.agent,
+        "skill": definition.skill,
+        "eval_id": definition.eval_id,
+        "preflight": materialized.preflight.as_dict(),
+        "candidate_runs": candidate_runs or [],
+        "judge_run": None,
+        "behavior_result": None,
+        "coverage_result": None,
+        "overall_result": "BLOCKED",
+        "blockers": blockers,
+    }
+    return result
+
+
+# Compatibility exports remain here while implementation ownership follows the
+# explicit execution/judging/persistence module boundaries.
+judge_command = eval_judging.judge_command
+recompute_overall = eval_judging.recompute_overall
+validate_judge_result = eval_judging.validate_judge_result
+_prepare_judge_package = eval_judging.prepare_judge_package
+_judge_prompt = eval_judging.judge_prompt
+_stage_file = eval_persistence._stage_file
+_transactional_replace = eval_persistence.transactional_replace
+_durable_comparison = eval_persistence.durable_comparison
+_updated_inventory = eval_persistence.updated_inventory
+persist_durable_result = eval_persistence.persist_durable_result
+
+
+def run_selected_eval(
+    *,
+    repository_root: Path,
+    agent: str,
+    skill: str,
+    eval_id: str,
+    runtime_root: Path | None = None,
+    model_available: bool | None = None,
+    command_runner: CommandRunner = run_command,
+    permission_probe: PermissionProbe = run_permission_probe,
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    definition = load_eval_definition(repository_root, agent, skill, eval_id)
+    judge_schema_bytes = build_judge_schema_bytes(definition.item["assertions"])
+    identity = source_identity(definition, judge_schema_bytes=judge_schema_bytes)
+    if runtime_root is None:
+        runtime_root = (
+            repository_root.resolve()
+            / f"tmp/eval-runs/{agent}/{skill}/{eval_id}"
+        )
+    if model_available is None:
+        model_available = check_model_available(repository_root)
+    dependencies = [
+        repository_root.resolve() / value
+        for value in definition.metadata.get("skill_dependencies", [])
+    ]
+    materialized: MaterializedEvalRun | None = None
+    try:
+        materialized = materialize_eval_run(
+            fixture_root=definition.workspace_root,
+            repository_root=repository_root,
+            target_skill=repository_root.resolve() / f"agents/{agent}/skills/{skill}",
+            skill_dependencies=dependencies,
+            prompt=definition.item["prompt"],
+            runtime_isolation=definition.metadata.get("runtime_isolation", {}),
+            runtime_root=runtime_root,
+            model_available=model_available,
+            cleanup_paths=definition.metadata.get("execution_cleanup", []),
+            git_topology=definition.metadata.get("git_topology"),
+            judge_schema_bytes=judge_schema_bytes,
+        )
+        locked_inputs = {
+            "fixture": materialized.canonical_hash,
+            "skill overlay": materialized.locked_overlay_hash,
+            "judge schema": materialized.locked_judge_schema_hash,
+        }
+        expected_inputs = {
+            "fixture": identity["fixture_sha256"],
+            "skill overlay": identity["skill_overlay_sha256"],
+            "judge schema": identity["judge_schema_sha256"],
+        }
+        mismatches = [name for name in locked_inputs if locked_inputs[name] != expected_inputs[name]]
+        if mismatches:
+            return _blocked_result(
+                definition, materialized,
+                [f"locked eval inputs differ from initial identity: {', '.join(mismatches)}"],
+                [],
+            )
+        candidate_runs: list[dict[str, Any]] = []
+        for mode in ("without_skill", "with_skill"):
+            context = open_context(materialized, mode)
+            preflight = evaluate_context_preflight(
+                materialized, context, mode, permission_probe,
+            )
+            record_preflight(materialized, mode, preflight)
+            if preflight.status != "PASS":
+                close_context(materialized, context, evidence_locked=True)
+                return _blocked_result(definition, materialized, preflight.blockers, candidate_runs)
+            try:
+                run = _candidate_run(
+                    materialized, context, command_runner=command_runner,
+                    timeout_seconds=timeout_seconds,
+                )
+                run["declared_outputs"] = _output_checks(
+                    run["delivery_snapshot"], definition.metadata.get(f"{mode}_outputs"), mode,
+                )
+            except ValueError as exc:
+                close_context(materialized, context, evidence_locked=True)
+                return _blocked_result(definition, materialized, [str(exc)], candidate_runs)
+            candidate_runs.append(run)
+            close_context(materialized, context, evidence_locked=True)
+            boundary_definition = load_eval_definition(repository_root, agent, skill, eval_id)
+            if not _same_source_inputs(
+                _current_run_identity(boundary_definition), identity,
+            ):
+                return _blocked_result(
+                    definition, materialized,
+                    ["eval source inputs changed during the isolated run"], candidate_runs,
+                )
+            if run["dependency_evidence"].get("status") != "PASS":
+                return _blocked_result(
+                    definition, materialized,
+                    [f"{run['mode']} runtime dependencies changed during candidate execution"],
+                    candidate_runs,
+                )
+            if run["status"].get("returncode") != 0 or not run["output_exists"]:
+                status = run["status"]
+                return _blocked_result(
+                    definition, materialized,
+                    [
+                        f"{run['mode']} candidate did not complete with a final output "
+                        f"(returncode={status.get('returncode')}, "
+                        f"timed_out={bool(status.get('timed_out'))})"
+                    ],
+                    candidate_runs,
+                )
+            if mode == "with_skill" and any(not check["ok"] for check in run["declared_outputs"]):
+                return _blocked_result(
+                    definition, materialized,
+                    ["with_skill did not produce every declared deterministic output"], candidate_runs,
+                )
+
+        judge = open_context(materialized, "judge")
+        _prepare_judge_package(definition, materialized, judge, candidate_runs)
+        judge_preflight = evaluate_context_preflight(
+            materialized, judge, "judge", permission_probe,
+        )
+        record_preflight(materialized, "judge", judge_preflight)
+        if judge_preflight.status != "PASS":
+            close_context(materialized, judge, evidence_locked=True)
+            return _blocked_result(definition, materialized, judge_preflight.blockers, candidate_runs)
+        verdict_path = materialized.runtime_root / "outputs/judge/judge-verdict.json"
+        verdict_path.parent.mkdir(parents=True, exist_ok=True)
+        command = judge_command(
+            judge.workspace_root, verdict_path,
+            schema=materialized.locked_judge_schema_path,
+        )
+        judge_status = command_runner(
+            command, prompt=_judge_prompt(), env=judge.env, timeout_seconds=timeout_seconds,
+        )
+        if judge_status.get("returncode") != 0 or not verdict_path.is_file():
+            close_context(materialized, judge, evidence_locked=True)
+            return _blocked_result(
+                definition, materialized,
+                ["fresh judge did not complete with a structured verdict"], candidate_runs,
+            )
+        try:
+            raw_verdict = _load_json(verdict_path)
+            assertion_ids = {item["id"] for item in definition.item["assertions"]}
+            verdict = validate_judge_result(raw_verdict, assertion_ids)
+        except (KeyError, ValueError, json.JSONDecodeError) as exc:
+            close_context(materialized, judge, evidence_locked=True)
+            return _blocked_result(
+                definition, materialized,
+                [f"judge verdict failed schema validation: {exc}"], candidate_runs,
+            )
+        close_context(materialized, judge, evidence_locked=True)
+
+        for run in candidate_runs:
+            verdict["lane_summaries"][run["mode"]]["run_source"] = _lane_run_source(
+                run, materialized,
+            )
+
+        final_definition = load_eval_definition(repository_root, agent, skill, eval_id)
+        if not _same_source_inputs(
+            _current_run_identity(final_definition), identity,
+        ):
+            return _blocked_result(
+                definition, materialized,
+                ["eval source inputs changed during the isolated run"], candidate_runs,
+            )
+
+        result = {
+            "agent": definition.agent,
+            "skill": definition.skill,
+            "eval_id": definition.eval_id,
+            "preflight": materialized.preflight.as_dict(),
+            "candidate_runs": candidate_runs,
+            "judge_run": {"command": command, "status": judge_status},
+            "source_identity": identity,
+            **verdict,
+        }
+        persist_durable_result(definition, result)
+        return result
+    finally:
+        if materialized is not None:
+            materialized.cleanup()
+        if runtime_root.exists():
+            shutil.rmtree(runtime_root)
+        _prune_runtime_parents(runtime_root, repository_root)

--- a/scripts/eval_identity.py
+++ b/scripts/eval_identity.py
@@ -1,0 +1,151 @@
+"""Compute eval identity schema v2 and the complete same-run source lock."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from scripts.eval_runtime import (
+    content_tree_hash,
+    copy_canonical_fixture,
+    fixture_manifest,
+    manifest_hash,
+    skill_overlay_hash,
+)
+
+
+IDENTITY_SCHEMA_VERSION = 2
+FRESHNESS_FIELDS = (
+    "target_skill_sha256",
+    "eval_definition_sha256",
+    "metadata_sha256",
+    "fixture_sha256",
+    "execution_protocol_sha256",
+    "runtime_protocol_sha256",
+    "judge_schema_sha256",
+)
+EXECUTION_PROTOCOL_FILES = (
+    "eval_execution.py",
+    "eval_judging.py",
+)
+RUNTIME_PROTOCOL_FILES = ("eval_runtime.py",)
+SOURCE_LOCK_FILES = (
+    "run_skill_eval.py",
+    "eval_identity.py",
+    "eval_execution.py",
+    "eval_judging.py",
+    "eval_runtime.py",
+    "eval_persistence.py",
+    "check_eval_contract.py",
+    "eval_judge_result.schema.json",
+)
+
+
+def _hash_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _manifest_hash(manifest: dict[str, str]) -> str:
+    canonical = json.dumps(
+        manifest, ensure_ascii=False, sort_keys=True, separators=(",", ":"),
+    ).encode()
+    return _hash_bytes(canonical)
+
+
+def source_manifest(script_root: Path | None = None) -> dict[str, str]:
+    root = (script_root or Path(__file__).resolve().parent).resolve()
+    return {name: _hash_bytes((root / name).read_bytes()) for name in SOURCE_LOCK_FILES}
+
+
+def source_lock_sha256(manifest: dict[str, str]) -> str:
+    if set(manifest) != set(SOURCE_LOCK_FILES):
+        raise ValueError("source manifest must contain the exact eval source lock files")
+    return _manifest_hash(manifest)
+
+
+def protocol_hashes(
+    script_root: Path | None = None, *, judge_schema_bytes: bytes | None = None,
+) -> dict[str, str]:
+    root = (script_root or Path(__file__).resolve().parent).resolve()
+    execution = {name: _hash_bytes((root / name).read_bytes()) for name in EXECUTION_PROTOCOL_FILES}
+    runtime = {name: _hash_bytes((root / name).read_bytes()) for name in RUNTIME_PROTOCOL_FILES}
+    schema = (
+        (root / "eval_judge_result.schema.json").read_bytes()
+        if judge_schema_bytes is None else judge_schema_bytes
+    )
+    return {
+        "execution_protocol_sha256": _manifest_hash(execution),
+        "runtime_protocol_sha256": _manifest_hash(runtime),
+        "judge_schema_sha256": _hash_bytes(schema),
+    }
+
+
+def current_identity_v2(
+    definition: Any, *, judge_schema_bytes: bytes | None = None,
+) -> dict[str, Any]:
+    repository_root = definition.repository_root
+    target = repository_root / f"agents/{definition.agent}/skills/{definition.skill}"
+    with tempfile.TemporaryDirectory() as temporary:
+        canonical = Path(temporary) / "canonical"
+        copy_canonical_fixture(
+            definition.workspace_root, canonical,
+            cleanup_paths=definition.metadata.get("execution_cleanup", []),
+        )
+        fixture_hash = manifest_hash(fixture_manifest(canonical))
+    protocols = protocol_hashes(judge_schema_bytes=judge_schema_bytes)
+    freshness = {
+        "target_skill_sha256": content_tree_hash(target),
+        "eval_definition_sha256": _hash_bytes(json.dumps(
+            definition.item, ensure_ascii=False, sort_keys=True, separators=(",", ":"),
+        ).encode()),
+        "metadata_sha256": _hash_bytes(definition.metadata_bytes),
+        "fixture_sha256": fixture_hash,
+        **protocols,
+    }
+    return {
+        "identity_schema": IDENTITY_SCHEMA_VERSION,
+        "freshness": freshness,
+        **freshness,
+    }
+
+
+def source_identity(
+    definition: Any, *, judge_schema_bytes: bytes | None = None,
+) -> dict[str, Any]:
+    repository_root = definition.repository_root
+    identity = current_identity_v2(definition, judge_schema_bytes=judge_schema_bytes)
+    head = subprocess.run(
+        ["git", "rev-parse", "--verify", "HEAD"], cwd=repository_root,
+        capture_output=True, text=True,
+    )
+    status = subprocess.run(
+        ["git", "status", "--porcelain", "--untracked-files=all"],
+        cwd=repository_root, capture_output=True, text=True,
+    )
+    target = repository_root / f"agents/{definition.agent}/skills/{definition.skill}"
+    overlay_paths = [target, *(
+        repository_root / value for value in definition.metadata.get("skill_dependencies", [])
+    )]
+    manifest = source_manifest()
+    return {
+        **identity,
+        "repository_head": head.stdout.strip() if head.returncode == 0 else "unavailable",
+        "repository_dirty": status.returncode != 0 or bool(status.stdout),
+        "skill_overlay_sha256": skill_overlay_hash(overlay_paths, repository_root),
+        "source_manifest": manifest,
+        "source_lock_sha256": source_lock_sha256(manifest),
+    }
+
+
+def same_source_inputs(left: dict[str, Any], right: dict[str, Any]) -> bool:
+    return (
+        left.get("identity_schema") == right.get("identity_schema") == IDENTITY_SCHEMA_VERSION
+        and left.get("freshness") == right.get("freshness")
+        and left.get("skill_overlay_sha256") == right.get("skill_overlay_sha256")
+        and left.get("source_manifest") == right.get("source_manifest")
+        and left.get("source_lock_sha256") == right.get("source_lock_sha256")
+    )

--- a/scripts/eval_judging.py
+++ b/scripts/eval_judging.py
@@ -1,0 +1,150 @@
+"""Independent judge protocol and schema handling for paired skill evals."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from typing import Any
+
+JUDGE_SCHEMA = Path(__file__).with_name("eval_judge_result.schema.json")
+MODEL = "gpt-5.6-luna"
+REASONING_EFFORT = "medium"
+
+
+def _judge_codex_command(workspace: Path, output_path: Path, schema: Path) -> list[str]:
+    return [
+        "codex", "--ask-for-approval", "never", "--strict-config", "exec", "-C", str(workspace),
+        "--ephemeral", "--ignore-rules", "--model", MODEL,
+        "-c", f'model_reasoning_effort="{REASONING_EFFORT}"',
+        "--output-schema", str(schema), "--output-last-message", str(output_path), "-",
+    ]
+
+
+def build_judge_schema_bytes(
+    assertions: list[dict[str, Any]], *, schema_path: Path | None = None,
+) -> bytes:
+    schema = json.loads((schema_path or JUDGE_SCHEMA).read_text(encoding="utf-8"))
+    assertion_ids = [assertion["id"] for assertion in assertions]
+    results = schema["properties"]["assertion_results"]
+    results["minItems"] = len(assertion_ids)
+    results["maxItems"] = len(assertion_ids)
+    results["items"]["properties"]["id"] = {"enum": assertion_ids}
+    return json.dumps(
+        schema, ensure_ascii=False, sort_keys=True, separators=(",", ":"),
+    ).encode()
+
+
+def judge_command(
+    workspace: Path, output_path: Path, *, schema: Path | None = None,
+) -> list[str]:
+    return _judge_codex_command(workspace, output_path, schema or JUDGE_SCHEMA)
+
+
+def recompute_overall(behavior_result: str, coverage_result: str) -> str:
+    if behavior_result == "FAIL":
+        return "FAIL"
+    if behavior_result == "PASS" and coverage_result in {"FULL", "PARTIAL"}:
+        return "PASS" if coverage_result == "FULL" else "PASS (partial coverage)"
+    raise ValueError(f"invalid judge result pair: {behavior_result}/{coverage_result}")
+
+
+def validate_judge_result(payload: dict[str, Any], assertion_ids: set[str]) -> dict[str, Any]:
+    required = {
+        "assertion_results", "lane_summaries", "behavior_result", "coverage_result",
+        "overall_result", "uncovered_reasons", "blockers", "failures", "next_steps",
+    }
+    if set(payload) != required:
+        raise ValueError("judge result fields do not match the required schema")
+    results = payload.get("assertion_results")
+    if not isinstance(results, list) or not results:
+        raise ValueError("judge result assertion_results must be non-empty")
+    seen: set[str] = set()
+    statuses: list[str] = []
+    for result in results:
+        if not isinstance(result, dict) or set(result) != {"id", "status", "evidence"}:
+            raise ValueError("judge assertion result fields are invalid")
+        assertion_id, status, evidence = result.get("id"), result.get("status"), result.get("evidence")
+        if assertion_id not in assertion_ids or assertion_id in seen:
+            raise ValueError(f"judge assertion id is missing, unknown, or duplicate: {assertion_id}")
+        if status not in {"PASS", "FAIL", "NOT_EXERCISED"}:
+            raise ValueError(f"judge assertion status is invalid: {status}")
+        if not isinstance(evidence, str) or not evidence.strip():
+            raise ValueError("judge assertion evidence must be non-empty")
+        seen.add(assertion_id)
+        statuses.append(status)
+    if seen != assertion_ids:
+        raise ValueError("judge result does not cover every assertion")
+    summaries = payload.get("lane_summaries")
+    if not isinstance(summaries, dict) or set(summaries) != {"without_skill", "with_skill"}:
+        raise ValueError("judge lane_summaries must cover both lanes")
+    for summary in summaries.values():
+        if not isinstance(summary, dict) or set(summary) != {"run_source", "behavior_summary"}:
+            raise ValueError("judge lane summary fields are invalid")
+        if not all(isinstance(value, str) and value.strip() for value in summary.values()):
+            raise ValueError("judge lane summary values must be non-empty strings")
+    expected_behavior = "FAIL" if "FAIL" in statuses else "PASS"
+    expected_coverage = "PARTIAL" if "NOT_EXERCISED" in statuses else "FULL"
+    for field in ("uncovered_reasons", "blockers", "failures", "next_steps"):
+        value = payload.get(field)
+        if not isinstance(value, list) or not all(isinstance(item, str) and item.strip() for item in value):
+            raise ValueError(f"judge result {field} must be an array of non-empty strings")
+    if expected_coverage == "PARTIAL" and not payload["uncovered_reasons"]:
+        raise ValueError("partial coverage requires uncovered_reasons")
+    normalized = dict(payload)
+    normalized["behavior_result"] = expected_behavior
+    normalized["coverage_result"] = expected_coverage
+    normalized["overall_result"] = recompute_overall(expected_behavior, expected_coverage)
+    return normalized
+
+
+def prepare_judge_package(definition: Any, materialized: Any, judge: Any,
+                          candidate_runs: list[dict[str, Any]]) -> None:
+    fixture_destination = judge.workspace_root / "fixture"
+    shutil.copytree(materialized.canonical_root, fixture_destination)
+    package = {
+        "prompt": materialized.prompt,
+        "assertions": definition.item["assertions"],
+        "candidate_outputs": [{
+            "mode": run["mode"], "output": run["output"], "git_status": run["git_status"],
+            "git_diff": run["git_diff"], "workspace_manifest": run["workspace_manifest"],
+            "delivery_snapshot": run["delivery_snapshot"], "git_evidence": run["git_evidence"],
+            "dependency_evidence": run["dependency_evidence"],
+            "declared_outputs": run["declared_outputs"],
+            "runner_captured_trace": {
+                "stdout_jsonl_tail": run["status"].get("stdout_tail", ""),
+                "stderr_tail": run["status"].get("stderr_tail", ""),
+            },
+        } for run in candidate_runs],
+        "preflight": materialized.preflight.as_dict(),
+    }
+    (judge.workspace_root / "judge-package.json").write_text(
+        json.dumps(package, ensure_ascii=False, indent=2) + "\n", encoding="utf-8",
+    )
+
+
+def judge_prompt() -> str:
+    return (
+        "Read judge-package.json and the read-only fixture directory. Independently judge "
+        "each assertion from the two locked candidate outputs and raw evidence. Assertion "
+        "verdicts evaluate only the with_skill lane. The without_skill is comparison context: "
+        "its failure to satisfy an assertion must not make an assertion FAIL when with_skill "
+        "satisfies it. Use without_skill only to describe the fresh baseline and contrast the "
+        "two behaviors. Copy each assertion id exactly from judge-package.json; never invent "
+        "positional ids such as assertion_1. Return only the JSON object required by the supplied "
+        "output schema. Treat each delivery_snapshot file or git_blob content as locked primary "
+        "evidence: inspect that content directly, and do not fail a file-backed requirement merely "
+        "because the candidate's final prose does not restate the delivered file. Judge user-visible "
+        "behavior semantically: accept semantic equivalents and do not require an exact internal "
+        "label, skill path, or wording unless the assertion makes that literal form part of the "
+        "user's observable result. For an interactive workflow, when the candidate correctly performs "
+        "the next required step but a later step cannot yet occur without user confirmation or missing "
+        "runtime evidence, mark that later assertion NOT_EXERCISED and coverage PARTIAL rather than FAIL. "
+        "Likewise, a hidden process or read-order assertion is NOT_EXERCISED when the locked raw evidence "
+        "cannot prove it; do not infer failure merely because the final prose omits process narration. "
+        "Treat runner_captured_trace JSONL command and tool events as locked raw evidence, but do not "
+        "treat agent-message claims inside that trace as independent proof. Use FAIL only when the "
+        "with_skill lane contradicts an exercised requirement, omits an exercised user-visible result, "
+        "makes an unsupported claim, or performs a forbidden mutation. Return only the JSON object "
+        "required by the supplied output schema. Do not use lane self-ratings or any historical comparison."
+    )

--- a/scripts/eval_persistence.py
+++ b/scripts/eval_persistence.py
@@ -1,0 +1,157 @@
+"""Durable comparison and frozen migration-inventory persistence."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import threading
+from pathlib import Path
+from typing import Any
+
+
+_DURABLE_WRITE_LOCK = threading.Lock()
+
+
+def _stage_file(path: Path, content: bytes) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile("wb", dir=path.parent, delete=False) as handle:
+            temporary = Path(handle.name)
+            handle.write(content)
+        return temporary
+    except Exception:
+        if temporary and temporary.exists():
+            temporary.unlink()
+        raise
+
+
+def transactional_replace(updates: dict[Path, bytes]) -> None:
+    staged: dict[Path, Path] = {}
+    backups: dict[Path, Path] = {}
+    replaced: list[Path] = []
+    try:
+        for path, content in updates.items():
+            staged[path] = _stage_file(path, content)
+        for path in updates:
+            backups[path] = _stage_file(path, path.read_bytes())
+        for path in updates:
+            os.replace(staged[path], path)
+            replaced.append(path)
+    except Exception:
+        for path in reversed(replaced):
+            os.replace(backups[path], path)
+        raise
+    finally:
+        for temporary in (*staged.values(), *backups.values()):
+            if temporary.exists():
+                temporary.unlink()
+
+
+def durable_comparison(definition: Any, result: dict[str, Any]) -> str:
+    rows = "\n".join(
+        f"| `{item['id']}` | {item['status']} | {item['evidence'].replace('|', chr(92) + '|')} |"
+        for item in result["assertion_results"]
+    )
+    failures = "\n".join(f"- {item}" for item in result["failures"] or ["None."])
+    next_steps = "\n".join(f"- Next: {item}" for item in result["next_steps"] or ["None."])
+    identity = result["source_identity"]
+    freshness = identity["freshness"]
+    without = result["lane_summaries"]["without_skill"]
+    with_skill = result["lane_summaries"]["with_skill"]
+    return f"""# Issue #246 Evaluation Result
+
+## Evaluation Target
+
+- Agent: `{definition.agent}`
+- Skill: `{definition.skill}`
+- Eval: `{definition.eval_id}`
+
+## Current Result
+
+- Evidence status: **FRESH**
+- Preflight status: **PASS**
+- Judge: third independent fresh judge completed after both candidates were locked.
+- Fixture version/source: canonical manifest `{result['preflight']['fixture_hash']}` from `{definition.workspace_root.relative_to(definition.repository_root)}`.
+- Identity schema: `2`
+- target_skill_sha256: `{freshness['target_skill_sha256']}`
+- eval_definition_sha256: `{freshness['eval_definition_sha256']}`
+- metadata_sha256: `{freshness['metadata_sha256']}`
+- fixture_sha256: `{freshness['fixture_sha256']}`
+- execution_protocol_sha256: `{freshness['execution_protocol_sha256']}`
+- runtime_protocol_sha256: `{freshness['runtime_protocol_sha256']}`
+- judge_schema_sha256: `{freshness['judge_schema_sha256']}`
+- Source lock SHA-256: `{identity['source_lock_sha256']}`
+- Prompt SHA-256: `{result['preflight']['prompt_hash']}`
+- Repository HEAD: `{identity['repository_head']}`
+- Repository worktree state: **{'DIRTY' if identity['repository_dirty'] else 'CLEAN'}**
+- Skill overlay SHA-256: `{identity['skill_overlay_sha256']}`
+- Behavior result: **{result['behavior_result']}**
+- Coverage result: **{result['coverage_result']}**
+Overall result: {result['overall_result']}
+
+## Assertion Results
+
+| Assertion | Result | Evidence |
+| --- | --- | --- |
+{rows}
+
+## With-Skill Behavior
+
+- Run source: {with_skill['run_source']}
+- Behavior: {with_skill['behavior_summary']}
+- The with-skill context was created only after the baseline evidence was locked and destroyed.
+
+## Fresh Without-Skill Baseline
+
+- Run source: {without['run_source']}
+- Behavior: {without['behavior_summary']}
+- The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
+
+## Failures and Next Steps
+
+{failures}
+{next_steps}
+
+## Runtime Artifact Policy
+
+- Candidate outputs, snapshots, judge packages, verdict payloads, timing, diagnostics, and other runtime files are deleted before the runner exits, including after FAIL, BLOCKED, or exceptions.
+- This durable comparison retains only the latest reviewable conclusion; Git history preserves earlier revisions.
+"""
+
+
+def updated_inventory(definition: Any) -> tuple[Path, dict[str, Any]] | None:
+    path = definition.repository_root / (
+        "docs/engineer/repository-governance/eval-scenario-isolation/migration-inventory.json"
+    )
+    if not path.is_file():
+        return None
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    matches = [record for record in payload.get("old_evals", []) if (
+        record.get("agent"), record.get("skill"), record.get("new_eval_id")
+    ) == (definition.agent, definition.skill, definition.eval_id)
+        and record.get("disposition") == "retained"]
+    if not matches:
+        return None
+    if len(matches) > 1:
+        raise ValueError("migration inventory contains more than one matching retained eval")
+    matches[0]["migration_status"] = "complete"
+    statuses = [record.get("migration_status") for record in payload["old_evals"]]
+    payload["counts"]["migration_status"] = {
+        status: statuses.count(status) for status in ("pending", "complete")
+    }
+    return path, payload
+
+
+def persist_durable_result(definition: Any, result: dict[str, Any]) -> None:
+    with _DURABLE_WRITE_LOCK:
+        inventory = updated_inventory(definition)
+        comparison = definition.workspace_root / "comparison.md"
+        updates = {comparison: durable_comparison(definition, result).encode("utf-8")}
+        if inventory:
+            path, payload = inventory
+            updates[path] = (
+                json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
+            ).encode("utf-8")
+        transactional_replace(updates)

--- a/scripts/migrate_eval_identity_v2.py
+++ b/scripts/migrate_eval_identity_v2.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""One-time, Git-attested migration of durable eval identities to schema v2."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.eval_identity import FRESHNESS_FIELDS as FRESHNESS_KEYS
+from scripts.eval_identity import current_identity_v2
+from scripts.run_skill_eval import build_judge_schema_bytes, load_eval_definition
+
+
+AUDIT_RELATIVE_PATH = Path(
+    "docs/engineer/repository-governance/eval-scenario-isolation/"
+    "eval-identity-v2-migration-audit.json"
+)
+INVENTORY_RELATIVE_PATH = Path(
+    "docs/engineer/repository-governance/eval-scenario-isolation/migration-inventory.json"
+)
+MANUAL_COMPARISON = Path("agents/docs/test/manual-gen/comparison.md")
+LEGACY_LABELS = {
+    "Target skill tree SHA-256": "target_skill_sha256",
+    "Eval definition SHA-256": "eval_definition_sha256",
+    "Metadata SHA-256": "metadata_sha256",
+    "Fixture SHA-256": "fixture_sha256",
+    "Judge schema SHA-256": "judge_schema_sha256",
+}
+EXPECTED_COUNTS = {"mechanical": 187, "stale": 6, "pending": 3, "manual_excluded": 1}
+PRESERVED_PATTERNS = {
+    "behavior": re.compile(rb"^- Behavior result:.*(?:\n|\Z)", re.M),
+    "coverage": re.compile(rb"^- Coverage result:.*(?:\n|\Z)", re.M),
+    "overall": re.compile(rb"^Overall result:.*(?:\n|\Z)", re.M),
+    "assertions": re.compile(rb"^## Assertion Results\n\n.*?(?=^## |\Z)", re.M | re.S),
+}
+
+
+@dataclass(frozen=True)
+class Target:
+    agent: str
+    skill: str
+    eval_id: str
+    comparison: Path
+
+
+def sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _git(root: Path, *args: str) -> bytes:
+    completed = subprocess.run(["git", *args], cwd=root, capture_output=True)
+    if completed.returncode:
+        raise ValueError(completed.stderr.decode(errors="replace").strip())
+    return completed.stdout
+
+
+def trusted_source(root: Path, source_ref: str) -> dict[str, str]:
+    commit = _git(root, "rev-parse", "--verify", f"{source_ref}^{{commit}}").decode().strip()
+    executor = _git(root, "show", f"{commit}:scripts/run_skill_eval.py")
+    runtime = _git(root, "show", f"{commit}:scripts/eval_runtime.py")
+    return {
+        "source_ref": source_ref,
+        "source_commit": commit,
+        "executor_sha256": sha256(executor),
+        "runtime_sha256": sha256(runtime),
+    }
+
+
+def enumerate_targets(root: Path) -> list[Target]:
+    targets: list[Target] = []
+    for evals_path in sorted(root.glob("agents/*/test/*/evals/evals.json")):
+        payload = json.loads(evals_path.read_text(encoding="utf-8"))
+        agent, skill = payload["agent"], payload["skill_name"]
+        for item in payload["evals"]:
+            definition = load_eval_definition(root, agent, skill, item["id"])
+            targets.append(Target(
+                agent, skill, item["id"], definition.workspace_root / "comparison.md",
+            ))
+    return targets
+
+
+def _line_value(text: str, label: str) -> str | None:
+    matches = re.findall(rf"^- {re.escape(label)}:\s*`([^`]+)`\s*$", text, re.M)
+    if len(matches) > 1:
+        raise ValueError(f"duplicate comparison field: {label}")
+    return matches[0] if matches else None
+
+
+def _preserved(data: bytes) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for name, pattern in PRESERVED_PATTERNS.items():
+        match = pattern.search(data)
+        if match is None:
+            raise ValueError(f"missing preserved comparison section: {name}")
+        result[name] = sha256(match.group(0))
+    return result
+
+
+def _identity_lines(identity: dict[str, Any]) -> list[str]:
+    if identity.get("identity_schema") not in {2, "2"}:
+        raise ValueError("current identity is not schema v2")
+    return ["- Identity schema: `2`", *(
+        f"- {key}: `{identity[key]}`" for key in FRESHNESS_KEYS
+    )]
+
+
+def _replace_identity(
+    text: str, identity: dict[str, Any], migration: dict[str, str], *, annotate: bool = True,
+) -> str:
+    lines = text.splitlines(keepends=True)
+    removable = {
+        "Fixture SHA-256", "Prompt SHA-256", "Target skill tree SHA-256",
+        "Skill overlay SHA-256", "Judge schema SHA-256", "Eval definition SHA-256",
+        "Metadata SHA-256", "Executor SHA-256", "Runtime SHA-256", "Identity schema",
+        "Identity migration", "Identity migration source commit", "Identity migration audit",
+        *FRESHNESS_KEYS,
+    }
+    kept: list[str] = []
+    insertion: int | None = None
+    for line in lines:
+        label = re.match(r"^- ([^:]+):", line)
+        if label and label.group(1) in removable:
+            if insertion is None:
+                insertion = len(kept)
+            continue
+        kept.append(line)
+    if insertion is None:
+        marker = next((i + 1 for i, line in enumerate(kept)
+                       if line.startswith("- Repository worktree state:")), None)
+        if marker is None:
+            marker = next((i + 1 for i, line in enumerate(kept)
+                           if line.startswith("- Preflight status:")), None)
+        if marker is None:
+            raise ValueError("comparison has no identity insertion point")
+        insertion = marker
+    block = [f"{line}\n" for line in _identity_lines(identity)]
+    if annotate:
+        block.extend([
+            "- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**\n",
+            f"- Identity migration source commit: `{migration['source_commit']}`\n",
+            f"- Identity migration audit: `{AUDIT_RELATIVE_PATH.as_posix()}`\n",
+        ])
+    kept[insertion:insertion] = block
+    return "".join(kept)
+
+
+def _mark_state(text: str, state: str, target: Target) -> str:
+    text = re.sub(
+        r"^- Evidence status:.*$", f"- Evidence status: **{state}**", text,
+        count=1, flags=re.M,
+    )
+    if state == "PENDING":
+        text = text.replace("- Eval: `PENDING`", f"- Eval: `{target.eval_id}`", 1)
+    elif state == "STALE":
+        text = re.sub(r"^Overall result:.*$", "Overall result: BLOCKED", text, count=1, flags=re.M)
+    return text
+
+
+def classify(target: Target, text: str, identity: dict[str, Any], source: dict[str, str]) -> tuple[str, list[str]]:
+    evidence = re.search(r"^- Evidence status:\s*\*\*([^*]+)\*\*", text, re.M)
+    if evidence and evidence.group(1) == "PENDING":
+        return "pending", ["no_fresh_evidence"]
+    if _line_value(text, "Identity schema") == "2":
+        mismatches = [key for key in FRESHNESS_KEYS if _line_value(text, key) != identity[key]]
+        if evidence and evidence.group(1) == "STALE":
+            return "stale", [f"input_changed:{key}" for key in mismatches] or ["awaiting_fresh_rerun"]
+        if mismatches:
+            protocol_fields = {
+                "execution_protocol_sha256", "runtime_protocol_sha256", "judge_schema_sha256",
+            }
+            if (
+                not set(mismatches).issubset(protocol_fields)
+                or "MIGRATED_WITHOUT_MODEL_RERUN" not in text
+                or _line_value(text, "Identity migration source commit") != source["source_commit"]
+            ):
+                raise ValueError(f"{target.eval_id}: schema v2 input mismatch: {mismatches}")
+            return "mechanical", ["identity_v2_protocol_finalized"]
+        if "MIGRATED_WITHOUT_MODEL_RERUN" not in text:
+            raise ValueError(f"{target.eval_id}: schema v2 comparison lacks migration evidence")
+        return "mechanical", ["identity_v2_already_migrated"]
+    old_executor = _line_value(text, "Executor SHA-256")
+    old_runtime = _line_value(text, "Runtime SHA-256")
+    if old_executor != source["executor_sha256"] or old_runtime != source["runtime_sha256"]:
+        raise ValueError(f"{target.eval_id}: legacy protocol hash does not match --source-ref")
+    mismatches = [
+        key for label, key in LEGACY_LABELS.items()
+        if _line_value(text, label) != identity[key]
+    ]
+    if mismatches:
+        if target.agent == "engineer" and target.skill == "trd-gen":
+            return "stale", [f"input_changed:{key}" for key in mismatches]
+        raise ValueError(f"{target.eval_id}: unexpected current input mismatch: {mismatches}")
+    return "mechanical", ["trusted_legacy_protocol", "current_inputs_match"]
+
+
+def build_migration(root: Path, source_ref: str) -> tuple[dict[Path, bytes], dict[str, Any]]:
+    inventory_path = root / INVENTORY_RELATIVE_PATH
+    inventory_before = inventory_path.read_bytes()
+    inventory = json.loads(inventory_before)
+    inventory_paths = {record["comparison_path"] for record in inventory["old_evals"]}
+    if len(inventory["old_evals"]) != 193 or len(inventory_paths) != 193:
+        raise ValueError("frozen inventory must contain 193 unique comparison paths")
+    source = trusted_source(root, source_ref)
+    updates: dict[Path, bytes] = {}
+    entries: list[dict[str, Any]] = []
+    counts = {key: 0 for key in EXPECTED_COUNTS}
+    assertion_rows = {"total": 0, "PASS": 0, "NOT_EXERCISED": 0, "FAIL": 0}
+
+    for target in enumerate_targets(root):
+        path = target.comparison
+        rel = path.relative_to(root).as_posix()
+        before = path.read_bytes()
+        text = before.decode("utf-8")
+        definition = load_eval_definition(root, target.agent, target.skill, target.eval_id)
+        identity = current_identity_v2(
+            definition,
+            judge_schema_bytes=build_judge_schema_bytes(definition.item["assertions"]),
+        )
+        category, reasons = classify(target, text, identity, source)
+        counts[category] += 1
+        preserved_before = _preserved(before) if category != "pending" else {}
+        migrated = _replace_identity(text, identity, source, annotate=category == "mechanical")
+        if category == "stale":
+            migrated = _mark_state(migrated, "STALE", target)
+        elif category == "pending":
+            migrated = _mark_state(migrated, "PENDING", target)
+        after = migrated.encode("utf-8")
+        preserved_after = _preserved(after) if category != "pending" else {}
+        if category == "mechanical" and preserved_before != preserved_after:
+            raise ValueError(f"{target.eval_id}: verdict or assertion evidence changed")
+        if category == "mechanical":
+            section = PRESERVED_PATTERNS["assertions"].search(before)
+            assert section is not None
+            rows = re.findall(rb"^\| `[^`]+` \| (PASS|FAIL|NOT_EXERCISED) \|", section.group(0), re.M)
+            assertion_rows["total"] += len(rows)
+            for status in rows:
+                assertion_rows[status.decode()] += 1
+        updates[path] = after
+        entries.append({
+            "agent": target.agent, "skill": target.skill, "eval_id": target.eval_id,
+            "comparison_path": rel, "inventory_match_count": int(rel in inventory_paths),
+            "classification": category, "reason_codes": reasons,
+            "legacy_executor_sha256": _line_value(text, "Executor SHA-256"),
+            "legacy_runtime_sha256": _line_value(text, "Runtime SHA-256"),
+            "identity_v2": {key: identity[key] for key in FRESHNESS_KEYS},
+            "preserved_raw_sha256_before": preserved_before,
+            "preserved_raw_sha256_after": preserved_after,
+            "before_sha256": sha256(before), "after_sha256": sha256(after),
+        })
+
+    if (root / MANUAL_COMPARISON).is_file():
+        counts["manual_excluded"] = 1
+    if counts != EXPECTED_COUNTS:
+        raise ValueError(f"migration classification counts differ: {counts}")
+    if assertion_rows != {"total": 807, "PASS": 717, "NOT_EXERCISED": 70, "FAIL": 20}:
+        raise ValueError(f"mechanical assertion counts differ: {assertion_rows}")
+    if inventory_path.read_bytes() != inventory_before:
+        raise ValueError("frozen inventory changed during migration planning")
+    audit = {
+        "schema_version": "2.0", "migration": "eval-identity-v2",
+        "mode": "dry-run", "source_attestation": source,
+        "audit_path": AUDIT_RELATIVE_PATH.as_posix(),
+        "verification_contract": [
+            "uv run --with pytest pytest scripts/test_migrate_eval_identity_v2.py agents/test_eval_contract.py",
+            "uv run scripts/check_eval_contract.py",
+            "uv run scripts/check_eval_artifacts.py",
+            "git diff --check",
+        ],
+        "counts": counts, "mechanical_assertion_rows": assertion_rows,
+        "inventory_sha256_before": sha256(inventory_before),
+        "inventory_sha256_after": sha256(inventory_path.read_bytes()),
+        "entries": entries,
+    }
+    return updates, audit
+
+
+def atomic_write(updates: dict[Path, bytes]) -> None:
+    staged: dict[Path, Path] = {}
+    backups: dict[Path, bytes] = {}
+    existed: dict[Path, bool] = {}
+    replaced: list[Path] = []
+    try:
+        for path, content in updates.items():
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with tempfile.NamedTemporaryFile(dir=path.parent, delete=False) as handle:
+                handle.write(content)
+                staged[path] = Path(handle.name)
+            existed[path] = path.exists()
+            backups[path] = path.read_bytes() if existed[path] else b""
+            os.chmod(staged[path], path.stat().st_mode if existed[path] else 0o644)
+        for path, temporary in staged.items():
+            os.replace(temporary, path)
+            replaced.append(path)
+    except Exception:
+        for path in reversed(replaced):
+            if existed[path]:
+                path.write_bytes(backups[path])
+            else:
+                path.unlink(missing_ok=True)
+        raise
+    finally:
+        for temporary in staged.values():
+            temporary.unlink(missing_ok=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source-ref", required=True)
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument("--audit-output", type=Path)
+    args = parser.parse_args(argv)
+    root = Path(__file__).resolve().parents[1]
+    updates, audit = build_migration(root, args.source_ref)
+    if args.apply:
+        if args.audit_output not in {None, AUDIT_RELATIVE_PATH}:
+            parser.error(f"--apply audit path must be {AUDIT_RELATIVE_PATH.as_posix()}")
+        audit["mode"] = "applied"
+        audit_path = root / AUDIT_RELATIVE_PATH
+        updates[audit_path] = (json.dumps(audit, ensure_ascii=False, indent=2) + "\n").encode()
+        atomic_write(updates)
+    elif args.audit_output:
+        if args.audit_output != AUDIT_RELATIVE_PATH:
+            parser.error(f"audit path must be {AUDIT_RELATIVE_PATH.as_posix()}")
+        audit_path = args.audit_output if args.audit_output.is_absolute() else root / args.audit_output
+        atomic_write({audit_path: (json.dumps(audit, ensure_ascii=False, indent=2) + "\n").encode()})
+    else:
+        print(json.dumps(audit, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_skill_eval.py
+++ b/scripts/run_skill_eval.py
@@ -1,1057 +1,43 @@
 #!/usr/bin/env python3
-"""Run paired skill evals with one shared isolation and judging boundary."""
+"""Run paired skill evals through the shared execution protocol."""
 
 from __future__ import annotations
 
 import argparse
-import base64
-import hashlib
 import json
-import os
 import re
-import shutil
-import subprocess
 import sys
-import tempfile
-import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from scripts.eval_runtime import (  # noqa: E402
-    IsolatedContext,
-    MaterializedEvalRun,
-    PermissionProbe,
-    close_context,
-    content_tree_hash,
-    copy_canonical_fixture,
-    evaluate_context_preflight,
-    fixture_manifest,
-    manifest_hash,
-    materialize_eval_run,
-    open_context,
-    record_preflight,
-    run_permission_probe,
-    skill_overlay_hash,
-    verify_context_dependencies,
-)
+from scripts import eval_execution as _execution  # noqa: E402
+from scripts import eval_judging as _judging  # noqa: E402
+from scripts import eval_persistence as _persistence  # noqa: E402
 
 
-MODEL = "gpt-5.6-luna"
-REASONING_EFFORT = "medium"
-DEFAULT_TIMEOUT_SECONDS = 600
-MAX_CANDIDATE_TRACE_CHARS = 250_000
-JUDGE_SCHEMA = Path(__file__).with_name("eval_judge_result.schema.json")
-_DURABLE_WRITE_LOCK = threading.Lock()
-_SOURCE_INPUT_KEYS = (
-    "target_skill_sha256", "skill_overlay_sha256", "judge_schema_sha256",
-    "eval_definition_sha256", "metadata_sha256", "executor_sha256",
-    "runtime_sha256", "fixture_sha256",
-)
+for _name in dir(_execution):
+    if not _name.startswith("__"):
+        globals()[_name] = getattr(_execution, _name)
 
-
-@dataclass(frozen=True)
-class EvalDefinition:
-    repository_root: Path
-    agent: str
-    skill: str
-    eval_id: str
-    workspace_root: Path
-    item: dict[str, Any]
-    metadata: dict[str, Any]
-    evals_bytes: bytes
-    metadata_bytes: bytes
-
-
-CommandRunner = Callable[..., dict[str, Any]]
+JUDGE_SCHEMA = _judging.JUDGE_SCHEMA
+_stage_file = _persistence._stage_file
+_transactional_replace = _persistence.transactional_replace
+_durable_comparison = _persistence.durable_comparison
+_updated_inventory = _persistence.updated_inventory
+persist_durable_result = _persistence.persist_durable_result
 
 
 def build_judge_schema_bytes(assertions: list[dict[str, Any]]) -> bytes:
-    schema = json.loads(JUDGE_SCHEMA.read_text(encoding="utf-8"))
-    assertion_ids = [assertion["id"] for assertion in assertions]
-    results = schema["properties"]["assertion_results"]
-    results["minItems"] = len(assertion_ids)
-    results["maxItems"] = len(assertion_ids)
-    results["items"]["properties"]["id"] = {"enum": assertion_ids}
-    return json.dumps(
-        schema, ensure_ascii=False, sort_keys=True, separators=(",", ":"),
-    ).encode()
+    return _judging.build_judge_schema_bytes(assertions, schema_path=JUDGE_SCHEMA)
 
 
-def _load_json(path: Path) -> dict[str, Any]:
-    payload = json.loads(path.read_text(encoding="utf-8"))
-    if not isinstance(payload, dict):
-        raise ValueError(f"JSON root must be an object: {path}")
-    return payload
-
-
-def source_identity(
-    definition: EvalDefinition, *, judge_schema_bytes: bytes | None = None,
-) -> dict[str, Any]:
-    head = subprocess.run(
-        ["git", "rev-parse", "--verify", "HEAD"], cwd=definition.repository_root,
-        capture_output=True, text=True,
-    )
-    status = subprocess.run(
-        ["git", "status", "--porcelain", "--untracked-files=all"],
-        cwd=definition.repository_root, capture_output=True, text=True,
-    )
-    executor = Path(__file__).resolve()
-    runtime = executor.with_name("eval_runtime.py")
-    target = definition.repository_root / f"agents/{definition.agent}/skills/{definition.skill}"
-    overlay_paths = [target, *(
-        definition.repository_root / value
-        for value in definition.metadata.get("skill_dependencies", [])
-    )]
-    overlay_hash = skill_overlay_hash(overlay_paths, definition.repository_root)
-    schema_bytes = (
-        build_judge_schema_bytes(definition.item["assertions"])
-        if judge_schema_bytes is None else judge_schema_bytes
-    )
-    with tempfile.TemporaryDirectory() as temporary:
-        canonical = Path(temporary) / "canonical"
-        copy_canonical_fixture(
-            definition.workspace_root, canonical,
-            cleanup_paths=definition.metadata.get("execution_cleanup", []),
-        )
-        fixture_hash = manifest_hash(fixture_manifest(canonical))
-    return {
-        "repository_head": head.stdout.strip() if head.returncode == 0 else "unavailable",
-        "repository_dirty": status.returncode != 0 or bool(status.stdout),
-        "target_skill_sha256": content_tree_hash(target),
-        "skill_overlay_sha256": overlay_hash,
-        "judge_schema_sha256": hashlib.sha256(schema_bytes).hexdigest(),
-        "eval_definition_sha256": hashlib.sha256(json.dumps(
-            definition.item, ensure_ascii=False, sort_keys=True, separators=(",", ":"),
-        ).encode()).hexdigest(),
-        "metadata_sha256": hashlib.sha256(definition.metadata_bytes).hexdigest(),
-        "executor_sha256": hashlib.sha256(executor.read_bytes()).hexdigest(),
-        "runtime_sha256": hashlib.sha256(runtime.read_bytes()).hexdigest(),
-        "fixture_sha256": fixture_hash,
-    }
-
-
-def _same_source_inputs(left: dict[str, Any], right: dict[str, Any]) -> bool:
-    return all(left.get(key) == right.get(key) for key in _SOURCE_INPUT_KEYS)
-
-
-def _prune_runtime_parents(runtime_root: Path, repository_root: Path) -> None:
-    stop = (repository_root.resolve() / "tmp/eval-runs").resolve()
-    current = runtime_root.resolve().parent
-    if current != stop and stop not in current.parents:
-        return
-    while current == stop or stop in current.parents:
-        try:
-            current.rmdir()
-        except OSError:
-            return
-        if current == stop:
-            return
-        current = current.parent
-
-
-def _resolve_workspace(evals_path: Path, workspace: str) -> Path:
-    for candidate in (evals_path.parents[1] / workspace, evals_path.parent / workspace):
-        if candidate.exists():
-            return candidate.resolve()
-    raise ValueError(f"eval workspace does not exist: {workspace}")
-
-
-def load_eval_definition(
-    repository_root: Path,
-    agent: str,
-    skill: str,
-    eval_id: str,
-    *,
-    metadata_snapshot: tuple[dict[str, Any], bytes] | None = None,
-) -> EvalDefinition:
-    repository_root = repository_root.resolve()
-    evals_path = repository_root / f"agents/{agent}/test/{skill}/evals/evals.json"
-    evals_bytes = evals_path.read_bytes()
-    payload = json.loads(evals_bytes)
-    if not isinstance(payload, dict):
-        raise ValueError(f"JSON root must be an object: {evals_path}")
-    if payload.get("agent") != agent or payload.get("skill_name") != skill:
-        raise ValueError(f"eval suite identity does not match {agent}/{skill}")
-    item = next(
-        (candidate for candidate in payload.get("evals", []) if candidate.get("id") == eval_id),
-        None,
-    )
-    if item is None:
-        raise ValueError(f"eval {eval_id!r} not found in {evals_path}")
-    workspace = item.get("workspace")
-    if not isinstance(workspace, str):
-        raise ValueError(f"eval {eval_id!r} has no workspace")
-    workspace_root = _resolve_workspace(evals_path, workspace)
-    metadata_path = workspace_root / "eval_metadata.json"
-    if metadata_snapshot is None:
-        metadata_bytes = metadata_path.read_bytes()
-        metadata = json.loads(metadata_bytes)
-    else:
-        metadata, metadata_bytes = metadata_snapshot
-    if not isinstance(metadata, dict):
-        raise ValueError(f"JSON root must be an object: {metadata_path}")
-    if metadata.get("eval_id") != eval_id:
-        raise ValueError(f"metadata eval_id does not match {eval_id!r}")
-    return EvalDefinition(
-        repository_root, agent, skill, eval_id, workspace_root, item, metadata,
-        evals_bytes, metadata_bytes,
-    )
-
-
-def definition_from_metadata(
-    metadata_path: Path,
-    *,
-    repository_root: Path | None = None,
-) -> EvalDefinition:
-    metadata_path = metadata_path.resolve()
-    repository_root = (repository_root or Path(__file__).resolve().parents[1]).resolve()
-    relative = metadata_path.relative_to(repository_root)
-    parts = relative.parts
-    if len(parts) < 7 or parts[0] != "agents" or parts[2] != "test":
-        raise ValueError(f"metadata path is not in an agent eval workspace: {metadata_path}")
-    agent = parts[1]
-    skill = parts[3]
-    metadata_bytes = metadata_path.read_bytes()
-    metadata = json.loads(metadata_bytes)
-    if not isinstance(metadata, dict):
-        raise ValueError(f"JSON root must be an object: {metadata_path}")
-    eval_id = metadata.get("eval_id")
-    if not isinstance(eval_id, str):
-        raise ValueError(f"metadata is missing eval_id: {metadata_path}")
-    definition = load_eval_definition(
-        repository_root, agent, skill, eval_id,
-        metadata_snapshot=(metadata, metadata_bytes),
-    )
-    if definition.workspace_root / "eval_metadata.json" != metadata_path:
-        raise ValueError("metadata path does not match the eval definition workspace")
-    return definition
-
-
-def _codex_command(
-    workspace: Path,
-    output_path: Path,
-    *,
-    schema: Path | None = None,
-) -> list[str]:
-    command = [
-        "codex", "--ask-for-approval", "never", "--strict-config", "exec", "-C", str(workspace),
-        "--ephemeral", "--ignore-rules",
-        "--model", MODEL, "-c", f'model_reasoning_effort="{REASONING_EFFORT}"',
-    ]
-    if schema is not None:
-        command.extend(["--output-schema", str(schema)])
-    return [*command, "--output-last-message", str(output_path), "-"]
-
-
-def candidate_command(workspace: Path, output_path: Path) -> list[str]:
-    command = _codex_command(workspace, output_path)
-    command.insert(command.index("--output-last-message"), "--json")
-    return command
-
-
-def judge_command(
-    workspace: Path, output_path: Path, *, schema: Path | None = None,
-) -> list[str]:
-    return _codex_command(workspace, output_path, schema=schema or JUDGE_SCHEMA)
-
-
-def run_command(
-    command: list[str],
-    *,
-    prompt: str,
-    env: dict[str, str],
-    timeout_seconds: int,
-) -> dict[str, Any]:
-    try:
-        completed = subprocess.run(command, input=prompt, text=True, capture_output=True,
-                                   env=env, timeout=timeout_seconds)
-        return {
-            "returncode": completed.returncode,
-            "timed_out": False,
-            "stdout_tail": completed.stdout[-MAX_CANDIDATE_TRACE_CHARS:],
-            "stderr_tail": completed.stderr[-50_000:],
-        }
-    except subprocess.TimeoutExpired as exc:
-        stdout = exc.stdout.decode(errors="replace") if isinstance(exc.stdout, bytes) else exc.stdout or ""
-        stderr = exc.stderr.decode(errors="replace") if isinstance(exc.stderr, bytes) else exc.stderr or ""
-        return {
-            "returncode": 124,
-            "timed_out": True,
-            "stdout_tail": stdout[-MAX_CANDIDATE_TRACE_CHARS:],
-            "stderr_tail": stderr[-50_000:],
-        }
-
-
-def check_model_available(repository_root: Path) -> bool:
-    if shutil.which("codex") is None:
-        return False
-    try:
-        completed = subprocess.run(["codex", "debug", "models"], cwd=repository_root,
-                                   capture_output=True, text=True, timeout=30)
-    except (OSError, subprocess.TimeoutExpired):
-        return False
-    return completed.returncode == 0 and MODEL in completed.stdout
-
-
-def recompute_overall(behavior_result: str, coverage_result: str) -> str:
-    if behavior_result == "FAIL":
-        return "FAIL"
-    if behavior_result == "PASS" and coverage_result in {"FULL", "PARTIAL"}:
-        return "PASS" if coverage_result == "FULL" else "PASS (partial coverage)"
-    raise ValueError(f"invalid judge result pair: {behavior_result}/{coverage_result}")
-
-
-def validate_judge_result(
-    payload: dict[str, Any],
-    assertion_ids: set[str],
-) -> dict[str, Any]:
-    required = {"assertion_results", "lane_summaries", "behavior_result", "coverage_result", "overall_result",
-                "uncovered_reasons", "blockers", "failures", "next_steps"}
-    if set(payload) != required:
-        raise ValueError("judge result fields do not match the required schema")
-    results = payload.get("assertion_results")
-    if not isinstance(results, list) or not results:
-        raise ValueError("judge result assertion_results must be non-empty")
-    seen: set[str] = set()
-    statuses: list[str] = []
-    for result in results:
-        if not isinstance(result, dict) or set(result) != {"id", "status", "evidence"}:
-            raise ValueError("judge assertion result fields are invalid")
-        assertion_id, status, evidence = result.get("id"), result.get("status"), result.get("evidence")
-        if assertion_id not in assertion_ids or assertion_id in seen:
-            raise ValueError(f"judge assertion id is missing, unknown, or duplicate: {assertion_id}")
-        if status not in {"PASS", "FAIL", "NOT_EXERCISED"}:
-            raise ValueError(f"judge assertion status is invalid: {status}")
-        if not isinstance(evidence, str) or not evidence.strip():
-            raise ValueError("judge assertion evidence must be non-empty")
-        seen.add(assertion_id)
-        statuses.append(status)
-    if seen != assertion_ids:
-        raise ValueError("judge result does not cover every assertion")
-
-    summaries = payload.get("lane_summaries")
-    if not isinstance(summaries, dict) or set(summaries) != {"without_skill", "with_skill"}:
-        raise ValueError("judge lane_summaries must cover both lanes")
-    for summary in summaries.values():
-        if not isinstance(summary, dict) or set(summary) != {"run_source", "behavior_summary"}:
-            raise ValueError("judge lane summary fields are invalid")
-        if not all(isinstance(value, str) and value.strip() for value in summary.values()):
-            raise ValueError("judge lane summary values must be non-empty strings")
-
-    expected_behavior = "FAIL" if "FAIL" in statuses else "PASS"
-    expected_coverage = "PARTIAL" if "NOT_EXERCISED" in statuses else "FULL"
-    for field in ("uncovered_reasons", "blockers", "failures", "next_steps"):
-        value = payload.get(field)
-        if not isinstance(value, list) or not all(isinstance(item, str) and item.strip() for item in value):
-            raise ValueError(f"judge result {field} must be an array of non-empty strings")
-    if expected_coverage == "PARTIAL" and not payload["uncovered_reasons"]:
-        raise ValueError("partial coverage requires uncovered_reasons")
-
-    normalized = dict(payload)
-    normalized["behavior_result"] = expected_behavior
-    normalized["coverage_result"] = expected_coverage
-    normalized["overall_result"] = recompute_overall(expected_behavior, expected_coverage)
-    return normalized
-
-
-def _git(context: IsolatedContext, *args: str, check: bool = True) -> str:
-    result = subprocess.run(
-        ["git", *args], cwd=context.git_root, capture_output=True, text=True,
-    )
-    if check and result.returncode:
-        raise ValueError(f"git evidence command failed: git {' '.join(args)}")
-    return result.stdout
-
-
-def _git_ref_state(context: IsolatedContext) -> dict[str, dict[str, str | None]]:
-    refs: dict[str, dict[str, str | None]] = {}
-    for name in filter(None, _git(context, "for-each-ref", "--format=%(refname)").splitlines()):
-        commit = _git(context, "rev-parse", "--verify", f"{name}^{{commit}}", check=False).strip()
-        tree = _git(context, "rev-parse", "--verify", f"{name}^{{tree}}", check=False).strip()
-        refs[name] = {
-            "object": _git(context, "rev-parse", "--verify", name).strip(),
-            "commit": commit or None,
-            "tree": tree or None,
-        }
-    return refs
-
-
-def _git_reflog(context: IsolatedContext) -> list[dict[str, str]]:
-    entries: list[dict[str, str]] = []
-    output = _git(context, "reflog", "--all", "--format=%H%x00%gs", check=False)
-    for line in output.splitlines():
-        oid, separator, subject = line.partition("\0")
-        if separator and oid:
-            entries.append({"oid": oid, "subject": subject})
-    return entries
-
-
-def _capture_git_baseline(context: IsolatedContext) -> dict[str, Any]:
-    head = _git(context, "rev-parse", "--verify", "HEAD").strip()
-    untracked: list[dict[str, Any]] = []
-    for relative in filter(None, _git(
-        context, "ls-files", "--others", "--exclude-standard", "-z",
-    ).split("\0")):
-        path = context.workspace_root / relative
-        if path.is_file() and not path.is_symlink():
-            untracked.append(_render_snapshot(relative, "untracked", path.read_bytes()))
-    return {
-        "head": head,
-        "branch": _git(context, "symbolic-ref", "-q", "--short", "HEAD", check=False).strip() or None,
-        "refs": _git_ref_state(context),
-        "commits": sorted(filter(None, _git(
-            context, "rev-list", "--all", "--reflog", check=False,
-        ).splitlines())),
-        "reflog": _git_reflog(context),
-        "manifest": fixture_manifest(context.workspace_root),
-        "status_porcelain_v1": _git(
-            context, "status", "--porcelain=v1", "--untracked-files=all",
-        ),
-        "index_diff": _git(context, "diff", "--cached", "--no-ext-diff", "--binary"),
-        "worktree_diff": _git(context, "diff", "--no-ext-diff", "--binary"),
-        "untracked": untracked,
-        "worktrees": sorted(
-            line.removeprefix("worktree ") for line in _git(
-                context, "worktree", "list", "--porcelain",
-            ).splitlines() if line.startswith("worktree ")
-        ),
-    }
-
-
-def _render_snapshot(path: str, kind: str, content: bytes, **fields: Any) -> dict[str, Any]:
-    if len(content) > 2_000_000:
-        raise ValueError(f"candidate delivery exceeds 2 MB snapshot limit: {path}")
-    try:
-        rendered, encoding = content.decode("utf-8"), "utf-8"
-    except UnicodeDecodeError:
-        rendered, encoding = base64.b64encode(content).decode("ascii"), "base64"
-    return {
-        "path": path, "kind": kind, "encoding": encoding,
-        "sha256": hashlib.sha256(content).hexdigest(), "content": rendered, **fields,
-    }
-
-
-def _commit_blob(context: IsolatedContext, commit: str, path: str) -> bytes | None:
-    tree = subprocess.run(
-        ["git", "ls-tree", "-z", commit, "--", path], cwd=context.git_root,
-        capture_output=True,
-    )
-    if tree.returncode or not tree.stdout:
-        return None
-    header = tree.stdout.split(b"\t", 1)[0].decode("ascii")
-    oid = header.split()[2]
-    blob = subprocess.run(
-        ["git", "cat-file", "blob", oid], cwd=context.git_root, capture_output=True,
-    )
-    if blob.returncode:
-        raise ValueError(f"git evidence could not read changed blob: {path}")
-    return blob.stdout
-
-
-def _git_evidence(context: IsolatedContext, before: dict[str, Any]) -> dict[str, Any]:
-    after = _capture_git_baseline(context)
-    changed = {
-        relative for relative in set(before["manifest"]) | set(after["manifest"])
-        if before["manifest"].get(relative) != after["manifest"].get(relative)
-    }
-    snapshot: list[dict[str, Any]] = []
-    for relative in sorted(changed):
-        path = context.workspace_root / relative
-        if not path.exists() and not path.is_symlink():
-            snapshot.append({"path": relative, "kind": "deleted", "content": None})
-            continue
-        if path.is_symlink():
-            snapshot.append({"path": relative, "kind": "symlink", "content": os.readlink(path)})
-            continue
-        if not path.is_file():
-            continue
-        content = path.read_bytes()
-        snapshot.append(_render_snapshot(relative, "file", content))
-
-    ref_delta = {
-        name: {"before": before["refs"].get(name), "after": after["refs"].get(name)}
-        for name in sorted(set(before["refs"]) | set(after["refs"]))
-        if before["refs"].get(name) != after["refs"].get(name)
-    }
-    before_reflog = {(entry["oid"], entry["subject"]) for entry in before["reflog"]}
-    reflog_delta = [
-        entry for entry in after["reflog"]
-        if (entry["oid"], entry["subject"]) not in before_reflog
-    ]
-    new_commits = sorted(set(after["commits"]) - set(before["commits"]))
-    before_reachable = {
-        value["commit"] for value in before["refs"].values() if value["commit"]
-    } | {before["head"]}
-    after_reachable = {
-        value["commit"] for value in after["refs"].values() if value["commit"]
-    } | {after["head"]}
-    new_reachable = sorted(after_reachable - before_reachable)
-    changed_ref_commits = {
-        delta["after"]["commit"] for delta in ref_delta.values()
-        if delta["after"] and delta["after"]["commit"]
-    }
-    if before["head"] != after["head"]:
-        changed_ref_commits.add(after["head"])
-    result_commits = sorted(changed_ref_commits | set(new_commits))
-    result_diffs: list[dict[str, str]] = []
-    git_blob_keys: set[tuple[str, str, str]] = set()
-    evidence_bytes = 0
-    for commit in result_commits:
-        name_status = _git(context, "diff", "--name-status", before["head"], commit)
-        binary_diff = _git(context, "diff", "--no-ext-diff", "--binary", before["head"], commit)
-        evidence_bytes += len(name_status.encode()) + len(binary_diff.encode())
-        result_diffs.append({"commit": commit, "name_status": name_status, "binary_diff": binary_diff})
-        paths = filter(None, _git(
-            context, "diff", "--name-only", "-z", before["head"], commit,
-        ).split("\0"))
-        for relative in paths:
-            content = _commit_blob(context, commit, relative)
-            if content is None:
-                key = (relative, "deleted", commit)
-                if key not in git_blob_keys:
-                    snapshot.append({
-                        "path": relative, "kind": "git_blob", "content": None,
-                        "origin_commit": commit,
-                    })
-                    git_blob_keys.add(key)
-                continue
-            digest = hashlib.sha256(content).hexdigest()
-            key = (relative, digest, commit)
-            if key not in git_blob_keys:
-                snapshot.append(_render_snapshot(
-                    relative, "git_blob", content, origin_commit=commit,
-                    final_reachable=commit in after_reachable,
-                ))
-                git_blob_keys.add(key)
-                evidence_bytes += len(content)
-    if evidence_bytes > 32_000_000:
-        raise ValueError("candidate Git evidence exceeds 32 MB limit")
-
-    manifest = fixture_manifest(context.workspace_root)
-    return {
-        "git_status": _git(context, "status", "--short"),
-        "git_diff": _git(context, "diff", "--no-ext-diff", "--binary", "HEAD"),
-        "workspace_manifest": manifest,
-        "delivery_snapshot": snapshot,
-        "git_evidence": {
-            "head": {
-                "before": before["head"], "after": after["head"],
-                "changed": before["head"] != after["head"],
-            },
-            "branch": {
-                "before": before["branch"], "after": after["branch"],
-                "changed": before["branch"] != after["branch"],
-            },
-            "ref_delta": ref_delta,
-            "new_reachable_commits": new_reachable,
-            "new_commits": new_commits,
-            "reflog_delta": reflog_delta,
-            "result_diffs": result_diffs,
-            "initial_state": {
-                "status_porcelain_v1": before["status_porcelain_v1"],
-                "index_diff": before["index_diff"],
-                "worktree_diff": before["worktree_diff"],
-                "untracked": before["untracked"],
-            },
-            "status_porcelain_v1": _git(
-                context, "status", "--porcelain=v1", "--untracked-files=all",
-            ),
-            "index_diff": _git(context, "diff", "--cached", "--no-ext-diff", "--binary"),
-            "worktree_diff": _git(context, "diff", "--no-ext-diff", "--binary"),
-            "temporary_worktree_cleanup": {
-                "used": "unknown",
-                "before": before["worktrees"],
-                "after": after["worktrees"],
-                "residual_delta": sorted(set(after["worktrees"]) - set(before["worktrees"])),
-                "cleaned": not (set(after["worktrees"]) - set(before["worktrees"])),
-            },
-        },
-        "dependency_evidence": verify_context_dependencies(context),
-    }
-
-
-def _output_checks(
-    snapshot: list[dict[str, Any]], value: Any, mode: str,
-) -> list[dict[str, Any]]:
-    if value is None:
-        return []
-    specs = value if isinstance(value, list) else [value]
-    results: list[dict[str, Any]] = []
-    for spec in specs:
-        alternatives = spec if isinstance(spec, list) else [spec]
-        paths = [item for item in alternatives if isinstance(item, str)]
-        normalized: list[str] = []
-        for path in paths:
-            prefix = path.split("/", 1)[0]
-            if prefix in {"with_skill", "without_skill"}:
-                if prefix != mode:
-                    raise ValueError(f"declared output uses wrong lane prefix: {path}")
-                path = path.split("/", 1)[1] if "/" in path else ""
-            normalized.append(path)
-        delivered = {
-            item["path"] for item in snapshot
-            if (
-                item.get("kind") == "file"
-                or item.get("kind") == "git_blob" and item.get("final_reachable") is True
-            ) and bool(item.get("content"))
-        }
-        ok = bool(paths) and any(
-            changed == path.rstrip("/") or changed.startswith(path.rstrip("/") + "/")
-            for path in normalized for changed in delivered
-        )
-        results.append({"paths": paths, "semantics": "OR", "ok": ok})
-    return results
-
-
-def _candidate_run(
-    materialized: MaterializedEvalRun,
-    context: IsolatedContext,
-    *,
-    command_runner: CommandRunner,
-    timeout_seconds: int,
-) -> dict[str, Any]:
-    mode = context.mode.replace("-", "_")
-    output_path = materialized.runtime_root / f"outputs/{mode}/candidate-output.md"
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    command = candidate_command(context.workspace_root, output_path)
-    git_before = _capture_git_baseline(context)
-    status = command_runner(
-        command,
-        prompt=materialized.prompt,
-        env=context.env,
-        timeout_seconds=timeout_seconds,
-    )
-    output = output_path.read_text(encoding="utf-8") if output_path.is_file() else ""
-    run = {
-        "mode": mode,
-        "command": command,
-        "output_exists": bool(output.strip()),
-        "output": output,
-        "output_sha256": hashlib.sha256(output.encode()).hexdigest(),
-        "status": status,
-        **_git_evidence(context, git_before),
-    }
-    return run
-
-
-def _lane_run_source(run: dict[str, Any], materialized: MaterializedEvalRun) -> str:
-    snapshot = json.dumps(
-        run["delivery_snapshot"], ensure_ascii=False, sort_keys=True, separators=(",", ":"),
-    ).encode()
-    status = run["status"]
-    return (
-        f"fresh {run['mode']} candidate; model={MODEL}; effort={REASONING_EFFORT}; "
-        f"returncode={status.get('returncode')}; timed_out={bool(status.get('timed_out'))}; "
-        f"prompt_sha256={materialized.prompt_hash}; fixture_sha256={materialized.canonical_hash}; "
-        f"output_sha256={run['output_sha256']}; "
-        f"snapshot_sha256={hashlib.sha256(snapshot).hexdigest()}"
-    )
-
-
-def _blocked_result(
-    definition: EvalDefinition,
-    materialized: MaterializedEvalRun,
-    blockers: list[str],
-    candidate_runs: list[dict[str, Any]] | None = None,
-) -> dict[str, Any]:
-    result = {
-        "agent": definition.agent,
-        "skill": definition.skill,
-        "eval_id": definition.eval_id,
-        "preflight": materialized.preflight.as_dict(),
-        "candidate_runs": candidate_runs or [],
-        "judge_run": None,
-        "behavior_result": None,
-        "coverage_result": None,
-        "overall_result": "BLOCKED",
-        "blockers": blockers,
-    }
-    return result
-
-
-def _prepare_judge_package(
-    definition: EvalDefinition,
-    materialized: MaterializedEvalRun,
-    judge: IsolatedContext,
-    candidate_runs: list[dict[str, Any]],
-) -> None:
-    fixture_destination = judge.workspace_root / "fixture"
-    shutil.copytree(materialized.canonical_root, fixture_destination)
-    package = {
-        "prompt": materialized.prompt,
-        "assertions": definition.item["assertions"],
-        "candidate_outputs": [
-            {
-                "mode": run["mode"],
-                "output": run["output"],
-                "git_status": run["git_status"],
-                "git_diff": run["git_diff"],
-                "workspace_manifest": run["workspace_manifest"],
-                "delivery_snapshot": run["delivery_snapshot"],
-                "git_evidence": run["git_evidence"],
-                "dependency_evidence": run["dependency_evidence"],
-                "declared_outputs": run["declared_outputs"],
-                "runner_captured_trace": {
-                    "stdout_jsonl_tail": run["status"].get("stdout_tail", ""),
-                    "stderr_tail": run["status"].get("stderr_tail", ""),
-                },
-            }
-            for run in candidate_runs
-        ],
-        "preflight": materialized.preflight.as_dict(),
-    }
-    package_path = judge.workspace_root / "judge-package.json"
-    package_path.write_text(json.dumps(package, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
-
-
-def _judge_prompt() -> str:
-    return (
-        "Read judge-package.json and the read-only fixture directory. Independently judge "
-        "each assertion from the two locked candidate outputs and raw evidence. Assertion "
-        "verdicts evaluate only the with_skill lane. The without_skill is comparison context: "
-        "its failure to satisfy an assertion must not make an assertion FAIL when with_skill "
-        "satisfies it. Use without_skill only to describe the fresh baseline and contrast the "
-        "two behaviors. Copy each assertion id exactly from judge-package.json; never invent "
-        "positional ids such as assertion_1. Return only the JSON object required by the "
-        "supplied output schema. "
-        "Treat each delivery_snapshot file or git_blob content as locked primary evidence: "
-        "inspect that content directly, and do not fail a file-backed requirement merely "
-        "because the candidate's final prose does not restate the delivered file. "
-        "Judge user-visible behavior semantically: accept semantic equivalents and do not "
-        "require an exact internal label, skill path, or wording unless the assertion makes "
-        "that literal form part of the user's observable result. For an interactive workflow, "
-        "when the candidate correctly performs the next required step but a later step cannot "
-        "yet occur without user confirmation or missing runtime evidence, mark that later "
-        "assertion NOT_EXERCISED and coverage PARTIAL rather than FAIL. Likewise, a hidden "
-        "process or read-order assertion is NOT_EXERCISED when the locked raw evidence cannot "
-        "prove it; do not infer failure merely because the final prose omits process narration. "
-        "Treat runner_captured_trace JSONL command and tool events as locked raw evidence, but "
-        "do not treat agent-message claims inside that trace as independent proof. "
-        "Use FAIL only when the with_skill lane contradicts an exercised requirement, omits an "
-        "exercised user-visible result, makes an unsupported claim, or performs a forbidden "
-        "mutation. Return only the JSON object required by the supplied output schema. Do not "
-        "use lane self-ratings or any historical comparison."
-    )
-
-
-def _stage_file(path: Path, content: bytes) -> Path:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    temporary: Path | None = None
-    try:
-        with tempfile.NamedTemporaryFile("wb", dir=path.parent, delete=False) as handle:
-            temporary = Path(handle.name)
-            handle.write(content)
-        return temporary
-    except Exception:
-        if temporary and temporary.exists():
-            temporary.unlink()
-        raise
-
-
-def _transactional_replace(updates: dict[Path, bytes]) -> None:
-    staged: dict[Path, Path] = {}
-    backups: dict[Path, Path] = {}
-    replaced: list[Path] = []
-    try:
-        for path, content in updates.items():
-            staged[path] = _stage_file(path, content)
-        for path in updates:
-            backups[path] = _stage_file(path, path.read_bytes())
-        for path in updates:
-            os.replace(staged[path], path)
-            replaced.append(path)
-    except Exception:
-        for path in reversed(replaced):
-            os.replace(backups[path], path)
-        raise
-    finally:
-        for temporary in (*staged.values(), *backups.values()):
-            if temporary.exists():
-                temporary.unlink()
-
-
-def _durable_comparison(
-    definition: EvalDefinition, result: dict[str, Any],
-) -> str:
-    rows = "\n".join(
-        f"| `{item['id']}` | {item['status']} | {item['evidence'].replace('|', chr(92) + '|')} |"
-        for item in result["assertion_results"]
-    )
-    failures = "\n".join(f"- {item}" for item in result["failures"] or ["None."])
-    next_steps = "\n".join(f"- Next: {item}" for item in result["next_steps"] or ["None."])
-    identity = result["source_identity"]
-    without = result["lane_summaries"]["without_skill"]
-    with_skill = result["lane_summaries"]["with_skill"]
-    return f"""# Issue #246 Evaluation Result
-
-## Evaluation Target
-
-- Agent: `{definition.agent}`
-- Skill: `{definition.skill}`
-- Eval: `{definition.eval_id}`
-
-## Current Result
-
-- Evidence status: **FRESH**
-- Preflight status: **PASS**
-- Judge: third independent fresh judge completed after both candidates were locked.
-- Fixture version/source: canonical manifest `{result['preflight']['fixture_hash']}` from `{definition.workspace_root.relative_to(definition.repository_root)}`.
-- Fixture SHA-256: `{result['preflight']['fixture_hash']}`
-- Prompt SHA-256: `{result['preflight']['prompt_hash']}`
-- Repository HEAD: `{identity['repository_head']}`
-- Repository worktree state: **{'DIRTY' if identity['repository_dirty'] else 'CLEAN'}**
-- Target skill tree SHA-256: `{identity['target_skill_sha256']}`
-- Skill overlay SHA-256: `{identity['skill_overlay_sha256']}`
-- Judge schema SHA-256: `{identity['judge_schema_sha256']}`
-- Eval definition SHA-256: `{identity['eval_definition_sha256']}`
-- Metadata SHA-256: `{identity['metadata_sha256']}`
-- Executor SHA-256: `{identity['executor_sha256']}`
-- Runtime SHA-256: `{identity['runtime_sha256']}`
-- Behavior result: **{result['behavior_result']}**
-- Coverage result: **{result['coverage_result']}**
-Overall result: {result['overall_result']}
-
-## Assertion Results
-
-| Assertion | Result | Evidence |
-| --- | --- | --- |
-{rows}
-
-## With-Skill Behavior
-
-- Run source: {with_skill['run_source']}
-- Behavior: {with_skill['behavior_summary']}
-- The with-skill context was created only after the baseline evidence was locked and destroyed.
-
-## Fresh Without-Skill Baseline
-
-- Run source: {without['run_source']}
-- Behavior: {without['behavior_summary']}
-- The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
-
-## Failures and Next Steps
-
-{failures}
-{next_steps}
-
-## Runtime Artifact Policy
-
-- Candidate outputs, snapshots, judge packages, verdict payloads, timing, diagnostics, and other runtime files are deleted before the runner exits, including after FAIL, BLOCKED, or exceptions.
-- This durable comparison retains only the latest reviewable conclusion; Git history preserves earlier revisions.
-"""
-
-
-def _updated_inventory(definition: EvalDefinition) -> tuple[Path, dict[str, Any]] | None:
-    path = definition.repository_root / (
-        "docs/engineer/repository-governance/eval-scenario-isolation/migration-inventory.json"
-    )
-    if not path.is_file():
-        return None
-    payload = _load_json(path)
-    matches = [record for record in payload.get("old_evals", []) if (
-        record.get("agent"), record.get("skill"), record.get("new_eval_id")
-    ) == (definition.agent, definition.skill, definition.eval_id)
-        and record.get("disposition") == "retained"]
-    if len(matches) != 1:
-        raise ValueError("migration inventory must contain exactly one matching retained eval")
-    matches[0]["migration_status"] = "complete"
-    statuses = [record.get("migration_status") for record in payload["old_evals"]]
-    payload["counts"]["migration_status"] = {
-        status: statuses.count(status) for status in ("pending", "complete")
-    }
-    return path, payload
-
-
-def persist_durable_result(definition: EvalDefinition, result: dict[str, Any]) -> None:
-    with _DURABLE_WRITE_LOCK:
-        inventory = _updated_inventory(definition)
-        comparison = definition.workspace_root / "comparison.md"
-        comparison_bytes = _durable_comparison(definition, result).encode("utf-8")
-        updates: dict[Path, bytes] = {}
-        if inventory:
-            path, payload = inventory
-            updates[path] = (
-                json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
-            ).encode("utf-8")
-        updates[comparison] = comparison_bytes
-        _transactional_replace(updates)
-
-
-def run_selected_eval(
-    *,
-    repository_root: Path,
-    agent: str,
-    skill: str,
-    eval_id: str,
-    runtime_root: Path | None = None,
-    model_available: bool | None = None,
-    command_runner: CommandRunner = run_command,
-    permission_probe: PermissionProbe = run_permission_probe,
-    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
-) -> dict[str, Any]:
-    definition = load_eval_definition(repository_root, agent, skill, eval_id)
-    judge_schema_bytes = build_judge_schema_bytes(definition.item["assertions"])
-    identity = source_identity(definition, judge_schema_bytes=judge_schema_bytes)
-    if runtime_root is None:
-        runtime_root = (
-            repository_root.resolve()
-            / f"tmp/eval-runs/{agent}/{skill}/{eval_id}"
-        )
-    if model_available is None:
-        model_available = check_model_available(repository_root)
-    dependencies = [
-        repository_root.resolve() / value
-        for value in definition.metadata.get("skill_dependencies", [])
-    ]
-    materialized: MaterializedEvalRun | None = None
-    try:
-        materialized = materialize_eval_run(
-            fixture_root=definition.workspace_root,
-            repository_root=repository_root,
-            target_skill=repository_root.resolve() / f"agents/{agent}/skills/{skill}",
-            skill_dependencies=dependencies,
-            prompt=definition.item["prompt"],
-            runtime_isolation=definition.metadata.get("runtime_isolation", {}),
-            runtime_root=runtime_root,
-            model_available=model_available,
-            cleanup_paths=definition.metadata.get("execution_cleanup", []),
-            git_topology=definition.metadata.get("git_topology"),
-            judge_schema_bytes=judge_schema_bytes,
-        )
-        locked_inputs = {
-            "fixture": materialized.canonical_hash,
-            "skill overlay": materialized.locked_overlay_hash,
-            "judge schema": materialized.locked_judge_schema_hash,
-        }
-        expected_inputs = {
-            "fixture": identity["fixture_sha256"],
-            "skill overlay": identity["skill_overlay_sha256"],
-            "judge schema": identity["judge_schema_sha256"],
-        }
-        mismatches = [name for name in locked_inputs if locked_inputs[name] != expected_inputs[name]]
-        if mismatches:
-            return _blocked_result(
-                definition, materialized,
-                [f"locked eval inputs differ from initial identity: {', '.join(mismatches)}"],
-                [],
-            )
-        candidate_runs: list[dict[str, Any]] = []
-        for mode in ("without_skill", "with_skill"):
-            context = open_context(materialized, mode)
-            preflight = evaluate_context_preflight(
-                materialized, context, mode, permission_probe,
-            )
-            record_preflight(materialized, mode, preflight)
-            if preflight.status != "PASS":
-                close_context(materialized, context, evidence_locked=True)
-                return _blocked_result(definition, materialized, preflight.blockers, candidate_runs)
-            try:
-                run = _candidate_run(
-                    materialized, context, command_runner=command_runner,
-                    timeout_seconds=timeout_seconds,
-                )
-                run["declared_outputs"] = _output_checks(
-                    run["delivery_snapshot"], definition.metadata.get(f"{mode}_outputs"), mode,
-                )
-            except ValueError as exc:
-                close_context(materialized, context, evidence_locked=True)
-                return _blocked_result(definition, materialized, [str(exc)], candidate_runs)
-            candidate_runs.append(run)
-            close_context(materialized, context, evidence_locked=True)
-            if run["dependency_evidence"].get("status") != "PASS":
-                return _blocked_result(
-                    definition, materialized,
-                    [f"{run['mode']} runtime dependencies changed during candidate execution"],
-                    candidate_runs,
-                )
-            if run["status"].get("returncode") != 0 or not run["output_exists"]:
-                status = run["status"]
-                return _blocked_result(
-                    definition, materialized,
-                    [
-                        f"{run['mode']} candidate did not complete with a final output "
-                        f"(returncode={status.get('returncode')}, "
-                        f"timed_out={bool(status.get('timed_out'))})"
-                    ],
-                    candidate_runs,
-                )
-            if mode == "with_skill" and any(not check["ok"] for check in run["declared_outputs"]):
-                return _blocked_result(
-                    definition, materialized,
-                    ["with_skill did not produce every declared deterministic output"], candidate_runs,
-                )
-
-        judge = open_context(materialized, "judge")
-        _prepare_judge_package(definition, materialized, judge, candidate_runs)
-        judge_preflight = evaluate_context_preflight(
-            materialized, judge, "judge", permission_probe,
-        )
-        record_preflight(materialized, "judge", judge_preflight)
-        if judge_preflight.status != "PASS":
-            close_context(materialized, judge, evidence_locked=True)
-            return _blocked_result(definition, materialized, judge_preflight.blockers, candidate_runs)
-        verdict_path = materialized.runtime_root / "outputs/judge/judge-verdict.json"
-        verdict_path.parent.mkdir(parents=True, exist_ok=True)
-        command = judge_command(
-            judge.workspace_root, verdict_path,
-            schema=materialized.locked_judge_schema_path,
-        )
-        judge_status = command_runner(
-            command, prompt=_judge_prompt(), env=judge.env, timeout_seconds=timeout_seconds,
-        )
-        if judge_status.get("returncode") != 0 or not verdict_path.is_file():
-            close_context(materialized, judge, evidence_locked=True)
-            return _blocked_result(
-                definition, materialized,
-                ["fresh judge did not complete with a structured verdict"], candidate_runs,
-            )
-        try:
-            raw_verdict = _load_json(verdict_path)
-            assertion_ids = {item["id"] for item in definition.item["assertions"]}
-            verdict = validate_judge_result(raw_verdict, assertion_ids)
-        except (KeyError, ValueError, json.JSONDecodeError) as exc:
-            close_context(materialized, judge, evidence_locked=True)
-            return _blocked_result(
-                definition, materialized,
-                [f"judge verdict failed schema validation: {exc}"], candidate_runs,
-            )
-        close_context(materialized, judge, evidence_locked=True)
-
-        for run in candidate_runs:
-            verdict["lane_summaries"][run["mode"]]["run_source"] = _lane_run_source(
-                run, materialized,
-            )
-
-        final_definition = load_eval_definition(repository_root, agent, skill, eval_id)
-        if not _same_source_inputs(source_identity(final_definition), identity):
-            return _blocked_result(
-                definition, materialized,
-                ["eval source inputs changed during the isolated run"], candidate_runs,
-            )
-
-        result = {
-            "agent": definition.agent,
-            "skill": definition.skill,
-            "eval_id": definition.eval_id,
-            "preflight": materialized.preflight.as_dict(),
-            "candidate_runs": candidate_runs,
-            "judge_run": {"command": command, "status": judge_status},
-            "source_identity": identity,
-            **verdict,
-        }
-        persist_durable_result(definition, result)
-        return result
-    finally:
-        if materialized is not None:
-            materialized.cleanup()
-        if runtime_root.exists():
-            shutil.rmtree(runtime_root)
-        _prune_runtime_parents(runtime_root, repository_root)
+def source_identity(definition: Any, *, judge_schema_bytes: bytes | None = None) -> dict[str, Any]:
+    schema = judge_schema_bytes or build_judge_schema_bytes(definition.item["assertions"])
+    return _execution.eval_identity.source_identity(definition, judge_schema_bytes=schema)
 
 
 def _targets(
@@ -1061,18 +47,15 @@ def _targets(
         raise ValueError("--eval requires --skill")
     if skill and not agent:
         raise ValueError("--skill requires --agent")
-    pattern = "agents/*/test/*/evals/evals.json"
     targets: list[tuple[str, str, str]] = []
-    for path in sorted(repository_root.glob(pattern)):
-        payload = _load_json(path)
-        path_agent = payload.get("agent")
-        path_skill = payload.get("skill_name")
-        if (agent and path_agent != agent) or (skill and path_skill != skill):
+    for path in sorted(repository_root.glob("agents/*/test/*/evals/evals.json")):
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        agent_name, skill_name = payload.get("agent"), payload.get("skill_name")
+        if (agent and agent_name != agent) or (skill and skill_name != skill):
             continue
         for item in payload.get("evals", []):
-            if eval_id and item.get("id") != eval_id:
-                continue
-            targets.append((path_agent, path_skill, item["id"]))
+            if not eval_id or item.get("id") == eval_id:
+                targets.append((agent_name, skill_name, item["id"]))
     return targets
 
 
@@ -1105,9 +88,10 @@ def compatibility_main(agent: str, argv: list[str] | None = None) -> int:
             return 2
         print(conclusion, end="" if conclusion.endswith("\n") else "\n")
         return 0 if match.group(1).startswith("PASS") else 1
-    result = run_selected_eval(repository_root=definition.repository_root,
-                               agent=definition.agent, skill=definition.skill,
-                               eval_id=definition.eval_id)
+    result = run_selected_eval(
+        repository_root=definition.repository_root, agent=definition.agent,
+        skill=definition.skill, eval_id=definition.eval_id,
+    )
     print(json.dumps(result, ensure_ascii=False, indent=2))
     return 0 if result["overall_result"].startswith("PASS") else 1
 
@@ -1117,10 +101,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--agent")
     parser.add_argument("--skill")
     parser.add_argument("--eval", dest="eval_id")
-    parser.add_argument(
-        "--select", action="append", default=[], metavar="AGENT/SKILL/EVAL",
-        help="repeatable exact cross-agent target selector",
-    )
+    parser.add_argument("--select", action="append", default=[], metavar="AGENT/SKILL/EVAL")
     parser.add_argument("--metadata", type=Path)
     parser.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT_SECONDS)
     parser.add_argument("--jobs", type=int, choices=range(1, 11), default=10)
@@ -1141,45 +122,35 @@ def main(argv: list[str] | None = None) -> int:
                 raise ValueError("--select cannot be combined with agent/skill/eval filters")
             targets = _targets(repository_root, args.agent, args.skill, args.eval_id)
             if args.select:
-                selected: set[tuple[str, str, str]] = set()
-                for value in args.select:
-                    parts = tuple(value.split("/", 2))
-                    if len(parts) != 3 or not all(parts):
-                        raise ValueError(f"invalid --select target: {value}")
-                    selected.add(parts)
-                available = set(targets)
-                missing = selected - available
+                selected = {tuple(value.split("/", 2)) for value in args.select}
+                if any(len(target) != 3 or not all(target) for target in selected):
+                    raise ValueError("invalid --select target")
+                missing = selected - set(targets)
                 if missing:
-                    raise ValueError(
-                        "unknown --select target(s): "
-                        + ", ".join("/".join(target) for target in sorted(missing))
-                    )
+                    raise ValueError("unknown --select target(s): " + ", ".join(
+                        "/".join(target) for target in sorted(missing)
+                    ))
                 targets = [target for target in targets if target in selected]
         if not targets:
             raise ValueError("no eval targets matched")
     except (OSError, ValueError, json.JSONDecodeError) as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 2
-
     model_available = check_model_available(repository_root)
     outcomes: dict[tuple[str, str, str], dict[str, Any] | Exception] = {}
     with ThreadPoolExecutor(max_workers=min(args.jobs, len(targets))) as executor:
-        futures = {}
-        for agent, skill, eval_id in targets:
-            print(f"==> {agent}/{skill}/{eval_id}", flush=True)
-            future = executor.submit(
-                run_selected_eval, repository_root=repository_root, agent=agent,
-                skill=skill, eval_id=eval_id, timeout_seconds=args.timeout,
-                model_available=model_available,
-            )
-            futures[future] = (agent, skill, eval_id)
+        futures = {
+            executor.submit(
+                run_selected_eval, repository_root=repository_root, agent=agent, skill=skill,
+                eval_id=eval_id, timeout_seconds=args.timeout, model_available=model_available,
+            ): (agent, skill, eval_id)
+            for agent, skill, eval_id in targets
+        }
         for future in as_completed(futures):
-            target = futures[future]
             try:
-                outcomes[target] = future.result()
-            except Exception as exc:  # noqa: BLE001 - report every batch target
-                outcomes[target] = exc
-
+                outcomes[futures[future]] = future.result()
+            except Exception as exc:  # noqa: BLE001
+                outcomes[futures[future]] = exc
     failures = 0
     for target in targets:
         outcome = outcomes[target]
@@ -1187,12 +158,11 @@ def main(argv: list[str] | None = None) -> int:
         if isinstance(outcome, Exception):
             failures += 1
             print(f"{label}: ERROR: {outcome}", file=sys.stderr)
-            continue
-        print(f"{label}: Overall result: {outcome['overall_result']}")
-        if outcome["overall_result"] == "BLOCKED" and outcome.get("blockers"):
-            print(f"{label}: blockers: {'; '.join(outcome['blockers'])}")
-        if not outcome["overall_result"].startswith("PASS"):
-            failures += 1
+        else:
+            print(f"{label}: Overall result: {outcome['overall_result']}")
+            if outcome["overall_result"] == "BLOCKED" and outcome.get("blockers"):
+                print(f"{label}: blockers: {'; '.join(outcome['blockers'])}")
+            failures += not outcome["overall_result"].startswith("PASS")
     print(f"Ran {len(targets)} eval(s); {failures} non-passing")
     return 1 if failures else 0
 

--- a/scripts/test_eval_execution.py
+++ b/scripts/test_eval_execution.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts import eval_identity
+from scripts import run_skill_eval
+
+
+def test_identity_v2_has_exact_freshness_fields_and_complete_source_lock(tmp_path: Path) -> None:
+    repository = run_skill_eval_test_repository(tmp_path)
+    definition = run_skill_eval.load_eval_definition(
+        repository, "qa", "bug-analyzer", "eval-001-real-user",
+    )
+
+    identity = run_skill_eval.source_identity(definition)
+
+    assert identity["identity_schema"] == 2
+    assert set(identity["freshness"]) == set(eval_identity.FRESHNESS_FIELDS)
+    assert set(identity["source_manifest"]) == set(eval_identity.SOURCE_LOCK_FILES)
+    assert identity["source_lock_sha256"] == eval_identity.source_lock_sha256(
+        identity["source_manifest"]
+    )
+
+
+def test_current_identity_v2_does_not_invoke_git(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    repository = run_skill_eval_test_repository(tmp_path)
+    definition = run_skill_eval.load_eval_definition(
+        repository, "qa", "bug-analyzer", "eval-001-real-user",
+    )
+    monkeypatch.setattr(
+        eval_identity.subprocess, "run",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("git must not run")),
+    )
+
+    identity = eval_identity.current_identity_v2(definition)
+
+    assert identity["identity_schema"] == 2
+    assert set(identity["freshness"]) == set(eval_identity.FRESHNESS_FIELDS)
+
+
+def test_protocol_hashes_follow_explicit_module_boundaries(tmp_path: Path) -> None:
+    root = tmp_path / "scripts"
+    root.mkdir()
+    files = {
+        "run_skill_eval.py": b"cli\n",
+        "eval_identity.py": b"identity\n",
+        "eval_execution.py": b"execution\n",
+        "eval_judging.py": b"judging\n",
+        "eval_runtime.py": b"runtime\n",
+        "eval_persistence.py": b"persistence\n",
+        "eval_judge_result.schema.json": b"schema\n",
+    }
+    for name, content in files.items():
+        (root / name).write_bytes(content)
+
+    initial = eval_identity.protocol_hashes(root)
+    (root / "eval_persistence.py").write_bytes(b"changed persistence\n")
+    persistence = eval_identity.protocol_hashes(root)
+    (root / "eval_execution.py").write_bytes(b"changed execution\n")
+    execution = eval_identity.protocol_hashes(root)
+    (root / "eval_runtime.py").write_bytes(b"changed runtime\n")
+    runtime = eval_identity.protocol_hashes(root)
+    (root / "eval_judge_result.schema.json").write_bytes(b"changed schema\n")
+    schema = eval_identity.protocol_hashes(root)
+
+    assert persistence == initial
+    assert execution["execution_protocol_sha256"] != initial["execution_protocol_sha256"]
+    assert execution["runtime_protocol_sha256"] == initial["runtime_protocol_sha256"]
+    assert runtime["runtime_protocol_sha256"] != execution["runtime_protocol_sha256"]
+    assert schema["judge_schema_sha256"] != runtime["judge_schema_sha256"]
+
+
+def test_source_lock_detects_persistence_and_identity_drift(tmp_path: Path) -> None:
+    root = tmp_path / "scripts"
+    root.mkdir()
+    for name in eval_identity.SOURCE_LOCK_FILES:
+        (root / name).write_text(name + "\n", encoding="utf-8")
+    before = eval_identity.source_manifest(root)
+
+    (root / "eval_persistence.py").write_text("persistence changed\n", encoding="utf-8")
+    after_persistence = eval_identity.source_manifest(root)
+    (root / "eval_identity.py").write_text("identity changed\n", encoding="utf-8")
+    after_identity = eval_identity.source_manifest(root)
+
+    assert eval_identity.source_lock_sha256(before) != eval_identity.source_lock_sha256(
+        after_persistence
+    )
+    assert eval_identity.source_lock_sha256(after_persistence) != eval_identity.source_lock_sha256(
+        after_identity
+    )
+
+
+def run_skill_eval_test_repository(tmp_path: Path) -> Path:
+    root = tmp_path / "repo"
+    skill = root / "agents/qa/skills/bug-analyzer"
+    workspace = root / "agents/qa/test/bug-analyzer/evals/workspace/eval-001-real-user"
+    skill.mkdir(parents=True)
+    workspace.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("---\nname: bug-analyzer\n---\n", encoding="utf-8")
+    (workspace / "incident.md").write_text("checkout returns 500", encoding="utf-8")
+    (workspace / "comparison.md").write_text("Overall result: BLOCKED", encoding="utf-8")
+    (workspace / "eval_metadata.json").write_text(json.dumps({
+        "eval_id": "eval-001-real-user",
+        "skill_dependencies": [],
+        "runtime_isolation": {name: "not_used" for name in (
+            "processes", "ports", "database", "browser", "login_state", "downloads",
+        )},
+    }), encoding="utf-8")
+    (workspace.parents[1] / "evals.json").write_text(json.dumps({
+        "schema_version": "1.0", "agent": "qa", "skill_name": "bug-analyzer",
+        "evals": [{
+            "id": "eval-001-real-user", "name": "real-user", "description": "incident",
+            "scenario": {"persona": "support", "situation": "incident", "trigger": "500",
+                         "goal": "diagnose", "materials": ["incident.md"],
+                         "constraints": ["read only"], "success_criteria": ["assessment"]},
+            "prompt": "请分析 incident.md。", "workspace": "workspace/eval-001-real-user",
+            "expected_output": "assessment",
+            "assertions": [{"id": "uses_evidence", "description": "evidence", "text": "uses 500"}],
+        }],
+    }), encoding="utf-8")
+    return root

--- a/scripts/test_eval_persistence.py
+++ b/scripts/test_eval_persistence.py
@@ -1,0 +1,19 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.test_run_skill_eval import (
+    test_duplicate_retained_inventory_matches_reject_durable_update,
+    test_durable_update_rolls_back_both_files_when_replace_fails,
+    test_post_freeze_eval_persists_comparison_without_changing_inventory,
+    test_transaction_cleans_staged_files_when_staging_fails,
+)
+
+
+__all__ = [
+    "test_post_freeze_eval_persists_comparison_without_changing_inventory",
+    "test_duplicate_retained_inventory_matches_reject_durable_update",
+    "test_durable_update_rolls_back_both_files_when_replace_fails",
+    "test_transaction_cleans_staged_files_when_staging_fails",
+]

--- a/scripts/test_migrate_eval_identity_v2.py
+++ b/scripts/test_migrate_eval_identity_v2.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import hashlib
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from scripts import migrate_eval_identity_v2 as migration
+
+
+def _identity(marker: str = "a") -> dict[str, str | int]:
+    return {"identity_schema": 2, **{key: marker * 64 for key in migration.FRESHNESS_KEYS}}
+
+
+def _comparison(executor: str, runtime: str, *, target: str = "a", definition: str = "a") -> str:
+    return f"""# Issue #246 Evaluation Result
+
+## Evaluation Target
+
+- Agent: `qa`
+- Skill: `bug-analyzer`
+- Eval: `eval-001-real-user`
+
+## Current Result
+
+- Evidence status: **FRESH**
+- Preflight status: **PASS**
+- Repository worktree state: **CLEAN**
+- Target skill tree SHA-256: `{target * 64}`
+- Eval definition SHA-256: `{definition * 64}`
+- Metadata SHA-256: `{'a' * 64}`
+- Fixture SHA-256: `{'a' * 64}`
+- Judge schema SHA-256: `{'a' * 64}`
+- Executor SHA-256: `{executor}`
+- Runtime SHA-256: `{runtime}`
+- Behavior result: **PASS**
+- Coverage result: **FULL**
+Overall result: PASS
+
+## Assertion Results
+
+| Assertion | Result | Evidence |
+| --- | --- | --- |
+| `uses_evidence` | PASS | exact evidence bytes |
+
+## With-Skill Behavior
+
+- Behavior: done
+"""
+
+
+def _target(tmp_path: Path) -> migration.Target:
+    return migration.Target("qa", "bug-analyzer", "eval-001-real-user", tmp_path / "comparison.md")
+
+
+def test_trusted_source_attests_actual_git_blobs(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    (root / "scripts").mkdir(parents=True)
+    (root / "scripts/run_skill_eval.py").write_bytes(b"executor")
+    (root / "scripts/eval_runtime.py").write_bytes(b"runtime")
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=root, check=True)
+    subprocess.run(["git", "add", "."], cwd=root, check=True)
+    subprocess.run([
+        "git", "-c", "user.name=Test", "-c", "user.email=test@example.invalid",
+        "commit", "-q", "-m", "source",
+    ], cwd=root, check=True)
+
+    attestation = migration.trusted_source(root, "HEAD")
+
+    assert attestation["source_commit"] == subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=root, check=True, capture_output=True, text=True,
+    ).stdout.strip()
+    assert attestation["executor_sha256"] == hashlib.sha256(b"executor").hexdigest()
+    assert attestation["runtime_sha256"] == hashlib.sha256(b"runtime").hexdigest()
+
+
+def test_trusted_source_rejects_unreachable_ref(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        migration.trusted_source(tmp_path, "missing-ref")
+
+
+def test_classify_rejects_forged_legacy_protocol_hash(tmp_path: Path) -> None:
+    source = {"executor_sha256": "e" * 64, "runtime_sha256": "r" * 64}
+    text = _comparison("f" * 64, "r" * 64)
+
+    with pytest.raises(ValueError, match="legacy protocol hash"):
+        migration.classify(_target(tmp_path), text, _identity(), source)
+
+
+def test_classify_current_input_change_only_allows_trd_stale(tmp_path: Path) -> None:
+    source = {"executor_sha256": "e" * 64, "runtime_sha256": "r" * 64}
+    text = _comparison("e" * 64, "r" * 64, target="b")
+
+    with pytest.raises(ValueError, match="unexpected current input mismatch"):
+        migration.classify(_target(tmp_path), text, _identity(), source)
+
+    trd = migration.Target("engineer", "trd-gen", "eval-001-trd", tmp_path / "trd.md")
+    category, reasons = migration.classify(trd, text, _identity(), source)
+    assert category == "stale"
+    assert reasons == ["input_changed:target_skill_sha256"]
+
+
+def test_identity_replacement_preserves_verdict_and_assertion_bytes(tmp_path: Path) -> None:
+    before = _comparison("e" * 64, "r" * 64).encode()
+    migrated = migration._replace_identity(
+        before.decode(), _identity(), {"source_commit": "c" * 40},
+    ).encode()
+
+    assert migration._preserved(before) == migration._preserved(migrated)
+    assert b"Executor SHA-256" not in migrated
+    assert b"Runtime SHA-256" not in migrated
+    assert b"Prompt SHA-256" not in migrated
+    assert b"- Identity schema: `2`" in migrated
+    assert b"MIGRATED_WITHOUT_MODEL_RERUN" in migrated
+
+
+def test_checker_policy_keeps_nonfreshness_audit_fields_outside_migration():
+    before = _comparison("e" * 64, "r" * 64)
+    before = before.replace(
+        "- Executor SHA-256:",
+        f"- Prompt SHA-256: `{'p' * 64}`\n- Skill overlay SHA-256: `{'s' * 64}`\n"
+        "- Executor SHA-256:",
+    )
+    migrated = migration._replace_identity(before, _identity(), {"source_commit": "c" * 40})
+    assert "Prompt SHA-256" not in migrated
+    assert "Skill overlay SHA-256" not in migrated
+
+
+def test_preserved_digest_detects_evidence_tampering() -> None:
+    before = _comparison("e" * 64, "r" * 64).encode()
+    after = before.replace(b"exact evidence bytes", b"altered evidence bytes")
+    assert migration._preserved(before) != migration._preserved(after)
+
+
+def test_atomic_write_rolls_back_all_replaced_files(tmp_path: Path, monkeypatch) -> None:
+    first, second = tmp_path / "first", tmp_path / "second"
+    first.write_bytes(b"old-first")
+    second.write_bytes(b"old-second")
+    real_replace = migration.os.replace
+    calls = 0
+
+    def fail_second(source: Path, target: Path) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise OSError("injected replacement failure")
+        real_replace(source, target)
+
+    monkeypatch.setattr(migration.os, "replace", fail_second)
+    with pytest.raises(OSError, match="injected"):
+        migration.atomic_write({first: b"new-first", second: b"new-second"})
+
+    assert first.read_bytes() == b"old-first"
+    assert second.read_bytes() == b"old-second"
+
+
+def test_identity_replacement_is_idempotent() -> None:
+    source = {"source_commit": "c" * 40}
+    once = migration._replace_identity(_comparison("e" * 64, "r" * 64), _identity(), source)
+    twice = migration._replace_identity(once, _identity(), source)
+    assert twice == once
+
+
+def test_classify_accepts_matching_already_migrated_v2() -> None:
+    source = {"source_commit": "c" * 40}
+    migrated = migration._replace_identity(
+        _comparison("e" * 64, "r" * 64), _identity(), source,
+    )
+
+    category, reasons = migration.classify(
+        _target(Path(".")), migrated, _identity(),
+        {"executor_sha256": "e" * 64, "runtime_sha256": "r" * 64},
+    )
+
+    assert category == "mechanical"
+    assert reasons == ["identity_v2_already_migrated"]
+
+
+def test_classify_only_refreshes_protocol_fields_for_attested_migration() -> None:
+    source = {
+        "source_commit": "c" * 40,
+        "executor_sha256": "e" * 64,
+        "runtime_sha256": "r" * 64,
+    }
+    migrated = migration._replace_identity(
+        _comparison("e" * 64, "r" * 64), _identity("a"), source,
+    )
+    protocol_update = _identity("a")
+    protocol_update["execution_protocol_sha256"] = "b" * 64
+    assert migration.classify(
+        _target(Path(".")), migrated, protocol_update, source,
+    ) == ("mechanical", ["identity_v2_protocol_finalized"])
+
+    business_update = _identity("a")
+    business_update["target_skill_sha256"] = "b" * 64
+    with pytest.raises(ValueError, match="schema v2 input mismatch"):
+        migration.classify(_target(Path(".")), migrated, business_update, source)

--- a/scripts/test_run_skill_eval.py
+++ b/scripts/test_run_skill_eval.py
@@ -11,7 +11,7 @@ from types import SimpleNamespace
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from scripts import run_skill_eval
+from scripts import eval_persistence, run_skill_eval
 
 
 def judge_schema_variant(marker: str) -> bytes:
@@ -398,6 +398,56 @@ def test_failed_candidate_keeps_comparison_stale_and_inventory_pending(tmp_path:
     assert json.loads(inventory.read_text())["old_evals"][0]["migration_status"] == "pending"
 
 
+def test_post_freeze_eval_persists_comparison_without_changing_inventory(tmp_path: Path) -> None:
+    repository = write_eval(tmp_path)
+    inventory = write_inventory(repository)
+    payload = json.loads(inventory.read_text(encoding="utf-8"))
+    payload["old_evals"][0]["new_eval_id"] = "eval-000-frozen-baseline"
+    inventory.write_text(json.dumps(payload), encoding="utf-8")
+    original_inventory = inventory.read_bytes()
+    definition = run_skill_eval.load_eval_definition(
+        repository, "qa", "bug-analyzer", "eval-001-real-user",
+    )
+    comparison = definition.workspace_root / "comparison.md"
+    original_comparison = comparison.read_bytes()
+    result = {
+        "preflight": {"fixture_hash": "f" * 64, "prompt_hash": "p" * 64},
+        "source_identity": run_skill_eval.source_identity(definition),
+        **judge_payload(),
+    }
+
+    run_skill_eval.persist_durable_result(definition, result)
+
+    assert comparison.read_bytes() != original_comparison
+    assert "Overall result: PASS" in comparison.read_text(encoding="utf-8")
+    assert inventory.read_bytes() == original_inventory
+
+
+def test_duplicate_retained_inventory_matches_reject_durable_update(tmp_path: Path) -> None:
+    repository = write_eval(tmp_path)
+    inventory = write_inventory(repository)
+    payload = json.loads(inventory.read_text(encoding="utf-8"))
+    payload["old_evals"].append(dict(payload["old_evals"][0]))
+    inventory.write_text(json.dumps(payload), encoding="utf-8")
+    definition = run_skill_eval.load_eval_definition(
+        repository, "qa", "bug-analyzer", "eval-001-real-user",
+    )
+    comparison = definition.workspace_root / "comparison.md"
+    original_comparison = comparison.read_bytes()
+    original_inventory = inventory.read_bytes()
+    result = {
+        "preflight": {"fixture_hash": "f" * 64, "prompt_hash": "p" * 64},
+        "source_identity": run_skill_eval.source_identity(definition),
+        **judge_payload(),
+    }
+
+    with pytest.raises(ValueError, match="more than one matching retained eval"):
+        run_skill_eval.persist_durable_result(definition, result)
+
+    assert comparison.read_bytes() == original_comparison
+    assert inventory.read_bytes() == original_inventory
+
+
 def test_declared_outputs_use_lane_delta_with_nested_or_and_baseline_is_report_only(
     tmp_path: Path,
 ) -> None:
@@ -569,13 +619,15 @@ def test_paired_run_uses_identical_prompt_in_without_then_with_order_and_fresh_j
     assert "Fixture version/source:" in comparison
     assert "Repository HEAD:" in comparison
     assert "Repository worktree state:" in comparison
-    assert "Target skill tree SHA-256:" in comparison
+    assert "target_skill_sha256:" in comparison
     assert "Skill overlay SHA-256:" in comparison
-    assert "Judge schema SHA-256:" in comparison
-    assert "Eval definition SHA-256:" in comparison
-    assert "Metadata SHA-256:" in comparison
-    assert "Executor SHA-256:" in comparison
-    assert "Runtime SHA-256:" in comparison
+    assert "judge_schema_sha256:" in comparison
+    assert "eval_definition_sha256:" in comparison
+    assert "metadata_sha256:" in comparison
+    assert "Identity schema: `2`" in comparison
+    assert "execution_protocol_sha256:" in comparison
+    assert "runtime_protocol_sha256:" in comparison
+    assert "Source lock SHA-256:" in comparison
     assert "## With-Skill Behavior" in comparison
     assert "## Fresh Without-Skill Baseline" in comparison
     assert "## Runtime Artifact Policy" in comparison
@@ -604,6 +656,7 @@ def test_unrelated_worktree_dirty_transition_does_not_invalidate_locked_inputs(
     schema = tmp_path / "judge-schema.json"
     schema.write_bytes(judge_schema_variant("concurrent"))
     monkeypatch.setattr(run_skill_eval, "JUDGE_SCHEMA", schema)
+    monkeypatch.setattr(run_skill_eval._execution, "JUDGE_SCHEMA", schema)
     candidate_count = 0
 
     def concurrent_result_writer(command, *, prompt, env, timeout_seconds):
@@ -651,7 +704,7 @@ def test_runtime_root_is_removed_when_materialization_raises(
         (kwargs["runtime_root"] / "partial-artifact.bin").write_bytes(b"partial")
         raise ValueError("materialization failed")
 
-    monkeypatch.setattr(run_skill_eval, "materialize_eval_run", broken_materializer)
+    monkeypatch.setattr(run_skill_eval._execution, "materialize_eval_run", broken_materializer)
 
     with pytest.raises(ValueError, match="materialization failed"):
         run_skill_eval.run_selected_eval(
@@ -763,6 +816,7 @@ def test_source_identity_records_dirty_current_skill_dependency_and_schema_conte
     schema = tmp_path / "judge-schema.json"
     schema.write_bytes(judge_schema_variant("version-1"))
     monkeypatch.setattr(run_skill_eval, "JUDGE_SCHEMA", schema)
+    monkeypatch.setattr(run_skill_eval._execution, "JUDGE_SCHEMA", schema)
     subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repository, check=True)
     subprocess.run(["git", "add", "."], cwd=repository, check=True)
     subprocess.run([
@@ -815,10 +869,16 @@ def test_source_identity_records_dirty_current_skill_dependency_and_schema_conte
     assert dependency_dirty["judge_schema_sha256"] != schema_dirty["judge_schema_sha256"]
     assert schema_dirty["metadata_sha256"] != metadata_dirty["metadata_sha256"]
     assert metadata_dirty["eval_definition_sha256"] != definition_dirty["eval_definition_sha256"]
-    assert len(dirty["executor_sha256"]) == len(dirty["runtime_sha256"]) == 64
+    assert len(dirty["execution_protocol_sha256"]) == 64
+    assert len(dirty["runtime_protocol_sha256"]) == 64
+    assert set(dirty["freshness"]) == {
+        "target_skill_sha256", "eval_definition_sha256", "metadata_sha256",
+        "fixture_sha256", "execution_protocol_sha256", "runtime_protocol_sha256",
+        "judge_schema_sha256",
+    }
 
 
-def test_transient_skill_and_schema_changes_use_locked_inputs(
+def test_transient_skill_and_schema_changes_block_the_run(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     repository = write_eval(tmp_path)
@@ -839,6 +899,7 @@ def test_transient_skill_and_schema_changes_use_locked_inputs(
     original_schema = judge_schema_variant("version-1")
     schema.write_bytes(original_schema)
     monkeypatch.setattr(run_skill_eval, "JUDGE_SCHEMA", schema)
+    monkeypatch.setattr(run_skill_eval._execution, "JUDGE_SCHEMA", schema)
     expected_locked_schema = run_skill_eval.build_judge_schema_bytes([
         {"id": "uses_evidence"},
     ])
@@ -880,8 +941,9 @@ def test_transient_skill_and_schema_changes_use_locked_inputs(
         permission_probe=permission_probe,
     )
 
-    assert result["overall_result"] == "PASS"
-    assert "Evidence status: **FRESH**" in (
+    assert result["overall_result"] == "BLOCKED"
+    assert result["blockers"] == ["eval source inputs changed during the isolated run"]
+    assert "Evidence status: **FRESH**" not in (
         repository / "agents/qa/test/bug-analyzer/evals/workspace/"
         "eval-001-real-user/comparison.md"
     ).read_text(encoding="utf-8")
@@ -902,6 +964,7 @@ def test_source_drift_blocks_durable_persist(
     schema = tmp_path / "judge-schema.json"
     schema.write_bytes(judge_schema_variant("version-1"))
     monkeypatch.setattr(run_skill_eval, "JUDGE_SCHEMA", schema)
+    monkeypatch.setattr(run_skill_eval._execution, "JUDGE_SCHEMA", schema)
     candidate_count = 0
 
     def drifting_runner(command, *, prompt, env, timeout_seconds):
@@ -999,7 +1062,7 @@ def test_transaction_cleans_staged_files_when_staging_fails(
     first, second = tmp_path / "first", tmp_path / "second"
     first.write_bytes(b"old-first")
     second.write_bytes(b"old-second")
-    real_stage = run_skill_eval._stage_file
+    real_stage = eval_persistence._stage_file
     created: list[Path] = []
 
     def fail_after_first(path: Path, content: bytes) -> Path:
@@ -1009,7 +1072,7 @@ def test_transaction_cleans_staged_files_when_staging_fails(
         created.append(temporary)
         return temporary
 
-    monkeypatch.setattr(run_skill_eval, "_stage_file", fail_after_first)
+    monkeypatch.setattr(eval_persistence, "_stage_file", fail_after_first)
     with pytest.raises(OSError, match="staging"):
         run_skill_eval._transactional_replace({first: b"new-first", second: b"new-second"})
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -4,7 +4,7 @@
     "pm-agent": {
       "source": "agents/product_manager/skills/pm-agent",
       "sourceType": "local",
-      "computedHash": "c76184ead334ff8883cc8b4ee578479b9dc9afc5213381af63816037baebc9cb"
+      "computedHash": "b34a4d30ef30c3ba4faa5b1a657325266a5ef271c9c660327eb4d4dac6d389c9"
     },
     "idea-to-spec": {
       "source": "agents/product_manager/skills/idea-to-spec",
@@ -59,7 +59,7 @@
     "trd-gen": {
       "source": "agents/engineer/skills/trd-gen",
       "sourceType": "local",
-      "computedHash": "0b456fae9d729cb3f1b8e9b64b3a18d896eafa4d54c774e2be12d0b712507952"
+      "computedHash": "cc81942c0cf6727c52e4bd8446fc8877ba0440cd76ec84a001a3cca907a02390"
     },
     "feature-implementor": {
       "source": "agents/engineer/skills/feature-implementor",


### PR DESCRIPTION
## 变更概述

- 将 durable eval identity 升级为 schema v2，拆分 target skill、eval definition、metadata、fixture、execution、runtime 和 judge schema 七类跨版本身份。
- 将 execution/judging、runtime/isolation、persistence/inventory 分离为明确模块；完整源码 manifest 只用于同轮 source-drift 阻断。
- 新增一次性迁移器和审计报告，机械迁移 187 份仍有效 comparison；trd-gen 6 条与 PM 新增 3 条通过 fresh 模型执行补齐证据。
- 修复冻结后新增 eval 的 0/1/>1 inventory 匹配语义，并让 checker 对所有常规 comparison 强制 v2、对所有 FRESH 结果统一校验当前 digest。
- 收紧 trd-gen 的正文/交付摘要边界和 pm-agent 显式调用 Scope Guard 行为，修复 Issue #277 中的 eval-006 与 eval-018。

## 根因

旧 identity 将整个 runner 源码作为历史 freshness 输入，导致 persistence/inventory 格式变化使全部 comparison stale；同时冻结 inventory 被错误当作后续新增 eval 的登记表。trd-gen 与 pm-agent 还各有一处指令显著性不足，分别导致 routing 写入 TRD 正文、显式调用仍被 Scope Guard 拦截。

## 验证

- `uv run scripts/check_repository_contract.py`
- `uv run scripts/check_eval_contract.py`
- `uv run scripts/check_eval_artifacts.py`
- `uv run scripts/check_doc_contract.py`
- 受影响 pytest：`175 passed, 6 subtests passed`
- 一次性迁移后二次 dry-run：`0 changes`
- 196 份常规 comparison 全部 FRESH，无 BLOCKED/UNKNOWN
- trd-gen：6/6 通过
- pm-agent：18/19 通过；eval-016 保留有效 FULL FAIL，属于与 #277 无关的显式 route 显著性后续缺陷
- `migration-inventory.json` 与 manual-only comparison 未修改；`tmp/eval-runs/` 不存在

## 影响

正常 checker 只接受 identity schema v2，不保留 v1/v2 双轨或 Git 历史兼容桥。冻结的 Issue #246 inventory 仍保持 193 条和原 schema/bytes。

关联 Issue：#277
