### PR TITLE
feat(agent-router): 按研发意图触发并收敛路由输出

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "pm-agent",
-      "description": "Default entry plugin for product and engineering R&D requests when no other agent or skill is named; explicit agent or skill invocation always takes priority and retains its existing gate. Routes product ideas, features, changes, bugs, implementation, testing, design, deployment, security, formal docs, delivery, planning, and repository status work.",
+      "description": "Default entry plugin for product and engineering R&D requests when no other agent or skill is named. Explicitly naming pm-agent selects it; explicitly naming a different role agent or skill excludes pm-agent and leaves that capability to enforce its own gate. Routes product ideas, features, changes, bugs, implementation, testing, design, deployment, security, formal docs, delivery, planning, and repository status work.",
       "source": "./agents/product_manager",
       "strict": true,
       "skills": [

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "pm-agent",
-      "description": "Default entry plugin for product and engineering R&D requests when no other agent or skill is named. Explicitly naming pm-agent selects it; explicitly naming a different role agent or skill excludes pm-agent and leaves that capability to enforce its own gate. Routes product ideas, features, changes, bugs, implementation, testing, design, deployment, security, formal docs, delivery, planning, and repository status work.",
+      "description": "Default entry plugin for product and engineering R&D requests when no other agent or skill is named. Explicitly naming pm-agent selects it even when a downstream capability is also named; naming another role agent or skill without pm-agent excludes pm-agent and leaves that capability to enforce its own gate. Routes product ideas, features, changes, bugs, implementation, testing, design, deployment, security, formal docs, delivery, planning, and repository status work.",
       "source": "./agents/product_manager",
       "strict": true,
       "skills": [

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "pm-agent",
-      "description": "Default entry plugin for new user requests. Use when the user describes product ideas, feature requests, requirement changes, bugs, build/test/deploy/review/status requests, feature catalogs, competitive research, release communication, roadmaps, or GitHub project status. Classifies scope first, then routes to PM specialists or hands off to downstream role agents.",
+      "description": "Default entry plugin for product and engineering R&D requests when no other agent or skill is named; explicit agent or skill invocation always takes priority and retains its existing gate. Routes product ideas, features, changes, bugs, implementation, testing, design, deployment, security, formal docs, delivery, planning, and repository status work.",
       "source": "./agents/product_manager",
       "strict": true,
       "skills": [

--- a/.codex/INSTALL.md
+++ b/.codex/INSTALL.md
@@ -57,13 +57,13 @@ CLONE_ROOT="$HOME/.agents/dev-agent-skills"
 SKILL_ROOT="$HOME/.agents/skills"
 ```
 
-A personal install is discoverable in every project Codex opens. In projects
-without an enable marker, `pm-agent`'s scope guard stops general conversation,
-local-machine operations, and generic file work with a one-line notice;
-project-oriented requests and explicit invocation still proceed. Choose
-`personal` only when that global trigger surface is intended; a project
-install keeps the skills inside the project and gives it an explicit enable
-marker (`.agents/skills/.dev-agent-skills/.dev-agent-skills-mirror.json`).
+A personal install is discoverable in every project Codex opens. Explicitly
+named agents and skills always run their existing gates; otherwise product or
+engineering R&D intent enters `pm-agent`, and ordinary non-R&D work remains
+with the current assistant. Project docs, code, and enable markers are context
+after PM entry rather than trigger conditions. Choose `personal` only when
+that global discovery surface is intended; a project install keeps the skills
+inside the project.
 
 For a project install, run from the project root:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ PM / Engineer / QA / DevOps（条件式）→ Docs Agent（正式文档生产 / 
 
 **PM 唯一入口与下游 gate 指针**
 
-- 用户侧新需求、变更、bug、测试、部署、安全、交付或仓库状态诉求默认先进入 `pm-agent` 分类；用户未显式点名任何 skill 或 agent 时同样默认进入 `pm-agent`，显式点名是受支持的直达路径，但仍必须经过对应入口 gate 的安全网。例外（`pm-agent` Scope Guard）：未启用 dev-agent-skills 的目录中的一般对话、本机操作与通用文件处理直接给出提示并停止，不进入分类；显式点名或已启用目录放行的一般请求若无法归入任何 PM 类别或下游角色，诚实说明并停在 PM，不输出 Routing decision、不伪造 request_type/owner。下游 role router 和 specialist 只在 PM handoff packet 或等效已确认文档链存在时承接。
+- 用户显式点名 `pm-agent`、role agent 或 skill 时优先使用该能力，并继续其既有入口 gate；未显式点名时，产品或工程研发意图（新需求、变更、bug、实现、测试、设计、部署、安全、正式项目文档、交付或仓库状态）默认进入 `pm-agent`，普通非研发请求由当前助手直接处理。项目文档、代码与 marker 只在进入 PM 后作为分类和门禁证据，不决定是否自动触发。下游 role router 和 specialist 只在 PM handoff packet 或等效已确认文档链存在时承接。
 - 下游安全网包含前置与收尾两面：缺少 PM handoff packet、等效已确认文档链或 specialist entry basis 时，不执行下游协议，温和引导用户经 `pm-agent` 补齐前置并完成入口分类（脚手架请求同样走正常 PM 分类）；完成当前事项后，主动建议协作链下一步并等待确认，用户已授权 `auto-continue` 时可连续推进直到链路结束或用户喊停。
 - SKILL.md frontmatter 的 `visibility: internal` 是声明层标记，Claude Code 与 Codex 都不消费该字段，不隐藏 slash 命令也不阻止显式直调；`pm-agent` 是默认入口，下游标记为 `internal` 仅表示非默认入口。
 - 6 个 role router 只保留入口凭据检查和分流指针，其中 `docs-agent` 分流正式文档站点 bootstrap、API/database/design/ops/product 当前事实 sync、基于运行界面截图的图文用户操作手册、站内 Release Notes 和 audit；PM `github-release-gen` 按 SKILL.md 的宿主文档站适用性判断生成 GitHub Release：有文档站宿主要求站内 Release Notes 已确认且 docs-audit 门禁通过；无文档站宿主降级为维护者确认的版本事实源与维护者显式批准；具体执行 gate 的权威副本留在对应 specialist `SKILL.md`，例如 `feature-implementor` 的 PRD/TRD/plan/archive gate、`debugger` 的 expected-behavior gate、QA specialist 的 E2E gate，以及 Designer/DevOps/Security/Docs specialist 的 feature-scope gate。

--- a/README.md
+++ b/README.md
@@ -77,14 +77,11 @@ Skills previously installed Codex-style into `~/.agents/skills/` are also discov
 
 ## Scope
 
-These agents target in-project R&D workflows. A personal install — the Codex
-path (`~/.agents/skills/`), a user-scope Claude plugin, or the Kimi plugin —
-makes the skills discoverable in every project the host sees. In a project
-that has not enabled dev-agent-skills, `pm-agent` applies a scope guard:
-general conversation, local-machine operations, and generic file work stop
-with a one-line notice instead of entering the heavy PM workflow. Project
-requests and explicit invocation of `pm-agent` or any skill still proceed
-normally.
+These agents target product and engineering R&D workflows. Explicitly naming
+`pm-agent`, a role agent, or a skill always uses that capability and preserves
+its existing gate. Otherwise, R&D intent enters `pm-agent`, while ordinary
+non-R&D requests remain with the current assistant. Project docs, code, and
+enable markers provide context only after PM entry; they do not trigger it.
 
 For the tightest isolation, prefer a Codex project install (see
 [`docs/README.codex.md`](./docs/README.codex.md)), which keeps the skills

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Implementation details and troubleshooting are in the [Codex Guide](./docs/READM
 /plugins install https://github.com/Neplich/dev-agent-skills/tree/main
 ```
 
-The repository ships a `.kimi-plugin/plugin.json` manifest: all seven role skill directories are registered as a single plugin, and `pm-agent` loads automatically at session start via `sessionStart.skill`. The `tree/main` form installs the latest development state, which includes the pm-agent scope guard. Once a release that includes the scope guard is published, pin an immutable version with `/plugins install https://github.com/Neplich/dev-agent-skills/releases/tag/vX.Y.Z`.
+The repository ships a `.kimi-plugin/plugin.json` manifest: all seven role skill directories are registered as a single plugin, and `pm-agent` loads automatically at session start via `sessionStart.skill`. The `tree/main` form installs the latest development state, where explicit capability names take priority and otherwise product or engineering R&D intent enters `pm-agent`. Once this policy is released, pin an immutable version with `/plugins install https://github.com/Neplich/dev-agent-skills/releases/tag/vX.Y.Z`.
 
 Skills previously installed Codex-style into `~/.agents/skills/` are also discovered by Kimi Code automatically; the native plugin above is the recommended path.
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -69,7 +69,7 @@ Fetch and follow instructions from https://raw.githubusercontent.com/Neplich/dev
 /plugins install https://github.com/Neplich/dev-agent-skills/tree/main
 ```
 
-仓库内置 `.kimi-plugin/plugin.json` manifest：7 个角色 skill 目录注册为单个插件，`pm-agent` 随会话启动自动加载（`sessionStart.skill`）。上面的 `tree/main` 形式安装最新开发状态，包含 pm-agent 的 Scope Guard。包含 Scope Guard 的版本发布后，可改用 `/plugins install https://github.com/Neplich/dev-agent-skills/releases/tag/vX.Y.Z` 固定不可变版本。
+仓库内置 `.kimi-plugin/plugin.json` manifest：7 个角色 skill 目录注册为单个插件，`pm-agent` 随会话启动自动加载（`sessionStart.skill`）。上面的 `tree/main` 形式安装最新开发状态；版本发布后，可改用 `/plugins install https://github.com/Neplich/dev-agent-skills/releases/tag/vX.Y.Z` 固定不可变版本。
 
 已按 Codex 方式安装到 `~/.agents/skills/` 的 skill 也会被 Kimi Code 自动扫描到；推荐优先使用上面的原生插件方式。
 
@@ -77,7 +77,7 @@ Fetch and follow instructions from https://raw.githubusercontent.com/Neplich/dev
 
 ## 使用范围
 
-这些 Agent 面向项目内研发工作流。个人级安装——Codex 路径（`~/.agents/skills/`）、用户级 Claude 插件或 Kimi 插件——会让 skill 在宿主可见的每个项目中都可被发现。在未启用 dev-agent-skills 的项目中，`pm-agent` 会执行使用范围判定：一般对话、本机环境操作与通用文件处理只输出一句提示后停止，不进入重型 PM 工作流；项目向请求与显式点名 `pm-agent` 或任意 skill 仍正常执行。
+这些 Agent 面向产品与工程研发工作流。显式点名 `pm-agent`、role agent 或 skill 时始终使用对应能力并保留其既有门禁；未显式点名时，研发意图进入 `pm-agent`，普通非研发请求由当前助手直接处理。项目文档、代码与启用 marker 只在进入 PM 后提供上下文，不决定是否触发。
 
 若需要最严格的隔离，优先使用 Codex 项目级安装（见 [`docs/README.codex.md`](./docs/README.codex.md)），它会将 skill 保持在项目目录内，并为项目提供明确的启用标记。
 

--- a/agents/designer/skills/designer-agent/SKILL.md
+++ b/agents/designer/skills/designer-agent/SKILL.md
@@ -10,11 +10,11 @@ visibility: internal
 the narrowest design skill while preserving the strict boundary that design
 stops at design handoff and does not continue into code.
 
-## Mandatory Routing Decision
+## Routing Decision
 
-Before producing design work, state the accepted entry basis, resolved
+Before producing design work, confirm the accepted entry basis, resolved
 `feature_path`, selected design specialist, preserved source documents, and
-required design output. An Engineer UI-maintenance handoff is a valid design
+required design output internally. An Engineer UI-maintenance handoff is a valid design
 entry basis when it identifies the design gap; accept it without treating it as
 implementation authority. After the selected design deliverables are complete,
 stop and hand the confirmed paths and remaining implementation scope back to
@@ -135,8 +135,6 @@ not perform the missing agent's responsibilities yourself.
 
 When routing is complete:
 
-- state which design skill should handle the request
-- if relevant, state the follow-up design chain
 - make the design-only stopping point explicit and name `engineer-agent` as the
   next step for implementation
 - after the routed skill or role stage completes, apply the cross-role

--- a/agents/designer/test/designer-agent/evals/evals.json
+++ b/agents/designer/test/designer-agent/evals/evals.json
@@ -27,7 +27,7 @@
       },
       "prompt": "账单通知设置的需求已经写在 `docs/pm/billing-notifications/PRD.md`。请把设置页的流程和视觉风格都设计好；后续还要做 React 组件，如果设计阶段能一并处理也请帮我完成。",
       "workspace": "workspace/eval-1-route-design-handoff",
-      "expected_output": "设计路由决策，明确 ui-ux-design 和 visual-design 的顺序，使用真实设计产物文件名，并停在 engineer-agent handoff 前。",
+      "expected_output": "明确 ui-ux-design 和 visual-design 的处理顺序，使用真实设计产物文件名，并保持设计交付边界。",
       "assertions": [
         {
           "id": "routes_ux_first",
@@ -81,7 +81,7 @@
       },
       "prompt": "聊天历史搜索的产品需求在 `docs/pm/chat-interface/messages/history/search/PRD.md`，技术约束在同层级对应的 TRD。请完成这项功能需要的界面与视觉设计，继续沿用现有功能树，不要另拆一个同名功能。",
       "workspace": "workspace/eval-2-feature-path-design-handoff",
-      "expected_output": "设计路由决策，读取同一 feature_path 的 PM/Engineer 文档，输出 docs/design/chat-interface/messages/history/search 下的设计产物路径，并在 design handoff 停止",
+      "expected_output": "读取同一 feature_path 的 PM/Engineer 文档，确定 docs/design/chat-interface/messages/history/search 下的设计产物路径，并保持 design handoff 边界",
       "assertions": [
         {
           "id": "uses_confirmed_feature_path",

--- a/agents/designer/test/designer-agent/evals/workspace/eval-003-engineer-ui-maintenance-handoff/comparison.md
+++ b/agents/designer/test/designer-agent/evals/workspace/eval-003-engineer-ui-maintenance-handoff/comparison.md
@@ -13,18 +13,18 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `821c99c85df4188cff291d55bb3f776ec720f8cbbd3f93df4bf7a03b6520bf3a` from `agents/designer/test/designer-agent/evals/workspace/eval-003-engineer-ui-maintenance-handoff`.
 - Identity schema: `2`
-- target_skill_sha256: `e8c75de1d6f9996313bad1fce4ede6ed7cde9c08fd07355edd02169db57e8e68`
+- target_skill_sha256: `0ea73feefb23eaaa1087f7930615deb60bd48042a3221450dac25110527e9a02`
 - eval_definition_sha256: `138aebdae4a1049db8b791a6754cc321fff06d447fcae99b0206d1d5aa26e929`
 - metadata_sha256: `f547a888a015d9e9862374a63fae63a3c03679e1e0f3c3c280b9cf0370c3b020`
 - fixture_sha256: `821c99c85df4188cff291d55bb3f776ec720f8cbbd3f93df4bf7a03b6520bf3a`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
 - runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
 - judge_schema_sha256: `642d6c7ee5330dc1af39bc9648e9c1bffdb74e1229fc98a9c317e40e13baaebf`
-- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
-- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
-- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
-- Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
+- Prompt SHA-256: `92f4c4b043cb3aab774531019133e8d4e6f2d81d21a277f0cd9696a8cc0a58e7`
+- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
 - Repository worktree state: **DIRTY**
+- Skill overlay SHA-256: `08aafb5ab4f6346282a3571edc0bcbd3cde0a44d4f90ceae2c697a568d95ad53`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,22 +33,22 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `accepts_engineer_design_handoff` | PASS | 交付文档将 TRD 识别为前端设计缺口，并将设计交接回 Engineer。 |
-| `uses_confirmed_feature_path` | PASS | 两个设计快照均使用 feature_path customer-portal/profile-settings，并列明对应 PRD 与 TRD 为源文档。 |
-| `routes_design_skills` | PASS | 交付了 ui-ux-spec.md 与 visual-system.md，分别覆盖页面信息层级和主按钮视觉规范。 |
-| `writes_design_outputs_only` | PASS | 工作区仅新增 docs/design/customer-portal/profile-settings/ui-ux-spec.md 与 visual-system.md；无代码、测试或配置变更。 |
-| `hands_back_to_engineer` | PASS | 最终输出及设计文档明确指定 engineer-agent 负责 TRD、IMPLEMENTATION_PLAN.md、前端实现和代码/测试验证。 |
+| `accepts_engineer_design_handoff` | PASS | The design artifacts identify the confirmed frontend design gap, cite the Engineer TRD as an input, and describe the work as a design handoff. |
+| `uses_confirmed_feature_path` | PASS | Both locked design files use feature_path `customer-portal/profile-settings` and list the PM PRD and Engineer TRD as source documents. |
+| `routes_design_skills` | PASS | The captured command events show ui-ux-design and visual-design skill instructions being read and the visual-design reference data being queried; the resulting artifacts cover both information hierarchy and primary-button visuals. |
+| `writes_design_outputs_only` | PASS | The locked delivery snapshot contains only `ui-ux-spec.md` and `visual-system.md`; no code, tests, shell commands, deployment configuration, or engineering implementation artifact was delivered. |
+| `hands_back_to_engineer` | PASS | Both locked design artifacts explicitly state that the next owner is `engineer-agent` for TRD consumption, IMPLEMENTATION_PLAN, frontend implementation, and tests. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=92f4c4b043cb3aab774531019133e8d4e6f2d81d21a277f0cd9696a8cc0a58e7; fixture_sha256=821c99c85df4188cff291d55bb3f776ec720f8cbbd3f93df4bf7a03b6520bf3a; output_sha256=cfa29c62c0e3097f8bfb2c9629e002af1daabe9116a57479e8e40b90b06f0770; snapshot_sha256=6d92ebd3d5782c6493ebca9ecf080e97280c354156f8ddf197607738a8df6684
-- Behavior: 完成双文档设计交付，覆盖信息架构、响应式布局、主按钮视觉状态，并明确交回 engineer-agent。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=92f4c4b043cb3aab774531019133e8d4e6f2d81d21a277f0cd9696a8cc0a58e7; fixture_sha256=821c99c85df4188cff291d55bb3f776ec720f8cbbd3f93df4bf7a03b6520bf3a; output_sha256=1e9a8d25428f2976ad892473005a1d7ef26dc76562e5db15d39e4317e26f3868; snapshot_sha256=d8c7dc423ce5f606f0eb1064e70a53bf4de2dc3834adec30463697518b65aca0
+- Behavior: Delivered focused UI/UX and visual design specifications for the confirmed profile-settings frontend design gap, with explicit Engineer handoff.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=92f4c4b043cb3aab774531019133e8d4e6f2d81d21a277f0cd9696a8cc0a58e7; fixture_sha256=821c99c85df4188cff291d55bb3f776ec720f8cbbd3f93df4bf7a03b6520bf3a; output_sha256=09716fbf43b75f3b4a1f475d44b0e0f950ae4269ed99d4e0dc4dc880301d4918; snapshot_sha256=8c67d2592cd99c15764cd0d853cf1336b13c4362499e177dbf7435b9257d4225
-- Behavior: 基线产出非约定的 DESIGN.md，并修改 TRD，未按要求路由或限定设计输出。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=92f4c4b043cb3aab774531019133e8d4e6f2d81d21a277f0cd9696a8cc0a58e7; fixture_sha256=821c99c85df4188cff291d55bb3f776ec720f8cbbd3f93df4bf7a03b6520bf3a; output_sha256=476d7e98373ad65bdc20e791e27ebf50b38496e31f950a29ca375df05b3f1915; snapshot_sha256=08dec7f7c1f876e226259c98f38eea23f8a0c2c5827893970e4adb7fb14f82a0
+- Behavior: Fresh baseline created a generic DESIGN.md and modified the Engineer TRD, rather than using the required design-only output paths and skill-routed split artifacts.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/designer/test/designer-agent/evals/workspace/eval-1-route-design-handoff/comparison.md
+++ b/agents/designer/test/designer-agent/evals/workspace/eval-1-route-design-handoff/comparison.md
@@ -13,18 +13,18 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `318a6ed6ff151cee086f75e2b1924aa867c873c059722194e1d201fc514c9d89` from `agents/designer/test/designer-agent/evals/workspace/eval-1-route-design-handoff`.
 - Identity schema: `2`
-- target_skill_sha256: `e8c75de1d6f9996313bad1fce4ede6ed7cde9c08fd07355edd02169db57e8e68`
-- eval_definition_sha256: `22532d649002dfa1851fec27c554d610e1ed3e70ab860965c5b4914f96d4ccce`
+- target_skill_sha256: `0ea73feefb23eaaa1087f7930615deb60bd48042a3221450dac25110527e9a02`
+- eval_definition_sha256: `81da08302867bb0360b62db9057e07b009cd93243321e4fb904ab779192971e2`
 - metadata_sha256: `b228adbda9579c0023d949fdd52d3bd090b6ff85b7c6c2610e5202c6900dbe10`
 - fixture_sha256: `318a6ed6ff151cee086f75e2b1924aa867c873c059722194e1d201fc514c9d89`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
 - runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
 - judge_schema_sha256: `463caa76fbf321564869d8651cfcd73afe8721c939c5039c5cfd81c4ab25d935`
-- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
-- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
-- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
-- Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
+- Prompt SHA-256: `6928263198e744f0628528a64ad381eb51b57dfc5347279a1b5dc49c697dfc6c`
+- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
 - Repository worktree state: **DIRTY**
+- Skill overlay SHA-256: `08aafb5ab4f6346282a3571edc0bcbd3cde0a44d4f90ceae2c697a568d95ad53`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,22 +33,22 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `routes_ux_first` | PASS | Raw trace records the design specialist chain as `ui-ux-design` → `visual-design`, with UI/UX skill inspection before visual skill inspection. |
-| `routes_visual_followup` | PASS | Raw trace explicitly records `ui-ux-design` → `visual-design`; visual-system delivery snapshot contains visual-system content. |
-| `uses_real_output_filenames` | PASS | Locked delivery snapshot contains `docs/design/billing-notifications/ui-ux-spec.md` and `docs/design/billing-notifications/visual-system.md`. |
-| `stops_before_code` | PASS | Git status and locked delivery snapshot show only the two design documents; no React, test, script, or deployment files were delivered. |
-| `hands_off_to_engineer` | PASS | Final output and locked design documents state that React implementation and tests should be handed to `engineer-agent`. |
+| `routes_ux_first` | PASS | Trace records the route as `ui-ux-design → visual-design`, with UX handling flows, structure, IA, wireframes, and interaction states first. |
+| `routes_visual_followup` | PASS | Trace explicitly selects `ui-ux-design → visual-design`; the visual-system snapshot contains visual direction, components, colors, typography, and copy tone. |
+| `uses_real_output_filenames` | PASS | Locked delivery snapshots contain exactly `docs/design/billing-notifications/ui-ux-spec.md` and `docs/design/billing-notifications/visual-system.md`. |
+| `stops_before_code` | PASS | Locked git evidence shows only the two design Markdown files were added; the final message states React implementation was not performed in the design stage. |
+| `hands_off_to_engineer` | PASS | Both locked design documents and the final message explicitly hand implementation to `engineer-agent`. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=6928263198e744f0628528a64ad381eb51b57dfc5347279a1b5dc49c697dfc6c; fixture_sha256=318a6ed6ff151cee086f75e2b1924aa867c873c059722194e1d201fc514c9d89; output_sha256=6e8f78c380b0f1741a592a3e8bdf21a807cad4046113e5ee5300d78359fe2eb5; snapshot_sha256=633edb41b2870772daec4de620c7cf056975ca1533938ca57938eb1a97f70531
-- Behavior: Followed the UX-first then visual-design route, delivered the required design documents, stopped before implementation, and handed off to engineer-agent.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=6928263198e744f0628528a64ad381eb51b57dfc5347279a1b5dc49c697dfc6c; fixture_sha256=318a6ed6ff151cee086f75e2b1924aa867c873c059722194e1d201fc514c9d89; output_sha256=85a702ea051ebd9173bfbe1e7eed290dfcc8d5cab1f65c3db058e9c08e9940d6; snapshot_sha256=b38bacb6fa723effc9b27f97c0b8a3e799567f6d3f770a9017b34ccb94445fe4
+- Behavior: Completed the UX-first then visual-design workflow, delivered both required design documents, stopped before implementation, and handed off to engineer-agent.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=6928263198e744f0628528a64ad381eb51b57dfc5347279a1b5dc49c697dfc6c; fixture_sha256=318a6ed6ff151cee086f75e2b1924aa867c873c059722194e1d201fc514c9d89; output_sha256=4f38869817214bf915cea73c378c08ef7a552167599657c8adc3bcd88bcbf4fb; snapshot_sha256=b4c8dcdf073a861e788eb9c386dd6573c61408b68d58e2c0c906969669738668
-- Behavior: Implemented React UI and supporting project files directly, using DESIGN.md under the PM directory instead of the required design-only handoff.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=6928263198e744f0628528a64ad381eb51b57dfc5347279a1b5dc49c697dfc6c; fixture_sha256=318a6ed6ff151cee086f75e2b1924aa867c873c059722194e1d201fc514c9d89; output_sha256=110788c730e80691d82689fff9666550eb0e485bf08728ea36e2fb259d207a21; snapshot_sha256=fdde5ac550abb0aea166b4fa44322913028de46ba2823a4527996dd088909fe9
+- Behavior: Produced a React implementation and source files directly, without the required design workflow or design deliverables.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/designer/test/designer-agent/evals/workspace/eval-2-feature-path-design-handoff/comparison.md
+++ b/agents/designer/test/designer-agent/evals/workspace/eval-2-feature-path-design-handoff/comparison.md
@@ -13,18 +13,18 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `f51ab76601713bed8d87e8e33016aaf394374041676e06644b8b383a6a3f1ef6` from `agents/designer/test/designer-agent/evals/workspace/eval-2-feature-path-design-handoff`.
 - Identity schema: `2`
-- target_skill_sha256: `e8c75de1d6f9996313bad1fce4ede6ed7cde9c08fd07355edd02169db57e8e68`
-- eval_definition_sha256: `53f91ea5792318b5883984b62004cc098b15b6389da8f0c2233bdab77fbf2aa6`
+- target_skill_sha256: `0ea73feefb23eaaa1087f7930615deb60bd48042a3221450dac25110527e9a02`
+- eval_definition_sha256: `9f0bcf8d0817f9f62b224c251f6b0df43d09e6b597facabfb572c220908b85a8`
 - metadata_sha256: `e6f9e581a9240bd876422c7ab0f1f1ca860fda8f563a8f02f87555323c8c7b30`
 - fixture_sha256: `f51ab76601713bed8d87e8e33016aaf394374041676e06644b8b383a6a3f1ef6`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
 - runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
 - judge_schema_sha256: `173af1b9ec0e079651ca3a9820c63dda3723644385c5a202331578e8f1a93950`
-- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
-- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
-- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
-- Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
+- Prompt SHA-256: `e85929c91fa7ac5d9cb93339a38a992d155e1c545a4c3e5f4af6c78a44404dd1`
+- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
 - Repository worktree state: **DIRTY**
+- Skill overlay SHA-256: `08aafb5ab4f6346282a3571edc0bcbd3cde0a44d4f90ceae2c697a568d95ad53`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,21 +33,21 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `uses_confirmed_feature_path` | PASS | With-skill delivery snapshots explicitly set `feature_path` to `chat-interface/messages/history/search` and cite the matching PRD and TRD paths. |
-| `mirrors_design_outputs` | PASS | The locked with-skill snapshots are exactly `docs/design/chat-interface/messages/history/search/ui-ux-spec.md` and `docs/design/chat-interface/messages/history/search/visual-system.md`. |
-| `no_synonym_top_level` | PASS | The with-skill manifest contains only the required full design path; no synonym or truncated design directory is delivered or proposed. |
-| `stops_before_code` | PASS | With-skill delivery contains design documents only and explicitly marks the work as stopping at design handoff; no code, patch, or test command is included. |
+| `uses_confirmed_feature_path` | PASS | With-skill UI/UX delivery declares feature_path `chat-interface/messages/history/search` and explicitly cites the matching PRD and TRD paths as source documents. |
+| `mirrors_design_outputs` | PASS | With-skill delivery snapshot contains exactly `docs/design/chat-interface/messages/history/search/ui-ux-spec.md` and `docs/design/chat-interface/messages/history/search/visual-system.md`. |
+| `no_synonym_top_level` | PASS | Locked design artifacts preserve the existing parent feature tree and explicitly reject new top-level or synonym search areas; no prohibited design paths are delivered. |
+| `stops_before_code` | PASS | With-skill delivery contains design artifacts only and ends at the design handoff to engineer-agent; no code, implementation steps, test commands, or patch are delivered. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=e85929c91fa7ac5d9cb93339a38a992d155e1c545a4c3e5f4af6c78a44404dd1; fixture_sha256=f51ab76601713bed8d87e8e33016aaf394374041676e06644b8b383a6a3f1ef6; output_sha256=df2d7773d9762c1c31cf3de86000df8bcef9517fa9911472036de308f62558e3; snapshot_sha256=0bcd4e9ff309457ece97296421bb8a0f504ffe13bebd36c30f9a3d40f61d7110
-- Behavior: Delivered the required UI/UX and visual-system design artifacts at the confirmed feature path and stopped at design handoff.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=e85929c91fa7ac5d9cb93339a38a992d155e1c545a4c3e5f4af6c78a44404dd1; fixture_sha256=f51ab76601713bed8d87e8e33016aaf394374041676e06644b8b383a6a3f1ef6; output_sha256=c2f413a94733d484a7bf629bcadbf5405338e2ca5db530eac97548c1ab110b5a; snapshot_sha256=c3ef3720b40e4c1ca81ecc2b80400540e2f8d955bf18cd7d647b2aafadf7be58
+- Behavior: Delivered the requested UI/UX and visual design artifacts under the confirmed feature path, with explicit PRD/TRD inputs and a clear design handoff boundary.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=e85929c91fa7ac5d9cb93339a38a992d155e1c545a4c3e5f4af6c78a44404dd1; fixture_sha256=f51ab76601713bed8d87e8e33016aaf394374041676e06644b8b383a6a3f1ef6; output_sha256=727852146ff958574726e77dfced27fda6831f156a4c0b21512b1edf8f452482; snapshot_sha256=642b822c68ddfb757698624340ccabf36a88b736024c928af675080f55e5879d
-- Behavior: Delivered an implemented HTML/CSS/JS prototype at the workspace root, including a syntax-check command, rather than the required design handoff artifacts.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=e85929c91fa7ac5d9cb93339a38a992d155e1c545a4c3e5f4af6c78a44404dd1; fixture_sha256=f51ab76601713bed8d87e8e33016aaf394374041676e06644b8b383a6a3f1ef6; output_sha256=b05fd54ce842a7239e17c840eefb2e31745107cff1c11b5baeb964d2e7a47ac0; snapshot_sha256=ec4d03cf673030607dd2de11956cc2d159c7dc9cc2b87d8d7a7d911d8da9cb29
+- Behavior: Fresh baseline implemented a static chat-history search interface under a non-design path and included a syntax-check command, contrasting with the with_skill design-only handoff.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/devops/skills/devops-agent/SKILL.md
+++ b/agents/devops/skills/devops-agent/SKILL.md
@@ -11,9 +11,9 @@ request is about deployment setup, delivery automation, configuration
 governance, or operational readiness, then routes to the narrowest downstream
 DevOps skill.
 
-## Mandatory Routing Decision
+## Routing Decision
 
-Before any specialist work, state the accepted entry basis, selected DevOps
+Before any specialist work, preserve the accepted entry basis, selected DevOps
 specialist or ordered chain, preserved source evidence, scope, and required
 output. A documentation-site completeness remediation keeps ownership
 separate: DevOps may plan deployment units, CI, configuration, and runtime
@@ -122,8 +122,6 @@ not perform the missing agent's responsibilities yourself.
 
 When routing is complete:
 
-- state which DevOps skill should handle the request
-- if relevant, state the follow-up DevOps chain
 - make it clear whether outputs are expected under `deploy/`,
   repo-native CI/CD paths such as `.github/workflows/`, or durable operational
   docs under `docs/devops/{feature_path}/` or `deploy/`

--- a/agents/devops/test/devops-agent/evals/evals.json
+++ b/agents/devops/test/devops-agent/evals/evals.json
@@ -28,7 +28,7 @@
       },
       "prompt": "这个服务已经有 Docker 部署目录，但还没有 GitHub Actions 的 PR 检查；我也担心环境变量和回滚文档不完整。相关背景在 `PM_HANDOFF.md`，请先帮我确定处理顺序和每一步的交付，暂时不要改配置。",
       "workspace": "workspace/eval-1-route-ci-readiness",
-      "expected_output": "DevOps 路由决策，明确 CI/CD 是当前主 route，配置审计和 runbook 是后续检查，而不是一次性直接执行所有 DevOps skill。",
+      "expected_output": "明确 CI/CD 是当前主要工作，配置审计和 runbook 是后续检查，而不是一次性直接执行所有 DevOps skill。",
       "assertions": [
         {
           "id": "routes_primary_to_cicd",
@@ -52,8 +52,8 @@
         },
         {
           "id": "does_not_write_workflow",
-          "description": "只做路由不写文件",
-          "text": "因为用户要求先做路由，不能直接新增 `.github/workflows` 文件。"
+          "description": "遵守暂不修改边界",
+          "text": "因为用户明确要求先确认推进方式且暂不改配置，不能直接新增 `.github/workflows` 文件。"
         }
       ]
     },

--- a/agents/devops/test/devops-agent/evals/workspace/eval-002-route-docs-site-completeness-chain/comparison.md
+++ b/agents/devops/test/devops-agent/evals/workspace/eval-002-route-docs-site-completeness-chain/comparison.md
@@ -13,18 +13,18 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `db76812ee462c1a8d89decf8e6fae581930c1406d7c6f72f3847172ed0bb02f3` from `agents/devops/test/devops-agent/evals/workspace/eval-002-route-docs-site-completeness-chain`.
 - Identity schema: `2`
-- target_skill_sha256: `d688e19912770823b0aab741fb33c331e4eee7536315cf3080fbad81ca1e904f`
+- target_skill_sha256: `32901f32eb5b31c7ae31e0ec3b0112e3fe1d219e06d0edd2c1c57630d43202e0`
 - eval_definition_sha256: `dc1b04424607a1675278b8e310c3f7b0da94f3cf1e857f037b9a6a8dbbf9482f`
 - metadata_sha256: `2718def12280e05b73752266e8d3b39d6929d0781f7ca1aa2088b55bd4e38e9c`
 - fixture_sha256: `db76812ee462c1a8d89decf8e6fae581930c1406d7c6f72f3847172ed0bb02f3`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
 - runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
 - judge_schema_sha256: `fdb2fd9254bbcae4d1c5e9dd4a0df1a9be1ee48991c72d5d1ea96147641ed710`
-- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
-- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
-- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
-- Repository HEAD: `f2aa9b2c49be68550ec45538c221425607f428ce`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
+- Prompt SHA-256: `520c4aa6ac767af388d73d9adeec0eb6b05a688f692c19decf65da48e498c67e`
+- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
 - Repository worktree state: **DIRTY**
+- Skill overlay SHA-256: `b95c78069c4a6a805dc918675b58a1f4ba98b532673108e30f6ce81c7e8d2976`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `accepts_repo_wide_docs_handoff` | PASS | With-skill output explicitly accepts the repo-wide DevOps entry, cites request_type: deployment and feature_path: N/A, preserves the completeness evidence sources, and does not request feature_path clarification. |
-| `routes_dependency_order` | PASS | With-skill output states the complete ordered chain: deployment-planner, cicd-bootstrap, env-config-auditor, then docs-agent:formal-docs-sync. |
-| `preserves_role_and_authority_boundaries` | PASS | With-skill output states that Docs consumes only landed and verified facts, DevOps does not modify formal documentation, and the handoff does not authorize commit, push, image publication, deployment, or release. |
+| `accepts_repo_wide_docs_handoff` | PASS | With-skill output explicitly accepts request_type deployment, feature_path N/A, repo-wide documentation completeness scope, and proceeds without requesting feature-path clarification. |
+| `routes_dependency_order` | PASS | With-skill output explicitly lists deployment-planner -> cicd-bootstrap -> env-config-auditor -> docs-agent:formal-docs-sync, including the conditional handoff to Docs after verified facts. |
+| `preserves_role_and_authority_boundaries` | PASS | With-skill output states DevOps does not modify formal documentation and explicitly preserves no authorization for commit, push, image publication, or deployment. Locked git evidence shows no changes. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=520c4aa6ac767af388d73d9adeec0eb6b05a688f692c19decf65da48e498c67e; fixture_sha256=db76812ee462c1a8d89decf8e6fae581930c1406d7c6f72f3847172ed0bb02f3; output_sha256=28a5f4dac5bb3435b3021cc70f84448dabe96a9b0799366133556b2fcd3c607e; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Accepted the repo-wide deployment handoff, routed the required dependency chain, and preserved role and authorization boundaries.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=520c4aa6ac767af388d73d9adeec0eb6b05a688f692c19decf65da48e498c67e; fixture_sha256=db76812ee462c1a8d89decf8e6fae581930c1406d7c6f72f3847172ed0bb02f3; output_sha256=1958fcbe1092b3973529b6da089aecf2d1a383770448b582491fa31015e049da; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly accepts and routes the repo-wide deployment handoff while preserving role and authority boundaries.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=520c4aa6ac767af388d73d9adeec0eb6b05a688f692c19decf65da48e498c67e; fixture_sha256=db76812ee462c1a8d89decf8e6fae581930c1406d7c6f72f3847172ed0bb02f3; output_sha256=71049f1725d7680694f929729439a6190f923b42ef41b05f8d72654c94ccd80b; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Provided a broad deployment plan but treated missing source files as a reason to defer exact routing and did not state the required named chain as precisely.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=520c4aa6ac767af388d73d9adeec0eb6b05a688f692c19decf65da48e498c67e; fixture_sha256=db76812ee462c1a8d89decf8e6fae581930c1406d7c6f72f3847172ed0bb02f3; output_sha256=69db6f72ceb836e7393a2c4d3217e333c8326da4228548b6816d1ef07fd1e398; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Provides a useful generic staged deployment plan and preserves no-preauthorization, but does not provide the required named conditional specialist chain.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/devops/test/devops-agent/evals/workspace/eval-1-route-ci-readiness/comparison.md
+++ b/agents/devops/test/devops-agent/evals/workspace/eval-1-route-ci-readiness/comparison.md
@@ -13,18 +13,18 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `01efe0f9d93680399a4e60a121c590987f01c7feeb295910c354e36c32f0a756` from `agents/devops/test/devops-agent/evals/workspace/eval-1-route-ci-readiness`.
 - Identity schema: `2`
-- target_skill_sha256: `d688e19912770823b0aab741fb33c331e4eee7536315cf3080fbad81ca1e904f`
-- eval_definition_sha256: `bf26d801d111c094ffb06e4f6cd89e1f8a4b7c9a1e7fc76f302a33c493a411f4`
+- target_skill_sha256: `32901f32eb5b31c7ae31e0ec3b0112e3fe1d219e06d0edd2c1c57630d43202e0`
+- eval_definition_sha256: `f7117f9350e70c8fb5cb6272bd6b59ffb1bebf3c95dfcda1ac024612c9eb455c`
 - metadata_sha256: `7dd2e52b200852fa05d4eb58b51c5b9cc7af5f7c62ced61947f3e3d4b9b7a2c0`
 - fixture_sha256: `01efe0f9d93680399a4e60a121c590987f01c7feeb295910c354e36c32f0a756`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
 - runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
 - judge_schema_sha256: `c7039dc2c9d829f51219a90df8027752cbbdaa32f7d8b6eb4b07c94a61b14320`
-- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
-- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
-- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
-- Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
+- Prompt SHA-256: `0724714db74641157eee897f7a5f22bd3898815bc5861281390b10275748d63d`
+- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
 - Repository worktree state: **DIRTY**
+- Skill overlay SHA-256: `df8d1c81654b45ca866c7dc4460562101014a579db40445bcd3bbe134bd8f67e`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,22 +33,22 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `routes_primary_to_cicd` | PASS | With-skill output explicitly selects `cicd-bootstrap` as the current priority for GitHub Actions PR checks. |
-| `keeps_deployment_context` | PASS | With-skill output preserves and cites `PM_HANDOFF.md` and `deploy/docker/README.md`, recognizing the existing Docker deployment context. |
-| `names_followups` | PASS | With-skill output names `env-config-auditor` for environment-variable coverage and `incident-playbook-writer` for rollback documentation. |
-| `does_not_run_all_skills` | PASS | With-skill output distinguishes the primary route from follow-up routes, excludes `deployment-planner`, and requests confirmation before implementation. |
-| `does_not_write_workflow` | PASS | With-skill output states no file changes are authorized; locked git evidence shows unchanged HEAD, status, and diffs, with no delivery snapshot. |
+| `routes_primary_to_cicd` | PASS | The with_skill output names `cicd-bootstrap` as the first-stage route for GitHub Actions PR checks. |
+| `keeps_deployment_context` | PASS | It targets existing `deploy/docker` assets and cites `deploy/docker/README.md`. |
+| `names_followups` | PASS | It names `env-config-auditor` and `incident-playbook-writer` as follow-ups. |
+| `does_not_run_all_skills` | PASS | It distinguishes the primary route from follow-ups and excludes `deployment-planner`. |
+| `does_not_write_workflow` | PASS | It states no configuration was modified; locked git evidence confirms no changes. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=0724714db74641157eee897f7a5f22bd3898815bc5861281390b10275748d63d; fixture_sha256=01efe0f9d93680399a4e60a121c590987f01c7feeb295910c354e36c32f0a756; output_sha256=020d40ed2d68028d80c942566d921eb2c8adb83148871fa8f800ea9ef4f15020; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly routes the GitHub Actions PR-gate gap to `cicd-bootstrap`, preserves deployment context, names the two follow-ups, and stops before implementation.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=0724714db74641157eee897f7a5f22bd3898815bc5861281390b10275748d63d; fixture_sha256=01efe0f9d93680399a4e60a121c590987f01c7feeb295910c354e36c32f0a756; output_sha256=05f6fa921dd896d23f4af872830f42e540afd90ca9e8d89e6297b409f0322607; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Selects the correct primary route, preserves deployment context, names follow-ups, scopes execution, and makes no workflow changes.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=0724714db74641157eee897f7a5f22bd3898815bc5861281390b10275748d63d; fixture_sha256=01efe0f9d93680399a4e60a121c590987f01c7feeb295910c354e36c32f0a756; output_sha256=f03691e184f36eeaf033e3ff98dfcdd2b3e994311a07b7801b21c6db852230be; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Provides a generic phased DevOps plan but does not select the required specialist route names.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=0724714db74641157eee897f7a5f22bd3898815bc5861281390b10275748d63d; fixture_sha256=01efe0f9d93680399a4e60a121c590987f01c7feeb295910c354e36c32f0a756; output_sha256=ede884ab6ed34a240c8f6cb184f04bdef40f9554275ab79a0cd1ac433ded31f7; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Provides a read-only plan but does not select the required primary route or named follow-ups.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/docs/skills/docs-agent/SKILL.md
+++ b/agents/docs/skills/docs-agent/SKILL.md
@@ -10,10 +10,9 @@ visibility: internal
 downstream entry basis, selects the narrowest documentation specialist, and
 preserves confirmed scope and evidence through the handoff.
 
-## Mandatory Routing Decision
+## Routing Decision
 
-This router produces a routing decision, not specialist output. Before any
-write, it must:
+Before any write, this router must:
 
 - identify which explicit packet, equivalent confirmed chain, or specialist
   entry basis was accepted; if incomplete, return to `pm-agent` and name every
@@ -25,7 +24,7 @@ write, it must:
 - name the selected specialist's authoritative gate without exposing a local
   filesystem path, copying its protocol, or executing that gate
 
-Emit one compact `Routing decision` block with explicit fields:
+Preserve these fields in the internal routing decision:
 `selected_specialist`, `accepted_entry_basis`, `request_type`, `change_tier`,
 `feature_path`, `host_repository`, `source_documents`, `confirmed_scope`,
 `evidence_sources`, `required_output`, `blockers_risks`, and
@@ -35,14 +34,14 @@ one specialist and stop at its router boundary. Do not add an unrelated site
 bootstrap prerequisite, second specialist, or PM round-trip after the selected
 specialist's documented entry basis is already complete.
 
-When routing is blocked, make the missing-entry result equally explicit: name
+When routing is blocked, name
 each missing credential and the exact credential combination that would make
 the selected specialist entry basis complete. For an explicit site-
 initialization request that lacks only the host path, state that the existing
 explicit request plus a confirmed host repository path completes the
 `docs-site-bootstrap` entry basis; do not merely repeat that the path is
 missing.
-Render blocked routing with `missing_credentials`, `unblock_credentials`,
+Preserve `missing_credentials`, `unblock_credentials`,
 `entry_basis_after_unblock`, and `return_owner`. For site initialization,
 `entry_basis_after_unblock` must explicitly state whether the combination of an
 explicit site-initialization request and a confirmed host repository path is
@@ -180,9 +179,6 @@ perform its responsibilities.
 
 When routing is complete:
 
-- state the selected specialist, or the blocked stage if a required target is
-  unavailable
-- state the accepted entry basis and the expected documentation artifact
 - preserve unresolved evidence or ownership gaps for the selected specialist
 - when a specialist triggers the documentation-site deployment-completeness
   safety-net, preserve its stable status, evidence paths, covered variants,

--- a/agents/docs/test/docs-agent/evals/evals.json
+++ b/agents/docs/test/docs-agent/evals/evals.json
@@ -26,8 +26,8 @@
           "不复制 specialist 执行协议或写入文档站"
         ]
       },
-      "prompt": "搜索 API 的实现和合同测试已经完成，交接信息在 `pm-handoff.md`。请帮我安排正式文档同步，告诉我接下来由哪个文档能力处理，以及会带上哪些已确认上下文。",
-      "expected_output": "选择正确的正式文档同步 specialist，完整保留 handoff 上下文并停在 router 交接边界。",
+    "prompt": "搜索 API 的实现和合同测试已经完成，交接信息在 `pm-handoff.md`。请帮我安排正式文档同步并说明下一步，不需要展示内部路由记录。",
+    "expected_output": "让正式文档同步成为明确下一步，继续使用既有 handoff 事实并停在 router 交接边界。",
       "workspace": "workspace/eval-001-route-formal-docs-sync",
       "assertions": [
         {
@@ -37,17 +37,17 @@
         },
         {
           "id": "preserves_handoff_context",
-          "description": "无损保留已确认交接上下文",
-          "text": "准确保留 `pm-handoff.md` 中的搜索 API 功能范围、来源证据、正式 API 页面和 change-map 输出、排除范围及风险，不重分类或遗漏已提供字段。"
+      "description": "继续使用已确认交接上下文",
+      "text": "下一步以 `pm-handoff.md` 中已确认的搜索 API 范围、证据、正式 API 页面和 change-map 输出为依据，不要求向用户逐字段复述 handoff packet。"
         },
         {
           "id": "points_to_authoritative_gate",
           "description": "只指向 specialist 权威合同",
-          "text": "明确由 `formal-docs-sync` specialist 接管后续执行并停在 router 边界；不要求向用户暴露本地 SKILL.md 路径，也不复制八步同步协议或 change-map 写入细节。"
+          "text": "后续执行必须交给 `formal-docs-sync` specialist，router 不执行同步流程；不向用户暴露本地 SKILL.md 路径，也不复制八步同步协议或 change-map 写入细节。"
         },
         {
           "id": "stops_at_router_boundary",
-          "description": "停在文档路由边界",
+          "description": "保持文档职责边界",
           "text": "本轮只完成路由与上下文交接，不修改 `docs/site/` 或执行 formal-docs-sync 的写入流程。"
         }
       ]
@@ -116,7 +116,7 @@
         {
           "id": "references_audit_gate_only",
           "description": "只引用审计 specialist gate",
-          "text": "明确由 `docs-audit` specialist 接管审计并停在 router 边界；不要求向用户暴露本地 SKILL.md 路径，也不复制 base/target、确定性层、事实层或统一盖章协议。"
+          "text": "后续审计必须交给 `docs-audit` specialist，router 不执行审计；不向用户暴露本地 SKILL.md 路径，也不复制 base/target、确定性层、事实层或统一盖章协议。"
         }
       ],
       "scenario": {
@@ -143,7 +143,7 @@
       "name": "站内 Release Notes 请求分流",
       "description": "验证 router 接受完整 Release Notes 入口依据，保留 handoff 上下文并只指向 release-notes-gen 的权威 gate。",
       "prompt": "请根据 `release-handoff.md` 处理 v1.0.0 的站内版本说明请求。",
-      "expected_output": "接受完整 entry basis，选择 release-notes-gen，保留版本、scope、宿主、证据与输出上下文，并仅引用 specialist gate，不复制确认、metadata、checks 或 `pm-agent:github-release-gen` handoff 执行协议。",
+      "expected_output": "接受现有 entry basis，让站内版本说明成为明确下一步，并继续使用已确认的版本、scope、宿主、证据与输出上下文；不展示原始 routing packet 或复制 specialist 协议。",
       "workspace": "workspace/eval-004-route-release-notes",
       "assertions": [
         {
@@ -158,13 +158,13 @@
         },
         {
           "id": "preserves_handoff_context",
-          "description": "保留入口上下文",
-          "text": "保留 request_type、change_tier、feature_path、release_version、release_scope、host_repository、source_documents、evidence_sources、required_output 与 blockers_risks。"
+          "description": "继续使用入口上下文",
+          "text": "后续以 `release-handoff.md` 中已确认的版本、scope、宿主、证据和输出要求为依据，不改写这些事实；是否满足 specialist entry basis 由独立断言判断，不要求向用户逐字段复述内部 handoff packet。"
         },
         {
           "id": "references_release_notes_gate_only",
           "description": "仅指向 specialist gate",
-          "text": "明确由 `release-notes-gen` specialist 接管站内版本说明并停在 router 边界；不要求向用户暴露本地 SKILL.md 路径，也不复制正文确认、metadata/index、docs checks 或 GitHub Release handoff 的详细协议。"
+          "text": "后续站内版本说明由 `release-notes-gen` 的既有 gate 承接，router 不执行生成流程且不向用户暴露本地 SKILL.md 路径；是否简述恢复条件不影响本断言。"
         }
       ],
       "scenario": {
@@ -323,7 +323,7 @@
         {
           "id": "references_manual_gate_only",
           "description": "仅指向 manual specialist gate",
-          "text": "明确由 `manual-gen` specialist 接管图文手册并停在 router 边界；不要求向用户暴露本地 SKILL.md 路径，router 不代为协商环境、采集截图、写入站点或执行审计 handoff。"
+          "text": "后续图文手册必须交给 `manual-gen` specialist，router 不执行生成流程；不向用户暴露本地 SKILL.md 路径，router 不代为协商环境、采集截图、写入站点或执行审计 handoff。"
         }
       ],
       "scenario": {

--- a/agents/docs/test/docs-agent/evals/evals.json
+++ b/agents/docs/test/docs-agent/evals/evals.json
@@ -26,7 +26,7 @@
           "不复制 specialist 执行协议或写入文档站"
         ]
       },
-    "prompt": "搜索 API 的实现和合同测试已经完成，交接信息在 `pm-handoff.md`。请帮我安排正式文档同步并说明下一步，不需要展示内部路由记录。",
+    "prompt": "搜索 API 的实现和合同测试已经完成，交接信息在 `pm-handoff.md`。请帮我安排正式文档同步并说明下一步。",
     "expected_output": "让正式文档同步成为明确下一步，继续使用既有 handoff 事实并停在 router 交接边界。",
       "workspace": "workspace/eval-001-route-formal-docs-sync",
       "assertions": [

--- a/agents/docs/test/docs-agent/evals/workspace/eval-001-route-formal-docs-sync/comparison.md
+++ b/agents/docs/test/docs-agent/evals/workspace/eval-001-route-formal-docs-sync/comparison.md
@@ -13,18 +13,18 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `5bfe584ec04ca9f6271a87eb0a6a94432a493cce40c865cd7e77c63d4d5a5991` from `agents/docs/test/docs-agent/evals/workspace/eval-001-route-formal-docs-sync`.
 - Identity schema: `2`
-- target_skill_sha256: `cf92649952a97be677cf5e900a4d9c793a6c0724813cf1fa3154f57e7d2c08f3`
-- eval_definition_sha256: `4f62b001057b225d1029a6284046afacf46248ad92aa43b0c065e0a0456b7450`
+- target_skill_sha256: `af94ca4b38768885230f6271f3d4ae9e1b1be30fcd2f5bdf1098250b4ded0306`
+- eval_definition_sha256: `feba21121d4c3b05845e70bb42290b3e48f9ac62ef8bf5b095426802bc992c41`
 - metadata_sha256: `320948f19ccb8c159c24fdc827ddc592aac02ee3f64236dd9e4896bae8e4979e`
 - fixture_sha256: `5bfe584ec04ca9f6271a87eb0a6a94432a493cce40c865cd7e77c63d4d5a5991`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
 - runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
 - judge_schema_sha256: `d9120b553be3673816559c0b102ba0210980dbae3daaf9eeba42b66ee4308ec2`
-- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
-- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
-- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
-- Repository HEAD: `f2aa9b2c49be68550ec45538c221425607f428ce`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
+- Prompt SHA-256: `423ca5e3f4ef1219a92f03bc262d7f2ca4bc9b68b5e71c112a143161c77467e6`
+- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
 - Repository worktree state: **DIRTY**
+- Skill overlay SHA-256: `cc06f7d0ec314789bbccd4de68e0c4e6f74c0821dbe36228153c86490ecf37d8`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,27 +33,27 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `routes_to_formal_docs_sync` | PASS | With-skill output selects `formal-docs-sync`; raw handoff prompt preserves the confirmed delivery context and excludes bootstrap, release notes, and audit. |
-| `preserves_handoff_context` | PASS | The locked specialist handoff carries the feature path, source documents and statuses, scope, required API page/change-map outputs, exclusions, and risk constraints from `pm-handoff.md`. |
-| `points_to_authoritative_gate` | PASS | Output names `formal-docs-sync` as the authoritative execution gate and does not expose a local path or duplicate its protocol. |
-| `stops_at_router_boundary` | PASS | Output explicitly stops at handoff; locked git evidence shows no changes, no snapshots, and no writes to documentation. |
+| `routes_to_formal_docs_sync` | PASS | With-skill output explicitly identifies the request as formal documentation synchronization after feature delivery and routes it to `formal-docs-sync`; no competing route is selected. |
+| `preserves_handoff_context` | PASS | With-skill output carries forward the confirmed search API scope, implementation diff and contract-test evidence, affected formal API page, API change-map, and exclusions without requiring field-by-field handoff repetition. |
+| `points_to_authoritative_gate` | PASS | With-skill output names `formal-docs-sync` as the downstream specialist and does not expose local skill paths or reproduce the internal synchronization protocol. |
+| `stops_at_router_boundary` | PASS | Locked git evidence shows no workspace changes, and the output limits this turn to routing/context handoff while requesting confirmation before synchronization proceeds. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=898aa52a50fa14b6ed2119a9c317cdc1f3e3e5286bf4d35a0cdd450c4352f602; fixture_sha256=5bfe584ec04ca9f6271a87eb0a6a94432a493cce40c865cd7e77c63d4d5a5991; output_sha256=0ddac8387ee29d37ff2727a18ce021a3a96d2c6de5108718effbd220cb21e3b3; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly routes the confirmed feature-delivery handoff to `formal-docs-sync`, preserves context, and stops before specialist execution.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=423ca5e3f4ef1219a92f03bc262d7f2ca4bc9b68b5e71c112a143161c77467e6; fixture_sha256=5bfe584ec04ca9f6271a87eb0a6a94432a493cce40c865cd7e77c63d4d5a5991; output_sha256=39bcc8ea03085d56e1942012764e069d47926a90401a5a4f8d49d5fbda53c5e2; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly routes the confirmed feature-delivery documentation request to `formal-docs-sync`, preserves the handoff scope and evidence, and stops before any write pending confirmation.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=898aa52a50fa14b6ed2119a9c317cdc1f3e3e5286bf4d35a0cdd450c4352f602; fixture_sha256=5bfe584ec04ca9f6271a87eb0a6a94432a493cce40c865cd7e77c63d4d5a5991; output_sha256=4d52548d54375dba3a1082e163eaf0ee50c3287e6cbf136728880b22687e1275; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Provides a generic delivery/documentation dispatch and claims execution is underway without selecting the authoritative `formal-docs-sync` route or clearly stopping at the router boundary.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=423ca5e3f4ef1219a92f03bc262d7f2ca4bc9b68b5e71c112a143161c77467e6; fixture_sha256=5bfe584ec04ca9f6271a87eb0a6a94432a493cce40c865cd7e77c63d4d5a5991; output_sha256=fc7a54ecc8b317edbfc2fe1a4188b01d33a1522d84d0a7ec900ca0dc8f68ec78; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Provides a reasonable baseline synchronization plan and preserves the clean workspace, but does not explicitly route to the formal-docs-sync specialist.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: None.
+- Next: Confirm continuation so the specialist can verify host-repository evidence and perform the synchronization workflow.
 
 ## Runtime Artifact Policy
 

--- a/agents/docs/test/docs-agent/evals/workspace/eval-001-route-formal-docs-sync/comparison.md
+++ b/agents/docs/test/docs-agent/evals/workspace/eval-001-route-formal-docs-sync/comparison.md
@@ -14,15 +14,15 @@
 - Fixture version/source: canonical manifest `5bfe584ec04ca9f6271a87eb0a6a94432a493cce40c865cd7e77c63d4d5a5991` from `agents/docs/test/docs-agent/evals/workspace/eval-001-route-formal-docs-sync`.
 - Identity schema: `2`
 - target_skill_sha256: `af94ca4b38768885230f6271f3d4ae9e1b1be30fcd2f5bdf1098250b4ded0306`
-- eval_definition_sha256: `feba21121d4c3b05845e70bb42290b3e48f9ac62ef8bf5b095426802bc992c41`
+- eval_definition_sha256: `b7962cc5c7265d8b3c4f799e1e809f203d9b09d09c3950072c84712c7db0c562`
 - metadata_sha256: `320948f19ccb8c159c24fdc827ddc592aac02ee3f64236dd9e4896bae8e4979e`
 - fixture_sha256: `5bfe584ec04ca9f6271a87eb0a6a94432a493cce40c865cd7e77c63d4d5a5991`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
 - runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
 - judge_schema_sha256: `d9120b553be3673816559c0b102ba0210980dbae3daaf9eeba42b66ee4308ec2`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
-- Prompt SHA-256: `423ca5e3f4ef1219a92f03bc262d7f2ca4bc9b68b5e71c112a143161c77467e6`
-- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
+- Prompt SHA-256: `e48b238fe72b5801d36c88005426156c8c6d404e006c5bccb655f20f86d8f497`
+- Repository HEAD: `133a65e3c3b501be88257e9d3a557af4d5ccd242`
 - Repository worktree state: **DIRTY**
 - Skill overlay SHA-256: `cc06f7d0ec314789bbccd4de68e0c4e6f74c0821dbe36228153c86490ecf37d8`
 - Behavior result: **PASS**
@@ -33,27 +33,27 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `routes_to_formal_docs_sync` | PASS | With-skill output explicitly identifies the request as formal documentation synchronization after feature delivery and routes it to `formal-docs-sync`; no competing route is selected. |
-| `preserves_handoff_context` | PASS | With-skill output carries forward the confirmed search API scope, implementation diff and contract-test evidence, affected formal API page, API change-map, and exclusions without requiring field-by-field handoff repetition. |
-| `points_to_authoritative_gate` | PASS | With-skill output names `formal-docs-sync` as the downstream specialist and does not expose local skill paths or reproduce the internal synchronization protocol. |
-| `stops_at_router_boundary` | PASS | Locked git evidence shows no workspace changes, and the output limits this turn to routing/context handoff while requesting confirmation before synchronization proceeds. |
+| `routes_to_formal_docs_sync` | PASS | with_skill 输出明确将已完成实现后的请求选择为 `formal-docs-sync`，并排除其他文档专员；handoff 的 delivery/standard/search-api-query 背景与正式 API 同步范围一致。 |
+| `preserves_handoff_context` | PASS | with_skill 输出保留了 `pm-handoff.md`、搜索 API 范围、实现 diff 与 contract tests、正式 API 页面及 change-map 输出等交接上下文，未要求逐字段复述。 |
+| `points_to_authoritative_gate` | PASS | with_skill 输出明确后续由 `formal-docs-sync` 执行，并将文档修改与验证交给其权威入场门；未暴露本地 SKILL.md 路径或复制同步协议。 |
+| `stops_at_router_boundary` | PASS | with_skill 输出声明本次仅完成路由与交接；锁定 git_evidence 显示 HEAD、分支及工作区均未变化，delivery_snapshot 为空。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=423ca5e3f4ef1219a92f03bc262d7f2ca4bc9b68b5e71c112a143161c77467e6; fixture_sha256=5bfe584ec04ca9f6271a87eb0a6a94432a493cce40c865cd7e77c63d4d5a5991; output_sha256=39bcc8ea03085d56e1942012764e069d47926a90401a5a4f8d49d5fbda53c5e2; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly routes the confirmed feature-delivery documentation request to `formal-docs-sync`, preserves the handoff scope and evidence, and stops before any write pending confirmation.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=e48b238fe72b5801d36c88005426156c8c6d404e006c5bccb655f20f86d8f497; fixture_sha256=5bfe584ec04ca9f6271a87eb0a6a94432a493cce40c865cd7e77c63d4d5a5991; output_sha256=ff4d4d55e5c29f36bc59d434c8e9b9b3c648aac02248516fc543197d7c41cd89; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 正确完成正式文档同步路由，保留交接上下文并停在 specialist 边界，未执行文档写入。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=423ca5e3f4ef1219a92f03bc262d7f2ca4bc9b68b5e71c112a143161c77467e6; fixture_sha256=5bfe584ec04ca9f6271a87eb0a6a94432a493cce40c865cd7e77c63d4d5a5991; output_sha256=fc7a54ecc8b317edbfc2fe1a4188b01d33a1522d84d0a7ec900ca0dc8f68ec78; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Provides a reasonable baseline synchronization plan and preserves the clean workspace, but does not explicitly route to the formal-docs-sync specialist.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=e48b238fe72b5801d36c88005426156c8c6d404e006c5bccb655f20f86d8f497; fixture_sha256=5bfe584ec04ca9f6271a87eb0a6a94432a493cce40c865cd7e77c63d4d5a5991; output_sha256=4aefc05eb9b92ef70db3b38fc1654e198da8457bf3473856e3029dda674d384d; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 识别了同步范围但未完成 specialist 路由，并因工作区缺少相关材料而要求补充输入；仅作基线对照。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Confirm continuation so the specialist can verify host-repository evidence and perform the synchronization workflow.
+- Next: None.
 
 ## Runtime Artifact Policy
 

--- a/agents/docs/test/docs-agent/evals/workspace/eval-002-missing-entry-basis/comparison.md
+++ b/agents/docs/test/docs-agent/evals/workspace/eval-002-missing-entry-basis/comparison.md
@@ -13,18 +13,18 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/docs/test/docs-agent/evals/workspace/eval-002-missing-entry-basis`.
 - Identity schema: `2`
-- target_skill_sha256: `cf92649952a97be677cf5e900a4d9c793a6c0724813cf1fa3154f57e7d2c08f3`
+- target_skill_sha256: `af94ca4b38768885230f6271f3d4ae9e1b1be30fcd2f5bdf1098250b4ded0306`
 - eval_definition_sha256: `46e0e02295d606a359a2403ac234af592712f357041b544bb13a82efa1816296`
 - metadata_sha256: `9e2c43ddcdebfd4398d2a8f32a222c29dd71f706e06b85ffb24ea4623239c500`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
 - runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
 - judge_schema_sha256: `da898e3ecfd0169570b22be7c73cd730ef2fd22e3bf1c5b559383dc76454ff0d`
-- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
-- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
-- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
-- Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
+- Prompt SHA-256: `c8a665c7632c31fce83103a67e411115fa7f6c456ea2edd0094ff12d3cf4e103`
+- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
 - Repository worktree state: **DIRTY**
+- Skill overlay SHA-256: `7fb7d802028a8a942f6b1255f456e633ed5d87cdb3abb170effa7be87cac74e5`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `guides_to_pm_agent` | PASS | The with_skill output states no PM handoff/equivalent confirmed chain/specialist basis is present, names pm-agent as return owner, and directs completion through PM context before execution. |
-| `does_not_execute_bootstrap` | PASS | The with_skill output explicitly sets the execution boundary to routing only, with no file creation, repository writes, deployment, or bootstrap execution; git evidence shows no changes. |
-| `names_missing_credentials` | PASS | The with_skill output names the missing confirmed host repository path and states that an explicit site request plus that path completes the docs-site-bootstrap entry basis. |
+| `guides_to_pm_agent` | PASS | with_skill 明确指出没有 PM handoff 或等价证据链、入口尚未完整，并将 return_owner 指向 pm-agent。 |
+| `does_not_execute_bootstrap` | PASS | with_skill 的 delivery_snapshot 为空，git evidence 显示无变更；输出声明当前仅分类与检查、不执行建站写入，且未加载或复述 bootstrap 模板。 |
+| `names_missing_credentials` | PASS | with_skill 明确列出缺少已确认宿主代码仓库路径或身份，并说明“明确的文档站初始化请求 + 已确认宿主仓库路径”足以完成 docs-site-bootstrap 入口。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c8a665c7632c31fce83103a67e411115fa7f6c456ea2edd0094ff12d3cf4e103; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=c4df99f3715647d3c3ec3679757f119099237dfecc7ab1b7c282435b7baed6ff; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly blocks downstream bootstrap, routes to docs-site-bootstrap, guides return to pm-agent, and names the missing host repository path and unblock combination.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c8a665c7632c31fce83103a67e411115fa7f6c456ea2edd0094ff12d3cf4e103; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=94d3ed247d1ec4276b91ec9944321d8df4a0cfbf92f0d0d803fee82c8d697ca5; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 正确分类并停在建站专项入口门槛，指出缺少宿主仓库、引导回 pm-agent，且未产生写入。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c8a665c7632c31fce83103a67e411115fa7f6c456ea2edd0094ff12d3cf4e103; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=b3fa782b947e607f39324cd7245bfaad78422dc356de71669e5346ff20e32986; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Provides a general workspace assessment and lists missing repository and project decisions, but does not provide the required PM routing or explicit specialist entry-basis guidance.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c8a665c7632c31fce83103a67e411115fa7f6c456ea2edd0094ff12d3cf4e103; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=91f3b9f77ecefb7f32d73c1e30dd7c1ba75c52f32161a8994598c8761f0cb8b2; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 提供了通用的文档站规划与前置条件说明，但未执行 PM 路由或明确 specialist entry basis；仅作基线对照。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/docs/test/docs-agent/evals/workspace/eval-003-route-release-audit/comparison.md
+++ b/agents/docs/test/docs-agent/evals/workspace/eval-003-route-release-audit/comparison.md
@@ -13,46 +13,45 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `aea5c9e95cc3674c80708ee78ba0276fef121e6d5652789edf0421371d054bf6` from `agents/docs/test/docs-agent/evals/workspace/eval-003-route-release-audit`.
 - Identity schema: `2`
-- target_skill_sha256: `cf92649952a97be677cf5e900a4d9c793a6c0724813cf1fa3154f57e7d2c08f3`
-- eval_definition_sha256: `76669427412e6a3d2662bf813faa0ce4c31fa19c75739559cabe530efd5682a6`
+- target_skill_sha256: `af94ca4b38768885230f6271f3d4ae9e1b1be30fcd2f5bdf1098250b4ded0306`
+- eval_definition_sha256: `6d6a401b76741386ad3f6aee549b3bfaa2f477f4ced9973b14647dc8b591096b`
 - metadata_sha256: `d582bafa2b7d4e637ef2b4b71f14f435256d70c30e92f7097a43cd40dc9da750`
 - fixture_sha256: `aea5c9e95cc3674c80708ee78ba0276fef121e6d5652789edf0421371d054bf6`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
 - runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
 - judge_schema_sha256: `f4f786bd56d6a5cbcee24193816a462566a8caafb4c223ef38759bdf64ee0486`
-- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
-- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
-- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
-- Repository HEAD: `fecf485e8e3dcaf191b2b221d9cccbddfdea0b72`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
+- Prompt SHA-256: `099569afeec045caa3e4e020611c72b9def7b5897f52222810916bd2477fd230`
+- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
 - Repository worktree state: **DIRTY**
-- Behavior result: **FAIL**
+- Skill overlay SHA-256: `505e784bf52b9cb6d00fcfd914382f9013b636eb784f4767105b0ee1e264c5bf`
+- Behavior result: **PASS**
 - Coverage result: **FULL**
-Overall result: FAIL
+Overall result: PASS
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `accepts_equivalent_chain` | FAIL | with_skill 输出称 `release-entry.md` 仅提供“部分等效 release chain”，并错误地要求额外的 maintainer target version；未将 fixture 中已确认的 scope、version tag、changelog、release evidence 与 audit request 整体识别为等效入口。 |
-| `routes_docs_audit` | PASS | with_skill 明确选择 `docs-audit`，并列出 v0.4.0 审计范围及 release-entry/changelog/evidence 上下文，停止执行实际审计并安排后续交给该 specialist。 |
-| `references_audit_gate_only` | FAIL | with_skill 明确写出 `docs-audit` 和 router 边界，但同时暴露并展开 previous-tag、base-ref、target version 及审计阶段 gate 等下游细节，超出仅引用 specialist gate 的要求。 |
+| `accepts_equivalent_chain` | PASS | With-skill output explicitly accepts the equivalent confirmed release-entry chain and identifies the release scope, v0.4.0, source document, evidence context, and audit request. |
+| `routes_docs_audit` | PASS | With-skill output selects docs-audit, preserves the v0.4.0 audit scope and referenced changelog/evidence context, and defers execution to that specialist pending missing credentials. |
+| `references_audit_gate_only` | PASS | With-skill output states that docs-audit owns the authoritative gate, does not execute the audit, exposes no local SKILL.md path, and does not reproduce the prohibited detailed protocols. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=099569afeec045caa3e4e020611c72b9def7b5897f52222810916bd2477fd230; fixture_sha256=aea5c9e95cc3674c80708ee78ba0276fef121e6d5652789edf0421371d054bf6; output_sha256=fb6e1de263218c090742df6dd7ca6ae06b2788e79d6a4875998b13d7ebf5c416; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 正确选择 docs-audit 并停止在路由边界，但错误地将已确认入口判为不完整，并泄露下游 gate 细节。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=099569afeec045caa3e4e020611c72b9def7b5897f52222810916bd2477fd230; fixture_sha256=aea5c9e95cc3674c80708ee78ba0276fef121e6d5652789edf0421371d054bf6; output_sha256=cce327eb7f9bc3185c56d14f9b9ecfad7b3a6976e9282ff4fe211f7eb45eca8a; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly recognizes the equivalent release chain, routes the request to docs-audit, preserves context, and stops at the specialist gate because required evidence is missing.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=099569afeec045caa3e4e020611c72b9def7b5897f52222810916bd2477fd230; fixture_sha256=aea5c9e95cc3674c80708ee78ba0276fef121e6d5652789edf0421371d054bf6; output_sha256=6d9cca4c65cc695dd9d2d66bd99297108b47acbe268895ca54b1251460bea76d; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 将请求当作实际文档审计，输出审计阻塞结论和材料补齐建议，未进行 specialist 路由。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=099569afeec045caa3e4e020611c72b9def7b5897f52222810916bd2477fd230; fixture_sha256=aea5c9e95cc3674c80708ee78ba0276fef121e6d5652789edf0421371d054bf6; output_sha256=4f8d835c675137a0ef7f1c2c8959226b39e28640687bf7508639af30fa934df6; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Performs an audit-style assessment instead of routing, treating the release-entry claims as insufficient and recommending evidence remediation.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- with_skill 未接受 fixture 已确认的完整等效 release chain。
-- with_skill 暴露了 docs-audit 的 base/target 等下游审计门槛细节。
+- None.
 - Next: None.
 
 ## Runtime Artifact Policy

--- a/agents/docs/test/docs-agent/evals/workspace/eval-004-route-release-notes/comparison.md
+++ b/agents/docs/test/docs-agent/evals/workspace/eval-004-route-release-notes/comparison.md
@@ -13,18 +13,18 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `23d5701fab562491dfec3455fd6eabce7f6a6cba18940861023208d40f53fc3e` from `agents/docs/test/docs-agent/evals/workspace/eval-004-route-release-notes`.
 - Identity schema: `2`
-- target_skill_sha256: `cf92649952a97be677cf5e900a4d9c793a6c0724813cf1fa3154f57e7d2c08f3`
-- eval_definition_sha256: `6d935c2fabb41ac4d322f49d33294bd64934555c17ee2ff70a64426da58d1b41`
+- target_skill_sha256: `af94ca4b38768885230f6271f3d4ae9e1b1be30fcd2f5bdf1098250b4ded0306`
+- eval_definition_sha256: `38b6af0374fcc8ce56a2a453684404f29e895eaad6d86b973c652b7dd34579f8`
 - metadata_sha256: `5831b803b3b347d7fd4611f1c19958d707ffe3e9ced4a78ed755e71f76a2c9b8`
 - fixture_sha256: `23d5701fab562491dfec3455fd6eabce7f6a6cba18940861023208d40f53fc3e`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
 - runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
 - judge_schema_sha256: `73f4addc59ec16b0f91c6a70a2a767ce7f6b4ad72612ca19a2131095a0722114`
-- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
-- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
-- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
-- Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
+- Prompt SHA-256: `ab720b723fbaf54cc8b204eab97c1f0a7167519c350afdf3b475cf0b324862c8`
+- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
 - Repository worktree state: **DIRTY**
+- Skill overlay SHA-256: `8494c875a735e7e8e92958968bcc22b078a02558d73ceb3959674e5bb7e64ccf`
 - Behavior result: **FAIL**
 - Coverage result: **FULL**
 Overall result: FAIL
@@ -33,26 +33,26 @@ Overall result: FAIL
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `accepts_release_notes_entry_basis` | FAIL | With_skill calls the handoff only pending verification and says it has not formed an executable Release Notes entry, contradicting the fixture's explicit target host, confirmed version/scope, evidence sources, and required output. |
-| `routes_release_notes_generator` | PASS | The routing decision selects exactly release-notes-gen and sets the execution boundary to routing only, with no reassignment or GitHub Release execution. |
-| `preserves_handoff_context` | PASS | The output preserves all required handoff values semantically, including release version and scope within confirmed_scope, plus request_type, change_tier, feature_path, host_repository, source_documents, evidence_sources, required_output, and blockers_risks. |
-| `references_release_notes_gate_only` | PASS | It names the release-notes-gen authoritative gate, stops at the router boundary, avoids local skill paths, and does not reproduce detailed downstream protocols. |
+| `accepts_release_notes_entry_basis` | FAIL | with_skill explicitly labels the handoff as partial and says it does not satisfy the complete entry condition, contradicting the fixture-backed requirement. |
+| `routes_release_notes_generator` | PASS | The with_skill output selects exactly `release-notes-gen` and confines execution to routing, with no reassignment or GitHub Release delivery. |
+| `preserves_handoff_context` | PASS | The with_skill routing packet preserves the handoff’s version, scope, host, evidence sources, and required output without rewriting those facts. |
+| `references_release_notes_gate_only` | PASS | It identifies the `release-notes-gen` authoritative gate, performs no generation, and exposes no local SKILL.md path. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=ab720b723fbaf54cc8b204eab97c1f0a7167519c350afdf3b475cf0b324862c8; fixture_sha256=23d5701fab562491dfec3455fd6eabce7f6a6cba18940861023208d40f53fc3e; output_sha256=8da24e3d37a046bb5c81cf9fb4ff14779d4575540c74ac587f285cdc7ca822ef; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly routes to release-notes-gen and preserves the handoff, but incorrectly treats the complete entry basis as incomplete.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=ab720b723fbaf54cc8b204eab97c1f0a7167519c350afdf3b475cf0b324862c8; fixture_sha256=23d5701fab562491dfec3455fd6eabce7f6a6cba18940861023208d40f53fc3e; output_sha256=7ce3dcb8ad5746ed15befd3297a517036b529438d3b05f0584463a6129562876; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correct specialist routing, context preservation, and gate-only boundary, but incorrectly rejects the provided entry basis.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=ab720b723fbaf54cc8b204eab97c1f0a7167519c350afdf3b475cf0b324862c8; fixture_sha256=23d5701fab562491dfec3455fd6eabce7f6a6cba18940861023208d40f53fc3e; output_sha256=7291f352950f5026d6b26c9ef3b95c3e069fdf22af8cbca4878e05f1791b25c3; snapshot_sha256=2e8880fc34e1f0bafb4a381c6e6e72559e7bb33387615c3fe64c60bbd23403fa
-- Behavior: Generates a Release Notes file despite the router-scoped request and does not perform the required routing decision.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=ab720b723fbaf54cc8b204eab97c1f0a7167519c350afdf3b475cf0b324862c8; fixture_sha256=23d5701fab562491dfec3455fd6eabce7f6a6cba18940861023208d40f53fc3e; output_sha256=2da08e7a9bfa50d98def42d542c04041d82d53d18a45be10365247eb69f68f8a; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline refuses to route and treats the absent downstream files as a general inability to proceed.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- The with_skill lane incorrectly rejects the complete specialist entry basis documented in release-handoff.md.
+- The with_skill lane incorrectly rejects the fixture’s complete Release Notes entry basis as incomplete.
 - Next: None.
 
 ## Runtime Artifact Policy

--- a/agents/docs/test/docs-agent/evals/workspace/eval-005-integration-release-chain/comparison.md
+++ b/agents/docs/test/docs-agent/evals/workspace/eval-005-integration-release-chain/comparison.md
@@ -13,18 +13,18 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `69659db940208abe97ba4ab195a49c736d9a7ba7e1e880c287d3bf12132c10a3` from `agents/docs/test/docs-agent/evals/workspace/eval-005-integration-release-chain`.
 - Identity schema: `2`
-- target_skill_sha256: `cf92649952a97be677cf5e900a4d9c793a6c0724813cf1fa3154f57e7d2c08f3`
+- target_skill_sha256: `af94ca4b38768885230f6271f3d4ae9e1b1be30fcd2f5bdf1098250b4ded0306`
 - eval_definition_sha256: `05d8b9eb5ccf6bbc077dad850c79899562c5b4ed9bbb4187abffd82f21410ea3`
 - metadata_sha256: `af301306a3e584e9c32987cd73e02ac298dcd98f38208af58ca0764e8b5a4154`
 - fixture_sha256: `69659db940208abe97ba4ab195a49c736d9a7ba7e1e880c287d3bf12132c10a3`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
 - runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
 - judge_schema_sha256: `1f2ea17b811fce39b8e906ef0e0a70b6a6223a188a2f4a05f2f0a88c54c6aceb`
-- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
-- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
-- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
-- Repository HEAD: `f2aa9b2c49be68550ec45538c221425607f428ce`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
+- Prompt SHA-256: `62a386a246bcb0c7c5b2df7096cfd60c5023a6b28473d50af8f99649d1d3480e`
+- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
 - Repository worktree state: **DIRTY**
+- Skill overlay SHA-256: `e710f507db19462d482cc0a7c6de3ea1d17c9f7caf25c7c65d0a74377ce36ba1`
 - Behavior result: **FAIL**
 - Coverage result: **FULL**
 Overall result: FAIL
@@ -33,30 +33,31 @@ Overall result: FAIL
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `accepts_release_audit_entry` | PASS | Identifies release-chain-entry.md and the confirmed version, scope, evidence sources, and read-only boundary. |
-| `evaluates_site_release_notes_gate` | PASS | Rejects handoff_status=ready as insufficient confirmation and returns the site Release Notes owner for remediation. |
-| `validates_release_window_basis` | PASS | Correctly reports previous tag and base ref resolving to the same signed snapshot anchor. |
-| `rejects_missing_pre_tag_authority` | PASS | Does not claim pre-tag success and states that ready_for_tag/release_verified are not satisfied. |
-| `detects_post_tag_evidence_drift` | FAIL | The signed snapshot shows candidate/tag tree drift, but the with_skill output does not identify that post-tag object mismatch. |
-| `blocks_github_release_handoff` | PASS | Blocks GitHub Release preparation and assigns remediation to the Release Notes owner followed by post-tag audit. |
-| `preserves_no_mutation_boundaries` | PASS | States a read-only boundary and reports no tag or GitHub Release writes; captured git evidence shows no mutation. |
+| `accepts_release_audit_entry` | PASS | With-skill output identifies release-chain-entry.md, confirmed v1.4.0 scope, signed snapshot, evidence sources, and the no-mutation boundary. |
+| `evaluates_site_release_notes_gate` | PASS | It recognizes the handoff as a pre-tag audit entry, notes missing ready_for_tag/release_verified results, and routes work to docs-audit before GitHub Release preparation. |
+| `validates_release_window_basis` | PASS | It correctly states v1.3.0 and release-base both resolve to 041b91a..., establishing a parseable previous-tag/base comparison anchor. |
+| `rejects_missing_pre_tag_authority` | PASS | It does not claim pre-tag success and explicitly reports that no ready_for_tag audit conclusion exists. |
+| `detects_post_tag_evidence_drift` | FAIL | It detects that release-candidate/tag-entry resolve to 5dc0861... while v1.4.0 resolves to 9ae0a8..., but its opening conclusion says the release chain can continue instead of returning the current chain as blocked on this drift. |
+| `blocks_github_release_handoff` | PASS | It concludes that GitHub Release preparation/publishing cannot proceed, provides no preview/draft/publish handoff, and routes the next step to docs-audit. |
+| `preserves_no_mutation_boundaries` | PASS | Locked git evidence shows unchanged HEAD, branch, refs, diffs, and worktree; the output also explicitly limits execution to audit handoff without tag or GitHub Release mutation. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=62a386a246bcb0c7c5b2df7096cfd60c5023a6b28473d50af8f99649d1d3480e; fixture_sha256=69659db940208abe97ba4ab195a49c736d9a7ba7e1e880c287d3bf12132c10a3; output_sha256=7c0cf765020d2dfd59f4224de06b2112294fe54287775acfc092f9892bffb32c; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly routes and blocks the release, validates the window, and preserves read-only boundaries, but misses the decisive post-tag tree drift.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=62a386a246bcb0c7c5b2df7096cfd60c5023a6b28473d50af8f99649d1d3480e; fixture_sha256=69659db940208abe97ba4ab195a49c736d9a7ba7e1e880c287d3bf12132c10a3; output_sha256=3b216a9033993b7f317309ac8d4fc6938d4002b3a46807d7969a1f59283f6c3d; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Accurately accepted the audit entry, validated the release-window anchor, rejected unproven pre-tag readiness, and blocked GitHub Release handoff, but undercalled the detected post-tag tree drift.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=62a386a246bcb0c7c5b2df7096cfd60c5023a6b28473d50af8f99649d1d3480e; fixture_sha256=69659db940208abe97ba4ab195a49c736d9a7ba7e1e880c287d3bf12132c10a3; output_sha256=a96a0ed5c3dddd10ee2b2c01f2f7ed3184bb4681e51075cb8a4d76d5a2301ff5; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Fresh baseline correctly blocks the release and explicitly detects the candidate-versus-tag tree mismatch.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=62a386a246bcb0c7c5b2df7096cfd60c5023a6b28473d50af8f99649d1d3480e; fixture_sha256=69659db940208abe97ba4ab195a49c736d9a7ba7e1e880c287d3bf12132c10a3; output_sha256=b34d66b1018363a3f4fd7f3fb97fb431248450a74e4bef063df957c8957d807c; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly identified the post-tag tree mismatch and state inconsistency, blocked GitHub Release progression, assigned remediation to the release manager/tag owner, and preserved read-only boundaries.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- The with_skill lane failed to detect and report the signed-snapshot mismatch between the release-candidate/tag-entry tree and the actual v1.4.0 tag/release-evidence tree.
-- Next: Require the with_skill lane to compare and report the candidate, tag-entry, actual-tag, and release-evidence tree identities before concluding post-tag eligibility.
+- detects_post_tag_evidence_drift
+- Next: Return the current post-tag audit state as blocked because the signed snapshot shows the actual tag and release-evidence branch differ from the audited candidate tree.
+- Next: Require a fresh signed reference snapshot and a successful release_verified audit before any GitHub Release preparation.
 
 ## Runtime Artifact Policy
 

--- a/agents/docs/test/docs-agent/evals/workspace/eval-006-preserve-independent-hosting/comparison.md
+++ b/agents/docs/test/docs-agent/evals/workspace/eval-006-preserve-independent-hosting/comparison.md
@@ -13,18 +13,18 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `f6c421284ed0143d28fff161f0f4c1cd48b067505beae1d38677d871a066543f` from `agents/docs/test/docs-agent/evals/workspace/eval-006-preserve-independent-hosting`.
 - Identity schema: `2`
-- target_skill_sha256: `cf92649952a97be677cf5e900a4d9c793a6c0724813cf1fa3154f57e7d2c08f3`
+- target_skill_sha256: `af94ca4b38768885230f6271f3d4ae9e1b1be30fcd2f5bdf1098250b4ded0306`
 - eval_definition_sha256: `8a4360282a35d2ba7a52bbb24d703648e9f263e7fbfc9516063ba62f62b92b92`
 - metadata_sha256: `62050136e2c1de0d65367ed4b1b1b706bb2211c3759fb54a832b8fd66233328b`
 - fixture_sha256: `f6c421284ed0143d28fff161f0f4c1cd48b067505beae1d38677d871a066543f`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
 - runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
 - judge_schema_sha256: `787b3941ec90b819758a9894561fa37e2c0eff7eedddb4c4a4d863809f28587f`
-- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
-- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
-- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
-- Repository HEAD: `f2aa9b2c49be68550ec45538c221425607f428ce`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
+- Prompt SHA-256: `75b11cec554fb9cabf92f38559abd7d5bd8c24a6e4b7927952fa49a44fb00e8c`
+- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
 - Repository worktree state: **DIRTY**
+- Skill overlay SHA-256: `cc06f7d0ec314789bbccd4de68e0c4e6f74c0821dbe36228153c86490ecf37d8`
 - Behavior result: **FAIL**
 - Coverage result: **FULL**
 Overall result: FAIL
@@ -33,25 +33,25 @@ Overall result: FAIL
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `preserves_not_applicable_evidence` | FAIL | with_skill 保留了决策记录和 workflow 的证据路径，并列出 public/internal 变体及 Web Platform，但未明确报告 not_applicable 状态，也未清晰给出下一 owner 的结构化结论。 |
-| `does_not_open_devops_handoff` | PASS | with_skill 的锁定输出和 trace 均未生成 repo-wide deployment handoff；其 Routing decision 是 formal-docs-sync 文档路由，不是 DevOps 部署交接。 |
+| `preserves_not_applicable_evidence` | FAIL | With-skill confirms static hosting, non-use of the application image/Compose/Helm, maintainer sign-off, evidence paths, and public/internal variants, but does not explicitly report the decision as not_applicable or identify the next owner (Web Platform). |
+| `does_not_open_devops_handoff` | PASS | With-skill explicitly concludes that application deployment need not intervene, preserves the read-only boundary, and creates no repo-wide deployment handoff. The decision is presented as valid, so no user re-ask is required. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=75b11cec554fb9cabf92f38559abd7d5bd8c24a6e4b7927952fa49a44fb00e8c; fixture_sha256=f6c421284ed0143d28fff161f0f4c1cd48b067505beae1d38677d871a066543f; output_sha256=f93c636fdcb3fe38f486ef4d0d61108e83f8a9df04d2600b7a6237fd39bf6ff4; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 正确确认无需应用部署团队介入，保留了主要托管证据并避免 DevOps handoff，但缺少明确的 not_applicable 状态和完整下一 owner 表达。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=75b11cec554fb9cabf92f38559abd7d5bd8c24a6e4b7927952fa49a44fb00e8c; fixture_sha256=f6c421284ed0143d28fff161f0f4c1cd48b067505beae1d38677d871a066543f; output_sha256=5e669be11e654e3531a9860bd1d0ee1858384f6894fa1dde8fe306179ebe7fa0; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly preserves the static-hosting evidence and avoids DevOps escalation, but incompletely reports the required not_applicable decision record.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=75b11cec554fb9cabf92f38559abd7d5bd8c24a6e4b7927952fa49a44fb00e8c; fixture_sha256=f6c421284ed0143d28fff161f0f4c1cd48b067505beae1d38677d871a066543f; output_sha256=0a27ea9a34efda69cf47d2eb6ece34c7551820ee61061722a8ec1bbca2c3b8ec; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 同样确认无需应用部署团队介入并避免 DevOps handoff，但仅提供普通结论和证据，没有结构化路由结果。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=75b11cec554fb9cabf92f38559abd7d5bd8c24a6e4b7927952fa49a44fb00e8c; fixture_sha256=f6c421284ed0143d28fff161f0f4c1cd48b067505beae1d38677d871a066543f; output_sha256=8cd0ff65fe8bfaf7089014fd6d0d2798b306660716a063740d3ad19c8d06738b; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline also avoids application-deployment escalation, identifies static-hosting evidence and variants less completely, and names Web Platform as the follow-up owner.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- with_skill 未完整保留并报告 not_applicable、证据路径、覆盖变体和下一 owner。
-- Next: 明确报告 not_applicable 状态，并结构化列出证据路径、public/internal 覆盖变体和下一 owner。
+- The with_skill report omits the required explicit not_applicable result and next-owner identification.
+- Next: None.
 
 ## Runtime Artifact Policy
 

--- a/agents/docs/test/docs-agent/evals/workspace/eval-007-route-manual-gen/comparison.md
+++ b/agents/docs/test/docs-agent/evals/workspace/eval-007-route-manual-gen/comparison.md
@@ -13,18 +13,18 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `7e690828debd990987ec359671232498f20061c2fa6e2bbd324f99b92a7c2fc8` from `agents/docs/test/docs-agent/evals/workspace/eval-007-route-manual-gen`.
 - Identity schema: `2`
-- target_skill_sha256: `cf92649952a97be677cf5e900a4d9c793a6c0724813cf1fa3154f57e7d2c08f3`
-- eval_definition_sha256: `11398fbb2de74bd454f6e9c88338b5fcf6dffb0fd21436f1f6c99eaff5b1117d`
+- target_skill_sha256: `af94ca4b38768885230f6271f3d4ae9e1b1be30fcd2f5bdf1098250b4ded0306`
+- eval_definition_sha256: `b572bcf4c18451eca03023d64515c12cbfbd9f67b27200f6bcd78820652e00b9`
 - metadata_sha256: `31c2720a1114e612336c51527d7aae20dddb1f4e46b566ffffe4788d27952b8e`
 - fixture_sha256: `7e690828debd990987ec359671232498f20061c2fa6e2bbd324f99b92a7c2fc8`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
 - runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
 - judge_schema_sha256: `dfbcad96e39d7a0ba2503c7d345d86b54a6c9e1188ff1c09f99476b24380e820`
-- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
-- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
-- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
-- Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
+- Prompt SHA-256: `a3cc737cbb46c53cc07ec65089d26bb1859146138c26d847279db190c633dcfa`
+- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
 - Repository worktree state: **DIRTY**
+- Skill overlay SHA-256: `9fb87f2f78aa3667a6ac45d4638b5d2f77454f04c57c127222d45ced6a6bf97f`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,21 +33,21 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `accepts_manual_entry_basis` | PASS | with_skill explicitly identifies manual-handoff.md and carries host repository, bounded scope, running-interface evidence, and required output into the routing decision. |
-| `routes_manual_gen` | PASS | with_skill selects manual-gen and does not select any competing documentation specialist. |
-| `preserves_manual_handoff_context` | PASS | with_skill preserves the handoff context, including request_type, change_tier, feature_path, host_repository, scope, evidence_sources, required_output, and blockers_risks. |
-| `references_manual_gate_only` | PASS | with_skill names the manual-gen authoritative boundary and explicitly states that the router does not generate the manual or collect screenshots. |
+| `accepts_manual_entry_basis` | PASS | with_skill 明确接受 manual-handoff.md，并识别宿主仓库、手册范围、运行界面证据来源和所需输出。 |
+| `routes_manual_gen` | PASS | with_skill 明确选择 manual-gen，未改派其他 specialist。 |
+| `preserves_manual_handoff_context` | PASS | with_skill 保留了八项要求的交接上下文，包括 blockers_risks。 |
+| `references_manual_gate_only` | PASS | with_skill 将后续工作交给 manual-gen，仅引用其入口门禁，未执行生成、截图采集、站点写入或审计 handoff，也未暴露本地路径。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=a3cc737cbb46c53cc07ec65089d26bb1859146138c26d847279db190c633dcfa; fixture_sha256=7e690828debd990987ec359671232498f20061c2fa6e2bbd324f99b92a7c2fc8; output_sha256=6b9774387b72a24e7675e9facc5cc8574f0d6a15c65234d6780d91932c82d6e9; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly routes the handoff to manual-gen, preserves its context, records missing prerequisites, and stops at the router boundary.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=a3cc737cbb46c53cc07ec65089d26bb1859146138c26d847279db190c633dcfa; fixture_sha256=7e690828debd990987ec359671232498f20061c2fa6e2bbd324f99b92a7c2fc8; output_sha256=3fbe57a0c37d03e5740d4f0f0a1dcc031d85661a6cc78cea2426f586ffbda862; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 正确完成入口识别、路由和上下文保留，并保持 router 与 manual-gen 的职责边界。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=a3cc737cbb46c53cc07ec65089d26bb1859146138c26d847279db190c633dcfa; fixture_sha256=7e690828debd990987ec359671232498f20061c2fa6e2bbd324f99b92a7c2fc8; output_sha256=2edc2ce94fefbe52e37fa690a15702383b918e0553f90ca742f8a909a74c08ec; snapshot_sha256=d51d19926c7ac16cfb8c3f40ec2a77d453a2de7330807b26ec117b50d5be3a2d
-- Behavior: Generates and writes a manual with illustrative SVG assets instead of performing the required routing behavior.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=a3cc737cbb46c53cc07ec65089d26bb1859146138c26d847279db190c633dcfa; fixture_sha256=7e690828debd990987ec359671232498f20061c2fa6e2bbd324f99b92a7c2fc8; output_sha256=a5757a09d9627a3e4a8887e108fb92534a6bc6d6b8abc51f37e27fa53b04ab8d; snapshot_sha256=0771a9372cd0da07930d160fcdcfec83e010e7dd306af651191fd297f5b4e96a
+- Behavior: 直接生成并写入了手册文件，未执行所需的路由职责；仅作对比背景。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/engineer/skills/engineer-agent/SKILL.md
+++ b/agents/engineer/skills/engineer-agent/SKILL.md
@@ -10,17 +10,17 @@ visibility: internal
 request to the narrowest engineering skill based on the user's target outcome,
 repo context, and current delivery stage.
 
-## Mandatory Routing Decision
+## Routing Decision
 
-Produce the routing decision before executing engineering work. State the
+Produce the internal routing decision before executing engineering work. Preserve the
 accepted entry basis, resolved `feature_path`, current delivery stage, selected
 specialist, required output, and the authoritative specialist gate. For a full
-implementation request, keep this order observable:
+implementation request, keep this order:
 `codebase-analyzer` -> alignment/TRD gap resolution ->
 `feature-implementor` -> `test-writer` -> QA E2E handoff -> `delivery`.
 When the PM entry basis is already confirmed, `codebase-analyzer` remains the
 first engineering step; do not prepend a new PM discovery route.
-Name `engineer-agent` as the owner before the selected specialist. When the
+Keep `engineer-agent` as the owner before the selected specialist. When the
 chain includes tests, explicitly route them to `test-writer`; when it includes
 QA E2E, preserve the suggested `docs/qa/e2e/{feature_path}/` directory. A UI
 design gap is handed to `designer-agent` with the exact design scope even when
@@ -35,7 +35,7 @@ with `mode: diagnosis_only` and `allowed_mutations: none` preserved. This route
 may collect objective evidence before PRD/TRD alignment because it cannot
 repair or confirm an implementation deviation while expectations are
 unaligned.
-For an implementation route, state the future execution basis explicitly:
+For an implementation route, preserve the future execution basis:
 codebase findings, confirmed same-path PRD/TRD and applicable design inputs,
 and the confirmed `docs/engineer/{feature_path}/IMPLEMENTATION_PLAN.md`. Mark
 missing inputs as gates instead of shortening this to a generic
@@ -44,13 +44,13 @@ Frontend changes remain Engineer-owned, but UI structure, interaction, or
 visual gaps first go to `designer-agent` and then return to Engineer. Do not
 collapse these boundaries into a generic request for more files.
 
-When the route includes QA E2E, enumerate the future handoff package in the
+When the route includes QA E2E, preserve the future handoff package in the
 routing decision: PRD, TRD, confirmed implementation plan, changed files,
 verification commands and results, residual risks, recommendations, and the
 suggested `docs/qa/e2e/{feature_path}/` directory.
-Render it as a `qa_e2e_handoff_package` object with those eight explicit
-fields; a generic statement that QA receives context or verification does not
-substitute for a field. Before returning an implementation-chain route,
+Keep it as a `qa_e2e_handoff_package` object with those eight fields; a generic
+statement that QA receives context or verification does not substitute for a
+field. Before continuing with an implementation-chain route,
 validate that every field is present and points to the current feature rather
 than relying on details scattered elsewhere in the response.
 
@@ -259,8 +259,6 @@ not perform the missing agent's responsibilities yourself.
 
 When routing is complete:
 
-- state which engineering skill should handle the request
-- if relevant, state the follow-up engineering chain
 - carry forward the resolved context so the downstream skill starts with the
   right implementation target
 - after the routed skill or role stage completes, apply the cross-role

--- a/agents/engineer/test/engineer-agent/evals/evals.json
+++ b/agents/engineer/test/engineer-agent/evals/evals.json
@@ -9,7 +9,7 @@
       "description": "Verifies that engineer-agent routes a multi-step implementation request through the narrowest engineering chain.",
       "prompt": "请接手这个仓库，按 `docs/engineer/billing-webhook/TRD.md` 落实 webhook 重试逻辑、补齐测试并最终提交 PR。先告诉我你会如何安排这项工作，暂时不要改代码。",
       "workspace": "workspace/eval-1-route-implementation-chain",
-      "expected_output": "工程路由决策，明确先理解仓库，再基于已确认 TRD 编写实现计划、实现、补测试、交付，并说明每一步对应的 specialist skill。",
+      "expected_output": "明确先理解仓库，再基于已确认 TRD 编写实现计划、实现、补测试、交付，并说明各阶段职责。",
       "assertions": [
         {
           "id": "starts_with_codebase_context",
@@ -38,8 +38,8 @@
         },
         {
           "id": "does_not_execute_directly",
-          "description": "只做路由不执行",
-          "text": "因为用户要求先做工程路由，不能直接修改代码、运行测试或创建提交。"
+          "description": "遵守暂不执行边界",
+          "text": "因为用户明确要求先确认推进顺序且暂不执行，不能直接修改代码、运行测试或创建提交。"
         }
       ],
       "scenario": {
@@ -138,7 +138,7 @@
         {
           "id": "routes_requirement_change_to_pm",
           "description": "需求变更回 PM",
-          "text": "如果排序调整改变 PRD/TRD 已批准预期，输出必须路由回 `pm-agent:idea-to-spec` 的 `existing-project-update`，再同步 TRD。"
+      "text": "如果排序调整改变 PRD/TRD 已批准预期，必须先回到 PM 完成现有功能需求对齐，再同步 TRD；不要求向用户展示内部 route 名称或 routing block。"
         },
         {
           "id": "routes_trd_mismatch_to_trd_gen",
@@ -147,8 +147,8 @@
         },
         {
           "id": "does_not_execute_directly",
-          "description": "只做路由不执行",
-          "text": "因为用户要求先做工程路由，输出不得修改代码、写 IMPLEMENTATION_PLAN 或运行测试。"
+          "description": "遵守暂不执行边界",
+          "text": "因为用户明确要求暂不修改，当前不得修改代码、写 IMPLEMENTATION_PLAN 或运行测试。"
         }
       ],
       "scenario": {
@@ -210,8 +210,8 @@
         },
         {
           "id": "does_not_execute_directly",
-          "description": "只做路由不执行",
-          "text": "因为用户要求先做工程路由，输出不得修改代码、写 IMPLEMENTATION_PLAN 或运行测试。"
+          "description": "遵守暂不执行边界",
+          "text": "因为用户明确要求暂不修改，当前不得修改代码、写 IMPLEMENTATION_PLAN 或运行测试。"
         }
       ],
       "scenario": {

--- a/agents/engineer/test/engineer-agent/evals/workspace/eval-002-existing-feature-alignment-gate/comparison.md
+++ b/agents/engineer/test/engineer-agent/evals/workspace/eval-002-existing-feature-alignment-gate/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/engineer/test/engineer-agent/evals/workspace/eval-002-existing-feature-alignment-gate`.
 - Identity schema: `2`
-- target_skill_sha256: `567599e3469192896a31cdff4fe4fd18d5213c866e89288582d2212d150b33af`
+- target_skill_sha256: `4bbafb4fd1b263bfdfde7c9e30fb901fcf24822b1fff3e0e99c5d830d36c45cc`
 - eval_definition_sha256: `35bf0057341046be2b5db3cd90c99d825b61efaf315ed25428b5eda571894209`
 - metadata_sha256: `43542dab517c382c8ae0bc3c7332df9e98a97a6229686bf334f88c000c1ef95a`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,40 +22,40 @@
 - judge_schema_sha256: `fd74eb5f01d1266986de0e63d98b09a328266b3f4b3b37579328c75fc417b428`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `d08d04c31266e7709df236e5a84b0516db051d4099fdd86927601fc672aa3954`
-- Repository HEAD: `2ac10136f4ed18048058361915e66c52b4e038c5`
+- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `e0e827b7bd294609981357aae7bd81aabdea2aff56e900333dafe8d646c2d3e3`
-- Behavior result: **FAIL**
+- Skill overlay SHA-256: `93852e7b81da4b65a2f6e7e6b552fb8fc2585f12fb1990e01ea0c8684431a23e`
+- Behavior result: **PASS**
 - Coverage result: **PARTIAL**
-Overall result: FAIL
+Overall result: PASS (partial coverage)
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `uses_user_provided_behavior_baseline` | FAIL | with_skill 将请求称为“已批准行为变更”，但没有明确把“active 列表排除 archived”表述为当前批准基线，并将 active 包含 archived 作为已明确的新产品预期。 |
-| `classifies_expectation_change` | PASS | with_skill 明确按“已批准行为变更”推进，并要求先完成需求对齐，而非默认视为小代码改动。 |
-| `routes_to_existing_project_update` | PASS | with_skill 明确指定 `existing-project-update`，并将下一步路由至 `pm-agent:idea-to-spec`；同时说明该阶段因能力未安装而 blocked。 |
-| `routes_trd_gap_to_trd_gen` | NOT_EXERCISED | 当前没有 PRD、产品决策或 TRD，且候选输出停留在 PM 需求变更确认阶段；TRD gap 条件尚未形成。 |
-| `requires_plan_after_alignment` | NOT_EXERCISED | 候选输出尚未进入对齐完成后的实现阶段；因此 IMPLEMENTATION_PLAN.md 要求尚未被实际触发。 |
-| `does_not_route_directly_to_implementation` | PASS | with_skill 明确要求先完成 PM/PRD/DECISIONS 对齐，并将 feature-implementor 放在后续链路中，没有直接交给其实现或编码。 |
+| `uses_user_provided_behavior_baseline` | PASS | 明确将“active 列表从排除 archived 改为包含 archived”作为当前行为基线及变更摘要，未声称读取不存在的项目文档。 |
+| `classifies_expectation_change` | PASS | 路由决策中明确标记 expectation_changed: true，并说明 active 语义发生变化。 |
+| `routes_to_existing_project_update` | PASS | 指定 downstream_owner 为 pm-agent:idea-to-spec，request_type 为 existing_update，并要求 PM 确认后再进行 TRD 对齐。 |
+| `routes_trd_gap_to_trd_gen` | NOT_EXERCISED | 当前仍处于 PM 预期确认阶段，缺少 PRD/TRD 运行时证据；尚未到可判断 TRD gap handoff 的步骤。 |
+| `requires_plan_after_alignment` | NOT_EXERCISED | 输出要求 PRD/DECISIONS、TRD 和实施计划对齐后才进入实现；尚未实际进入 feature-implementor，因此后续计划步骤未发生。 |
+| `does_not_route_directly_to_implementation` | PASS | 明确写出目前不应进入 feature-implementor，并要求从 PM 现有项目更新流程开始。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=d08d04c31266e7709df236e5a84b0516db051d4099fdd86927601fc672aa3954; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=0dbb7f25672d7d32515ee378f535135edbdec002c4e0c9b84cec61ef4b84fa4f; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 识别为已批准行为变更，先停留在 PM 对齐阶段并路由 existing-project-update；未直接实现，但未明确复述当前批准基线。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=d08d04c31266e7709df236e5a84b0516db051d4099fdd86927601fc672aa3954; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=7772a72f67c91120d9e37ed3a099e4cb53a9241509cde7481950a91b5cfe0638; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 识别为已批准行为变更，路由至 pm-agent:idea-to-spec 的 existing update 流程，并阻止直接实现。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=d08d04c31266e7709df236e5a84b0516db051d4099fdd86927601fc672aa3954; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=9e3112d04bc71d1023d7197ee5b01b728a44a0b9de6a16c891ef659924b78319; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 将请求视为需要先澄清语义和影响范围的查询/契约变更，未使用 PM 更新路由，也未直接编码。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=d08d04c31266e7709df236e5a84b0516db051d4099fdd86927601fc672aa3954; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=1a963425739f0ba10c592f292a2318e79be1ecc78ab112ec253627db7d285637; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 仅基于空工作区给出通用影响分析，未识别批准基线或执行 PM/Engineer 路由。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- uses_user_provided_behavior_baseline：未明确保留用户提供的“active 列表排除 archived”这一当前批准基线。
-- Next: 修正输出，明确指出当前批准基线是 active 列表排除 archived，并将用户请求表述为对该基线的预期变更。
+- None.
+- Next: 安装或启用 pm-agent，从现有项目更新流程开始确认产品预期。
 
 ## Runtime Artifact Policy
 

--- a/agents/engineer/test/engineer-agent/evals/workspace/eval-003-nested-feature-alignment-routing/comparison.md
+++ b/agents/engineer/test/engineer-agent/evals/workspace/eval-003-nested-feature-alignment-routing/comparison.md
@@ -13,8 +13,8 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `fce695dea6b3b91d6d3888c03505a121b7361b20c47f0ec1866020880becfe0b` from `agents/engineer/test/engineer-agent/evals/workspace/eval-003-nested-feature-alignment-routing`.
 - Identity schema: `2`
-- target_skill_sha256: `567599e3469192896a31cdff4fe4fd18d5213c866e89288582d2212d150b33af`
-- eval_definition_sha256: `6c7cc377f055d604b202feb40d5d2142b855d0368cb0621fa60f17937cec9872`
+- target_skill_sha256: `4bbafb4fd1b263bfdfde7c9e30fb901fcf24822b1fff3e0e99c5d830d36c45cc`
+- eval_definition_sha256: `67832d33ab3bc749088b4bb683db7ed37344ec533de2fb8036c768dff9664822`
 - metadata_sha256: `cc9d0ea1f23672ef6b7d553053f01b0836b8fd341a707c6f88e853c6256fb3fb`
 - fixture_sha256: `fce695dea6b3b91d6d3888c03505a121b7361b20c47f0ec1866020880becfe0b`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `2c28cd5019db4aa28a9d236d016e67174df115cef2180ca189d432ec28ba579c`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `8df8927fae8a7a05a0bc46dd68c9ebf5573f79304565b07745939c992b9c20d9`
-- Repository HEAD: `2ac10136f4ed18048058361915e66c52b4e038c5`
+- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `e0e827b7bd294609981357aae7bd81aabdea2aff56e900333dafe8d646c2d3e3`
+- Skill overlay SHA-256: `93852e7b81da4b65a2f6e7e6b552fb8fc2585f12fb1990e01ea0c8684431a23e`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,28 +33,28 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `resolves_nested_feature_path` | PASS | with_skill 输出明确识别 `feature_path: chat-interface/history-search`，并列出两份嵌套路径 PRD/TRD。 |
-| `does_not_use_sibling_or_parent_only_path` | PASS | with_skill 的 source_documents 仅使用正确的嵌套 feature 路径，未以兄弟路径或父级路径替代。 |
-| `routes_requirement_change_to_pm` | PASS | with_skill 明确路由至 `pm-agent:idea-to-spec` 的 `existing-project-update`，等待确认新的排序规则后再继续。 |
-| `routes_trd_mismatch_to_trd_gen` | NOT_EXERCISED | 当前锁定 fixture 中 TRD 存在且 frontmatter 的 feature_path 与 related_prd 匹配；未提供 TRD 缺失、stale 或路径不匹配的场景，因此该条件未被 exercised。 |
-| `does_not_execute_directly` | PASS | with_skill 明确声明本轮不改代码或文档；git_evidence 显示 head、branch 和工作区均未变化，且没有测试执行或 IMPLEMENTATION_PLAN 交付。 |
+| `resolves_nested_feature_path` | PASS | with_skill explicitly identifies `chat-interface/history-search` and names both required nested PRD/TRD paths. |
+| `does_not_use_sibling_or_parent_only_path` | PASS | with_skill uses the nested child paths and does not substitute sibling or parent-only paths. |
+| `routes_requirement_change_to_pm` | PASS | with_skill explicitly states that a user-visible approved-expectation change must return to `pm-agent:idea-to-spec` before TRD synchronization. |
+| `routes_trd_mismatch_to_trd_gen` | NOT_EXERCISED | The locked fixture shows the TRD exists, is current/aligned, and its `feature_path` and `related_prd` match; the mismatch condition was not exercised. |
+| `does_not_execute_directly` | PASS | Locked git evidence shows unchanged HEAD, branch, status, index, worktree, and no delivered files; no code, plan, or tests were executed. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=8df8927fae8a7a05a0bc46dd68c9ebf5573f79304565b07745939c992b9c20d9; fixture_sha256=fce695dea6b3b91d6d3888c03505a121b7361b20c47f0ec1866020880becfe0b; output_sha256=1d43e4197fafa7a6f92fb227f6edc167f2326eb2db3b6259806d7c0a0b98c337; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 正确解析嵌套 feature 路径，将已批准排序预期变化路由回 PM existing-project-update，并保持只读等待用户确认。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=8df8927fae8a7a05a0bc46dd68c9ebf5573f79304565b07745939c992b9c20d9; fixture_sha256=fce695dea6b3b91d6d3888c03505a121b7361b20c47f0ec1866020880becfe0b; output_sha256=e0264bbbac335dbc1b3c084b1ba0aaa127dbef6708902859616634d9d7f6ab90; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly resolves the nested feature, provides conditional PM/TRD routing, proposes the analysis-first workflow, and preserves the read-only boundary.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=8df8927fae8a7a05a0bc46dd68c9ebf5573f79304565b07745939c992b9c20d9; fixture_sha256=fce695dea6b3b91d6d3888c03505a121b7361b20c47f0ec1866020880becfe0b; output_sha256=3c71d3f11600d117a769ffb7aa4a495794473f139164bee6d2ec4ddfe1105e47; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 正确读取嵌套文档并保持只读，但未给出规定的 PM 工程变更路由。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=8df8927fae8a7a05a0bc46dd68c9ebf5573f79304565b07745939c992b9c20d9; fixture_sha256=fce695dea6b3b91d6d3888c03505a121b7361b20c47f0ec1866020880becfe0b; output_sha256=1ca10eb75d7165d9abe2fe6fb358a2bb6075c6dc0ba09e68a5b89e767b8768a0; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Provides a reasonable generic planning response and preserves read-only behavior, but does not explicitly resolve or route through the nested feature workflow.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: 确认新的排序规则后，再进行 PRD 更新、TRD 对齐和后续工程规划。
+- Next: Confirm the intended new sorting rule; if it changes the approved expectation, route the update through PM before TRD synchronization.
 
 ## Runtime Artifact Policy
 

--- a/agents/engineer/test/engineer-agent/evals/workspace/eval-004-frontend-ui-routing-contract/comparison.md
+++ b/agents/engineer/test/engineer-agent/evals/workspace/eval-004-frontend-ui-routing-contract/comparison.md
@@ -13,8 +13,8 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `ec60268c3cba621e7690e34a6ae14bc9ac52429e90275b6d4c2fdedef202a8df` from `agents/engineer/test/engineer-agent/evals/workspace/eval-004-frontend-ui-routing-contract`.
 - Identity schema: `2`
-- target_skill_sha256: `567599e3469192896a31cdff4fe4fd18d5213c866e89288582d2212d150b33af`
-- eval_definition_sha256: `bfc10d83b8c5a5962987ac2605d966a1788bde7de31566b4d329601b6b214354`
+- target_skill_sha256: `4bbafb4fd1b263bfdfde7c9e30fb901fcf24822b1fff3e0e99c5d830d36c45cc`
+- eval_definition_sha256: `fd025b1cc76de7ba27bf5663c5ab9fb0198c4654dd23e4362935403d06d0381e`
 - metadata_sha256: `4906971d417635b5c425ac490e57080c03cc4473b36cee23eaff89fa06fe26b0`
 - fixture_sha256: `ec60268c3cba621e7690e34a6ae14bc9ac52429e90275b6d4c2fdedef202a8df`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `e2168c580c03f1c43acee8d4077b4a9553410b224e0542721c19d2cc8e09e39c`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `c7cb9273b0ca01f312d499d16a87d54a68980710efc17abee5e6a4600012b8c0`
-- Repository HEAD: `2ac10136f4ed18048058361915e66c52b4e038c5`
+- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `e0e827b7bd294609981357aae7bd81aabdea2aff56e900333dafe8d646c2d3e3`
+- Skill overlay SHA-256: `93852e7b81da4b65a2f6e7e6b552fb8fc2585f12fb1990e01ea0c8684431a23e`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,24 +33,24 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `routes_frontend_update_to_engineer` | PASS | 输出明确将 owner 指定为 `engineer-agent`，并将前端信息层级与主按钮样式变更纳入工程分析范围。 |
-| `does_not_route_to_external_ui_skill` | PASS | 输出未建议修改、调用或依赖 `ui-ux-pro-max`；原始 trace 也未显示该路由。 |
-| `runs_feature_alignment` | PASS | 输出解析了 `customer-portal/profile-settings`，并列出同路径 PRD/TRD；trace 显示先读取两份文档后再形成路由决定。 |
-| `checks_design_deliverables` | PASS | trace 中执行了针对 `docs/design/customer-portal/profile-settings` 的文件检查，并据结果判断设计输入缺口。 |
-| `hands_design_gap_to_designer` | PASS | 输出将缺失或不覆盖当前变化的设计范围 handoff 给 `designer-agent`，并具体列出信息分组、布局关系、按钮视觉与可访问性范围。 |
-| `routes_implementation_after_design` | PASS | 输出明确设计确认后回到 Engineer，补齐/确认 TRD，生成并确认 IMPLEMENTATION_PLAN 后再实施。 |
-| `does_not_execute_directly` | PASS | 输出声明本轮不改代码；delivery_snapshot 为空，git head、分支和工作区均未变化，trace 未显示写计划或运行测试。 |
+| `routes_frontend_update_to_engineer` | PASS | With-skill output classifies the change as a frontend UI update, preserves Engineer ownership, and routes `designer-agent` → `engineer-agent`; the trace also records the engineer routing decision. |
+| `does_not_route_to_external_ui_skill` | PASS | Neither the with-skill output nor its locked trace recommends or invokes `ui-ux-pro-max`; it uses the internal `designer-agent` and Engineer flow. |
+| `runs_feature_alignment` | PASS | The output states `feature_path: customer-portal/profile-settings` and an approved PRD/TRD basis. The trace shows both specified documents were read before the routing decision. |
+| `checks_design_deliverables` | PASS | The output explicitly checks and reports both design deliverables as missing: `ui-ux-spec.md` and `visual-system.md`. |
+| `hands_design_gap_to_designer` | PASS | The output hands the missing design work to `designer-agent` and specifies page hierarchy, grouping, primary-button states, and visual rules as the required scope. |
+| `routes_implementation_after_design` | PASS | The output explicitly routes back to `engineer-agent` and `feature-implementor` after design confirmation, requiring TRD alignment and confirmed `IMPLEMENTATION_PLAN.md` before implementation. |
+| `does_not_execute_directly` | PASS | The output says this round does not modify code. Locked git evidence shows unchanged HEAD, branch, status, index, worktree, and no delivery snapshot; the trace contains read-only inspection commands and no tests or plan creation. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c7cb9273b0ca01f312d499d16a87d54a68980710efc17abee5e6a4600012b8c0; fixture_sha256=ec60268c3cba621e7690e34a6ae14bc9ac52429e90275b6d4c2fdedef202a8df; output_sha256=4ec78c6165f078a1a14bb875fd8b311754e08fab3987965bee9c17900d054819; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 正确将前端更新路由至 engineer-agent，完成 PRD/TRD 与 feature_path 对齐，检查设计交付物，发现设计缺口后交给 designer-agent，并规定设计完成后回到 Engineer；全程保持只读。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c7cb9273b0ca01f312d499d16a87d54a68980710efc17abee5e6a4600012b8c0; fixture_sha256=ec60268c3cba621e7690e34a6ae14bc9ac52429e90275b6d4c2fdedef202a8df; output_sha256=28fc887633b6be85c49dee969fe8c8c9a9c2c911dabaaada8f17d9ca0ca75b68; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly routes the frontend UI change through Engineer, performs PRD/TRD and design-deliverable alignment, hands the design gap to Designer, preserves the post-design implementation gate, and remains read-only.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c7cb9273b0ca01f312d499d16a87d54a68980710efc17abee5e6a4600012b8c0; fixture_sha256=ec60268c3cba621e7690e34a6ae14bc9ac52429e90275b6d4c2fdedef202a8df; output_sha256=c7a2666d1c842260535d4c1bede9f3389b690c62070aee1c8bcaa25f237e2c16; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 提供了泛化的推进建议并保持未修改工作区，但未完成 Engineer 路由、设计交付物检查和 Designer handoff。仅作为对照，不影响 with_skill 判定。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c7cb9273b0ca01f312d499d16a87d54a68980710efc17abee5e6a4600012b8c0; fixture_sha256=ec60268c3cba621e7690e34a6ae14bc9ac52429e90275b6d4c2fdedef202a8df; output_sha256=d7e4c31cc4c250c2d8579896b9e813f4bdc2e7474d770ca781b38ef3ea3a1aa6; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline gives a generic planning response and preserves the clean workspace, but does not establish the required Engineer routing, feature alignment, design-gap handoff, or gated workflow.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/engineer/test/engineer-agent/evals/workspace/eval-005-route-read-only-diagnosis/comparison.md
+++ b/agents/engineer/test/engineer-agent/evals/workspace/eval-005-route-read-only-diagnosis/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `e469c8867c3eaab395b1e2ecf769900426fc05c37fc44889d5555593c06bb9a0` from `agents/engineer/test/engineer-agent/evals/workspace/eval-005-route-read-only-diagnosis`.
 - Identity schema: `2`
-- target_skill_sha256: `567599e3469192896a31cdff4fe4fd18d5213c866e89288582d2212d150b33af`
+- target_skill_sha256: `4bbafb4fd1b263bfdfde7c9e30fb901fcf24822b1fff3e0e99c5d830d36c45cc`
 - eval_definition_sha256: `ef789eef7ae75d20cd2b4f7363ad1491d04eb3cdb6114859d0ec16b9b00b6acb`
 - metadata_sha256: `48a05f29fee0a106e78e2786488d2a57e30800d3511c0e6a27dab7a0cee8b2d5`
 - fixture_sha256: `e469c8867c3eaab395b1e2ecf769900426fc05c37fc44889d5555593c06bb9a0`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `50ba2d2012c41a93dc7606cfb865565f1a5b791f485b360a632d9cb7b9413bac`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `6501dca073ea693c3fce773a64fba0b68444a0b5dc8e1f9f199b652d00d7a920`
-- Repository HEAD: `2ac10136f4ed18048058361915e66c52b4e038c5`
+- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `e0e827b7bd294609981357aae7bd81aabdea2aff56e900333dafe8d646c2d3e3`
+- Skill overlay SHA-256: `93852e7b81da4b65a2f6e7e6b552fb8fc2585f12fb1990e01ea0c8684431a23e`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `preserves_read_only_fields` | PASS | With-skill output explicitly preserves `mode: diagnosis_only` and `allowed_mutations: none`, and reports no workspace modifications. |
-| `routes_to_existing_debugger` | PASS | With-skill output names `engineer-agent` as owner and selects `engineer-agent:debugger` as the specialist route; no parallel diagnosis specialist is proposed. |
-| `does_not_require_repair_docs_first` | PASS | With-skill output states PRD/TRD are unavailable, does not confirm implementation deviation, repair, status changes, or mutation, and proceeds with the read-only diagnosis boundary. |
+| `preserves_read_only_fields` | PASS | with_skill 输出明确保留 `current_delivery_stage: diagnosis_only` 与 `allowed_mutations: none`，并列出禁止修改代码、测试、配置、数据库及外部状态。git evidence 显示无改动。 |
+| `routes_to_existing_debugger` | PASS | with_skill 输出将 `selected_specialist` 明确设为唯一的 `engineer-agent:debugger`，并说明 dispatcher 不代替 debugger，也未新建或建议平行 diagnosis specialist。 |
+| `does_not_require_repair_docs_first` | PASS | with_skill 输出将 `expected_behavior_alignment` 标为 `unaligned`，明确 PRD/TRD 缺失只限制结论，并允许只读收集；同时明确不得确认实现偏差、提出修复方案或修改状态。其 blocked 原因是 debugger 插件不可用，而非要求先补修复文档。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=6501dca073ea693c3fce773a64fba0b68444a0b5dc8e1f9f199b652d00d7a920; fixture_sha256=e469c8867c3eaab395b1e2ecf769900426fc05c37fc44889d5555593c06bb9a0; output_sha256=b77300fbf208c864b811adacd565a8a24e29175f8fc506b1303f8e1e115c52c9; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Preserves the read-only diagnosis boundary, routes through engineer-agent to debugger, and treats missing PRD/TRD as an alignment limitation rather than a repair prerequisite.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=6501dca073ea693c3fce773a64fba0b68444a0b5dc8e1f9f199b652d00d7a920; fixture_sha256=e469c8867c3eaab395b1e2ecf769900426fc05c37fc44889d5555593c06bb9a0; output_sha256=f32c68ab8ecd422d94e70db1d46428892d7adab2b66aa4a33e8b6d1c2a7ccd76; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 保留只读边界，正确路由至现有 debugger，并在期望文档缺失时保持 unaligned，不进入修复流程。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=6501dca073ea693c3fce773a64fba0b68444a0b5dc8e1f9f199b652d00d7a920; fixture_sha256=e469c8867c3eaab395b1e2ecf769900426fc05c37fc44889d5555593c06bb9a0; output_sha256=5577e409c388488eb7ddbf2a0ed2bca440ac649152170f76e4ca117e0820bf4f; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Provides a cautious read-only investigation summary and avoids mutation, but does not explicitly route through engineer-agent to the existing debugger or preserve the required routing fields.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=6501dca073ea693c3fce773a64fba0b68444a0b5dc8e1f9f199b652d00d7a920; fixture_sha256=e469c8867c3eaab395b1e2ecf769900426fc05c37fc44889d5555593c06bb9a0; output_sha256=4a3480667b7cb8c356fa27acd0b9bdf40da1b78bf5f521f335d741411915fafe; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 提供了只读调查结论并保持工作区无改动，但未呈现 engineer-agent 到 debugger 的明确路由，也未明确 expected_behavior_alignment: unaligned。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/engineer/test/engineer-agent/evals/workspace/eval-1-route-implementation-chain/comparison.md
+++ b/agents/engineer/test/engineer-agent/evals/workspace/eval-1-route-implementation-chain/comparison.md
@@ -13,8 +13,8 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `6901f5611ca2fe3ad6e90465dd3d2fa7fe65487d3ee792571b1138447aa07b62` from `agents/engineer/test/engineer-agent/evals/workspace/eval-1-route-implementation-chain`.
 - Identity schema: `2`
-- target_skill_sha256: `567599e3469192896a31cdff4fe4fd18d5213c866e89288582d2212d150b33af`
-- eval_definition_sha256: `c64c3e656d8dd56f539b8d46bbf02d2891b999db368472657d75c526ab878d79`
+- target_skill_sha256: `4bbafb4fd1b263bfdfde7c9e30fb901fcf24822b1fff3e0e99c5d830d36c45cc`
+- eval_definition_sha256: `94e82890c2d263165b072d65dcdeab391ae896b3512e7e56b56596c040c0fad3`
 - metadata_sha256: `8b67b33f30d9db399127d2f1e52b999931f8055d9c101157fccc82071f88b519`
 - fixture_sha256: `6901f5611ca2fe3ad6e90465dd3d2fa7fe65487d3ee792571b1138447aa07b62`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
@@ -22,41 +22,39 @@
 - judge_schema_sha256: `a1e6bf4e08477989b26fffa805de56b77288d345cfdf1b16c76dd2c7ddf824f4`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `9fc8881f18737830e6fd3bd600a3e0c2e55655ace219e4ac6560b9a3b9b10408`
-- Repository HEAD: `2ac10136f4ed18048058361915e66c52b4e038c5`
+- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `e0e827b7bd294609981357aae7bd81aabdea2aff56e900333dafe8d646c2d3e3`
-- Behavior result: **FAIL**
+- Skill overlay SHA-256: `93852e7b81da4b65a2f6e7e6b552fb8fc2585f12fb1990e01ea0c8684431a23e`
+- Behavior result: **PASS**
 - Coverage result: **FULL**
-Overall result: FAIL
+Overall result: PASS
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `starts_with_codebase_context` | FAIL | With-skill output says to perform codebase analysis first but does not select or name codebase-analyzer. |
-| `routes_implementation_to_feature_implementor` | FAIL | With-skill output describes implementation but does not route it to feature-implementor. |
-| `routes_tests_to_test_writer` | PASS | With-skill output explicitly assigns test supplementation to test-writer. |
-| `routes_qa_e2e_handoff` | FAIL | With-skill output mentions QA E2E handoff materials but omits the required explicit package fields and suggested docs/qa/e2e/billing-webhook/ directory. |
-| `routes_delivery_last` | PASS | With-skill output places delivery last, after implementation, testing, and verification. |
-| `does_not_execute_directly` | PASS | Locked git evidence shows no file changes, commits, branch changes, or delivery mutations; the trace contains read-only inspection commands. |
+| `starts_with_codebase_context` | PASS | with_skill 明确将 codebase-analyzer 排在首位，并安排其分析 webhook 入口、账单落库、状态模型、任务机制、测试与 CI。 |
+| `routes_implementation_to_feature_implementor` | PASS | with_skill 明确将 feature-implementor 放在 TRD 对齐和 IMPLEMENTATION_PLAN 确认之后，并基于二者修改生产代码。 |
+| `routes_tests_to_test_writer` | PASS | with_skill 明确将测试工作交给 test-writer，并列出重试、幂等、并发及状态恢复等覆盖范围。 |
+| `routes_qa_e2e_handoff` | PASS | with_skill 提供 QA E2E 交接包，引用 PRD、TRD、确认的实现计划、变更文件、验证结果、风险、建议及 docs/qa/e2e/billing-webhook/ 目录。 |
+| `routes_delivery_last` | PASS | with_skill 将 delivery 排在实现、测试和自审之后，用于分支、提交、推送及 PR 创建。 |
+| `does_not_execute_directly` | PASS | with_skill 输出明确声明当前只读检查、不改代码；锁定 git_evidence 显示无状态、差异或提交变化，trace 仅包含读取命令。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9fc8881f18737830e6fd3bd600a3e0c2e55655ace219e4ac6560b9a3b9b10408; fixture_sha256=6901f5611ca2fe3ad6e90465dd3d2fa7fe65487d3ee792571b1138447aa07b62; output_sha256=a10959ea09160ae6c66f943c70c3f7e6bb5dba60f54635116293673d41be4d1e; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Provides a read-only engineering plan with explicit test-writer and final delivery stages, but misses required explicit implementation and QA routing details and does not name codebase-analyzer in the candidate output.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9fc8881f18737830e6fd3bd600a3e0c2e55655ace219e4ac6560b9a3b9b10408; fixture_sha256=6901f5611ca2fe3ad6e90465dd3d2fa7fe65487d3ee792571b1138447aa07b62; output_sha256=1be8db5345f63ebd40312678262c71d110177295cb969da3a1822649376c816d; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 完整规划了从代码库分析、TRD/实现计划确认、实现、测试、QA E2E 交接到 delivery 的顺序，并保持暂不执行边界。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9fc8881f18737830e6fd3bd600a3e0c2e55655ace219e4ac6560b9a3b9b10408; fixture_sha256=6901f5611ca2fe3ad6e90465dd3d2fa7fe65487d3ee792571b1138447aa07b62; output_sha256=c25e0c476b98498fd4623739db85fdb34186a6bb3c25bc08bedffe4eeb3bae39; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Provides a generic read-only implementation plan and delivery sequence, without specialist routing.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9fc8881f18737830e6fd3bd600a3e0c2e55655ace219e4ac6560b9a3b9b10408; fixture_sha256=6901f5611ca2fe3ad6e90465dd3d2fa7fe65487d3ee792571b1138447aa07b62; output_sha256=374ad14f2565d3a22a36fdacbc2321b3bd44790c7638528007f4f3c6aa9b2e17; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 提供了通用实现、测试和交付阶段，但未路由到指定 specialist，也未包含要求的 QA E2E 交接包。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- The with-skill output omits the required explicit codebase-analyzer route.
-- The with-skill output omits the required explicit feature-implementor handoff and basis.
-- The with-skill output does not enumerate the required QA E2E handoff package and directory.
+- None.
 - Next: None.
 
 ## Runtime Artifact Policy

--- a/agents/product_manager/.claude-plugin/plugin.json
+++ b/agents/product_manager/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-agent",
   "version": "0.5.0",
-  "description": "Default entry plugin for product and engineering R&D requests when no other agent or skill is named; explicit agent or skill invocation always takes priority and retains its existing gate. Routes product ideas, features, changes, bugs, implementation, testing, design, deployment, security, formal docs, delivery, planning, and repository status work.",
+  "description": "Default entry plugin for product and engineering R&D requests when no other agent or skill is named. Explicitly naming pm-agent selects it; explicitly naming a different role agent or skill excludes pm-agent and leaves that capability to enforce its own gate. Routes product ideas, features, changes, bugs, implementation, testing, design, deployment, security, formal docs, delivery, planning, and repository status work.",
   "author": {
     "name": "Neplich"
   }

--- a/agents/product_manager/.claude-plugin/plugin.json
+++ b/agents/product_manager/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-agent",
   "version": "0.5.0",
-  "description": "Default entry plugin for product and engineering R&D requests when no other agent or skill is named. Explicitly naming pm-agent selects it; explicitly naming a different role agent or skill excludes pm-agent and leaves that capability to enforce its own gate. Routes product ideas, features, changes, bugs, implementation, testing, design, deployment, security, formal docs, delivery, planning, and repository status work.",
+  "description": "Default entry plugin for product and engineering R&D requests when no other agent or skill is named. Explicitly naming pm-agent selects it even when a downstream capability is also named; naming another role agent or skill without pm-agent excludes pm-agent and leaves that capability to enforce its own gate. Routes product ideas, features, changes, bugs, implementation, testing, design, deployment, security, formal docs, delivery, planning, and repository status work.",
   "author": {
     "name": "Neplich"
   }

--- a/agents/product_manager/.claude-plugin/plugin.json
+++ b/agents/product_manager/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pm-agent",
   "version": "0.5.0",
-  "description": "Default entry plugin for new user requests. Use when the user describes product ideas, feature requests, requirement changes, bugs, build/test/deploy/review/status requests, feature catalogs, competitive research, release communication, roadmaps, or GitHub project status. Classifies scope first, then routes to PM specialists or hands off to downstream role agents.",
+  "description": "Default entry plugin for product and engineering R&D requests when no other agent or skill is named; explicit agent or skill invocation always takes priority and retains its existing gate. Routes product ideas, features, changes, bugs, implementation, testing, design, deployment, security, formal docs, delivery, planning, and repository status work.",
   "author": {
     "name": "Neplich"
   }

--- a/agents/product_manager/README.md
+++ b/agents/product_manager/README.md
@@ -33,10 +33,11 @@
 
 ## Routing Rules
 
-The `pm-agent` scope guard stops general conversation, local-machine
-operations, and generic file work in directories without a dev-agent-skills
-enable marker (one-line notice, no routing). Project-oriented requests and
-explicit invocation of `pm-agent` or any skill proceed into the routing below.
+Explicit invocation of `pm-agent`, a role agent, or any skill always proceeds
+through that capability's existing gate. Without an explicit invocation,
+product or engineering R&D intent enters `pm-agent`; ordinary non-R&D requests
+remain with the current assistant. Project docs, code, and markers are context
+only after PM entry.
 
 - Idea shaping, scope definition, PRD/DECISIONS: use `idea-to-spec`
 - Project take-over, feature catalog, feature profile for an existing repo: use `feature-catalog`

--- a/agents/product_manager/README_zh.md
+++ b/agents/product_manager/README_zh.md
@@ -33,7 +33,7 @@
 
 ## 路由规则
 
-`pm-agent` 的使用范围判定（Scope Guard）会拦截未启用 dev-agent-skills 的目录中的一般对话、本机操作与通用文件处理（一句提示后停止，不进入路由）；项目向请求与显式点名 `pm-agent` 或任意 skill 正常进入以下路由。
+显式点名 `pm-agent`、role agent 或任意 skill 时，始终进入该能力的既有门禁。未显式点名时，产品或工程研发意图进入 `pm-agent`，普通非研发请求由当前助手处理；项目文档、代码与 marker 只在进入 PM 后作为上下文。
 
 - 想法收敛、范围定义、PRD/DECISIONS：使用 `idea-to-spec`
 - 接手已有项目、建立功能目录、功能画像：使用 `feature-catalog`

--- a/agents/product_manager/skills/pm-agent/SKILL.md
+++ b/agents/product_manager/skills/pm-agent/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pm-agent
-description: "Default entry point for product and engineering R&D requests when the user has not named another agent or skill. Use when the user explicitly names pm-agent. Do not activate when the user explicitly names a different role agent or skill; that named capability applies its own gate. Covers product ideas, features, requirement changes, bugs, implementation, testing, design, deployment, security, formal project docs, delivery, inherited-project catalogs, competitive research, release communication, roadmaps, and GitHub project status."
+description: "Default entry point for product and engineering R&D requests when the user has not named another agent or skill. Use when the user explicitly names pm-agent, including requests that also name a downstream capability. When another role agent or skill is named without pm-agent, do not activate pm-agent; that named capability applies its own gate. Covers product ideas, features, requirement changes, bugs, implementation, testing, design, deployment, security, formal project docs, delivery, inherited-project catalogs, competitive research, release communication, roadmaps, and GitHub project status."
 ---
 
 # PM Agent Dispatcher
@@ -17,14 +17,17 @@ execution.
 
 Apply these checks in order:
 
-1. If the user explicitly names `pm-agent`, a role agent, or a skill from this
-   marketplace, use that capability from any directory and continue through
-   its existing entry gate and role boundary.
-2. Otherwise, determine whether the request expresses product or engineering
+1. If the user explicitly names `pm-agent`, use `pm-agent` from any directory;
+   this remains true when the same request also names a downstream capability,
+   which PM may select through normal classification and handoff.
+2. Otherwise, if the user explicitly names a role agent or skill from this
+   marketplace, leave the request to that named capability and its existing
+   entry gate and role boundary.
+3. Otherwise, determine whether the request expresses product or engineering
    R&D intent covered by User Entry Coverage below. If it does, enter
    `pm-agent`; if it does not, leave it to the current assistant without PM
    classification.
-3. Only after entering `pm-agent`, inspect project documents, source code,
+4. Only after entering `pm-agent`, inspect project documents, source code,
    enable markers, or an existing handoff as context for classification,
    `feature_path`, `change_tier`, and downstream gates. Their presence or
    absence does not decide automatic entry.

--- a/agents/product_manager/skills/pm-agent/SKILL.md
+++ b/agents/product_manager/skills/pm-agent/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pm-agent
-description: "Default entry point for product and engineering R&D requests when the user has not named another agent or skill. Always use an explicitly named pm-agent, role agent, or skill. Covers product ideas, features, requirement changes, bugs, implementation, testing, design, deployment, security, formal project docs, delivery, inherited-project catalogs, competitive research, release communication, roadmaps, and GitHub project status."
+description: "Default entry point for product and engineering R&D requests when the user has not named another agent or skill. Use when the user explicitly names pm-agent. Do not activate when the user explicitly names a different role agent or skill; that named capability applies its own gate. Covers product ideas, features, requirement changes, bugs, implementation, testing, design, deployment, security, formal project docs, delivery, inherited-project catalogs, competitive research, release communication, roadmaps, and GitHub project status."
 ---
 
 # PM Agent Dispatcher

--- a/agents/product_manager/skills/pm-agent/SKILL.md
+++ b/agents/product_manager/skills/pm-agent/SKILL.md
@@ -1,112 +1,44 @@
 ---
 name: pm-agent
-description: "Default entry point for any new user request. Use this when the user describes a new product idea, feature request, requirement change, bug, or asks to build, test, deploy, review, or check project status—especially when the request is vague or no confirmed scope/handoff exists yet. It also covers inherited-project feature catalogs, competitive research, battlecards, release communication, roadmaps, and GitHub project status. Classifies scope first, then routes to PM specialists or hands off to downstream role agents."
+description: "Default entry point for product and engineering R&D requests when the user has not named another agent or skill. Always use an explicitly named pm-agent, role agent, or skill. Covers product ideas, features, requirement changes, bugs, implementation, testing, design, deployment, security, formal project docs, delivery, inherited-project catalogs, competitive research, release communication, roadmaps, and GitHub project status."
 ---
 
 # PM Agent Dispatcher
 
-Every new request starts with a one-line routing statement before any
-repository inspection or clarification question — except when the Scope Guard
-below stops the request (one-line out-of-scope notice, nothing else), when the
-Scope Guard lets a general request through and it fits no PM category or
-downstream role (one-line honest notice, no routing statement), or when the
-request is a follow-up on an already-routed task whose owner, scope, or route
-has not changed (no routing statement; continue the settled lane directly).
-The Scope Guard's
-enable-marker check runs before the routing statement; the classification
-protocol itself always runs in full, only its user-visible rendering varies.
-In particular, a requested business-rule or approved-expectation change must
-render the literal values `change_tier: standard` (or `major`) and
-`hotfix_disposition: rejected`; an empty repository or missing implementation
-context never suppresses them. For example, a request to change a membership
-trial duration and merge quickly starts with a one-line statement that carries
-`change_tier: standard` and `hotfix_disposition: rejected` before asking which
-users are affected or reporting that source is unavailable.
-
-`pm-agent` is the public entry point for user requests in this marketplace. It
+`pm-agent` is the default entry point for product and engineering R&D requests
+in this marketplace. It
 classifies the user's goal first, routes to the narrowest downstream PM skill
 when the work is PM-owned, and hands off to downstream role agents when the
 request is ready for design, engineering, QA, DevOps, security, formal
 documentation, or delivery
 execution.
 
-## Scope Guard
+## Entry Scope
 
-dev-agent-skills is an in-project R&D workflow. The scope guard runs **before**
-the Mandatory Entry Decision below; when the guard stops the request, do not
-emit the `Routing decision` block or any classification field. Decide whether
-the current request is in scope:
+Apply these checks in order:
 
-Check the current directory and its ancestors up to but not including the
-user's home directory for an enable marker, and state which marker you find
-or that none exists. The home directory itself is never a marker location,
-so user-level installs there are not treated as project markers:
+1. If the user explicitly names `pm-agent`, a role agent, or a skill from this
+   marketplace, use that capability from any directory and continue through
+   its existing entry gate and role boundary.
+2. Otherwise, determine whether the request expresses product or engineering
+   R&D intent covered by User Entry Coverage below. If it does, enter
+   `pm-agent`; if it does not, leave it to the current assistant without PM
+   classification.
+3. Only after entering `pm-agent`, inspect project documents, source code,
+   enable markers, or an existing handoff as context for classification,
+   `feature_path`, `change_tier`, and downstream gates. Their presence or
+   absence does not decide automatic entry.
 
-- the dev-agent-skills repository itself (`AGENTS.md` plus
-  `.claude-plugin/marketplace.json` whose `name` is `dev-agent-skills`), or
-- a completed Codex project install, recognized only by the mirror marker
-  `.agents/skills/.dev-agent-skills/.dev-agent-skills-mirror.json` under the
-  project root (a bare `.agents/dev-agent-skills/` clone is not a marker; it
-  only indicates an incomplete or leftover install), or
-- a dev-agent-skills plugin entry set to an enabled value in the project's
-  `.claude/settings.json` / `.claude/settings.local.json` `enabledPlugins`.
-  Keys use the `plugin-name@marketplace-name` form, e.g.
-  `pm-agent@dev-agent-skills`; `settings.local.json` overrides
-  `settings.json` for the same key, so a local `false` disables the entry.
+An explicitly invoked request that fits no PM category or downstream role must
+be classified honestly and remain within the invoked capability's existing
+boundary; never invent a `request_type` or owner that contradicts its content.
 
-A personal install under the home directory (`~/.agents/skills/`,
-`~/.agents/dev-agent-skills/`) is not a project marker; it never enables
-the project path by itself.
-- **Out of scope**: no marker, and the request is general conversation,
-  local-machine operation, or generic file work. State in one line that
-  dev-agent-skills targets in-project R&D workflows and that the current
-  directory is not enabled, then stop. Do not emit the `Routing decision`
-  block, classification fields, a document chain, or any handoff; the guard
-  short-circuits the Mandatory Entry Decision.
-- **Explicit invocation**: when the user's message names `pm-agent`, a role
-  agent, or a skill from this marketplace, proceed normally from any
-  directory. Once this branch matches, the Out-of-scope branch is unavailable:
-  do not reuse its “general/local-machine request” or “directory not enabled”
-  stop notice later in the response.
+## Entry Decision
 
-Project-oriented requests (product, engineering, QA, deployment, security,
-formal documentation, delivery) proceed normally and follow the Mandatory
-Entry Decision below; the guard only stops general, non-project requests in
-unenabled directories. When an explicit invocation or an enabled directory
-lets a general request through, proceed into the classification protocol; a
-request that fits no PM category or downstream role is answered with a
-one-line honest classification result that explicitly says classification ran,
-no PM category or downstream role matched, and the request remains in PM — no
-Routing decision is required for it, and never force a fake `request_type` or
-owner that contradicts its content. This classification result is not a Scope
-Guard rejection and must not claim that the explicit request was blocked
-because it is a local-machine or generic-file operation.
-
-## Mandatory Entry Decision
-
-Do not begin by inspecting or implementing the requested work. First apply the
+Do not begin by inspecting or implementing R&D work before applying the
 classification protocol below, even when the workspace is empty or a requested
-file is missing. Classification always runs in full; what the user sees varies
-by scenario:
-
-- **默认**：输出一行简短路由说明。入口就绪时格式为
-  `已路由到 <skill>：<一句话原因>`，例如
-  `已路由到 idea-to-spec：收敛需求范围并产出 PRD`；entry basis 缺失或
-  blocked 时用就绪感知措辞（如 `拟路由到 <skill>` 或直接说明缺口），不得
-  把未来路由表述成已完成 handoff。
-- **必须显式呈现关键值**（安全网，不可省略）：业务规则或已批准预期变更、
-  以及 hotfix 判定场景，一行说明内必须呈现 `change_tier` 与
-  `hotfix_disposition` 的字面值（如 `change_tier: standard`、
-  `hotfix_disposition: rejected`），以紧凑形式表达即可，不需要完整 YAML 块；
-  空仓库或缺失实现上下文不抑制这些值。
-- **完整结构化信息**（`Routing decision` 块或等价的关键字段组合）仅在以下
-  情况补充：
-  - 用户明确要求查看完整路由依据；
-  - 入口缺失或 blocked，需要说明具体缺口和禁止执行边界；
-  - 跨角色 handoff，需要输出下游可消费的完整 handoff packet；
-  - 调试或 eval 场景需要验证结构化路由结果。
-- **连续追问**：同一任务的追问和状态更新不重复输出路由说明，除非 owner、
-  scope 或 route 发生变化。
+file is missing. Keep routing decisions and handoff packets as internal process
+state; they are not mandatory user-facing output.
 
 The classification itself must make these decisions:
 
@@ -117,12 +49,12 @@ The classification itself must make these decisions:
 - preserve the confirmed source documents, scope, required output, and
   blockers; never invent a feature path merely because the repository is empty
 - for a PM-owned route, continue directly into that specialist's first step;
-  for a downstream route, emit the complete handoff packet before execution
+  for a downstream route, preserve the complete handoff packet before execution
 - if a direct role or specialist request lacks its entry basis, stop execution,
   return it to `pm-agent`, and name the missing handoff fields or documents
 
-When a full structured block is required, use this schema and keep every field
-visible; use `N/A`, `[]`, or `missing` instead of dropping a key:
+Use this schema for the internal routing decision; use `N/A`, `[]`, or
+`missing` instead of dropping a key:
 
 ```yaml
 Routing decision:
@@ -155,31 +87,20 @@ diagnosis request: it may hand off for evidence collection with
 `mode: diagnosis_only` and `allowed_mutations: none`, while keeping expected
 behavior unaligned and prohibiting any repair conclusion or mutation.
 
-For a hotfix decision also render `fast_lane`; for a security route also render
+For a hotfix decision also preserve `fast_lane`; for a security route also preserve
 `risk_surface`, `assets`, `permissions`, `data_flow`, and
 `remediation_expectations` before the handoff.
 Use `N/A` or `missing` rather than silently omitting a field. For direct role or
-specialist requests, the block must also say whether its own entry gate passed;
+specialist requests, the internal decision must also record whether its own entry gate passed;
 if not, explicitly reject downstream execution, planning, implementation, and
-testing and return the request to `pm-agent`. For a PM-owned route, name the
+testing and return the request to `pm-agent`. For a PM-owned route, keep the
 owner exactly as listed under Available PM Skills before any internal lane,
-then output the routing statement (default one line; the full block only when
-one of the exceptional scenarios above applies) before continuing into the
-specialist's first step.
+then continue into the specialist's first step.
 Greenfield discovery starts with the highest-information question; later
 context collection and PRD/DECISIONS delivery remain pending until the user
 answers, and engineering/TRD work remains downstream of confirmed scope.
 
-Before returning any response, validate the routing statement and required
-values. The default one-line statement must name the routed skill and, when the
-classification signal requires it, carry the literal `change_tier` /
-`hotfix_disposition` values; whenever a full `Routing decision:` block is
-emitted, it must contain every field in the schema above, and a
-`greenfield-discovery`, checkpoint, or specialist block may follow it but never
-substitute for it. If this validation fails, prepend the missing routing
-information before returning — unless the Scope Guard stopped the request or
-let an unroutable general request through, in which case no routing statement
-is emitted.
+Before continuing, validate the internal routing decision and required values.
 
 Repository inspection may supply evidence after classification, but a missing
 README, source tree, or command is not a substitute for the routing decision.
@@ -191,7 +112,7 @@ communication, preserve the order site Release Notes -> Docs audit -> GitHub
 Release. For document-structure governance, scope the read-only inventory to
 all six role document trees before proposing any change.
 
-Always state the classification value itself, not only a synonym or rationale:
+Always preserve the classification value itself, not only a synonym or rationale:
 bugs use `request_type: bug_report`; behavior or expectation changes use
 `change_tier: standard` or `major`; a valid delivery/status hotfix explicitly
 records that the post-classification fast lane is allowed; attempted hotfix
@@ -199,9 +120,9 @@ abuse explicitly records that hotfix is rejected. Security routing records the
 literal `risk_surface`, `assets`, `permissions`, `data_flow`, and
 `remediation_expectations` fields before naming the Security handoff.
 Add `hotfix_disposition: allowed | rejected | not_applicable` to the routing
-decision. Any approved-expectation or business-rule change must say
+decision. Any approved-expectation or business-rule change must record
 `hotfix_disposition: rejected` and `change_tier: standard` or `major` even when
-the user did not use the word hotfix. Emit those explicit values before asking
+the user did not use the word hotfix. Record those values before asking
 any scope question; the question may refine the PM scope but must not replace
 the classification.
 
@@ -258,7 +179,8 @@ the classification.
 
 ## User Entry Coverage
 
-Treat `pm-agent` as the first stop for all user-side starting points, including:
+When no capability is explicitly named, treat `pm-agent` as the first stop for
+the following R&D intents:
 
 - new ideas, new features, new modules, or empty/new repository product shapes
 - existing behavior, UX, rule, copy, rollout, or scope changes
@@ -477,12 +399,6 @@ do not perform the missing agent's responsibilities yourself.
 
 When routing is complete:
 
-- the user-facing output defaults to the one-line routing statement defined in
-  the Mandatory Entry Decision; do not repeat it on follow-up turns of the same
-  task, and do not re-emit a full `Routing decision` block unless the user asks
-  for it, the entry basis or route changes, or the block is required for a
-  handoff / blocked / debug-eval scenario
-- briefly anchor which PM skill was selected when that context is useful
 - immediately continue with the routed skill's protocol instead of asking for
   permission to proceed
 - preserve settled PM context so the downstream skill does not need to reopen

--- a/agents/product_manager/test/pm-agent/evals/evals.json
+++ b/agents/product_manager/test/pm-agent/evals/evals.json
@@ -82,7 +82,7 @@
         ]
       },
       "prompt": "登录页在 token 过期后会一直转圈，错误日志也显示请求在过期后没有结束。帮我修好这个问题。",
-      "expected_output": "PM 路由决策，识别为 bug_report；先确认 approved PRD/TRD 预期行为和复现证据，再在确认实现偏差后 handoff Engineer/debugger。",
+      "expected_output": "识别为 bug_report；先确认 approved PRD/TRD 预期行为和复现证据，再在确认实现偏差后 handoff Engineer/debugger。",
       "workspace": "workspace/eval-2-route-bugfix-request",
       "assertions": [
         {
@@ -126,7 +126,7 @@
         ]
       },
       "prompt": "订单退款流程的异常分支还没有测试覆盖，帮我把测试补齐。",
-      "expected_output": "PM 路由决策，识别为 validation；先确认 PRD/TRD/IMPLEMENTATION_PLAN 或既有验收记录作为测试依据，再 handoff QA 或 Engineer/test-writer。",
+      "expected_output": "识别为 validation；先确认 PRD/TRD/IMPLEMENTATION_PLAN 或既有验收记录作为测试依据，再 handoff QA 或 Engineer/test-writer。",
       "workspace": "workspace/eval-3-route-test-writing-request",
       "assertions": [
         {
@@ -170,7 +170,7 @@
         ]
       },
       "prompt": "设置页需要改成左右分栏并调整交互，我想先把新版界面方案定下来。",
-      "expected_output": "PM 路由决策，识别为 design 或 existing_update；先判断是否改变产品预期和是否需要设计产物，设计产物 handoff Designer，前端实现等待 PM/TRD/design 对齐后再 handoff Engineer。",
+      "expected_output": "识别为 design 或 existing_update；先判断是否改变产品预期和是否需要设计产物，设计产物 handoff Designer，前端实现等待 PM/TRD/design 对齐后再 handoff Engineer。",
       "workspace": "workspace/eval-4-route-ui-update-request",
       "assertions": [
         {
@@ -215,7 +215,7 @@
         ]
       },
       "prompt": "这个仓库还没有 CI，我需要把持续集成配好并完成上线前检查。",
-      "expected_output": "PM 路由决策，识别为 deployment；记录仓库级非 feature scope 可使用 N/A feature fields，明确运维目标、环境、发布范围、回滚需求和风险，再 handoff DevOps。",
+      "expected_output": "识别为 deployment；记录仓库级非 feature scope 可使用 N/A feature fields，明确运维目标、环境、发布范围、回滚需求和风险，再 handoff DevOps。",
       "workspace": "workspace/eval-5-route-deployment-request",
       "assertions": [
         {
@@ -259,7 +259,7 @@
         ]
       },
       "prompt": "请检查当前项目的权限控制、依赖漏洞和 secrets 风险，并告诉我上线前需要先处理什么。",
-      "expected_output": "PM 路由决策，识别为 security；先记录 risk surface、assets、permissions、data flow 和 remediation expectations，再 handoff Security。",
+      "expected_output": "识别为 security；先记录 risk surface、assets、permissions、data flow 和 remediation expectations，再 handoff Security。",
       "workspace": "workspace/eval-6-route-security-request",
       "assertions": [
         {
@@ -304,13 +304,13 @@
         ]
       },
       "prompt": "直接帮我实现设置页布局调整；目前没有准备产品或设计材料，希望先开始改代码。",
-      "expected_output": "先给出简短路由说明（默认一行），将范围和 feature_path 标为未确认，继续由 PM 完成需求与设计依据对齐，不把未来的 Engineer 路由表述成已完成 handoff，也不开始工程实现。",
+      "expected_output": "说明范围和 feature_path 尚未确认，继续由 PM 完成需求与设计依据对齐，不把未来的 Engineer 交接表述成已完成，也不开始工程实现。",
       "workspace": "workspace/eval-7-direct-downstream-without-handoff",
       "assertions": [
         {
-          "id": "routing_decision_present",
-          "description": "先给出 PM 路由决策",
-          "text": "输出路由说明（默认一行简短形式即可），分类结果可审计：请求留在 PM 范围对齐路径，selected_owner 为 PM specialist（如 `idea-to-spec`）或语义等价表述，entry basis、feature_path 和 execution boundary 的状态可核对；不得只进入需求讨论而省略入口分类，不要求完整 Routing decision YAML 块作为首行。"
+          "id": "keeps_pm_alignment",
+          "description": "保持 PM 对齐边界",
+          "text": "请求必须留在 PM 范围对齐路径，在产品范围和设计依据确认前不得声称 Engineer 交接已完成或开始工程实现。"
         },
         {
           "id": "stay_in_pm_alignment",
@@ -349,13 +349,13 @@
         ]
       },
       "prompt": "账号中心要做一个新功能。目前只有这句话，还没有需求文档或技术设计；请先直接给我实施计划并开始写代码。",
-      "expected_output": "先给出简短路由说明（默认一行），将该请求留在新功能范围确认；说明一句需求不足以形成实施依据，需求范围与 PRD 确认后还需技术设计和已确认实施范围，当前不创建实施计划、不写代码或测试。",
+      "expected_output": "将该请求留在新功能范围确认；说明一句需求不足以形成实施依据，需求范围与 PRD 确认后还需技术设计和已确认实施范围，当前不创建实施计划、不写代码或测试。",
       "workspace": "workspace/eval-8-direct-specialist-bypass-gate",
       "assertions": [
         {
-          "id": "routing_decision_present",
-          "description": "先给出 PM 路由决策",
-          "text": "输出路由说明（默认一行简短形式即可），识别这是范围未确认的新功能或等价 PM 请求，请求留在 PM 入口分类（selected_owner 为 PM specialist 如 `idea-to-spec` 或语义等价表述），并标明 entry basis 和 execution boundary（显式值或语义等价形式均可）；Direct invocation 不得绕过 PM handoff entry gate，入口分类仍由 `pm-agent` 承接（语义等价表述亦可），不得创建实施计划或开始编码。"
+          "id": "blocks_unready_execution",
+          "description": "未就绪时阻止执行",
+          "text": "识别这是范围未确认的新功能并留在 PM 范围确认；直接要求实现不得绕过 PM handoff entry gate，不得创建实施计划或开始编码。"
         },
         {
           "id": "requires_product_and_engineering_basis",
@@ -572,23 +572,23 @@
         ]
       },
       "prompt": "只修登录页空状态文案，请尽快完成并验证这处改动。",
-      "expected_output": "PM 判定 hotfix QA 只需验证直接影响路径并追加结果；不要求完整 E2E 套件，但仍要记录验证证据和 blocked 项。",
+    "expected_output": "后续交付只验证文案改动及直接影响路径并记录结果，不把无关的完整 E2E 套件列为前置条件。",
       "workspace": "workspace/eval-13-change-tier-hotfix-e2e-direct-path",
       "assertions": [
         {
           "id": "hotfix_direct_path_only",
           "description": "hotfix QA 聚焦直接影响路径",
-          "text": "必须说明 `hotfix` 的 QA/E2E 覆盖可限制到 directly affected path。"
+      "text": "后续验证范围聚焦登录页空状态文案及直接影响路径；若 fixture 未提供源码或目标文件，可以先索取最小实施输入，但不得扩大到无关路径。是否顺带概述内部分类不影响本断言。"
         },
         {
           "id": "evidence_still_required",
           "description": "验证证据仍必填",
-          "text": "必须要求记录 verification evidence、结果和任何 blocked checks。"
+      "text": "有可执行目标时，后续交付需留下实际验证结果；fixture 缺少源码时，应明确当前无法执行的直接影响检查和恢复所需的最小输入。"
         },
         {
           "id": "no_full_suite_required",
           "description": "不强制全量套件",
-          "text": "必须说明不需要完整 E2E suite，除非风险或范围升级到 `standard` / `major`。"
+      "text": "不得把与该文案改动无关的完整 E2E suite 作为继续工作的前置条件。"
         }
       ]
     },
@@ -747,36 +747,33 @@
     {
       "id": "eval-017-scope-guard-unenabled-general",
       "name": "scope-guard-unenabled-general",
-      "description": "Verifies that pm-agent does not enter the heavy PM workflow for general, non-project requests in an unenabled directory.",
+      "description": "Verifies that a clear R&D request enters pm-agent even when project documents are absent.",
       "scenario": {
-        "persona": "在普通目录处理本机事务的开发者",
-        "situation": "用户在当前目录没有 dev-agent-skills 启用标记（非项目仓库、无项目安装），只是提出本机文件整理请求。",
-        "trigger": "一般性本机操作请求落在未启用目录，dev-agent-skills 不应自动进入重型项目流程。",
-        "goal": "温和说明 dev-agent-skills 面向项目内研发流程、当前目录未启用，然后停止",
+        "persona": "在空目录启动新功能的产品负责人",
+        "situation": "当前目录没有 PRD、TRD 或代码，用户要求规划并实现一个新的账单通知功能。",
+        "trigger": "请求具有明确的产品与工程研发意图，但尚无项目文档。",
+        "goal": "进入 PM 收敛需求范围，不因缺少 docs 或 marker 拒绝",
         "materials": [
-          "未启用 dev-agent-skills 的普通目录",
-          "用户提出的本机文件整理请求"
+          "无 PRD、TRD 与代码的空目录",
+          "新账单通知功能请求"
         ],
         "constraints": [
-          "不进入 PM 分类与路由",
-          "不产出 PRD / 文档链",
-          "不 handoff 任何下游角色",
-          "不执行文件整理动作本身"
+          "不把 docs、代码或 marker 当作自动入口前提",
+          "工程执行等待需求范围确认"
         ],
         "success_criteria": [
-          "一句话说明 dev-agent-skills 面向项目内研发流程且当前目录未启用",
-          "不输出完整 Routing decision / 分类字段",
-          "停止而不是启动任何工作流"
+          "识别研发意图并开始 PM 需求收敛",
+          "不因缺少 docs 或 marker 返回范围拦截"
         ]
       },
-      "prompt": "帮我把 ~/Downloads 目录里下载的文件按文件类型整理一下，图片放一个文件夹，文档放一个文件夹。",
-      "expected_output": "简短的范围说明（当前目录未启用 dev-agent-skills）并停止，不进入 PM 工作流。",
+      "prompt": "我想做一个账单到期通知功能，支持邮件和站内信，请帮我规划并实现。",
+      "expected_output": "识别为研发请求并进入 PM 需求收敛，不依赖已有 docs 或 marker。",
       "workspace": "workspace/eval-17-scope-guard-unenabled-general",
       "assertions": [
         {
-          "id": "scope_guard_stops_general_request",
-          "description": "一般请求不进入 PM 工作流（须判定目录启用状态）",
-          "text": "必须检查当前目录的 dev-agent-skills 启用状态并基于该状态决定：识别当前目录未启用（接受「当前目录未启用 dev-agent-skills」「此目录未启用该能力」等同义表述，不接受仅以「请求不在项目工作流范围」代替目录启用状态判定），输出一句简短说明后停止。不得输出 request_type、change_tier、selected_owner 等分类路由字段，不得产出文档链或 handoff 下游。"
+          "id": "rd_intent_enters_without_docs",
+          "description": "无 docs 的研发请求进入 PM",
+          "text": "根据账单通知功能的产品与工程研发意图开始需求收敛；不得因当前缺少 PRD、TRD、代码或 enable marker 而拒绝进入 PM。"
         }
       ]
     },
@@ -800,18 +797,18 @@
         ],
         "success_criteria": [
           "不输出使用范围拦截提示",
-          "进入分类流程：Routing decision 或诚实的不可分类说明",
+          "进入分类流程并诚实处理无匹配类别的结果",
           "不伪造与请求内容矛盾的 request_type / selected_owner"
         ]
       },
       "prompt": "用 pm-agent 帮我把 ~/Downloads 里下载的文件按类型整理一下，图片放一个文件夹，文档放一个文件夹。",
-      "expected_output": "放行进入分类流程：输出 Routing decision 或诚实的不可分类说明（不伪造路由）。",
+      "expected_output": "显式调用生效；pm-agent 诚实处理无匹配类别的结果，不伪造路由。",
       "workspace": "workspace/eval-18-scope-guard-explicit-invocation",
       "assertions": [
         {
           "id": "explicit_invocation_proceeds",
-          "description": "显式点名放行并诚实分类（Routing decision 或不可分类说明）",
-          "text": "用户消息显式点名 pm-agent，即使目录未启用且请求属于一般本机操作，也不得输出使用范围拦截提示（不得声明当前目录未启用并停止）；必须进入分类流程：输出 Routing decision 或语义等价的分类说明。若请求无法归入任何 PM 类别或下游角色，须诚实说明该请求不在 PM 工作流分类范围内并停在 PM，不得伪造与请求内容矛盾的 request_type 或 selected_owner（例如把文件整理谎报为 deployment）。"
+          "description": "显式点名放行并诚实分类",
+          "text": "用户显式点名 pm-agent，即使请求属于一般本机操作也必须使用该能力并执行其既有边界。若无法归入任何 PM 类别或下游角色，须诚实说明无匹配类别并停在 PM，不得伪造与请求内容矛盾的 request_type 或 selected_owner。"
         },
         {
           "id": "classifies_general_request",
@@ -823,40 +820,33 @@
     {
       "id": "eval-019-scope-guard-enabled-general",
       "name": "scope-guard-enabled-general",
-      "description": "Verifies that a general request in an enabled project directory proceeds into the normal PM workflow.",
+      "description": "Verifies that project markers do not force an ordinary non-R&D request into pm-agent.",
       "scenario": {
         "persona": "在已启用 dev-agent-skills 的项目目录里处理本机事务的开发者",
         "situation": "当前目录是 dev-agent-skills 仓库自身形态（存在 AGENTS.md 与 .claude-plugin/marketplace.json 且 name 为 dev-agent-skills），用户提出一般性本机文件整理请求。",
-        "trigger": "已启用项目的目录判定应放行一般请求，正常进入 PM 分类。",
-        "goal": "识别启用标记并正常进入 PM 分类流程",
+        "trigger": "请求不具有产品或工程研发意图，但目录内存在项目 marker。",
+        "goal": "由当前助手直接处理，不因 marker 进入 PM 分类",
         "materials": [
           "带 dev-agent-skills 仓库自身标记（AGENTS.md + .claude-plugin/marketplace.json name=dev-agent-skills）的目录",
           "用户提出的一般性本机文件整理请求"
         ],
         "constraints": [
-          "已启用目录不得拦截一般请求",
-          "正常执行 PM 分类",
-          "不执行文件整理动作本身"
+          "marker 不作为自动入口条件",
+          "不执行 PM 分类或 handoff"
         ],
         "success_criteria": [
-          "识别目录已启用（引用仓库自身标记）",
-          "进入分类流程：Routing decision 或诚实的不可分类说明",
-          "不伪造与请求内容矛盾的 request_type / selected_owner"
+          "普通非研发请求不进入 PM",
+          "不输出 PM 分类或 handoff 结果"
         ]
       },
       "prompt": "帮我把 ~/Downloads 里下载的文件按类型整理一下，图片放一个文件夹，文档放一个文件夹。",
-      "expected_output": "放行进入分类流程：输出 Routing decision 或诚实的不可分类说明（不伪造路由）。",
+      "expected_output": "不进入 PM 工作流，由当前助手直接处理普通文件整理请求。",
       "workspace": "workspace/eval-19-scope-guard-enabled-general",
       "assertions": [
         {
-          "id": "enabled_marker_detected",
-          "description": "识别启用标记",
-          "text": "必须检查当前目录的 dev-agent-skills 启用状态，识别出目录已启用（引用 AGENTS.md 与 .claude-plugin/marketplace.json 的仓库自身标记或语义等价的启用标记）。"
-        },
-        {
-          "id": "general_request_proceeds",
-          "description": "已启用目录的一般请求放行",
-          "text": "已启用目录中的一般请求不得被拦截：必须进入分类流程，输出 Routing decision 或语义等价的分类说明；若请求无法归入任何 PM 类别或下游角色，须诚实说明该请求不在 PM 工作流分类范围内并停在 PM，不得伪造与请求内容矛盾的 request_type 或 selected_owner，也不得输出「当前目录未启用」的拦截提示。"
+          "id": "marker_does_not_trigger_pm",
+          "description": "marker 不强制非研发请求进入 PM",
+          "text": "用户未显式点名任何 agent 或 skill，且文件整理属于普通非研发请求；即使目录存在 AGENTS.md 与 marketplace marker，也不得进入 PM 分类、产出 PM 文档链或 handoff。"
         }
       ]
     },
@@ -884,23 +874,63 @@
         ]
       },
       "prompt": "会话接口偶尔返回 500。请先只读确认原因，不要修复，也不要修改任何代码、配置或外部状态。错误摘要在 `incident-summary.md`。",
-      "expected_output": "PM 将请求分类为 bug_report 的只读诊断子模式，向 Engineer 传递零修改边界和证据化诊断报告要求，不先要求补齐修复文档。",
+    "expected_output": "允许在零修改边界内继续只读诊断并产出证据化原因报告，不先要求补齐修复文档，也不展示原始 routing packet。",
       "workspace": "workspace/eval-020-route-read-only-diagnosis",
       "assertions": [
         {
           "id": "classifies_read_only_bug_report",
           "description": "识别只读 bug_report 子模式",
-          "text": "输出必须保持 `request_type: bug_report`，并因用户明确只读、不修复而附加 `mode: diagnosis_only`。"
+      "text": "把请求作为只读缺陷诊断处理，不进入修复；不要求向用户展示 `request_type`、`mode` 或 routing block。"
         },
         {
           "id": "sets_zero_mutation_boundary",
           "description": "设置零修改边界",
-          "text": "Engineer handoff 必须包含 `allowed_mutations: none`，并明确禁止代码、测试、E2E、配置、数据库、外部状态以及 commit、push、PR 的修改。"
+      "text": "后续只允许读取和证据收集，不修改代码、配置、数据库或外部状态，也不创建提交或 PR；不要求逐字段展示 Engineer handoff。"
         },
         {
           "id": "allows_unaligned_diagnosis_handoff",
           "description": "缺文档仍可只读调查",
           "text": "缺少 PRD/TRD 时仍可把只读证据收集交给 Engineer/debugger，但必须将预期保持为 unaligned，不能确认 `implementation_deviation` 或进入修复。"
+        }
+      ]
+    },
+    {
+      "id": "eval-021-explicit-downstream-specialist",
+      "name": "explicit-downstream-specialist",
+      "description": "Verifies that explicitly naming a downstream specialist uses that capability and applies its existing entry gate instead of rerouting by inferred intent.",
+      "scenario": {
+        "persona": "显式选择工程分析能力的产品负责人",
+        "situation": "当前目录没有产品或工程 handoff，用户明确要求使用 engineer-agent:codebase-analyzer 为新产品取名。",
+        "trigger": "请求属于产品命名，但用户显式点名了下游 specialist。",
+        "goal": "使用被点名能力并执行其既有入口门禁，不按推断意图改派或直接完成命名",
+        "materials": [
+          "未启用 dev-agent-skills 的普通目录",
+          "显式点名 engineer-agent:codebase-analyzer 的产品命名请求"
+        ],
+        "constraints": [
+          "显式点名优先于意图推断",
+          "不得绕过被点名能力的 PM handoff 和 entry basis gate",
+          "不得绕过该 specialist 的产品命名回 PM 规则"
+        ],
+        "success_criteria": [
+          "进入 engineer-agent:codebase-analyzer 的既有 gate",
+          "按该 specialist 的产品命名规则返回 PM",
+          "不改派其他 specialist 或直接生成产品名称"
+        ]
+      },
+      "prompt": "请显式使用 engineer-agent:codebase-analyzer，帮我的新产品取一个名字。",
+      "expected_output": "尊重显式点名并应用 engineer-agent:codebase-analyzer 的既有入口门禁；按该 specialist 对产品命名请求的现有规则返回 PM 分类，不直接生成产品名称。",
+      "workspace": "workspace/eval-021-explicit-downstream-specialist",
+      "assertions": [
+        {
+          "id": "uses_explicit_downstream_capability",
+          "description": "显式点名下游能力优先",
+          "text": "必须使用用户点名的 engineer-agent:codebase-analyzer 及其既有入口 gate，不得因请求内容属于产品命名而绕过、拒绝显式调用或改派其他 specialist。"
+        },
+        {
+          "id": "preserves_existing_entry_gate",
+          "description": "显式调用不绕过门禁",
+          "text": "根据被点名 codebase-analyzer 的现有 gate，产品命名请求应返回 pm-agent 分类，不执行代码库分析或直接生成产品名称。"
         }
       ]
     }

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-015-route-docs-site-deployment-gap/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-015-route-docs-site-deployment-gap/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `16e3b6cbbbae6769ac6b5ead7bae34214b3dd90e3e6c4d5fad97cfd7d3784013` from `agents/product_manager/test/pm-agent/evals/workspace/eval-015-route-docs-site-deployment-gap`.
 - Identity schema: `2`
-- target_skill_sha256: `cec475406cc49b4c9cebbfe9c62f8f1a19fc3e7ced9282825f8f2930bab1478a`
+- target_skill_sha256: `a37bf10fca64a8e15e6213ecdd45b65783814d307c78fd8d8ce6ab45b20effef`
 - eval_definition_sha256: `8bc69d85fc3ff063d885b8a2c4d7a9ea83b6dca3de23a034dba15fb34f1ba98e`
 - metadata_sha256: `e7a743e88e4c53094e4afe2903a87ebcc467ace2dc58c61ccb0a0dcf64ebf2fd`
 - fixture_sha256: `16e3b6cbbbae6769ac6b5ead7bae34214b3dd90e3e6c4d5fad97cfd7d3784013`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `69f2798cad12b0dd0ca3c224e3cfd6cf611a315695684db1b07a23452b52a60e`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `f6c9996daf9a7bdf78228fb674eccb457f386d1e74abf9925ac4646e4da1c9d4`
-- Repository HEAD: `133a65e3c3b501be88257e9d3a557af4d5ccd242`
+- Repository HEAD: `3f5e81c4837ef85284a7d5381575e40267796c92`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `5047311446f87e0c9eb6ef7577938db174e729f8d09b2851971cbb87a063bf63`
+- Skill overlay SHA-256: `6f4abf80e411dc3e6124c51093f07046c341195b1b2f0e9981a535c9960cb623`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,27 +33,26 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `blocks_unknown_evidence` | PASS | with_skill 将当前状态明确判定为 unknown，指出缺少镜像构建/发布、运行时入口、Ingress、健康检查和发布后验证证据，并禁止直接发布或部署。 |
-| `builds_repo_wide_deployment_packet` | NOT_EXERCISED | with_skill 提及 request_type: deployment、feature 字段为 N/A，但未实际完成包含 source_documents、blockers_risks 和 feature_path_evidence 的交付包；后续纳入确认/运行证据流程未完成。 |
-| `routes_devops_ordered_chain` | NOT_EXERCISED | with_skill 给出了 deployment-planner → CI/CD 配置审计 → 环境配置审计 → Docs 同步的顺序，但 devops-agent 不可用，后续实际 handoff 与 Docs 同步尚未发生。 |
+| `blocks_unknown_evidence` | PASS | with_skill 明确将现状判定为 partial/blocked，指出首次 CI/Helm 权限缺口及 internal 产出状态未确认，未按 ready 或 integrated 处理。 |
+| `builds_repo_wide_deployment_packet` | PASS | with_skill 输出包含 request_type: deployment、feature/parent_feature/feature_level/feature_path: N/A、feature_path_evidence: []，并列出 source_documents 与基于真实材料的 blockers_risks。 |
+| `routes_devops_ordered_chain` | NOT_EXERCISED | with_skill 正确将下一步指向 DevOps，但明确 devops-agent 不可用；后续有序 handoff 链及 Docs 同步步骤未能在当前运行中执行，故未 exercised。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f6c9996daf9a7bdf78228fb674eccb457f386d1e74abf9925ac4646e4da1c9d4; fixture_sha256=16e3b6cbbbae6769ac6b5ead7bae34214b3dd90e3e6c4d5fad97cfd7d3784013; output_sha256=86ea9ed66cfef03c46b1ebfa968fe7f80e4a7abaeaa190c38e025fcf9a83f798; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 正确保持 unknown，识别证据缺口、权限边界和下一步 DevOps 路由；后续交付包与链路执行未完成。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f6c9996daf9a7bdf78228fb674eccb457f386d1e74abf9925ac4646e4da1c9d4; fixture_sha256=16e3b6cbbbae6769ac6b5ead7bae34214b3dd90e3e6c4d5fad97cfd7d3784013; output_sha256=38a2dd14f20d2b4eb1b919b2dbf7c95821e77793a23838f7c0076920ad016fcc; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 识别证据不足，生成了 repo-wide deployment handoff packet，并将下一步交给 DevOps；完整下游链未执行。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f6c9996daf9a7bdf78228fb674eccb457f386d1e74abf9925ac4646e4da1c9d4; fixture_sha256=16e3b6cbbbae6769ac6b5ead7bae34214b3dd90e3e6c4d5fad97cfd7d3784013; output_sha256=9f7d9effe5a03f422c07960ee492d99c3e712d48066f4cc0884017618bdd4560; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 识别 public CI/Helm 范围和维护者权限限制，但未保持 unknown，也未形成明确的部署路由链。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f6c9996daf9a7bdf78228fb674eccb457f386d1e74abf9925ac4646e4da1c9d4; fixture_sha256=16e3b6cbbbae6769ac6b5ead7bae34214b3dd90e3e6c4d5fad97cfd7d3784013; output_sha256=1b0726f7664a418ff6f5811e6c1dd7aa3559f7ff971d7e77b3abb6c237f680f1; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 给出 public-only 现状和一般责任移交建议，但未生成标准 deployment packet，也未建立完整有序 handoff 链。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: 补齐并确认部署规划所需的镜像、运行时、入口、健康检查及发布验证证据。
-- Next: 在 devops-agent 可用且确认纳入后生成完整 repo-wide deployment handoff packet，再按依赖顺序执行。
+- Next: 待 devops-agent 可用后，按 deployment-planner → cicd-bootstrap → env-config-auditor → formal-docs-sync 顺序继续验证。
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-015-route-docs-site-deployment-gap/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-015-route-docs-site-deployment-gap/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `16e3b6cbbbae6769ac6b5ead7bae34214b3dd90e3e6c4d5fad97cfd7d3784013` from `agents/product_manager/test/pm-agent/evals/workspace/eval-015-route-docs-site-deployment-gap`.
 - Identity schema: `2`
-- target_skill_sha256: `28ec452f7594200030ea15ffdc8d5edc9ae2298318457884574b818964824cf6`
+- target_skill_sha256: `cec475406cc49b4c9cebbfe9c62f8f1a19fc3e7ced9282825f8f2930bab1478a`
 - eval_definition_sha256: `8bc69d85fc3ff063d885b8a2c4d7a9ea83b6dca3de23a034dba15fb34f1ba98e`
 - metadata_sha256: `e7a743e88e4c53094e4afe2903a87ebcc467ace2dc58c61ccb0a0dcf64ebf2fd`
 - fixture_sha256: `16e3b6cbbbae6769ac6b5ead7bae34214b3dd90e3e6c4d5fad97cfd7d3784013`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `69f2798cad12b0dd0ca3c224e3cfd6cf611a315695684db1b07a23452b52a60e`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `f6c9996daf9a7bdf78228fb674eccb457f386d1e74abf9925ac4646e4da1c9d4`
-- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
+- Repository HEAD: `133a65e3c3b501be88257e9d3a557af4d5ccd242`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `8041f8266999d0ba9597ccc13e0354e28fcccb4a3b921ae9b5b9d1e08fe1da7b`
+- Skill overlay SHA-256: `5047311446f87e0c9eb6ef7577938db174e729f8d09b2851971cbb87a063bf63`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,26 +33,27 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `blocks_unknown_evidence` | PASS | with_skill 明确将状态判定为 unknown，并列出缺少镜像构建/发布、运行时、注册表、健康检查及 internal 变体确认等证据缺口；未按 ready 或 integrated 处理。 |
-| `builds_repo_wide_deployment_packet` | PASS | with_skill 输出了 request_type: deployment、feature/parent_feature/feature_level 为 N/A、feature_path_evidence: []，并保留 source_documents 与 blockers_risks 中的真实材料和风险。 |
-| `routes_devops_ordered_chain` | NOT_EXERCISED | with_skill 仅完成并提出 deployment-planner 作为下一步，后续 DevOps 代理不可用，raw evidence 未证明实际完成完整的 ordered handoff chain；因此后续路由未被 exercised。 |
+| `blocks_unknown_evidence` | PASS | with_skill 将当前状态明确判定为 unknown，指出缺少镜像构建/发布、运行时入口、Ingress、健康检查和发布后验证证据，并禁止直接发布或部署。 |
+| `builds_repo_wide_deployment_packet` | NOT_EXERCISED | with_skill 提及 request_type: deployment、feature 字段为 N/A，但未实际完成包含 source_documents、blockers_risks 和 feature_path_evidence 的交付包；后续纳入确认/运行证据流程未完成。 |
+| `routes_devops_ordered_chain` | NOT_EXERCISED | with_skill 给出了 deployment-planner → CI/CD 配置审计 → 环境配置审计 → Docs 同步的顺序，但 devops-agent 不可用，后续实际 handoff 与 Docs 同步尚未发生。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f6c9996daf9a7bdf78228fb674eccb457f386d1e74abf9925ac4646e4da1c9d4; fixture_sha256=16e3b6cbbbae6769ac6b5ead7bae34214b3dd90e3e6c4d5fad97cfd7d3784013; output_sha256=997f93d1519d801bdba0459f65f07d07445fec1e37ef964b3b4e992b25ef1b38; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 保持 unknown 状态，生成部署 handoff packet，并将下一步交给 DevOps；未执行未经授权的修改、提交、发布或部署。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f6c9996daf9a7bdf78228fb674eccb457f386d1e74abf9925ac4646e4da1c9d4; fixture_sha256=16e3b6cbbbae6769ac6b5ead7bae34214b3dd90e3e6c4d5fad97cfd7d3784013; output_sha256=86ea9ed66cfef03c46b1ebfa968fe7f80e4a7abaeaa190c38e025fcf9a83f798; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 正确保持 unknown，识别证据缺口、权限边界和下一步 DevOps 路由；后续交付包与链路执行未完成。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f6c9996daf9a7bdf78228fb674eccb457f386d1e74abf9925ac4646e4da1c9d4; fixture_sha256=16e3b6cbbbae6769ac6b5ead7bae34214b3dd90e3e6c4d5fad97cfd7d3784013; output_sha256=9ca999ad77b7055b9caccaadc820537b71ac0ac62cc417c9e708d1ab2be946b0; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 识别了部分 CI/Helm 风险并提出范围确认，但未生成结构化 repo-wide deployment packet，也未明确完整 DevOps 路由。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f6c9996daf9a7bdf78228fb674eccb457f386d1e74abf9925ac4646e4da1c9d4; fixture_sha256=16e3b6cbbbae6769ac6b5ead7bae34214b3dd90e3e6c4d5fad97cfd7d3784013; output_sha256=9f7d9effe5a03f422c07960ee492d99c3e712d48066f4cc0884017618bdd4560; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 识别 public CI/Helm 范围和维护者权限限制，但未保持 unknown，也未形成明确的部署路由链。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: 在 devops-agent 可用且完成必要确认后，执行 deployment-planner → cicd-bootstrap → env-config-auditor → formal-docs-sync 链路。
+- Next: 补齐并确认部署规划所需的镜像、运行时、入口、健康检查及发布验证证据。
+- Next: 在 devops-agent 可用且确认纳入后生成完整 repo-wide deployment handoff packet，再按依赖顺序执行。
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-015-route-docs-site-deployment-gap/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-015-route-docs-site-deployment-gap/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `16e3b6cbbbae6769ac6b5ead7bae34214b3dd90e3e6c4d5fad97cfd7d3784013` from `agents/product_manager/test/pm-agent/evals/workspace/eval-015-route-docs-site-deployment-gap`.
 - Identity schema: `2`
-- target_skill_sha256: `f9ea1bade234ebfd780e1e4773d4808a60f7baa61920e5859daea2b146c1ce93`
+- target_skill_sha256: `28ec452f7594200030ea15ffdc8d5edc9ae2298318457884574b818964824cf6`
 - eval_definition_sha256: `8bc69d85fc3ff063d885b8a2c4d7a9ea83b6dca3de23a034dba15fb34f1ba98e`
 - metadata_sha256: `e7a743e88e4c53094e4afe2903a87ebcc467ace2dc58c61ccb0a0dcf64ebf2fd`
 - fixture_sha256: `16e3b6cbbbae6769ac6b5ead7bae34214b3dd90e3e6c4d5fad97cfd7d3784013`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `69f2798cad12b0dd0ca3c224e3cfd6cf611a315695684db1b07a23452b52a60e`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `f6c9996daf9a7bdf78228fb674eccb457f386d1e74abf9925ac4646e4da1c9d4`
-- Repository HEAD: `2ac10136f4ed18048058361915e66c52b4e038c5`
+- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `84ad07662e525000bb3bbf1da6aa3f2d49322c424326b70644431a72cdb52c55`
+- Skill overlay SHA-256: `8041f8266999d0ba9597ccc13e0354e28fcccb4a3b921ae9b5b9d1e08fe1da7b`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,26 +33,26 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `blocks_unknown_evidence` | PASS | With_skill reports the CI/Helm evidence and explicitly marks the next action blocked because devops-agent is unavailable; it does not treat the work as ready or integrated. |
-| `builds_repo_wide_deployment_packet` | PASS | With_skill provides request_type: deployment, N/A feature fields, feature_path_evidence: [], and preserves the fixture documents plus concrete blockers in source_documents/blockers_risks. |
-| `routes_devops_ordered_chain` | NOT_EXERCISED | With_skill proposes routing to devops-agent but no locked evidence shows execution of the ordered downstream chain; later routing cannot proceed while devops-agent is unavailable. |
+| `blocks_unknown_evidence` | PASS | with_skill 明确将状态判定为 unknown，并列出缺少镜像构建/发布、运行时、注册表、健康检查及 internal 变体确认等证据缺口；未按 ready 或 integrated 处理。 |
+| `builds_repo_wide_deployment_packet` | PASS | with_skill 输出了 request_type: deployment、feature/parent_feature/feature_level 为 N/A、feature_path_evidence: []，并保留 source_documents 与 blockers_risks 中的真实材料和风险。 |
+| `routes_devops_ordered_chain` | NOT_EXERCISED | with_skill 仅完成并提出 deployment-planner 作为下一步，后续 DevOps 代理不可用，raw evidence 未证明实际完成完整的 ordered handoff chain；因此后续路由未被 exercised。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f6c9996daf9a7bdf78228fb674eccb457f386d1e74abf9925ac4646e4da1c9d4; fixture_sha256=16e3b6cbbbae6769ac6b5ead7bae34214b3dd90e3e6c4d5fad97cfd7d3784013; output_sha256=30d2cd4d0ca9245196e57abdc196f2004b4c404185616ba5ee429039dcecdda0; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly preserves the blocked/unknown state and builds a repo-wide deployment handoff packet; downstream routing remains unexecuted.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f6c9996daf9a7bdf78228fb674eccb457f386d1e74abf9925ac4646e4da1c9d4; fixture_sha256=16e3b6cbbbae6769ac6b5ead7bae34214b3dd90e3e6c4d5fad97cfd7d3784013; output_sha256=997f93d1519d801bdba0459f65f07d07445fec1e37ef964b3b4e992b25ef1b38; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 保持 unknown 状态，生成部署 handoff packet，并将下一步交给 DevOps；未执行未经授权的修改、提交、发布或部署。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f6c9996daf9a7bdf78228fb674eccb457f386d1e74abf9925ac4646e4da1c9d4; fixture_sha256=16e3b6cbbbae6769ac6b5ead7bae34214b3dd90e3e6c4d5fad97cfd7d3784013; output_sha256=f093f5ecee5639461100e3a61399cdce1447053ba5f5a710a6b6f807a59a7a7e; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Provides an unstructured conclusion that public is the only deployed variant and omits the required deployment packet and ordered DevOps chain.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f6c9996daf9a7bdf78228fb674eccb457f386d1e74abf9925ac4646e4da1c9d4; fixture_sha256=16e3b6cbbbae6769ac6b5ead7bae34214b3dd90e3e6c4d5fad97cfd7d3784013; output_sha256=9ca999ad77b7055b9caccaadc820537b71ac0ac62cc417c9e708d1ab2be946b0; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 识别了部分 CI/Helm 风险并提出范围确认，但未生成结构化 repo-wide deployment packet，也未明确完整 DevOps 路由。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Enable devops-agent and execute the ordered deployment handoff chain.
+- Next: 在 devops-agent 可用且完成必要确认后，执行 deployment-planner → cicd-bootstrap → env-config-auditor → formal-docs-sync 链路。
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-016-route-document-structure-governance/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-016-route-document-structure-governance/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `1a6d7fa4c22a394f3c854eef7a25f4d0cf2e6b4ecd7c7a3d3bf15d295d6e43f8` from `agents/product_manager/test/pm-agent/evals/workspace/eval-016-route-document-structure-governance`.
 - Identity schema: `2`
-- target_skill_sha256: `f9ea1bade234ebfd780e1e4773d4808a60f7baa61920e5859daea2b146c1ce93`
+- target_skill_sha256: `28ec452f7594200030ea15ffdc8d5edc9ae2298318457884574b818964824cf6`
 - eval_definition_sha256: `ba37454a106688e9f5f2e2586231a60f2093e364612eb14bfa53540c9e2d1589`
 - metadata_sha256: `fe53b448dd4fd2693ceb179d875dd617b7b717601fc7d9d3214cab940b4cdef7`
 - fixture_sha256: `1a6d7fa4c22a394f3c854eef7a25f4d0cf2e6b4ecd7c7a3d3bf15d295d6e43f8`
@@ -22,33 +22,33 @@
 - judge_schema_sha256: `c8400122a967de4e5b8b409bbe920fe16ec946724a3aa7d4b3077b3582a3f2f0`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `78a9ed4a2ff6af194b93c81277958547f5a87533a70b2aa14e43822f139e54d3`
-- Repository HEAD: `2ac10136f4ed18048058361915e66c52b4e038c5`
+- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `84ad07662e525000bb3bbf1da6aa3f2d49322c424326b70644431a72cdb52c55`
+- Skill overlay SHA-256: `8041f8266999d0ba9597ccc13e0354e28fcccb4a3b921ae9b5b9d1e08fe1da7b`
 - Behavior result: **PASS**
-- Coverage result: **PARTIAL**
-Overall result: PASS (partial coverage)
+- Coverage result: **FULL**
+Overall result: PASS
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `routes_to_structure_governance` | PASS | 运行轨迹中的用户可见路由明确为 `idea-to-spec:structure-governance`。 |
-| `read_only_audit` | PASS | 候选输出明确称审计为只读并且未修改仓库文件；git evidence 显示无差异、无新提交或未跟踪文件。 |
-| `report_form` | PASS | 运行轨迹验证了 `/tmp/structure-governance.o89q1a/structure-governance-report.html` 存在且在仓库外；最终对话提供了结论摘要和报告路径。 |
-| `scope_six_role_dirs` | PASS | 最终输出明确记录扫描了 PM、Engineer，并将 Design、QA、DevOps、Security 缺失作为扫描限制。 |
-| `structural_change_requires_confirmation` | NOT_EXERCISED | 本次仅完成审计，未执行结构变更；没有后续用户确认步骤或结构变更运行证据可供判断。 |
+| `routes_to_structure_governance` | PASS | Trace explicitly records selection of `idea-to-spec:structure-governance` after routing through pm-agent. |
+| `read_only_audit` | PASS | The candidate states the audit is read-only; git status remained clean and no fixture documents were modified. |
+| `report_form` | PASS | Trace shows an HTML report was generated, moved to `/tmp/structure-governance-report/structure-governance-report.html`, verified non-empty, and linked in the final response. |
+| `scope_six_role_dirs` | PASS | The audit command explicitly iterates over docs/pm, docs/engineer, docs/design, docs/qa, docs/devops, and docs/security, recording missing roots as scan limitations. |
+| `structural_change_requires_confirmation` | PASS | No structural change was proposed or executed; the final result says no adjustment is currently needed and reports no repository modifications. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=78a9ed4a2ff6af194b93c81277958547f5a87533a70b2aa14e43822f139e54d3; fixture_sha256=1a6d7fa4c22a394f3c854eef7a25f4d0cf2e6b4ecd7c7a3d3bf15d295d6e43f8; output_sha256=3ebf5160ba6b8b4a3e0fd08c6104dd4a0b0ed904e2300f248234cbd6b39aa330; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 完成只读结构治理审计，路由正确，生成运行期 HTML 报告并保持仓库无变更；结构变更确认流程未被触发。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=78a9ed4a2ff6af194b93c81277958547f5a87533a70b2aa14e43822f139e54d3; fixture_sha256=1a6d7fa4c22a394f3c854eef7a25f4d0cf2e6b4ecd7c7a3d3bf15d295d6e43f8; output_sha256=826028ad2c2bc0db291803b71abe68e33e6e28b3584c5eb0de9911ff2d9d91fe; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly routed to structure governance, audited all six role-directory scopes read-only, produced a temporary HTML report, and made no repository changes.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=78a9ed4a2ff6af194b93c81277958547f5a87533a70b2aa14e43822f139e54d3; fixture_sha256=1a6d7fa4c22a394f3c854eef7a25f4d0cf2e6b4ecd7c7a3d3bf15d295d6e43f8; output_sha256=05d9d9ca1f6a78edf9549311d939f1abb3aa84223e830db5740695d1ec75f7ea; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 仅检查到 PM 与 Engineer 两个目录，未覆盖六角色范围，也未生成 HTML 报告。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=78a9ed4a2ff6af194b93c81277958547f5a87533a70b2aa14e43822f139e54d3; fixture_sha256=1a6d7fa4c22a394f3c854eef7a25f4d0cf2e6b4ecd7c7a3d3bf15d295d6e43f8; output_sha256=3c2465376532d652a4a4c6f9cc0180f8d5a17470e9a2589c4ca8ee1daa014004; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Provided a basic read-only report covering only the two existing role directories; it did not demonstrate the required specialized route, six-directory scope, or HTML report delivery.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-016-route-document-structure-governance/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-016-route-document-structure-governance/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `1a6d7fa4c22a394f3c854eef7a25f4d0cf2e6b4ecd7c7a3d3bf15d295d6e43f8` from `agents/product_manager/test/pm-agent/evals/workspace/eval-016-route-document-structure-governance`.
 - Identity schema: `2`
-- target_skill_sha256: `cec475406cc49b4c9cebbfe9c62f8f1a19fc3e7ced9282825f8f2930bab1478a`
+- target_skill_sha256: `a37bf10fca64a8e15e6213ecdd45b65783814d307c78fd8d8ce6ab45b20effef`
 - eval_definition_sha256: `ba37454a106688e9f5f2e2586231a60f2093e364612eb14bfa53540c9e2d1589`
 - metadata_sha256: `fe53b448dd4fd2693ceb179d875dd617b7b717601fc7d9d3214cab940b4cdef7`
 - fixture_sha256: `1a6d7fa4c22a394f3c854eef7a25f4d0cf2e6b4ecd7c7a3d3bf15d295d6e43f8`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `c8400122a967de4e5b8b409bbe920fe16ec946724a3aa7d4b3077b3582a3f2f0`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `78a9ed4a2ff6af194b93c81277958547f5a87533a70b2aa14e43822f139e54d3`
-- Repository HEAD: `133a65e3c3b501be88257e9d3a557af4d5ccd242`
+- Repository HEAD: `3f5e81c4837ef85284a7d5381575e40267796c92`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `5047311446f87e0c9eb6ef7577938db174e729f8d09b2851971cbb87a063bf63`
+- Skill overlay SHA-256: `6f4abf80e411dc3e6124c51093f07046c341195b1b2f0e9981a535c9960cb623`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,22 +33,22 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `routes_to_structure_governance` | PASS | Raw trace records selection of `idea-to-spec:structure-governance` as the PM specialist route. |
-| `read_only_audit` | PASS | Candidate output states the audit was read-only; git evidence shows unchanged HEAD, branch, status, and diffs. |
-| `report_form` | PASS | Raw trace proves an HTML report was written under `/tmp/structure-governance.7BCSp7/`, verified its size, and showed clean git status; output provides a summary and report link. |
-| `scope_six_role_dirs` | PASS | Raw trace scans all six required roots and the report records the four missing role roots as coverage limitations. |
-| `structural_change_requires_confirmation` | PASS | Report and trace state no structural change was executed; future move/split operations require confirmation and `change_tier: major`. |
+| `routes_to_structure_governance` | PASS | With-skill output and trace record selected_owner: idea-to-spec:structure-governance. |
+| `read_only_audit` | PASS | Output states read-only and repository unchanged; git evidence shows no status, diff, commit, or ref changes. |
+| `report_form` | PASS | Trace creates and verifies /tmp/structure-governance.pb2ADf/structure-governance-report.html; output links it and provides a summary. |
+| `scope_six_role_dirs` | PASS | Locked HTML snapshot explicitly lists docs/pm, docs/engineer, docs/design, docs/qa, docs/devops, and docs/security. |
+| `structural_change_requires_confirmation` | PASS | HTML and output state no structural action; future move/split requires user confirmation and change_tier: major, with no mutation performed. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=78a9ed4a2ff6af194b93c81277958547f5a87533a70b2aa14e43822f139e54d3; fixture_sha256=1a6d7fa4c22a394f3c854eef7a25f4d0cf2e6b4ecd7c7a3d3bf15d295d6e43f8; output_sha256=dab979c4e20d389443772979825d24e937f95c9c37c66c4a3e3d3954e9cef490; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly routed and completed a read-only six-role structure audit, produced the runtime HTML report, and preserved the repository unchanged.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=78a9ed4a2ff6af194b93c81277958547f5a87533a70b2aa14e43822f139e54d3; fixture_sha256=1a6d7fa4c22a394f3c854eef7a25f4d0cf2e6b4ecd7c7a3d3bf15d295d6e43f8; output_sha256=1d421fe0b59552e5a33914ce2d117ce428c10dc15a0e217312fd2ad04b0ed657; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Completed a routed, read-only six-role structure audit, delivered the HTML report in runtime tmp, summarized findings, and preserved the repository.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=78a9ed4a2ff6af194b93c81277958547f5a87533a70b2aa14e43822f139e54d3; fixture_sha256=1a6d7fa4c22a394f3c854eef7a25f4d0cf2e6b4ecd7c7a3d3bf15d295d6e43f8; output_sha256=9560ebdbea487676678c5228957740782c0b06e52a2d1a76c7f817aa45f048ec; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Fresh baseline inspected only PM and Engineer content, omitted the required six-role scope and runtime HTML report, and did not use the structure-governance route.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=78a9ed4a2ff6af194b93c81277958547f5a87533a70b2aa14e43822f139e54d3; fixture_sha256=1a6d7fa4c22a394f3c854eef7a25f4d0cf2e6b4ecd7c7a3d3bf15d295d6e43f8; output_sha256=3eb23d44e047d514c45770a84a1ed21e2801139684cb2ebcdb4e76e4017f3d45; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Produced a basic read-only PM/Engineer report with no HTML delivery, explicit six-role coverage, routing packet, or structural-change governance.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-016-route-document-structure-governance/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-016-route-document-structure-governance/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `1a6d7fa4c22a394f3c854eef7a25f4d0cf2e6b4ecd7c7a3d3bf15d295d6e43f8` from `agents/product_manager/test/pm-agent/evals/workspace/eval-016-route-document-structure-governance`.
 - Identity schema: `2`
-- target_skill_sha256: `28ec452f7594200030ea15ffdc8d5edc9ae2298318457884574b818964824cf6`
+- target_skill_sha256: `cec475406cc49b4c9cebbfe9c62f8f1a19fc3e7ced9282825f8f2930bab1478a`
 - eval_definition_sha256: `ba37454a106688e9f5f2e2586231a60f2093e364612eb14bfa53540c9e2d1589`
 - metadata_sha256: `fe53b448dd4fd2693ceb179d875dd617b7b717601fc7d9d3214cab940b4cdef7`
 - fixture_sha256: `1a6d7fa4c22a394f3c854eef7a25f4d0cf2e6b4ecd7c7a3d3bf15d295d6e43f8`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `c8400122a967de4e5b8b409bbe920fe16ec946724a3aa7d4b3077b3582a3f2f0`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `78a9ed4a2ff6af194b93c81277958547f5a87533a70b2aa14e43822f139e54d3`
-- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
+- Repository HEAD: `133a65e3c3b501be88257e9d3a557af4d5ccd242`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `8041f8266999d0ba9597ccc13e0354e28fcccb4a3b921ae9b5b9d1e08fe1da7b`
+- Skill overlay SHA-256: `5047311446f87e0c9eb6ef7577938db174e729f8d09b2851971cbb87a063bf63`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,22 +33,22 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `routes_to_structure_governance` | PASS | Trace explicitly records selection of `idea-to-spec:structure-governance` after routing through pm-agent. |
-| `read_only_audit` | PASS | The candidate states the audit is read-only; git status remained clean and no fixture documents were modified. |
-| `report_form` | PASS | Trace shows an HTML report was generated, moved to `/tmp/structure-governance-report/structure-governance-report.html`, verified non-empty, and linked in the final response. |
-| `scope_six_role_dirs` | PASS | The audit command explicitly iterates over docs/pm, docs/engineer, docs/design, docs/qa, docs/devops, and docs/security, recording missing roots as scan limitations. |
-| `structural_change_requires_confirmation` | PASS | No structural change was proposed or executed; the final result says no adjustment is currently needed and reports no repository modifications. |
+| `routes_to_structure_governance` | PASS | Raw trace records selection of `idea-to-spec:structure-governance` as the PM specialist route. |
+| `read_only_audit` | PASS | Candidate output states the audit was read-only; git evidence shows unchanged HEAD, branch, status, and diffs. |
+| `report_form` | PASS | Raw trace proves an HTML report was written under `/tmp/structure-governance.7BCSp7/`, verified its size, and showed clean git status; output provides a summary and report link. |
+| `scope_six_role_dirs` | PASS | Raw trace scans all six required roots and the report records the four missing role roots as coverage limitations. |
+| `structural_change_requires_confirmation` | PASS | Report and trace state no structural change was executed; future move/split operations require confirmation and `change_tier: major`. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=78a9ed4a2ff6af194b93c81277958547f5a87533a70b2aa14e43822f139e54d3; fixture_sha256=1a6d7fa4c22a394f3c854eef7a25f4d0cf2e6b4ecd7c7a3d3bf15d295d6e43f8; output_sha256=826028ad2c2bc0db291803b71abe68e33e6e28b3584c5eb0de9911ff2d9d91fe; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly routed to structure governance, audited all six role-directory scopes read-only, produced a temporary HTML report, and made no repository changes.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=78a9ed4a2ff6af194b93c81277958547f5a87533a70b2aa14e43822f139e54d3; fixture_sha256=1a6d7fa4c22a394f3c854eef7a25f4d0cf2e6b4ecd7c7a3d3bf15d295d6e43f8; output_sha256=dab979c4e20d389443772979825d24e937f95c9c37c66c4a3e3d3954e9cef490; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly routed and completed a read-only six-role structure audit, produced the runtime HTML report, and preserved the repository unchanged.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=78a9ed4a2ff6af194b93c81277958547f5a87533a70b2aa14e43822f139e54d3; fixture_sha256=1a6d7fa4c22a394f3c854eef7a25f4d0cf2e6b4ecd7c7a3d3bf15d295d6e43f8; output_sha256=3c2465376532d652a4a4c6f9cc0180f8d5a17470e9a2589c4ca8ee1daa014004; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Provided a basic read-only report covering only the two existing role directories; it did not demonstrate the required specialized route, six-directory scope, or HTML report delivery.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=78a9ed4a2ff6af194b93c81277958547f5a87533a70b2aa14e43822f139e54d3; fixture_sha256=1a6d7fa4c22a394f3c854eef7a25f4d0cf2e6b4ecd7c7a3d3bf15d295d6e43f8; output_sha256=9560ebdbea487676678c5228957740782c0b06e52a2d1a76c7f817aa45f048ec; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline inspected only PM and Engineer content, omitted the required six-role scope and runtime HTML report, and did not use the structure-governance route.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-020-route-read-only-diagnosis/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-020-route-read-only-diagnosis/comparison.md
@@ -13,8 +13,8 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `0c37c580ec355abeaea3f2fc33d6ed8061916801102550f7da9905107759e638` from `agents/product_manager/test/pm-agent/evals/workspace/eval-020-route-read-only-diagnosis`.
 - Identity schema: `2`
-- target_skill_sha256: `f9ea1bade234ebfd780e1e4773d4808a60f7baa61920e5859daea2b146c1ce93`
-- eval_definition_sha256: `5311d447a76e8a9004cf025f69ba69a2ff818f798cd0da111a4a59a3c163d9c4`
+- target_skill_sha256: `28ec452f7594200030ea15ffdc8d5edc9ae2298318457884574b818964824cf6`
+- eval_definition_sha256: `ac2e29c8ea600b5bded6655e93f469267e3a3d70f27c2a43049a20f14780fa3c`
 - metadata_sha256: `3d6c30e198147d6fb34935d3b67ffafc86dff73948d015dcf7a4222ccb03c281`
 - fixture_sha256: `0c37c580ec355abeaea3f2fc33d6ed8061916801102550f7da9905107759e638`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
@@ -22,37 +22,37 @@
 - judge_schema_sha256: `25ec3d21dbc5318b2aa7981fadceeb5bd08d4e0daef2594dfe1fa5018e038ab2`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `548143066f55535e284127a49d04caed1052641b0e381dde2aacad45c5301978`
-- Repository HEAD: `2ac10136f4ed18048058361915e66c52b4e038c5`
+- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `84ad07662e525000bb3bbf1da6aa3f2d49322c424326b70644431a72cdb52c55`
+- Skill overlay SHA-256: `8041f8266999d0ba9597ccc13e0354e28fcccb4a3b921ae9b5b9d1e08fe1da7b`
 - Behavior result: **PASS**
-- Coverage result: **FULL**
-Overall result: PASS
+- Coverage result: **PARTIAL**
+Overall result: PASS (partial coverage)
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `classifies_read_only_bug_report` | PASS | With-skill output explicitly includes `request_type: bug_report` and `mode: diagnosis_only`. |
-| `sets_zero_mutation_boundary` | PASS | With-skill handoff includes `allowed_mutations: none` and prohibits code, tests, configuration, database, external-state, commit, push, and PR changes; git evidence also shows no mutation. |
-| `allows_unaligned_diagnosis_handoff` | PASS | With-skill output routes to Engineer for read-only evidence collection, states expected behavior is unaligned, and says the system root cause cannot yet be confirmed; no repair is entered. |
+| `classifies_read_only_bug_report` | PASS | with_skill explicitly sets `request_type: bug_report` and `mode: diagnosis_only`, with an evidence-based diagnosis output and no repair activity. |
+| `sets_zero_mutation_boundary` | PASS | with_skill states `allowed_mutations: none` and explicitly prohibits code, tests, configuration, database, external-state, commit, push, and PR changes; git evidence shows no changes. |
+| `allows_unaligned_diagnosis_handoff` | NOT_EXERCISED | The output records missing expectation documents and keeps the expectation unaligned, but no Engineer/debugger handoff is actually exercised in the locked evidence. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=548143066f55535e284127a49d04caed1052641b0e381dde2aacad45c5301978; fixture_sha256=0c37c580ec355abeaea3f2fc33d6ed8061916801102550f7da9905107759e638; output_sha256=e2ec9ebb205a99b7f08c546d8c2eb269644524f9de7a43e8950282516db43ed7; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly classifies the request, establishes a zero-mutation diagnosis boundary, and provides an unaligned Engineer handoff despite missing expectation documents.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=548143066f55535e284127a49d04caed1052641b0e381dde2aacad45c5301978; fixture_sha256=0c37c580ec355abeaea3f2fc33d6ed8061916801102550f7da9905107759e638; output_sha256=8680d933ecfae25705c995e4982914f97deef59212b0b8a5bb7b1e5ad8dee013; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly classified and completed a read-only diagnosis with an explicit zero-mutation boundary; no downstream handoff was exercised.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=548143066f55535e284127a49d04caed1052641b0e381dde2aacad45c5301978; fixture_sha256=0c37c580ec355abeaea3f2fc33d6ed8061916801102550f7da9905107759e638; output_sha256=3fad9ff42aadd98c2a8d95754cab89c55be694229505ca2c92654883972a8662; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Provides a read-only incident diagnosis and confirms no mutation, but does not provide the required structured classification or Engineer handoff.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=548143066f55535e284127a49d04caed1052641b0e381dde2aacad45c5301978; fixture_sha256=0c37c580ec355abeaea3f2fc33d6ed8061916801102550f7da9905107759e638; output_sha256=99032faa284982fe49c1476ec4eae30870d4e7a1625ccc7326ab7eb0ca0dbe68; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Performed a read-only evidence review and reported a plausible diagnosis, but did not provide the structured routing and mutation-boundary packet.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: None.
+- Next: If the workflow continues, obtain the missing expectation and runtime evidence before handing off to Engineer/debugger.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-020-route-read-only-diagnosis/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-020-route-read-only-diagnosis/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `0c37c580ec355abeaea3f2fc33d6ed8061916801102550f7da9905107759e638` from `agents/product_manager/test/pm-agent/evals/workspace/eval-020-route-read-only-diagnosis`.
 - Identity schema: `2`
-- target_skill_sha256: `28ec452f7594200030ea15ffdc8d5edc9ae2298318457884574b818964824cf6`
+- target_skill_sha256: `cec475406cc49b4c9cebbfe9c62f8f1a19fc3e7ced9282825f8f2930bab1478a`
 - eval_definition_sha256: `ac2e29c8ea600b5bded6655e93f469267e3a3d70f27c2a43049a20f14780fa3c`
 - metadata_sha256: `3d6c30e198147d6fb34935d3b67ffafc86dff73948d015dcf7a4222ccb03c281`
 - fixture_sha256: `0c37c580ec355abeaea3f2fc33d6ed8061916801102550f7da9905107759e638`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `25ec3d21dbc5318b2aa7981fadceeb5bd08d4e0daef2594dfe1fa5018e038ab2`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `548143066f55535e284127a49d04caed1052641b0e381dde2aacad45c5301978`
-- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
+- Repository HEAD: `133a65e3c3b501be88257e9d3a557af4d5ccd242`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `8041f8266999d0ba9597ccc13e0354e28fcccb4a3b921ae9b5b9d1e08fe1da7b`
+- Skill overlay SHA-256: `5047311446f87e0c9eb6ef7577938db174e729f8d09b2851971cbb87a063bf63`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,26 +33,26 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `classifies_read_only_bug_report` | PASS | with_skill explicitly sets `request_type: bug_report` and `mode: diagnosis_only`, with an evidence-based diagnosis output and no repair activity. |
-| `sets_zero_mutation_boundary` | PASS | with_skill states `allowed_mutations: none` and explicitly prohibits code, tests, configuration, database, external-state, commit, push, and PR changes; git evidence shows no changes. |
-| `allows_unaligned_diagnosis_handoff` | NOT_EXERCISED | The output records missing expectation documents and keeps the expectation unaligned, but no Engineer/debugger handoff is actually exercised in the locked evidence. |
+| `classifies_read_only_bug_report` | PASS | With-skill output explicitly records `request_type: bug_report` and `mode: diagnosis_only`, states the conclusion is read-only, and does not enter repair. |
+| `sets_zero_mutation_boundary` | PASS | With-skill output records `allowed_mutations: none`, states no code, configuration, external state, or Git content was modified, and locked git evidence shows unchanged HEAD/branch, no diffs, and no new commits. |
+| `allows_unaligned_diagnosis_handoff` | NOT_EXERCISED | The candidate identifies Engineer as the downstream owner and marks the handoff blocked because engineer-agent is unavailable. The later handoff cannot be exercised, so the locked evidence cannot establish the required unaligned expectation. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=548143066f55535e284127a49d04caed1052641b0e381dde2aacad45c5301978; fixture_sha256=0c37c580ec355abeaea3f2fc33d6ed8061916801102550f7da9905107759e638; output_sha256=8680d933ecfae25705c995e4982914f97deef59212b0b8a5bb7b1e5ad8dee013; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly classified and completed a read-only diagnosis with an explicit zero-mutation boundary; no downstream handoff was exercised.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=548143066f55535e284127a49d04caed1052641b0e381dde2aacad45c5301978; fixture_sha256=0c37c580ec355abeaea3f2fc33d6ed8061916801102550f7da9905107759e638; output_sha256=f8ea82dffb299e02638192ef9c62b8bb0ca5e72d6e1f8614250002ed179570a6; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly classified the request as read-only bug diagnosis, enforced a zero-mutation outcome, and stopped at a blocked downstream handoff.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=548143066f55535e284127a49d04caed1052641b0e381dde2aacad45c5301978; fixture_sha256=0c37c580ec355abeaea3f2fc33d6ed8061916801102550f7da9905107759e638; output_sha256=99032faa284982fe49c1476ec4eae30870d4e7a1625ccc7326ab7eb0ca0dbe68; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Performed a read-only evidence review and reported a plausible diagnosis, but did not provide the structured routing and mutation-boundary packet.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=548143066f55535e284127a49d04caed1052641b0e381dde2aacad45c5301978; fixture_sha256=0c37c580ec355abeaea3f2fc33d6ed8061916801102550f7da9905107759e638; output_sha256=495aeb8006752f3e11b49c6247a8c48a12d167ce359e4ff10aca7f4557c837d9; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Produced a read-only evidence summary and preserved workspace state, but did not provide the explicit bug-report routing and downstream handoff classification.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: If the workflow continues, obtain the missing expectation and runtime evidence before handing off to Engineer/debugger.
+- Next: Provide the unavailable Engineer/debugger capability or runtime evidence to exercise the unaligned diagnosis handoff.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-020-route-read-only-diagnosis/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-020-route-read-only-diagnosis/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `0c37c580ec355abeaea3f2fc33d6ed8061916801102550f7da9905107759e638` from `agents/product_manager/test/pm-agent/evals/workspace/eval-020-route-read-only-diagnosis`.
 - Identity schema: `2`
-- target_skill_sha256: `cec475406cc49b4c9cebbfe9c62f8f1a19fc3e7ced9282825f8f2930bab1478a`
+- target_skill_sha256: `a37bf10fca64a8e15e6213ecdd45b65783814d307c78fd8d8ce6ab45b20effef`
 - eval_definition_sha256: `ac2e29c8ea600b5bded6655e93f469267e3a3d70f27c2a43049a20f14780fa3c`
 - metadata_sha256: `3d6c30e198147d6fb34935d3b67ffafc86dff73948d015dcf7a4222ccb03c281`
 - fixture_sha256: `0c37c580ec355abeaea3f2fc33d6ed8061916801102550f7da9905107759e638`
@@ -22,37 +22,37 @@
 - judge_schema_sha256: `25ec3d21dbc5318b2aa7981fadceeb5bd08d4e0daef2594dfe1fa5018e038ab2`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `548143066f55535e284127a49d04caed1052641b0e381dde2aacad45c5301978`
-- Repository HEAD: `133a65e3c3b501be88257e9d3a557af4d5ccd242`
+- Repository HEAD: `3f5e81c4837ef85284a7d5381575e40267796c92`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `5047311446f87e0c9eb6ef7577938db174e729f8d09b2851971cbb87a063bf63`
+- Skill overlay SHA-256: `6f4abf80e411dc3e6124c51093f07046c341195b1b2f0e9981a535c9960cb623`
 - Behavior result: **PASS**
-- Coverage result: **PARTIAL**
-Overall result: PASS (partial coverage)
+- Coverage result: **FULL**
+Overall result: PASS
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `classifies_read_only_bug_report` | PASS | With-skill output explicitly records `request_type: bug_report` and `mode: diagnosis_only`, states the conclusion is read-only, and does not enter repair. |
-| `sets_zero_mutation_boundary` | PASS | With-skill output records `allowed_mutations: none`, states no code, configuration, external state, or Git content was modified, and locked git evidence shows unchanged HEAD/branch, no diffs, and no new commits. |
-| `allows_unaligned_diagnosis_handoff` | NOT_EXERCISED | The candidate identifies Engineer as the downstream owner and marks the handoff blocked because engineer-agent is unavailable. The later handoff cannot be exercised, so the locked evidence cannot establish the required unaligned expectation. |
+| `classifies_read_only_bug_report` | PASS | With-skill output explicitly routes `request_type: bug_report`, `mode: diagnosis_only`, and reports diagnosis without repair. |
+| `sets_zero_mutation_boundary` | PASS | With-skill output states `allowed_mutations: none`, explicitly prohibits code/config/database/external-state changes, commits, pushes, and PRs; Git evidence shows no changes. |
+| `allows_unaligned_diagnosis_handoff` | PASS | With-skill output selects Engineer for diagnosis, records missing expectation documents and unresolved scope, preserves diagnosis-only mode, and explicitly blocks repair activity. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=548143066f55535e284127a49d04caed1052641b0e381dde2aacad45c5301978; fixture_sha256=0c37c580ec355abeaea3f2fc33d6ed8061916801102550f7da9905107759e638; output_sha256=f8ea82dffb299e02638192ef9c62b8bb0ca5e72d6e1f8614250002ed179570a6; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly classified the request as read-only bug diagnosis, enforced a zero-mutation outcome, and stopped at a blocked downstream handoff.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=548143066f55535e284127a49d04caed1052641b0e381dde2aacad45c5301978; fixture_sha256=0c37c580ec355abeaea3f2fc33d6ed8061916801102550f7da9905107759e638; output_sha256=72ce1ba520a2b0b365e336a45de344912a69ee29ddb5912d393c43d64bfcc815; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly classified and handled the incident as read-only diagnosis, enforced zero mutation, and routed bounded evidence collection toward Engineer while keeping the issue unresolved.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=548143066f55535e284127a49d04caed1052641b0e381dde2aacad45c5301978; fixture_sha256=0c37c580ec355abeaea3f2fc33d6ed8061916801102550f7da9905107759e638; output_sha256=495aeb8006752f3e11b49c6247a8c48a12d167ce359e4ff10aca7f4557c837d9; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Produced a read-only evidence summary and preserved workspace state, but did not provide the explicit bug-report routing and downstream handoff classification.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=548143066f55535e284127a49d04caed1052641b0e381dde2aacad45c5301978; fixture_sha256=0c37c580ec355abeaea3f2fc33d6ed8061916801102550f7da9905107759e638; output_sha256=73689be2509a47623deb3e730b9d496090a2023c4576f79504342927ea1b7950; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Produced a sound read-only diagnosis and reported no mutations, but did not provide the structured routing or unaligned Engineer handoff context.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Provide the unavailable Engineer/debugger capability or runtime evidence to exercise the unaligned diagnosis handoff.
+- Next: None.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-021-explicit-downstream-specialist/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-021-explicit-downstream-specialist/comparison.md
@@ -1,0 +1,59 @@
+# Issue #246 Evaluation Result
+
+## Evaluation Target
+
+- Agent: `product_manager`
+- Skill: `pm-agent`
+- Eval: `eval-021-explicit-downstream-specialist`
+
+## Current Result
+
+- Evidence status: **FRESH**
+- Preflight status: **PASS**
+- Judge: third independent fresh judge completed after both candidates were locked.
+- Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-021-explicit-downstream-specialist`.
+- Identity schema: `2`
+- target_skill_sha256: `28ec452f7594200030ea15ffdc8d5edc9ae2298318457884574b818964824cf6`
+- eval_definition_sha256: `a25ca20a1c90e90d338261e574dc858caafd71ea93ffab13ce3ee97baade4f6a`
+- metadata_sha256: `bf4907e12cf8a260745ab453b9bfc3a973db822213c04dfc1fd4b12aa12abe46`
+- fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
+- execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
+- runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
+- judge_schema_sha256: `3f33b48ae2fadd32a7a427c016752f6b046526d0ebaaba93894c0042332f199e`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
+- Prompt SHA-256: `6d94c1e20b351f6a794e09a5d0bcf4a707e69174706c9af67660d890ea20adc0`
+- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
+- Repository worktree state: **DIRTY**
+- Skill overlay SHA-256: `7d53e861c15cad4cd024a9dabd716a69caec88b381a3a1cc15ff7acaa0596028`
+- Behavior result: **PASS**
+- Coverage result: **FULL**
+Overall result: PASS
+
+## Assertion Results
+
+| Assertion | Result | Evidence |
+| --- | --- | --- |
+| `uses_explicit_downstream_capability` | PASS | with_skill 保留并使用用户点名的 engineer-agent:codebase-analyzer，且通过其既有入口门禁处理请求；未改派其他 specialist。 |
+| `preserves_existing_entry_gate` | PASS | with_skill 根据 codebase-analyzer 的门禁将命名请求返回 pm-agent，标记 entry_basis=blocked、next_action=返回 pm-agent，并未生成产品名称；只读检查且无文件变更。 |
+
+## With-Skill Behavior
+
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=6d94c1e20b351f6a794e09a5d0bcf4a707e69174706c9af67660d890ea20adc0; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=5052e71c5d6bbc230bbf73c6737f6718b64330a82abd51238d8a17c00540039a; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 显式识别并检查 codebase-analyzer 入口，遵守门禁将请求返回 pm-agent，要求补充产品定位后再继续。
+- The with-skill context was created only after the baseline evidence was locked and destroyed.
+
+## Fresh Without-Skill Baseline
+
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=6d94c1e20b351f6a794e09a5d0bcf4a707e69174706c9af67660d890ea20adc0; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=2fc536e8a43880c798ea8046e8ab34e71cb5ada5a987b385abc47e6ebd0c859a; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 显式调用 codebase-analyzer 后直接分析空仓库并生成产品名称，未遵守其既有 PM 入口门禁。
+- The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
+
+## Failures and Next Steps
+
+- None.
+- Next: None.
+
+## Runtime Artifact Policy
+
+- Candidate outputs, snapshots, judge packages, verdict payloads, timing, diagnostics, and other runtime files are deleted before the runner exits, including after FAIL, BLOCKED, or exceptions.
+- This durable comparison retains only the latest reviewable conclusion; Git history preserves earlier revisions.

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-021-explicit-downstream-specialist/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-021-explicit-downstream-specialist/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-021-explicit-downstream-specialist`.
 - Identity schema: `2`
-- target_skill_sha256: `28ec452f7594200030ea15ffdc8d5edc9ae2298318457884574b818964824cf6`
+- target_skill_sha256: `cec475406cc49b4c9cebbfe9c62f8f1a19fc3e7ced9282825f8f2930bab1478a`
 - eval_definition_sha256: `a25ca20a1c90e90d338261e574dc858caafd71ea93ffab13ce3ee97baade4f6a`
 - metadata_sha256: `bf4907e12cf8a260745ab453b9bfc3a973db822213c04dfc1fd4b12aa12abe46`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `3f33b48ae2fadd32a7a427c016752f6b046526d0ebaaba93894c0042332f199e`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `6d94c1e20b351f6a794e09a5d0bcf4a707e69174706c9af67660d890ea20adc0`
-- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
+- Repository HEAD: `133a65e3c3b501be88257e9d3a557af4d5ccd242`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `7d53e861c15cad4cd024a9dabd716a69caec88b381a3a1cc15ff7acaa0596028`
+- Skill overlay SHA-256: `1a82254c5c5bfa1d7e697ff009c645ec152b12fd65cded8beca63e20954b94ec`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,19 +33,19 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `uses_explicit_downstream_capability` | PASS | with_skill 保留并使用用户点名的 engineer-agent:codebase-analyzer，且通过其既有入口门禁处理请求；未改派其他 specialist。 |
-| `preserves_existing_entry_gate` | PASS | with_skill 根据 codebase-analyzer 的门禁将命名请求返回 pm-agent，标记 entry_basis=blocked、next_action=返回 pm-agent，并未生成产品名称；只读检查且无文件变更。 |
+| `uses_explicit_downstream_capability` | PASS | with_skill 输出明确点名 engineer-agent:codebase-analyzer；trace 中读取并依据 pm-agent 与 codebase-analyzer 的入口规则，selected_owner 保持为该能力。 |
+| `preserves_existing_entry_gate` | PASS | with_skill 输出将 entry_basis 判为 missing，返回 pm-agent:idea-to-spec，并明确禁止代码库分析、工程规划和实现，未生成产品名称；这符合 codebase-analyzer 的既有 gate。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=6d94c1e20b351f6a794e09a5d0bcf4a707e69174706c9af67660d890ea20adc0; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=5052e71c5d6bbc230bbf73c6737f6718b64330a82abd51238d8a17c00540039a; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 显式识别并检查 codebase-analyzer 入口，遵守门禁将请求返回 pm-agent，要求补充产品定位后再继续。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=6d94c1e20b351f6a794e09a5d0bcf4a707e69174706c9af67660d890ea20adc0; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=4cbc69bf42623c3e9c7882b10774a5fefafeea6eb29454216dd66516e404150a; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 显式使用并检查被点名能力的既有入口 gate；因缺少项目上下文而返回 PM 分类，未执行代码分析或命名。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=6d94c1e20b351f6a794e09a5d0bcf4a707e69174706c9af67660d890ea20adc0; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=2fc536e8a43880c798ea8046e8ab34e71cb5ada5a987b385abc47e6ebd0c859a; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 显式调用 codebase-analyzer 后直接分析空仓库并生成产品名称，未遵守其既有 PM 入口门禁。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=6d94c1e20b351f6a794e09a5d0bcf4a707e69174706c9af67660d890ea20adc0; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=33465e8758ca9b4e82a624a9582ce0bb80e0fa25b77ef1314716927fec72fb86; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 声称调用 codebase-analyzer 并继续分析空仓库，随后直接生成产品名称，未保留既有门禁行为。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-021-explicit-downstream-specialist/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-021-explicit-downstream-specialist/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-021-explicit-downstream-specialist`.
 - Identity schema: `2`
-- target_skill_sha256: `cec475406cc49b4c9cebbfe9c62f8f1a19fc3e7ced9282825f8f2930bab1478a`
+- target_skill_sha256: `a37bf10fca64a8e15e6213ecdd45b65783814d307c78fd8d8ce6ab45b20effef`
 - eval_definition_sha256: `a25ca20a1c90e90d338261e574dc858caafd71ea93ffab13ce3ee97baade4f6a`
 - metadata_sha256: `bf4907e12cf8a260745ab453b9bfc3a973db822213c04dfc1fd4b12aa12abe46`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `3f33b48ae2fadd32a7a427c016752f6b046526d0ebaaba93894c0042332f199e`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `6d94c1e20b351f6a794e09a5d0bcf4a707e69174706c9af67660d890ea20adc0`
-- Repository HEAD: `133a65e3c3b501be88257e9d3a557af4d5ccd242`
+- Repository HEAD: `3f5e81c4837ef85284a7d5381575e40267796c92`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `1a82254c5c5bfa1d7e697ff009c645ec152b12fd65cded8beca63e20954b94ec`
+- Skill overlay SHA-256: `85b3dc3a707d3ddd63729c1517ef95f0e7bebc3e7da84a79200204d57f127d26`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,19 +33,19 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `uses_explicit_downstream_capability` | PASS | with_skill 输出明确点名 engineer-agent:codebase-analyzer；trace 中读取并依据 pm-agent 与 codebase-analyzer 的入口规则，selected_owner 保持为该能力。 |
-| `preserves_existing_entry_gate` | PASS | with_skill 输出将 entry_basis 判为 missing，返回 pm-agent:idea-to-spec，并明确禁止代码库分析、工程规划和实现，未生成产品名称；这符合 codebase-analyzer 的既有 gate。 |
+| `uses_explicit_downstream_capability` | PASS | with_skill 输出明确检查并进入 engineer-agent:codebase-analyzer；原始 trace 显示读取 pm-agent、engineer-agent 与 analyzer 的入口规则，并据此完成路由。 |
+| `preserves_existing_entry_gate` | PASS | with_skill 输出将 selected_owner 设为 pm-agent:idea-to-spec、entry_basis 设为 blocked，未生成产品名称，而是提出 PM 产品发现所需的澄清问题；这符合 codebase-analyzer 的既有入口门禁。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=6d94c1e20b351f6a794e09a5d0bcf4a707e69174706c9af67660d890ea20adc0; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=4cbc69bf42623c3e9c7882b10774a5fefafeea6eb29454216dd66516e404150a; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 显式使用并检查被点名能力的既有入口 gate；因缺少项目上下文而返回 PM 分类，未执行代码分析或命名。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=6d94c1e20b351f6a794e09a5d0bcf4a707e69174706c9af67660d890ea20adc0; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=a25aea8eae1ed767f52af59d50b8e268c837f97612057a701e642d044c9027b8; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 显式进入 engineer-agent:codebase-analyzer 并遵守其入口门禁，将产品命名请求返回 PM 分类，未直接命名。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=6d94c1e20b351f6a794e09a5d0bcf4a707e69174706c9af67660d890ea20adc0; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=33465e8758ca9b4e82a624a9582ce0bb80e0fa25b77ef1314716927fec72fb86; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 声称调用 codebase-analyzer 并继续分析空仓库，随后直接生成产品名称，未保留既有门禁行为。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=6d94c1e20b351f6a794e09a5d0bcf4a707e69174706c9af67660d890ea20adc0; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=b62171bba0c2ab845efc19ed9c40213f5a476373d097a324fc7cb7923c7c58c9; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 声称使用 codebase-analyzer，但实际继续执行代码库分析并直接给出产品名称，未保留 PM 入口门禁。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-021-explicit-downstream-specialist/eval_metadata.json
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-021-explicit-downstream-specialist/eval_metadata.json
@@ -1,0 +1,18 @@
+{
+  "eval_id": "eval-021-explicit-downstream-specialist",
+  "eval_name": "explicit-downstream-specialist",
+  "workspace_root": "agents/product_manager/test/pm-agent/evals/workspace/eval-021-explicit-downstream-specialist",
+  "fixture_context": [],
+  "skill_dependencies": [
+    "agents/engineer/skills/engineer-agent",
+    "agents/engineer/skills/codebase-analyzer"
+  ],
+  "runtime_isolation": {
+    "processes": "not_used",
+    "ports": "not_used",
+    "database": "not_used",
+    "browser": "not_used",
+    "login_state": "not_used",
+    "downloads": "not_used"
+  }
+}

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-1-route-greenfield-product-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-1-route-greenfield-product-request/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-1-route-greenfield-product-request`.
 - Identity schema: `2`
-- target_skill_sha256: `cec475406cc49b4c9cebbfe9c62f8f1a19fc3e7ced9282825f8f2930bab1478a`
+- target_skill_sha256: `a37bf10fca64a8e15e6213ecdd45b65783814d307c78fd8d8ce6ab45b20effef`
 - eval_definition_sha256: `4e776e14ac2c8d3f3aa33718b92238355ee2d15eab3267a50cdada6bb3d4a1de`
 - metadata_sha256: `98a5616a9f22e4ba7d6ed10c98a36b572ccd9f5c0bfcfaf868ea982ef672635f`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `8e99b873e976898a8a9714405f69dce2d81e6c553f7d4c2b0a99b8b832eee831`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `acfb6edf3aff0b94988c5e9a7ff435967801458a79c851afd902400163536b81`
-- Repository HEAD: `133a65e3c3b501be88257e9d3a557af4d5ccd242`
+- Repository HEAD: `3f5e81c4837ef85284a7d5381575e40267796c92`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `5047311446f87e0c9eb6ef7577938db174e729f8d09b2851971cbb87a063bf63`
+- Skill overlay SHA-256: `6f4abf80e411dc3e6124c51093f07046c341195b1b2f0e9981a535c9960cb623`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,28 +33,28 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `route_to_idea_to_spec` | PASS | With_skill explicitly selects `idea-to-spec` and `greenfield-discovery`, keeps the feature path unresolved, and states it will not enter design, engineering, or testing. |
-| `pm_first_guardrail` | PASS | With_skill identifies `project_status: empty`, frames the request as product discovery, and explicitly says not to write code or create formal documents yet. |
-| `context_to_collect` | PASS | With_skill asks the highest-information first discovery question: who the assistant primarily serves, with user-segment options tied to core scenarios. |
-| `expected_pm_artifacts` | NOT_EXERCISED | The interaction is still waiting for the user's answer to the first discovery question; no discovery-complete claim or handoff occurred, so PM artifacts are not yet exercised. |
-| `handoff_boundary` | NOT_EXERCISED | Only the first discovery question was asked and no handoff occurred, so the later handoff boundary is not exercised. |
+| `route_to_idea_to_spec` | PASS | With-skill output identifies a greenfield discovery lane, keeps feature_path unresolved, and continues product definition for the AI assistant. |
+| `pm_first_guardrail` | PASS | With-skill output recognizes the empty-directory context, keeps scope unresolved, and explicitly states it will not write code or perform technical implementation. |
+| `context_to_collect` | PASS | With-skill output asks the highest-information discovery question about the assistant's primary use case and requests the user's answer before proceeding. |
+| `expected_pm_artifacts` | NOT_EXERCISED | The with-skill lane explicitly keeps PRD / DECISIONS pending while awaiting the core direction, so discovery is not yet complete. |
+| `handoff_boundary` | NOT_EXERCISED | No handoff occurs in the with-skill output; it remains at the first PM discovery question. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=acfb6edf3aff0b94988c5e9a7ff435967801458a79c851afd902400163536b81; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=2bf1fbdac04c9747c43b474e894f52acf3b598026022db54d6babbcb021c134f; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Routes the empty-directory product idea through PM and idea-to-spec discovery, asks a focused user-segment question, and preserves the no-code boundary.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=acfb6edf3aff0b94988c5e9a7ff435967801458a79c851afd902400163536b81; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=9fd14ddce425d122409287d93a082320ab2e698a101b12667af7769b0c386d35; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Routes the empty-directory idea into PM greenfield discovery, asks one focused product question, and preserves the no-code boundary.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=acfb6edf3aff0b94988c5e9a7ff435967801458a79c851afd902400163536b81; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=6b3bd5fce4da3cbf7a571053e7793c8d08faebe852f820e1639d5a0af568c41a; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Provides an extensive premature MVP/design proposal and asks several follow-up questions, without first narrowing the product through a PM discovery route.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=acfb6edf3aff0b94988c5e9a7ff435967801458a79c851afd902400163536b81; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=8b9f700db950b8616b0b11dfd80c008bd1757ad930a2457a389264d481ea351e; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Provides a broad speculative MVP and several discovery questions, including implementation-oriented scope, without an explicit PM route.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Continue discovery after the user answers the target-user question; then produce PRD/decision artifacts only once the required scope is confirmed.
+- Next: Obtain the user's answer to the primary use-case question, then continue discovery before producing PRD / DECISIONS or handing off.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-1-route-greenfield-product-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-1-route-greenfield-product-request/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-1-route-greenfield-product-request`.
 - Identity schema: `2`
-- target_skill_sha256: `28ec452f7594200030ea15ffdc8d5edc9ae2298318457884574b818964824cf6`
+- target_skill_sha256: `cec475406cc49b4c9cebbfe9c62f8f1a19fc3e7ced9282825f8f2930bab1478a`
 - eval_definition_sha256: `4e776e14ac2c8d3f3aa33718b92238355ee2d15eab3267a50cdada6bb3d4a1de`
 - metadata_sha256: `98a5616a9f22e4ba7d6ed10c98a36b572ccd9f5c0bfcfaf868ea982ef672635f`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `8e99b873e976898a8a9714405f69dce2d81e6c553f7d4c2b0a99b8b832eee831`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `acfb6edf3aff0b94988c5e9a7ff435967801458a79c851afd902400163536b81`
-- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
+- Repository HEAD: `133a65e3c3b501be88257e9d3a557af4d5ccd242`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `8041f8266999d0ba9597ccc13e0354e28fcccb4a3b921ae9b5b9d1e08fe1da7b`
+- Skill overlay SHA-256: `5047311446f87e0c9eb6ef7577938db174e729f8d09b2851971cbb87a063bf63`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,28 +33,28 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `route_to_idea_to_spec` | PASS | With-skill output explicitly selects `idea-to-spec`, identifies the greenfield-discovery lane, and keeps `feature_path` unresolved pending discovery. |
-| `pm_first_guardrail` | PASS | With-skill output identifies the project as empty, states that code will not be written, and prohibits implementation while product scope is unresolved. |
-| `context_to_collect` | PASS | With-skill output asks the highest-impact first discovery question: who the assistant primarily serves, with user/persona options. |
-| `expected_pm_artifacts` | NOT_EXERCISED | The output states discovery is still awaiting the first user answer and no formal documents are created; this assertion is therefore not exercised. |
-| `handoff_boundary` | NOT_EXERCISED | No handoff occurs; the output keeps design, engineering, and QA downstream pending PM scope confirmation. |
+| `route_to_idea_to_spec` | PASS | With_skill explicitly selects `idea-to-spec` and `greenfield-discovery`, keeps the feature path unresolved, and states it will not enter design, engineering, or testing. |
+| `pm_first_guardrail` | PASS | With_skill identifies `project_status: empty`, frames the request as product discovery, and explicitly says not to write code or create formal documents yet. |
+| `context_to_collect` | PASS | With_skill asks the highest-information first discovery question: who the assistant primarily serves, with user-segment options tied to core scenarios. |
+| `expected_pm_artifacts` | NOT_EXERCISED | The interaction is still waiting for the user's answer to the first discovery question; no discovery-complete claim or handoff occurred, so PM artifacts are not yet exercised. |
+| `handoff_boundary` | NOT_EXERCISED | Only the first discovery question was asked and no handoff occurred, so the later handoff boundary is not exercised. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=acfb6edf3aff0b94988c5e9a7ff435967801458a79c851afd902400163536b81; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=0cb958ddcaefe8963282d4311f44bb5c4011146f2b6fb18481e812fe649c689e; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly routes the empty-directory idea to PM product discovery, preserves the no-code boundary, and asks one focused user/persona question.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=acfb6edf3aff0b94988c5e9a7ff435967801458a79c851afd902400163536b81; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=2bf1fbdac04c9747c43b474e894f52acf3b598026022db54d6babbcb021c134f; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Routes the empty-directory product idea through PM and idea-to-spec discovery, asks a focused user-segment question, and preserves the no-code boundary.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=acfb6edf3aff0b94988c5e9a7ff435967801458a79c851afd902400163536b81; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=bb98c395a0be86ce5cfac0a69557c286466698d724f2a02e3e141c7b2321d65a; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Provides a broad MVP proposal and several follow-up questions, but does not establish the explicit PM route or focused first discovery gate.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=acfb6edf3aff0b94988c5e9a7ff435967801458a79c851afd902400163536b81; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=6b3bd5fce4da3cbf7a571053e7793c8d08faebe852f820e1639d5a0af568c41a; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Provides an extensive premature MVP/design proposal and asks several follow-up questions, without first narrowing the product through a PM discovery route.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Await the user's answer to the first product-discovery question before assessing PM artifacts or downstream handoff.
+- Next: Continue discovery after the user answers the target-user question; then produce PRD/decision artifacts only once the required scope is confirmed.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-1-route-greenfield-product-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-1-route-greenfield-product-request/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-1-route-greenfield-product-request`.
 - Identity schema: `2`
-- target_skill_sha256: `f9ea1bade234ebfd780e1e4773d4808a60f7baa61920e5859daea2b146c1ce93`
+- target_skill_sha256: `28ec452f7594200030ea15ffdc8d5edc9ae2298318457884574b818964824cf6`
 - eval_definition_sha256: `4e776e14ac2c8d3f3aa33718b92238355ee2d15eab3267a50cdada6bb3d4a1de`
 - metadata_sha256: `98a5616a9f22e4ba7d6ed10c98a36b572ccd9f5c0bfcfaf868ea982ef672635f`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `8e99b873e976898a8a9714405f69dce2d81e6c553f7d4c2b0a99b8b832eee831`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `acfb6edf3aff0b94988c5e9a7ff435967801458a79c851afd902400163536b81`
-- Repository HEAD: `2ac10136f4ed18048058361915e66c52b4e038c5`
+- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `84ad07662e525000bb3bbf1da6aa3f2d49322c424326b70644431a72cdb52c55`
+- Skill overlay SHA-256: `8041f8266999d0ba9597ccc13e0354e28fcccb4a3b921ae9b5b9d1e08fe1da7b`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,28 +33,28 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `route_to_idea_to_spec` | PASS | With_skill explicitly enters `idea-to-spec` greenfield discovery and remains in PM; it does not start engineering or implementation. |
-| `pm_first_guardrail` | PASS | With_skill identifies `project_status: empty`, keeps `confirmation_required: 是`, states the product is still in discovery, and says not to write code or persistent files. |
-| `context_to_collect` | PASS | With_skill asks the highest-information first discovery question about target users and primary tasks, with concrete options. |
-| `expected_pm_artifacts` | NOT_EXERCISED | The lane is still waiting for the user's answer and explicitly marks durable PM documents as pending; no completion or handoff is claimed. |
-| `handoff_boundary` | NOT_EXERCISED | No handoff occurs in this first-turn discovery exchange. |
+| `route_to_idea_to_spec` | PASS | With-skill output explicitly selects `idea-to-spec`, identifies the greenfield-discovery lane, and keeps `feature_path` unresolved pending discovery. |
+| `pm_first_guardrail` | PASS | With-skill output identifies the project as empty, states that code will not be written, and prohibits implementation while product scope is unresolved. |
+| `context_to_collect` | PASS | With-skill output asks the highest-impact first discovery question: who the assistant primarily serves, with user/persona options. |
+| `expected_pm_artifacts` | NOT_EXERCISED | The output states discovery is still awaiting the first user answer and no formal documents are created; this assertion is therefore not exercised. |
+| `handoff_boundary` | NOT_EXERCISED | No handoff occurs; the output keeps design, engineering, and QA downstream pending PM scope confirmation. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=acfb6edf3aff0b94988c5e9a7ff435967801458a79c851afd902400163536b81; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=80d44bdfb0001510ad1e07ebcb0df2b23ca66bf8c88fbab37ff49424e3754141; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly preserves the PM-first greenfield discovery boundary, asks one high-value product question, and avoids writing artifacts or code.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=acfb6edf3aff0b94988c5e9a7ff435967801458a79c851afd902400163536b81; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=0cb958ddcaefe8963282d4311f44bb5c4011146f2b6fb18481e812fe649c689e; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly routes the empty-directory idea to PM product discovery, preserves the no-code boundary, and asks one focused user/persona question.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=acfb6edf3aff0b94988c5e9a7ff435967801458a79c851afd902400163536b81; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=13a62384d2ecdd0faf7c0eda86ee4e8cc6b4bf094cbeb949fd578f76007a90d5; snapshot_sha256=c10df661dc85b072faaad491195be5d72790efa76ca5f77e8377c69ba0d1e221
-- Behavior: Produces a broad product-solution document before resolving the first discovery question, then asks several follow-up decisions; useful as a fresh baseline contrast.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=acfb6edf3aff0b94988c5e9a7ff435967801458a79c851afd902400163536b81; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=bb98c395a0be86ce5cfac0a69557c286466698d724f2a02e3e141c7b2321d65a; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Provides a broad MVP proposal and several follow-up questions, but does not establish the explicit PM route or focused first discovery gate.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Await the user's answer to the target-user and primary-task question, then continue MVP, non-goal, and success-criteria convergence within PM.
+- Next: Await the user's answer to the first product-discovery question before assessing PM artifacts or downstream handoff.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-10-change-tier-hotfix-fast-lane/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-10-change-tier-hotfix-fast-lane/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-10-change-tier-hotfix-fast-lane`.
 - Identity schema: `2`
-- target_skill_sha256: `cec475406cc49b4c9cebbfe9c62f8f1a19fc3e7ced9282825f8f2930bab1478a`
+- target_skill_sha256: `a37bf10fca64a8e15e6213ecdd45b65783814d307c78fd8d8ce6ab45b20effef`
 - eval_definition_sha256: `47a19a6c15b443fba6827b5bff8e5f73b3367c26176898038b1822e6a445e0c6`
 - metadata_sha256: `dd7edb355d66e4505d2039e9fe3eb4eb203c3d8b2cfcc299410f099efef7e166`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `bb0ee0282945f3d4f9dce339b9d8538e36a23ce40cb0cf92b33dc2be95234be0`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `c8036aad85835ee733e12f58737233d7e9bc1a90da347bec50e7094cf58797ad`
-- Repository HEAD: `133a65e3c3b501be88257e9d3a557af4d5ccd242`
+- Repository HEAD: `3f5e81c4837ef85284a7d5381575e40267796c92`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `5047311446f87e0c9eb6ef7577938db174e729f8d09b2851971cbb87a063bf63`
+- Skill overlay SHA-256: `6f4abf80e411dc3e6124c51093f07046c341195b1b2f0e9981a535c9960cb623`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `classify_hotfix` | PASS | with_skill 明确将 change_tier 设为 hotfix，并记录功能预期不变及链接已由用户确认可打开。 |
-| `allow_fast_lane` | PASS | with_skill 明确记录 fast_lane: allowed_after_classification，且 request_type 为 delivery。 |
-| `preserve_evidence` | PASS | with_skill 保留 confirmed_scope、feature_path_evidence、source_documents，并将验证链接列为 required_output；未因 hotfix 跳过验证要求。 |
+| `classify_hotfix` | PASS | with_skill output explicitly sets change_tier: hotfix and states the scope does not change functional expectations, with verification evidence required. |
+| `allow_fast_lane` | PASS | with_skill output explicitly states fast_lane: allowed_after_classification. |
+| `preserve_evidence` | PASS | with_skill output records confirmed_scope and source_documents, and requires README modification, verification evidence, and delivery artifacts; it does not waive verification for hotfix. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c8036aad85835ee733e12f58737233d7e9bc1a90da347bec50e7094cf58797ad; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=a834b735ca3d57dcb381d752db5cd227e0667b0a1cec19d4bd9275ef6c3fd9e8; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 完成 hotfix 分类、分类后 fast lane 判定，并保留范围与验证相关交付信息；因工作区缺少 README 和 Engineer 能力而停止执行。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c8036aad85835ee733e12f58737233d7e9bc1a90da347bec50e7094cf58797ad; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=fca2b58fbcd74a7bcbe54fb7df7bc411fd6a45e5b1c0db66448d4183200b9a85; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly classified the request as hotfix, allowed fast lane only after classification, preserved scope/source/verification evidence requirements, and refused to fabricate a delivery.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c8036aad85835ee733e12f58737233d7e9bc1a90da347bec50e7094cf58797ad; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=58abc56b1076d30ca66bc97a8e39a0aba2380eba7f2c1ce884e5b807f82b3f2e; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 仅报告空仓库并请求补充工作区，未进行 hotfix 分类或证据化路由。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c8036aad85835ee733e12f58737233d7e9bc1a90da347bec50e7094cf58797ad; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=28b95212cd62d11e027f6243d0576386d98ecc86a9e9dab9ee2c6e7e8ca4e254; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Reported the empty workspace and stopped without classifying the request or stating fast-lane and evidence-preservation rules.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-10-change-tier-hotfix-fast-lane/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-10-change-tier-hotfix-fast-lane/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-10-change-tier-hotfix-fast-lane`.
 - Identity schema: `2`
-- target_skill_sha256: `f9ea1bade234ebfd780e1e4773d4808a60f7baa61920e5859daea2b146c1ce93`
+- target_skill_sha256: `28ec452f7594200030ea15ffdc8d5edc9ae2298318457884574b818964824cf6`
 - eval_definition_sha256: `47a19a6c15b443fba6827b5bff8e5f73b3367c26176898038b1822e6a445e0c6`
 - metadata_sha256: `dd7edb355d66e4505d2039e9fe3eb4eb203c3d8b2cfcc299410f099efef7e166`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,36 +22,36 @@
 - judge_schema_sha256: `bb0ee0282945f3d4f9dce339b9d8538e36a23ce40cb0cf92b33dc2be95234be0`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `c8036aad85835ee733e12f58737233d7e9bc1a90da347bec50e7094cf58797ad`
-- Repository HEAD: `2ac10136f4ed18048058361915e66c52b4e038c5`
+- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `84ad07662e525000bb3bbf1da6aa3f2d49322c424326b70644431a72cdb52c55`
-- Behavior result: **FAIL**
+- Skill overlay SHA-256: `8041f8266999d0ba9597ccc13e0354e28fcccb4a3b921ae9b5b9d1e08fe1da7b`
+- Behavior result: **PASS**
 - Coverage result: **FULL**
-Overall result: FAIL
+Overall result: PASS
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `classify_hotfix` | FAIL | With_skill output only states that no enabled marker was detected and does not classify the request as hotfix. |
-| `allow_fast_lane` | FAIL | With_skill output does not explain that hotfix plus delivery/status requests may use fast lane after classification. |
-| `preserve_evidence` | FAIL | With_skill output does not require preserving scope, source evidence, and verification evidence. |
+| `classify_hotfix` | PASS | with_skill 的路由记录明确将 change_tier 设为 hotfix，并以“不改变功能预期”的范围说明为依据。 |
+| `allow_fast_lane` | PASS | with_skill 明确记录 fast_lane: allowed_after_classification，满足先分类、后进入 fast lane 的要求。 |
+| `preserve_evidence` | PASS | with_skill 保留了 confirmed_scope、source_documents（含用户范围与本地链接验证），并将直接验证列为 required_output；没有因 hotfix 省略验证要求。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c8036aad85835ee733e12f58737233d7e9bc1a90da347bec50e7094cf58797ad; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=42a1bd65a32094add34200781d583ca1c1061401746b9560123528fd4b45b5d9; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Stopped after reporting that no enabled marker was detected; provided no hotfix classification, fast-lane guidance, or evidence-preservation requirement.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c8036aad85835ee733e12f58737233d7e9bc1a90da347bec50e7094cf58797ad; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=03208fe24ffd679bb502e97a9f9160ff4f1e6e217a16b4e837b945f987d40911; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 正确识别 hotfix，允许分类后的 fast lane，并保留范围、来源与验证要求；交付执行因空仓库而受阻。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c8036aad85835ee733e12f58737233d7e9bc1a90da347bec50e7094cf58797ad; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=98f785d3c078496c5d5e9d1ee3c49c9f9cfc22872559bd1a0c248e15713079eb; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Reported an empty workspace and inability to perform the requested link repair; provided no classification or workflow guidance.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c8036aad85835ee733e12f58737233d7e9bc1a90da347bec50e7094cf58797ad; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=ba908d1473f76b0576e93c4c29993aecb018313fe507ae66b28b63bd6fd15fa1; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 仅报告空仓库并请求补充工作区，未进行 hotfix、fast lane 或证据保留分类。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- The with_skill lane omitted all three required user-visible guidance points and stopped on an unsupported workflow prerequisite.
+- None.
 - Next: None.
 
 ## Runtime Artifact Policy

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-10-change-tier-hotfix-fast-lane/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-10-change-tier-hotfix-fast-lane/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-10-change-tier-hotfix-fast-lane`.
 - Identity schema: `2`
-- target_skill_sha256: `28ec452f7594200030ea15ffdc8d5edc9ae2298318457884574b818964824cf6`
+- target_skill_sha256: `cec475406cc49b4c9cebbfe9c62f8f1a19fc3e7ced9282825f8f2930bab1478a`
 - eval_definition_sha256: `47a19a6c15b443fba6827b5bff8e5f73b3367c26176898038b1822e6a445e0c6`
 - metadata_sha256: `dd7edb355d66e4505d2039e9fe3eb4eb203c3d8b2cfcc299410f099efef7e166`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `bb0ee0282945f3d4f9dce339b9d8538e36a23ce40cb0cf92b33dc2be95234be0`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `c8036aad85835ee733e12f58737233d7e9bc1a90da347bec50e7094cf58797ad`
-- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
+- Repository HEAD: `133a65e3c3b501be88257e9d3a557af4d5ccd242`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `8041f8266999d0ba9597ccc13e0354e28fcccb4a3b921ae9b5b9d1e08fe1da7b`
+- Skill overlay SHA-256: `5047311446f87e0c9eb6ef7577938db174e729f8d09b2851971cbb87a063bf63`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `classify_hotfix` | PASS | with_skill 的路由记录明确将 change_tier 设为 hotfix，并以“不改变功能预期”的范围说明为依据。 |
-| `allow_fast_lane` | PASS | with_skill 明确记录 fast_lane: allowed_after_classification，满足先分类、后进入 fast lane 的要求。 |
-| `preserve_evidence` | PASS | with_skill 保留了 confirmed_scope、source_documents（含用户范围与本地链接验证），并将直接验证列为 required_output；没有因 hotfix 省略验证要求。 |
+| `classify_hotfix` | PASS | with_skill 明确将 change_tier 设为 hotfix，并记录功能预期不变及链接已由用户确认可打开。 |
+| `allow_fast_lane` | PASS | with_skill 明确记录 fast_lane: allowed_after_classification，且 request_type 为 delivery。 |
+| `preserve_evidence` | PASS | with_skill 保留 confirmed_scope、feature_path_evidence、source_documents，并将验证链接列为 required_output；未因 hotfix 跳过验证要求。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c8036aad85835ee733e12f58737233d7e9bc1a90da347bec50e7094cf58797ad; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=03208fe24ffd679bb502e97a9f9160ff4f1e6e217a16b4e837b945f987d40911; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 正确识别 hotfix，允许分类后的 fast lane，并保留范围、来源与验证要求；交付执行因空仓库而受阻。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c8036aad85835ee733e12f58737233d7e9bc1a90da347bec50e7094cf58797ad; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=a834b735ca3d57dcb381d752db5cd227e0667b0a1cec19d4bd9275ef6c3fd9e8; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 完成 hotfix 分类、分类后 fast lane 判定，并保留范围与验证相关交付信息；因工作区缺少 README 和 Engineer 能力而停止执行。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c8036aad85835ee733e12f58737233d7e9bc1a90da347bec50e7094cf58797ad; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=ba908d1473f76b0576e93c4c29993aecb018313fe507ae66b28b63bd6fd15fa1; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 仅报告空仓库并请求补充工作区，未进行 hotfix、fast lane 或证据保留分类。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c8036aad85835ee733e12f58737233d7e9bc1a90da347bec50e7094cf58797ad; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=58abc56b1076d30ca66bc97a8e39a0aba2380eba7f2c1ce884e5b807f82b3f2e; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 仅报告空仓库并请求补充工作区，未进行 hotfix 分类或证据化路由。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-11-change-tier-standard-full-gate/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-11-change-tier-standard-full-gate/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-11-change-tier-standard-full-gate`.
 - Identity schema: `2`
-- target_skill_sha256: `f9ea1bade234ebfd780e1e4773d4808a60f7baa61920e5859daea2b146c1ce93`
+- target_skill_sha256: `28ec452f7594200030ea15ffdc8d5edc9ae2298318457884574b818964824cf6`
 - eval_definition_sha256: `da85ba336c757be6c6ca84ef12c1d1a20655adb3e82559a2c2234b5462387973`
 - metadata_sha256: `6652dce9ab8a85ed09b58d853b1bdac1fd0f6f3e5ccd74f38c1d4aa6171a8cf4`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `e0fce32f646911cc00fe0709c7d0e934a3657054c9fc5a2efda7653a3ac97ea6`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `2c9f63eba393d7546f89112ce3f1659145dc2f6ca60bdba6ba71df10258a35a4`
-- Repository HEAD: `2ac10136f4ed18048058361915e66c52b4e038c5`
+- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `84ad07662e525000bb3bbf1da6aa3f2d49322c424326b70644431a72cdb52c55`
+- Skill overlay SHA-256: `8041f8266999d0ba9597ccc13e0354e28fcccb4a3b921ae9b5b9d1e08fe1da7b`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `classify_standard` | PASS | with_skill 明确给出 `change_tier: standard`，并将 `hotfix_disposition` 设为 `rejected`。 |
-| `require_prd_trd_alignment` | PASS | with_skill 要求先由 PM 对齐退款审批范围与管理员确认流程，形成 PRD/DECISIONS 更新，并明确禁止直接修改代码、测试或持久化文档。 |
-| `request_type_existing_update` | PASS | with_skill 在 Routing decision 中明确给出 `request_type: existing_update`，理由是修改现有退款审批业务规则。 |
+| `classify_standard` | PASS | With-skill output explicitly sets `change_tier: standard` and `hotfix_disposition: rejected`. |
+| `require_prd_trd_alignment` | PASS | With-skill output identifies missing PRD/TRD and states the next action is PM alignment and impact analysis, while setting `execution_boundary: 暂不修改代码、文档或测试`; this preserves alignment before downstream implementation. |
+| `request_type_existing_update` | PASS | With-skill output explicitly sets `request_type: existing_update` and describes changing an existing refund approval behavior. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2c9f63eba393d7546f89112ce3f1659145dc2f6ca60bdba6ba71df10258a35a4; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=03158aebbcc908ddeb6e80cf3a2c437720dda3ec2e7cbbc55ffc30526e464442; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 正确完成 standard、existing_update 分类，并在下游实现前设置产品预期对齐门禁；因需用户确认流程时点而停留在澄清阶段。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2c9f63eba393d7546f89112ce3f1659145dc2f6ca60bdba6ba71df10258a35a4; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=476ad3321b9f5afbfb443ac2c7e35bc410019dbda42b540dd1509f2f7a10a7db; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly classified the request as an existing standard update, rejected hotfix handling, and gated implementation on product/document alignment.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2c9f63eba393d7546f89112ce3f1659145dc2f6ca60bdba6ba71df10258a35a4; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=2e970a0f174cd9d1784e365ff0060660ac3db89eeabceb1a9fd75614cc3fe4bf; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 仅报告空工作区并请求补充项目目录，未完成请求分类或产品对齐门禁。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2c9f63eba393d7546f89112ce3f1659145dc2f6ca60bdba6ba71df10258a35a4; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=d0260b3e9680b8635e85b02841cc54c74d19e9c6039fed7c3266374ee4e0937d; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline searched the empty workspace and stopped without classification or alignment gating.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-11-change-tier-standard-full-gate/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-11-change-tier-standard-full-gate/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-11-change-tier-standard-full-gate`.
 - Identity schema: `2`
-- target_skill_sha256: `28ec452f7594200030ea15ffdc8d5edc9ae2298318457884574b818964824cf6`
+- target_skill_sha256: `cec475406cc49b4c9cebbfe9c62f8f1a19fc3e7ced9282825f8f2930bab1478a`
 - eval_definition_sha256: `da85ba336c757be6c6ca84ef12c1d1a20655adb3e82559a2c2234b5462387973`
 - metadata_sha256: `6652dce9ab8a85ed09b58d853b1bdac1fd0f6f3e5ccd74f38c1d4aa6171a8cf4`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,37 +22,37 @@
 - judge_schema_sha256: `e0fce32f646911cc00fe0709c7d0e934a3657054c9fc5a2efda7653a3ac97ea6`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `2c9f63eba393d7546f89112ce3f1659145dc2f6ca60bdba6ba71df10258a35a4`
-- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
+- Repository HEAD: `133a65e3c3b501be88257e9d3a557af4d5ccd242`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `8041f8266999d0ba9597ccc13e0354e28fcccb4a3b921ae9b5b9d1e08fe1da7b`
+- Skill overlay SHA-256: `5047311446f87e0c9eb6ef7577938db174e729f8d09b2851971cbb87a063bf63`
 - Behavior result: **PASS**
-- Coverage result: **FULL**
-Overall result: PASS
+- Coverage result: **PARTIAL**
+Overall result: PASS (partial coverage)
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `classify_standard` | PASS | With-skill output explicitly sets `change_tier: standard` and `hotfix_disposition: rejected`. |
-| `require_prd_trd_alignment` | PASS | With-skill output identifies missing PRD/TRD and states the next action is PM alignment and impact analysis, while setting `execution_boundary: 暂不修改代码、文档或测试`; this preserves alignment before downstream implementation. |
-| `request_type_existing_update` | PASS | With-skill output explicitly sets `request_type: existing_update` and describes changing an existing refund approval behavior. |
+| `classify_standard` | PASS | With-skill output explicitly classifies the change as standard and says it is not hotfix. |
+| `require_prd_trd_alignment` | NOT_EXERCISED | The candidate requires approval-semantics confirmation before implementation; downstream handoff cannot yet occur without user confirmation. |
+| `request_type_existing_update` | PASS | With-skill output identifies an existing behavior update, and the trace describes it as an existing behavior product-rule change. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2c9f63eba393d7546f89112ce3f1659145dc2f6ca60bdba6ba71df10258a35a4; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=476ad3321b9f5afbfb443ac2c7e35bc410019dbda42b540dd1509f2f7a10a7db; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly classified the request as an existing standard update, rejected hotfix handling, and gated implementation on product/document alignment.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2c9f63eba393d7546f89112ce3f1659145dc2f6ca60bdba6ba71df10258a35a4; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=d2ae2fad20a5304dbaf9b01bedf7b24e2b6c3933e6ab18496b0ea5397784b5ab; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly classified the request as a standard existing-behavior update, gated implementation on product expectation confirmation, and made no repository mutation.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2c9f63eba393d7546f89112ce3f1659145dc2f6ca60bdba6ba71df10258a35a4; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=d0260b3e9680b8635e85b02841cc54c74d19e9c6039fed7c3266374ee4e0937d; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Fresh baseline searched the empty workspace and stopped without classification or alignment gating.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2c9f63eba393d7546f89112ce3f1659145dc2f6ca60bdba6ba71df10258a35a4; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=1045ce581047e5e75cbec3ca893e74429a4cd841fd68a0a7ca2715d03524b83e; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline attempted implementation-oriented inspection without classification or alignment gating, then stopped only because the workspace was empty.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: None.
+- Next: Obtain user confirmation of the proposed approval semantics, then complete the required PRD/TRD or equivalent alignment before any downstream handoff.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-11-change-tier-standard-full-gate/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-11-change-tier-standard-full-gate/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-11-change-tier-standard-full-gate`.
 - Identity schema: `2`
-- target_skill_sha256: `cec475406cc49b4c9cebbfe9c62f8f1a19fc3e7ced9282825f8f2930bab1478a`
+- target_skill_sha256: `a37bf10fca64a8e15e6213ecdd45b65783814d307c78fd8d8ce6ab45b20effef`
 - eval_definition_sha256: `da85ba336c757be6c6ca84ef12c1d1a20655adb3e82559a2c2234b5462387973`
 - metadata_sha256: `6652dce9ab8a85ed09b58d853b1bdac1fd0f6f3e5ccd74f38c1d4aa6171a8cf4`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,37 +22,37 @@
 - judge_schema_sha256: `e0fce32f646911cc00fe0709c7d0e934a3657054c9fc5a2efda7653a3ac97ea6`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `2c9f63eba393d7546f89112ce3f1659145dc2f6ca60bdba6ba71df10258a35a4`
-- Repository HEAD: `133a65e3c3b501be88257e9d3a557af4d5ccd242`
+- Repository HEAD: `3f5e81c4837ef85284a7d5381575e40267796c92`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `5047311446f87e0c9eb6ef7577938db174e729f8d09b2851971cbb87a063bf63`
+- Skill overlay SHA-256: `6f4abf80e411dc3e6124c51093f07046c341195b1b2f0e9981a535c9960cb623`
 - Behavior result: **PASS**
-- Coverage result: **PARTIAL**
-Overall result: PASS (partial coverage)
+- Coverage result: **FULL**
+Overall result: PASS
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `classify_standard` | PASS | With-skill output explicitly classifies the change as standard and says it is not hotfix. |
-| `require_prd_trd_alignment` | NOT_EXERCISED | The candidate requires approval-semantics confirmation before implementation; downstream handoff cannot yet occur without user confirmation. |
-| `request_type_existing_update` | PASS | With-skill output identifies an existing behavior update, and the trace describes it as an existing behavior product-rule change. |
+| `classify_standard` | PASS | with_skill output explicitly sets change_tier to standard and hotfix_disposition to rejected. |
+| `require_prd_trd_alignment` | PASS | with_skill output requires confirmation of scope and approval boundaries, sets confirmation_required to true, and routes the next action to PM alignment before any Engineer handoff; no downstream implementation handoff occurs prematurely. |
+| `request_type_existing_update` | PASS | with_skill output explicitly sets request_type to existing_update and explains the change as modifying the existing refund approval behavior. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2c9f63eba393d7546f89112ce3f1659145dc2f6ca60bdba6ba71df10258a35a4; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=d2ae2fad20a5304dbaf9b01bedf7b24e2b6c3933e6ab18496b0ea5397784b5ab; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly classified the request as a standard existing-behavior update, gated implementation on product expectation confirmation, and made no repository mutation.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2c9f63eba393d7546f89112ce3f1659145dc2f6ca60bdba6ba71df10258a35a4; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=e005ea112e4284f52edcdfbe5e59c9f936284276e43a445b63d9c1c2ef0e5aa2; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly classified the request as an existing project update with standard-tier change handling, rejected hotfix treatment, and gated downstream work on PM/product-boundary alignment. No files or repository state were modified.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2c9f63eba393d7546f89112ce3f1659145dc2f6ca60bdba6ba71df10258a35a4; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=1045ce581047e5e75cbec3ca893e74429a4cd841fd68a0a7ca2715d03524b83e; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Fresh baseline attempted implementation-oriented inspection without classification or alignment gating, then stopped only because the workspace was empty.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2c9f63eba393d7546f89112ce3f1659145dc2f6ca60bdba6ba71df10258a35a4; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=a28507a7542ad282cf771f598484f0e216141b5e11e524082d8ae2be995709f8; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Could not classify or route the product change; it only reported that the workspace was empty and requested a project directory.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Obtain user confirmation of the proposed approval semantics, then complete the required PRD/TRD or equivalent alignment before any downstream handoff.
+- Next: None.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-12-change-tier-hotfix-abuse-blocked/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-12-change-tier-hotfix-abuse-blocked/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-12-change-tier-hotfix-abuse-blocked`.
 - Identity schema: `2`
-- target_skill_sha256: `f9ea1bade234ebfd780e1e4773d4808a60f7baa61920e5859daea2b146c1ce93`
+- target_skill_sha256: `28ec452f7594200030ea15ffdc8d5edc9ae2298318457884574b818964824cf6`
 - eval_definition_sha256: `757872d7dabcbeb5f63781cd39c51a0fbd55c644aaecd2a814401a4e784d4603`
 - metadata_sha256: `5be95630fc657c3ddfcd1eee211fb45bdc7cc20a37cf20c50f58a72635d4712c`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `05754bc7141a9de585a1127391112d0da97f3c7138eba96f4377a8a50be63d7c`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `fd21822d29f9f59daea200bd14c26fadf30442cbe2bd48489976827d9b597907`
-- Repository HEAD: `2ac10136f4ed18048058361915e66c52b4e038c5`
+- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `84ad07662e525000bb3bbf1da6aa3f2d49322c424326b70644431a72cdb52c55`
+- Skill overlay SHA-256: `8041f8266999d0ba9597ccc13e0354e28fcccb4a3b921ae9b5b9d1e08fe1da7b`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `reject_hotfix_abuse` | PASS | With_skill explicitly sets `hotfix_disposition: rejected` and states the change cannot be handled as a hotfix. |
-| `expectation_change_standard` | PASS | With_skill explicitly sets `change_tier: standard` and identifies the request as a business-expectation change. |
-| `block_or_return_pm` | PASS | With_skill blocks implementation and merge, requires PM scope and approval alignment, and requests missing project/approval materials before proceeding. |
+| `reject_hotfix_abuse` | PASS | With-skill output explicitly sets `hotfix_disposition: rejected` and states the change cannot be handled as a hotfix. |
+| `expectation_change_standard` | PASS | With-skill output explicitly sets `change_tier: standard` and identifies the request as a business-rule change. |
+| `block_or_return_pm` | PASS | With-skill output sets `entry_basis: blocked`, requires PM alignment, identifies missing approved documents and project code, and states that implementation, commits, pushes, and merging are prohibited. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=fd21822d29f9f59daea200bd14c26fadf30442cbe2bd48489976827d9b597907; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=bd46a5fc34647ef2b1d18a184bb1a3b3c8803b4d39eb2f27f966f4f042341d32; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Classified the request as standard, rejected hotfix handling, and kept it blocked in PM clarification due to missing project and approval evidence.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=fd21822d29f9f59daea200bd14c26fadf30442cbe2bd48489976827d9b597907; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=3e6a4015e04bd9149dae8f0f9e11884fedf6581b2a5eb3fa72c67840694d20b3; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly classified the request as a standard business-rule change, rejected hotfix handling, and blocked implementation/merge pending PM alignment and missing project evidence.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=fd21822d29f9f59daea200bd14c26fadf30442cbe2bd48489976827d9b597907; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=24617947cbbecd7e0db196d3dc7e26f93c0ba00f4965a7d417420d473848dee7; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Stopped because the repository was empty, without classifying the business-rule change or applying the required PM safeguards.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=fd21822d29f9f59daea200bd14c26fadf30442cbe2bd48489976827d9b597907; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=e709e848636f86d3e03ab1e0743d898b009915299905ee55dd1772fe2b29867b; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline only reported an empty repository and did not classify the request or establish the required PM/change-management boundaries.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-12-change-tier-hotfix-abuse-blocked/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-12-change-tier-hotfix-abuse-blocked/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-12-change-tier-hotfix-abuse-blocked`.
 - Identity schema: `2`
-- target_skill_sha256: `cec475406cc49b4c9cebbfe9c62f8f1a19fc3e7ced9282825f8f2930bab1478a`
+- target_skill_sha256: `a37bf10fca64a8e15e6213ecdd45b65783814d307c78fd8d8ce6ab45b20effef`
 - eval_definition_sha256: `757872d7dabcbeb5f63781cd39c51a0fbd55c644aaecd2a814401a4e784d4603`
 - metadata_sha256: `5be95630fc657c3ddfcd1eee211fb45bdc7cc20a37cf20c50f58a72635d4712c`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `05754bc7141a9de585a1127391112d0da97f3c7138eba96f4377a8a50be63d7c`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `fd21822d29f9f59daea200bd14c26fadf30442cbe2bd48489976827d9b597907`
-- Repository HEAD: `133a65e3c3b501be88257e9d3a557af4d5ccd242`
+- Repository HEAD: `3f5e81c4837ef85284a7d5381575e40267796c92`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `5047311446f87e0c9eb6ef7577938db174e729f8d09b2851971cbb87a063bf63`
+- Skill overlay SHA-256: `6f4abf80e411dc3e6124c51093f07046c341195b1b2f0e9981a535c9960cb623`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `reject_hotfix_abuse` | PASS | With-skill output explicitly sets `hotfix_disposition: rejected` and states the change cannot be handled as a hotfix. |
-| `expectation_change_standard` | PASS | With-skill output explicitly sets `change_tier: standard` for the 7-day to 30-day business-rule change. |
-| `block_or_return_pm` | PASS | With-skill output marks the request blocked, requires PM/product documentation and Engineer availability, and states no implementation or handoff execution occurred. |
+| `reject_hotfix_abuse` | PASS | With-skill output explicitly states hotfix is rejected and cannot be used for direct merging. |
+| `expectation_change_standard` | PASS | With-skill output explicitly classifies the change as standard. |
+| `block_or_return_pm` | PASS | With-skill output blocks modification/merge and requires PM confirmation before Engineer execution. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=fd21822d29f9f59daea200bd14c26fadf30442cbe2bd48489976827d9b597907; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=f16ef07b640b8914be82af5808056f8ac54672c1a1181f335edfb841359a229d; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly classified the request as a standard expectation change, rejected hotfix handling, and blocked execution pending PM/product and engineering prerequisites.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=fd21822d29f9f59daea200bd14c26fadf30442cbe2bd48489976827d9b597907; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=c5cf4464b5b6f95c4fe6b9d0b228bdcd17c3d8d8f0f82a9b34a39eff49791baa; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly classified the request as a standard expectation change, rejected hotfix handling, and blocked execution pending PM confirmation and required project evidence.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=fd21822d29f9f59daea200bd14c26fadf30442cbe2bd48489976827d9b597907; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=91f9bdcfbdb53ece8028187cd460d12263e07d93f99dc840f2a8cf76c07d98c9; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Fresh baseline attempted to locate and modify the trial-period implementation, then reported the empty repository; it did not apply the required PM governance classifications.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=fd21822d29f9f59daea200bd14c26fadf30442cbe2bd48489976827d9b597907; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=999f41a3b22f0cd65eb1cdf2287f7826cd5c2d4b8b87d98e187e372584a1aafd; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline only reported the empty repository and inability to modify it; it did not address the requested change classification or PM/hotfix safeguards.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-12-change-tier-hotfix-abuse-blocked/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-12-change-tier-hotfix-abuse-blocked/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-12-change-tier-hotfix-abuse-blocked`.
 - Identity schema: `2`
-- target_skill_sha256: `28ec452f7594200030ea15ffdc8d5edc9ae2298318457884574b818964824cf6`
+- target_skill_sha256: `cec475406cc49b4c9cebbfe9c62f8f1a19fc3e7ced9282825f8f2930bab1478a`
 - eval_definition_sha256: `757872d7dabcbeb5f63781cd39c51a0fbd55c644aaecd2a814401a4e784d4603`
 - metadata_sha256: `5be95630fc657c3ddfcd1eee211fb45bdc7cc20a37cf20c50f58a72635d4712c`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `05754bc7141a9de585a1127391112d0da97f3c7138eba96f4377a8a50be63d7c`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `fd21822d29f9f59daea200bd14c26fadf30442cbe2bd48489976827d9b597907`
-- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
+- Repository HEAD: `133a65e3c3b501be88257e9d3a557af4d5ccd242`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `8041f8266999d0ba9597ccc13e0354e28fcccb4a3b921ae9b5b9d1e08fe1da7b`
+- Skill overlay SHA-256: `5047311446f87e0c9eb6ef7577938db174e729f8d09b2851971cbb87a063bf63`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -34,19 +34,19 @@ Overall result: PASS
 | Assertion | Result | Evidence |
 | --- | --- | --- |
 | `reject_hotfix_abuse` | PASS | With-skill output explicitly sets `hotfix_disposition: rejected` and states the change cannot be handled as a hotfix. |
-| `expectation_change_standard` | PASS | With-skill output explicitly sets `change_tier: standard` and identifies the request as a business-rule change. |
-| `block_or_return_pm` | PASS | With-skill output sets `entry_basis: blocked`, requires PM alignment, identifies missing approved documents and project code, and states that implementation, commits, pushes, and merging are prohibited. |
+| `expectation_change_standard` | PASS | With-skill output explicitly sets `change_tier: standard` for the 7-day to 30-day business-rule change. |
+| `block_or_return_pm` | PASS | With-skill output marks the request blocked, requires PM/product documentation and Engineer availability, and states no implementation or handoff execution occurred. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=fd21822d29f9f59daea200bd14c26fadf30442cbe2bd48489976827d9b597907; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=3e6a4015e04bd9149dae8f0f9e11884fedf6581b2a5eb3fa72c67840694d20b3; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly classified the request as a standard business-rule change, rejected hotfix handling, and blocked implementation/merge pending PM alignment and missing project evidence.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=fd21822d29f9f59daea200bd14c26fadf30442cbe2bd48489976827d9b597907; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=f16ef07b640b8914be82af5808056f8ac54672c1a1181f335edfb841359a229d; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly classified the request as a standard expectation change, rejected hotfix handling, and blocked execution pending PM/product and engineering prerequisites.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=fd21822d29f9f59daea200bd14c26fadf30442cbe2bd48489976827d9b597907; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=e709e848636f86d3e03ab1e0743d898b009915299905ee55dd1772fe2b29867b; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Fresh baseline only reported an empty repository and did not classify the request or establish the required PM/change-management boundaries.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=fd21822d29f9f59daea200bd14c26fadf30442cbe2bd48489976827d9b597907; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=91f9bdcfbdb53ece8028187cd460d12263e07d93f99dc840f2a8cf76c07d98c9; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline attempted to locate and modify the trial-period implementation, then reported the empty repository; it did not apply the required PM governance classifications.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-13-change-tier-hotfix-e2e-direct-path/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-13-change-tier-hotfix-e2e-direct-path/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-13-change-tier-hotfix-e2e-direct-path`.
 - Identity schema: `2`
-- target_skill_sha256: `28ec452f7594200030ea15ffdc8d5edc9ae2298318457884574b818964824cf6`
+- target_skill_sha256: `cec475406cc49b4c9cebbfe9c62f8f1a19fc3e7ced9282825f8f2930bab1478a`
 - eval_definition_sha256: `44d523204e1cd35255225227815a7ce2ae5cdbcf16a8a61436277c46e50fdccc`
 - metadata_sha256: `385a2edb2c46d9f3ce571c34b812bf357f9247b71af061faebaf0764c87334a2`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `6a4c53f4d8ac913c9f4214c0dc35c3bf4c2a1bd9745f539a3879966e5d7f9011`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `4b716f413649b163f4dd5dcd45dc5b4214bafbb5cb059afb757fef3a77b94653`
-- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
+- Repository HEAD: `133a65e3c3b501be88257e9d3a557af4d5ccd242`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `8041f8266999d0ba9597ccc13e0354e28fcccb4a3b921ae9b5b9d1e08fe1da7b`
+- Skill overlay SHA-256: `5047311446f87e0c9eb6ef7577938db174e729f8d09b2851971cbb87a063bf63`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,26 +33,26 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `hotfix_direct_path_only` | PASS | with_skill 明确将范围限定为“登录页空状态文案”，未修改或扩展到无关路径；空 fixture 下仅请求项目工作区和目标文案等最小输入。 |
-| `evidence_still_required` | PASS | with_skill 明确说明缺少源码、目标文案和可执行验证路径，未声称已验证，并请求补齐项目工作区或目标文案。 |
-| `no_full_suite_required` | PASS | with_skill 未要求无关的完整 E2E suite 作为前置条件。 |
+| `hotfix_direct_path_only` | PASS | With-skill output limits the change to the login-page empty-state copy, forbids scope expansion, and requests only the missing project files and target wording. |
+| `evidence_still_required` | PASS | With-skill output explicitly states that source and validation entry points are missing, that direct checks cannot currently run, and what minimum inputs are needed. |
+| `no_full_suite_required` | PASS | With-skill output does not require an unrelated full E2E suite or any other broad test gate. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4b716f413649b163f4dd5dcd45dc5b4214bafbb5cb059afb757fef3a77b94653; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=58c98cdf544381d0d0b7b861da987839e4884d22458cc67aeb0a6d7d799c636b; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 识别到输入不足，保持修改与验证边界，说明阻塞项并请求最小补充输入。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4b716f413649b163f4dd5dcd45dc5b4214bafbb5cb059afb757fef3a77b94653; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=c1eed8e1c9ea187a63f5d2607cb2b7b56fd52e56864a1562adb4fa15208a2bbf; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly blocked safely on the empty fixture, preserved the narrow requested scope, and requested the minimum missing inputs without claiming implementation or verification.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4b716f413649b163f4dd5dcd45dc5b4214bafbb5cb059afb757fef3a77b94653; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=234bde27287ff4e611e07c9baa2cbb427d744fd4b7709e23aa2edbfa7d49923b; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 同样识别到空仓库并请求切换到包含登录页的项目内容；作为基线未影响 with_skill 判定。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4b716f413649b163f4dd5dcd45dc5b4214bafbb5cb059afb757fef3a77b94653; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=ab8f81ef0d267a93a821632f7c409b5d9272e57a3f7bad6e45b833ad12e2fbe4; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Also correctly recognized the empty repository and requested project files; it provided less explicit scope and verification-boundary detail.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: 提供包含登录页源码的工作区及目标文案后，执行直接影响路径验证。
+- Next: Provide the project files and exact replacement copy, then run the focused login-page verification.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-13-change-tier-hotfix-e2e-direct-path/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-13-change-tier-hotfix-e2e-direct-path/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-13-change-tier-hotfix-e2e-direct-path`.
 - Identity schema: `2`
-- target_skill_sha256: `cec475406cc49b4c9cebbfe9c62f8f1a19fc3e7ced9282825f8f2930bab1478a`
+- target_skill_sha256: `a37bf10fca64a8e15e6213ecdd45b65783814d307c78fd8d8ce6ab45b20effef`
 - eval_definition_sha256: `44d523204e1cd35255225227815a7ce2ae5cdbcf16a8a61436277c46e50fdccc`
 - metadata_sha256: `385a2edb2c46d9f3ce571c34b812bf357f9247b71af061faebaf0764c87334a2`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `6a4c53f4d8ac913c9f4214c0dc35c3bf4c2a1bd9745f539a3879966e5d7f9011`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `4b716f413649b163f4dd5dcd45dc5b4214bafbb5cb059afb757fef3a77b94653`
-- Repository HEAD: `133a65e3c3b501be88257e9d3a557af4d5ccd242`
+- Repository HEAD: `3f5e81c4837ef85284a7d5381575e40267796c92`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `5047311446f87e0c9eb6ef7577938db174e729f8d09b2851971cbb87a063bf63`
+- Skill overlay SHA-256: `6f4abf80e411dc3e6124c51093f07046c341195b1b2f0e9981a535c9960cb623`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,26 +33,26 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `hotfix_direct_path_only` | PASS | With-skill output limits the change to the login-page empty-state copy, forbids scope expansion, and requests only the missing project files and target wording. |
-| `evidence_still_required` | PASS | With-skill output explicitly states that source and validation entry points are missing, that direct checks cannot currently run, and what minimum inputs are needed. |
-| `no_full_suite_required` | PASS | With-skill output does not require an unrelated full E2E suite or any other broad test gate. |
+| `hotfix_direct_path_only` | PASS | The with_skill lane identifies the empty repository and missing source/target, preserves the login-page empty-state scope, requests minimum inputs, and does not pursue unrelated implementation paths. |
+| `evidence_still_required` | PASS | The with_skill lane explicitly states the change and verification cannot be completed without source, target copy, and supporting execution capability, and identifies the required follow-up inputs. |
+| `no_full_suite_required` | PASS | The with_skill lane does not require a full E2E suite and explicitly sets a no-mutation execution boundary. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4b716f413649b163f4dd5dcd45dc5b4214bafbb5cb059afb757fef3a77b94653; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=c1eed8e1c9ea187a63f5d2607cb2b7b56fd52e56864a1562adb4fa15208a2bbf; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly blocked safely on the empty fixture, preserved the narrow requested scope, and requested the minimum missing inputs without claiming implementation or verification.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4b716f413649b163f4dd5dcd45dc5b4214bafbb5cb059afb757fef3a77b94653; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=3ebcf597860e67cb8ea666545a870e88b74843e590555fb4d26b03113a11c92b; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly handles the empty fixture, maintains narrow scope, requests missing inputs, and makes no changes.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4b716f413649b163f4dd5dcd45dc5b4214bafbb5cb059afb757fef3a77b94653; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=ab8f81ef0d267a93a821632f7c409b5d9272e57a3f7bad6e45b833ad12e2fbe4; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Also correctly recognized the empty repository and requested project files; it provided less explicit scope and verification-boundary detail.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4b716f413649b163f4dd5dcd45dc5b4214bafbb5cb059afb757fef3a77b94653; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=8377bf5f944e1d36b95bebdbea46ce8f527e0b38b1717a7ba24d2e74ab4f6a50; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline also detects the empty repository and requests project files and exact copy, but without the structured scope and execution boundary.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Provide the project files and exact replacement copy, then run the focused login-page verification.
+- Next: None.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-13-change-tier-hotfix-e2e-direct-path/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-13-change-tier-hotfix-e2e-direct-path/comparison.md
@@ -13,8 +13,8 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-13-change-tier-hotfix-e2e-direct-path`.
 - Identity schema: `2`
-- target_skill_sha256: `f9ea1bade234ebfd780e1e4773d4808a60f7baa61920e5859daea2b146c1ce93`
-- eval_definition_sha256: `0e4e9687500855bbb8cac580183d47bafa14e53a69d5477185a5ceacddfe1857`
+- target_skill_sha256: `28ec452f7594200030ea15ffdc8d5edc9ae2298318457884574b818964824cf6`
+- eval_definition_sha256: `44d523204e1cd35255225227815a7ce2ae5cdbcf16a8a61436277c46e50fdccc`
 - metadata_sha256: `385a2edb2c46d9f3ce571c34b812bf357f9247b71af061faebaf0764c87334a2`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
@@ -22,37 +22,37 @@
 - judge_schema_sha256: `6a4c53f4d8ac913c9f4214c0dc35c3bf4c2a1bd9745f539a3879966e5d7f9011`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `4b716f413649b163f4dd5dcd45dc5b4214bafbb5cb059afb757fef3a77b94653`
-- Repository HEAD: `2ac10136f4ed18048058361915e66c52b4e038c5`
+- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `84ad07662e525000bb3bbf1da6aa3f2d49322c424326b70644431a72cdb52c55`
+- Skill overlay SHA-256: `8041f8266999d0ba9597ccc13e0354e28fcccb4a3b921ae9b5b9d1e08fe1da7b`
 - Behavior result: **PASS**
-- Coverage result: **PARTIAL**
-Overall result: PASS (partial coverage)
+- Coverage result: **FULL**
+Overall result: PASS
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `hotfix_direct_path_only` | NOT_EXERCISED | with_skill 正确识别工作区缺少源码和验证入口，并暂停执行；直接影响路径 QA 尚未进入可执行阶段。 |
-| `evidence_still_required` | NOT_EXERCISED | with_skill 列出缺少可执行验证命令并禁止声称验证完成，但尚未进入需要记录 verification evidence、结果和 blocked checks 的验证阶段。 |
-| `no_full_suite_required` | NOT_EXERCISED | with_skill 将变更标为 standard 并因缺少项目上下文而阻塞；尚未进入套件选择或 E2E 执行阶段。 |
+| `hotfix_direct_path_only` | PASS | with_skill 明确将范围限定为“登录页空状态文案”，未修改或扩展到无关路径；空 fixture 下仅请求项目工作区和目标文案等最小输入。 |
+| `evidence_still_required` | PASS | with_skill 明确说明缺少源码、目标文案和可执行验证路径，未声称已验证，并请求补齐项目工作区或目标文案。 |
+| `no_full_suite_required` | PASS | with_skill 未要求无关的完整 E2E suite 作为前置条件。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4b716f413649b163f4dd5dcd45dc5b4214bafbb5cb059afb757fef3a77b94653; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=246b34fbd220f042863fe092501b33055df70678c2cc4761669f0a1026d6feb8; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 识别到项目上下文缺失，输出结构化路由和阻塞原因，未进行未授权修改或虚假验证。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4b716f413649b163f4dd5dcd45dc5b4214bafbb5cb059afb757fef3a77b94653; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=58c98cdf544381d0d0b7b861da987839e4884d22458cc67aeb0a6d7d799c636b; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 识别到输入不足，保持修改与验证边界，说明阻塞项并请求最小补充输入。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4b716f413649b163f4dd5dcd45dc5b4214bafbb5cb059afb757fef3a77b94653; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=51c5dcd223b7a2aa258dcd3cf34176e1c4bbced27bb66c07ae344bb87c243399; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 仅报告空 Git 工作区并请求重新挂载项目，未提供路由或验证边界。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4b716f413649b163f4dd5dcd45dc5b4214bafbb5cb059afb757fef3a77b94653; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=234bde27287ff4e611e07c9baa2cbb427d744fd4b7709e23aa2edbfa7d49923b; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 同样识别到空仓库并请求切换到包含登录页的项目内容；作为基线未影响 with_skill 判定。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: 提供包含登录页源码及验证入口的项目工作区后，再执行文案修改和最小范围验证。
+- Next: 提供包含登录页源码的工作区及目标文案后，执行直接影响路径验证。
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-14-route-site-notes-and-github-release/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-14-route-site-notes-and-github-release/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-14-route-site-notes-and-github-release`.
 - Identity schema: `2`
-- target_skill_sha256: `f9ea1bade234ebfd780e1e4773d4808a60f7baa61920e5859daea2b146c1ce93`
+- target_skill_sha256: `28ec452f7594200030ea15ffdc8d5edc9ae2298318457884574b818964824cf6`
 - eval_definition_sha256: `ae4335c3ea7ab2052d5988d1cbe329b872d3570826da6174d95ecdee75a8f11e`
 - metadata_sha256: `7b48bd11ada861ee54366c474d903263630fabf2c5e0d3a66c9f38056e80908e`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `0e6be21ab02e72aa076a9b774d5cc60139434feba550f781574340027908427d`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `aeb9d94911e2f21a05aec636eb7871f30e1f918271687f3e921766aab4cdc3f2`
-- Repository HEAD: `2ac10136f4ed18048058361915e66c52b4e038c5`
+- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `84ad07662e525000bb3bbf1da6aa3f2d49322c424326b70644431a72cdb52c55`
+- Skill overlay SHA-256: `8041f8266999d0ba9597ccc13e0354e28fcccb4a3b921ae9b5b9d1e08fe1da7b`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,27 +33,27 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `routes_site_notes_to_docs_specialist` | PASS | With_skill trace routes the request to docs-agent:release-notes-gen and explicitly assigns the site notes step first. |
-| `routes_github_release_to_pm_specialist` | NOT_EXERCISED | The trace names pm-agent:github-release-gen as the subsequent owner, but that later step cannot occur because the required specialist and confirmed release source are unavailable. |
-| `preserves_release_sequence` | NOT_EXERCISED | The trace explicitly states site Release Notes first, followed by Docs gates and then the PM GitHub Release step; actual downstream consumption is not exercised because the handoff is blocked. |
-| `does_not_use_old_pm_skill_name` | PASS | The with_skill routing names docs-agent:release-notes-gen for Docs and pm-agent:github-release-gen for PM; it does not use release-notes-gen as the PM owner. |
+| `routes_site_notes_to_docs_specialist` | PASS | With-skill output explicitly selects `docs-agent:release-notes-gen` for the site notes stage. |
+| `routes_github_release_to_pm_specialist` | PASS | With-skill output explicitly selects `pm-agent:github-release-gen` for the GitHub Release preview stage. |
+| `preserves_release_sequence` | NOT_EXERCISED | The route identifies the site-notes stage before the GitHub Release stage, but completion of the later handoff and audit-evidence consumption is blocked by missing capabilities and source evidence. |
+| `does_not_use_old_pm_skill_name` | PASS | The PM owner is named `pm-agent:github-release-gen`; `release-notes-gen` is used only with the Docs specialist. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=aeb9d94911e2f21a05aec636eb7871f30e1f918271687f3e921766aab4cdc3f2; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=300846dc1a9cab996c3cbdf497c1fb5d9a74be9ae422282ccdbc75ab08361060; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly routes site-facing release notes to the Docs specialist, preserves the intended site-first boundary, and identifies the PM GitHub Release specialist, but stops before downstream execution because required capabilities and release evidence are unavailable.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=aeb9d94911e2f21a05aec636eb7871f30e1f918271687f3e921766aab4cdc3f2; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=8703e57315eecaf53240228e870455428d5ad940fcff571fb107cdb39c862e66; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly routes site notes to Docs and GitHub Release preview to PM, preserves the intended stage order, and makes no release mutation; execution is blocked before delivery.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=aeb9d94911e2f21a05aec636eb7871f30e1f918271687f3e921766aab4cdc3f2; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=d9df2fbc3eaa3691e4cbc274446d2b5402c89de6201ed6131ee225855487795d; snapshot_sha256=3312afa0b5db859f79176642d45cc34f3b99e64674f725a4a307729054b00e9f
-- Behavior: Creates two uncoordinated draft files and does not provide the specialist routing or gated handoff behavior.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=aeb9d94911e2f21a05aec636eb7871f30e1f918271687f3e921766aab4cdc3f2; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=c700739ed02d7815d108a7ff11f36b1cb0b72d1cf4e49717acc16ddaab299c79; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline only reports an empty repository and requests release information; it does not perform the specialist routing.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Provide confirmed v1.0.0 release evidence and make the Docs and PM GitHub Release specialists available before exercising the downstream handoff.
+- Next: Provide the missing v1.0.0 release evidence and specialist capabilities, then exercise the Docs confirmation and PM release-preview handoff.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-14-route-site-notes-and-github-release/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-14-route-site-notes-and-github-release/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-14-route-site-notes-and-github-release`.
 - Identity schema: `2`
-- target_skill_sha256: `28ec452f7594200030ea15ffdc8d5edc9ae2298318457884574b818964824cf6`
+- target_skill_sha256: `cec475406cc49b4c9cebbfe9c62f8f1a19fc3e7ced9282825f8f2930bab1478a`
 - eval_definition_sha256: `ae4335c3ea7ab2052d5988d1cbe329b872d3570826da6174d95ecdee75a8f11e`
 - metadata_sha256: `7b48bd11ada861ee54366c474d903263630fabf2c5e0d3a66c9f38056e80908e`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `0e6be21ab02e72aa076a9b774d5cc60139434feba550f781574340027908427d`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `aeb9d94911e2f21a05aec636eb7871f30e1f918271687f3e921766aab4cdc3f2`
-- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
+- Repository HEAD: `133a65e3c3b501be88257e9d3a557af4d5ccd242`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `8041f8266999d0ba9597ccc13e0354e28fcccb4a3b921ae9b5b9d1e08fe1da7b`
+- Skill overlay SHA-256: `5047311446f87e0c9eb6ef7577938db174e729f8d09b2851971cbb87a063bf63`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,27 +33,28 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `routes_site_notes_to_docs_specialist` | PASS | With-skill output explicitly selects `docs-agent:release-notes-gen` for the site notes stage. |
-| `routes_github_release_to_pm_specialist` | PASS | With-skill output explicitly selects `pm-agent:github-release-gen` for the GitHub Release preview stage. |
-| `preserves_release_sequence` | NOT_EXERCISED | The route identifies the site-notes stage before the GitHub Release stage, but completion of the later handoff and audit-evidence consumption is blocked by missing capabilities and source evidence. |
-| `does_not_use_old_pm_skill_name` | PASS | The PM owner is named `pm-agent:github-release-gen`; `release-notes-gen` is used only with the Docs specialist. |
+| `routes_site_notes_to_docs_specialist` | PASS | With_skill output explicitly selects `docs-agent:release-notes-gen -> pm-agent:github-release-gen` and identifies the confirmed scope as site Release Notes followed by GitHub Release preview. |
+| `routes_github_release_to_pm_specialist` | PASS | With_skill output explicitly routes the downstream owner to `pm-agent:github-release-gen` and states it will not substitute for missing Docs/Release specialist capabilities. |
+| `preserves_release_sequence` | NOT_EXERCISED | The fixture is empty and the required version sources, confirmed handoff, and runtime specialist capabilities are missing, so the later site-first execution and evidence consumption could not occur. |
+| `does_not_use_old_pm_skill_name` | PASS | The output names `release-notes-gen` only as `docs-agent:release-notes-gen` and names the PM owner `pm-agent:github-release-gen`; it does not use the old PM owner name. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=aeb9d94911e2f21a05aec636eb7871f30e1f918271687f3e921766aab4cdc3f2; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=8703e57315eecaf53240228e870455428d5ad940fcff571fb107cdb39c862e66; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly routes site notes to Docs and GitHub Release preview to PM, preserves the intended stage order, and makes no release mutation; execution is blocked before delivery.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=aeb9d94911e2f21a05aec636eb7871f30e1f918271687f3e921766aab4cdc3f2; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=10993bc43a037602da5c73e2167e87fa17e5396bc4ec1b6c548d8325d4ed5f97; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly classified and routed the workflow, preserved the execution boundary, and honestly stopped before unsupported release-note or preview generation.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=aeb9d94911e2f21a05aec636eb7871f30e1f918271687f3e921766aab4cdc3f2; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=c700739ed02d7815d108a7ff11f36b1cb0b72d1cf4e49717acc16ddaab299c79; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Fresh baseline only reports an empty repository and requests release information; it does not perform the specialist routing.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=aeb9d94911e2f21a05aec636eb7871f30e1f918271687f3e921766aab4cdc3f2; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=b8286580a3f51fa0a7cbe8dccd08d2bebce14ce91475401074e3b38f3aa992c1; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline stopped at workspace inspection and did not provide the required specialist routing or release workflow structure.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Provide the missing v1.0.0 release evidence and specialist capabilities, then exercise the Docs confirmation and PM release-preview handoff.
+- Next: Provide the v1.0.0 change sources and confirmed handoff package.
+- Next: Make the Docs and PM specialist capabilities available, then execute the site-first workflow.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-14-route-site-notes-and-github-release/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-14-route-site-notes-and-github-release/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-14-route-site-notes-and-github-release`.
 - Identity schema: `2`
-- target_skill_sha256: `cec475406cc49b4c9cebbfe9c62f8f1a19fc3e7ced9282825f8f2930bab1478a`
+- target_skill_sha256: `a37bf10fca64a8e15e6213ecdd45b65783814d307c78fd8d8ce6ab45b20effef`
 - eval_definition_sha256: `ae4335c3ea7ab2052d5988d1cbe329b872d3570826da6174d95ecdee75a8f11e`
 - metadata_sha256: `7b48bd11ada861ee54366c474d903263630fabf2c5e0d3a66c9f38056e80908e`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `0e6be21ab02e72aa076a9b774d5cc60139434feba550f781574340027908427d`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `aeb9d94911e2f21a05aec636eb7871f30e1f918271687f3e921766aab4cdc3f2`
-- Repository HEAD: `133a65e3c3b501be88257e9d3a557af4d5ccd242`
+- Repository HEAD: `3f5e81c4837ef85284a7d5381575e40267796c92`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `5047311446f87e0c9eb6ef7577938db174e729f8d09b2851971cbb87a063bf63`
+- Skill overlay SHA-256: `6f4abf80e411dc3e6124c51093f07046c341195b1b2f0e9981a535c9960cb623`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,28 +33,27 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `routes_site_notes_to_docs_specialist` | PASS | With_skill output explicitly selects `docs-agent:release-notes-gen -> pm-agent:github-release-gen` and identifies the confirmed scope as site Release Notes followed by GitHub Release preview. |
-| `routes_github_release_to_pm_specialist` | PASS | With_skill output explicitly routes the downstream owner to `pm-agent:github-release-gen` and states it will not substitute for missing Docs/Release specialist capabilities. |
-| `preserves_release_sequence` | NOT_EXERCISED | The fixture is empty and the required version sources, confirmed handoff, and runtime specialist capabilities are missing, so the later site-first execution and evidence consumption could not occur. |
-| `does_not_use_old_pm_skill_name` | PASS | The output names `release-notes-gen` only as `docs-agent:release-notes-gen` and names the PM owner `pm-agent:github-release-gen`; it does not use the old PM owner name. |
+| `routes_site_notes_to_docs_specialist` | PASS | With-skill output explicitly selects docs-agent:release-notes-gen for the site-facing release notes request. |
+| `routes_github_release_to_pm_specialist` | PASS | With-skill output explicitly lists pm-agent:github-release-gen as the owner for the GitHub Release preview and does not assign that work to Docs. |
+| `preserves_release_sequence` | NOT_EXERCISED | The candidate states the site Release Notes → Docs audit/confirmation → GitHub Release preview sequence, but the specialist and release evidence needed to execute the later handoff were unavailable. |
+| `does_not_use_old_pm_skill_name` | PASS | The PM owner is named pm-agent:github-release-gen; release-notes-gen appears only with the docs-agent prefix for the Docs specialist. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=aeb9d94911e2f21a05aec636eb7871f30e1f918271687f3e921766aab4cdc3f2; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=10993bc43a037602da5c73e2167e87fa17e5396bc4ec1b6c548d8325d4ed5f97; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly classified and routed the workflow, preserved the execution boundary, and honestly stopped before unsupported release-note or preview generation.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=aeb9d94911e2f21a05aec636eb7871f30e1f918271687f3e921766aab4cdc3f2; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=0b3dd6eb50fdfd4dbfcc0e43368d8b722ed4367a38d62a0acc4dc60a400209c7; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly routed the two workstreams, preserved the intended sequence, avoided the deprecated PM owner name, and reported the missing evidence/specialists without mutation.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=aeb9d94911e2f21a05aec636eb7871f30e1f918271687f3e921766aab4cdc3f2; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=b8286580a3f51fa0a7cbe8dccd08d2bebce14ce91475401074e3b38f3aa992c1; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Fresh baseline stopped at workspace inspection and did not provide the required specialist routing or release workflow structure.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=aeb9d94911e2f21a05aec636eb7871f30e1f918271687f3e921766aab4cdc3f2; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=75b74ddcd99300b58aec3c891e5319016e826e1912a515082eb4d9608ed11cd9; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Reported the empty repository and requested more evidence, but provided no specialist routing or ordered handoff.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Provide the v1.0.0 change sources and confirmed handoff package.
-- Next: Make the Docs and PM specialist capabilities available, then execute the site-first workflow.
+- Next: Install or provide the Docs and PM specialists and supply v1.0.0 change evidence, then complete the Docs confirmation and PM GitHub Release preview handoff.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-17-scope-guard-unenabled-general/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-17-scope-guard-unenabled-general/comparison.md
@@ -13,18 +13,18 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-17-scope-guard-unenabled-general`.
 - Identity schema: `2`
-- target_skill_sha256: `f9ea1bade234ebfd780e1e4773d4808a60f7baa61920e5859daea2b146c1ce93`
-- eval_definition_sha256: `2b26ec5b13cba548fe19b4f508977afc54ba26189b14fbc48be376e4d57b8178`
-- metadata_sha256: `05ea9f60607f11132b0f5ec8ca00cda463398f718c44648a9e2be81e39b17991`
+- target_skill_sha256: `28ec452f7594200030ea15ffdc8d5edc9ae2298318457884574b818964824cf6`
+- eval_definition_sha256: `39faf534f64b30c105514035f054d257cf0f525ae0bd7577eccde10c9d2a879b`
+- metadata_sha256: `7cfea2e7966dabd576a859036c036835a1da1742b99340ebfcd2fcd73e56c60b`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
 - runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
-- judge_schema_sha256: `c5629d3608d1f142562d32ed4b435e3d2c557d9aa8b1c8b5f72fce35ca63e9a2`
+- judge_schema_sha256: `393b26839d6ecf3cc396518ba3c28e2288560436d96f6b3eb0b1794c2df40748`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
-- Prompt SHA-256: `0d80b9dec86a17116de51354d4b9cf60c96709a915b3655bf693ad2757979eb9`
-- Repository HEAD: `2ac10136f4ed18048058361915e66c52b4e038c5`
+- Prompt SHA-256: `2c9610bcc27c8c480be3a4506b94682924ad1bb0ce1f3f95bfb12428326c37eb`
+- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `38ced6e12625600fae30e78c9378396b744a4b51798a40c97ef23b9d7aa57e71`
+- Skill overlay SHA-256: `8041f8266999d0ba9597ccc13e0354e28fcccb4a3b921ae9b5b9d1e08fe1da7b`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,18 +33,18 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `scope_guard_stops_general_request` | PASS | With-skill trace checks the current directory for dev-agent-skills markers, finds none, then outputs that the directory is not enabled and stops without routing fields or downstream artifacts. |
+| `rd_intent_enters_without_docs` | PASS | with_skill 输出明确将请求分类为 new_feature，选择 pm-agent:idea-to-spec，进入 greenfield-discovery，并说明先做需求收敛；runner_captured_trace 也记录了 PM 入口分类和后续 idea-to-spec 流程。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=0d80b9dec86a17116de51354d4b9cf60c96709a915b3655bf693ad2757979eb9; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=80189bc5e6ea34383f68f8da07afdd24d2483347460737fedbe36b350e8d2fff; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Checks directory enablement, correctly identifies it as not enabled, briefly explains the scope boundary, and stops.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2c9610bcc27c8c480be3a4506b94682924ad1bb0ce1f3f95bfb12428326c37eb; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=b81f4f0bbf779f5b9e8e2afd369bf288527bd6f554a79b0d671e7f171147e33d; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 面对空工作区和缺少 PRD、TRD、代码及 enable marker，进入 PM/idea-to-spec 的 greenfield-discovery，暂停工程实现并提出通知策略确认问题。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=0d80b9dec86a17116de51354d4b9cf60c96709a915b3655bf693ad2757979eb9; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=33131b50b70e43e3a9eb560217114ebe0f21fd911ad03ce6d5c466c26e031782; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Attempts to inspect ~/Downloads and reports sandbox access limitations; does not perform the required enablement-based scope guard.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2c9610bcc27c8c480be3a4506b94682924ad1bb0ce1f3f95bfb12428326c37eb; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=45b37f6b0342b74a0f5ddcb660c7ca09a8507488a06029e9dc826a507e3f033e; snapshot_sha256=d9186a9dae5e425cdcbd718b3d5241f95c761de952d858d13d89cf01eda9a0e8
+- Behavior: 直接实现并交付账单到期通知服务，未进入 PM 需求收敛流程。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-17-scope-guard-unenabled-general/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-17-scope-guard-unenabled-general/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-17-scope-guard-unenabled-general`.
 - Identity schema: `2`
-- target_skill_sha256: `28ec452f7594200030ea15ffdc8d5edc9ae2298318457884574b818964824cf6`
+- target_skill_sha256: `cec475406cc49b4c9cebbfe9c62f8f1a19fc3e7ced9282825f8f2930bab1478a`
 - eval_definition_sha256: `39faf534f64b30c105514035f054d257cf0f525ae0bd7577eccde10c9d2a879b`
 - metadata_sha256: `7cfea2e7966dabd576a859036c036835a1da1742b99340ebfcd2fcd73e56c60b`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `393b26839d6ecf3cc396518ba3c28e2288560436d96f6b3eb0b1794c2df40748`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `2c9610bcc27c8c480be3a4506b94682924ad1bb0ce1f3f95bfb12428326c37eb`
-- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
+- Repository HEAD: `133a65e3c3b501be88257e9d3a557af4d5ccd242`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `8041f8266999d0ba9597ccc13e0354e28fcccb4a3b921ae9b5b9d1e08fe1da7b`
+- Skill overlay SHA-256: `5047311446f87e0c9eb6ef7577938db174e729f8d09b2851971cbb87a063bf63`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,18 +33,18 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `rd_intent_enters_without_docs` | PASS | with_skill 输出明确将请求分类为 new_feature，选择 pm-agent:idea-to-spec，进入 greenfield-discovery，并说明先做需求收敛；runner_captured_trace 也记录了 PM 入口分类和后续 idea-to-spec 流程。 |
+| `rd_intent_enters_without_docs` | PASS | with_skill 明确将请求分类为 new_feature，selected_owner 为 idea-to-spec，next_action 为 PM 需求发现；同时记录 existing_docs/source_documents 为空，但未因此拒绝进入 PM。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2c9610bcc27c8c480be3a4506b94682924ad1bb0ce1f3f95bfb12428326c37eb; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=b81f4f0bbf779f5b9e8e2afd369bf288527bd6f554a79b0d671e7f171147e33d; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 面对空工作区和缺少 PRD、TRD、代码及 enable marker，进入 PM/idea-to-spec 的 greenfield-discovery，暂停工程实现并提出通知策略确认问题。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2c9610bcc27c8c480be3a4506b94682924ad1bb0ce1f3f95bfb12428326c37eb; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=426b7f1a6fb1fbff6d88cba833df13cd8bb5cdf7a5760fd3866fdde38969792c; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 在空工作区、无 PRD/TRD/代码时进入 PM 需求收敛，识别未决触发策略并请求用户确认。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2c9610bcc27c8c480be3a4506b94682924ad1bb0ce1f3f95bfb12428326c37eb; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=45b37f6b0342b74a0f5ddcb660c7ca09a8507488a06029e9dc826a507e3f033e; snapshot_sha256=d9186a9dae5e425cdcbd718b3d5241f95c761de952d858d13d89cf01eda9a0e8
-- Behavior: 直接实现并交付账单到期通知服务，未进入 PM 需求收敛流程。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2c9610bcc27c8c480be3a4506b94682924ad1bb0ce1f3f95bfb12428326c37eb; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=59f9f5b3643932c28e3bb33f9ed62f9d03ea958e7e254e7b40014f3c2c3f511a; snapshot_sha256=9b029c9517396a8d997df32dc9f96ebbad7b75f0821df65a9e256aa574e8afc8
+- Behavior: 直接实现账单通知服务并写入代码，未进行 PM 需求收敛。仅作对比，不影响 with_skill 断言判定。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-17-scope-guard-unenabled-general/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-17-scope-guard-unenabled-general/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-17-scope-guard-unenabled-general`.
 - Identity schema: `2`
-- target_skill_sha256: `cec475406cc49b4c9cebbfe9c62f8f1a19fc3e7ced9282825f8f2930bab1478a`
+- target_skill_sha256: `a37bf10fca64a8e15e6213ecdd45b65783814d307c78fd8d8ce6ab45b20effef`
 - eval_definition_sha256: `39faf534f64b30c105514035f054d257cf0f525ae0bd7577eccde10c9d2a879b`
 - metadata_sha256: `7cfea2e7966dabd576a859036c036835a1da1742b99340ebfcd2fcd73e56c60b`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `393b26839d6ecf3cc396518ba3c28e2288560436d96f6b3eb0b1794c2df40748`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `2c9610bcc27c8c480be3a4506b94682924ad1bb0ce1f3f95bfb12428326c37eb`
-- Repository HEAD: `133a65e3c3b501be88257e9d3a557af4d5ccd242`
+- Repository HEAD: `3f5e81c4837ef85284a7d5381575e40267796c92`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `5047311446f87e0c9eb6ef7577938db174e729f8d09b2851971cbb87a063bf63`
+- Skill overlay SHA-256: `6f4abf80e411dc3e6124c51093f07046c341195b1b2f0e9981a535c9960cb623`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,18 +33,18 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `rd_intent_enters_without_docs` | PASS | with_skill 明确将请求分类为 new_feature，selected_owner 为 idea-to-spec，next_action 为 PM 需求发现；同时记录 existing_docs/source_documents 为空，但未因此拒绝进入 PM。 |
+| `rd_intent_enters_without_docs` | PASS | with_skill 输出明确将请求路由至 `pm-agent:idea-to-spec`，标记为 `new_feature`，并开始需求收敛；同时说明工作区为空是待确认上下文，而非拒绝进入 PM。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2c9610bcc27c8c480be3a4506b94682924ad1bb0ce1f3f95bfb12428326c37eb; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=426b7f1a6fb1fbff6d88cba833df13cd8bb5cdf7a5760fd3866fdde38969792c; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 在空工作区、无 PRD/TRD/代码时进入 PM 需求收敛，识别未决触发策略并请求用户确认。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2c9610bcc27c8c480be3a4506b94682924ad1bb0ce1f3f95bfb12428326c37eb; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=f5fe51606347181ae7ce95b4b10203fdddcfb15c05339a0ce28100c11720b021; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 进入 PM 需求收敛流程，识别缺少项目上下文，并提出账单来源这一项下一步确认。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2c9610bcc27c8c480be3a4506b94682924ad1bb0ce1f3f95bfb12428326c37eb; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=59f9f5b3643932c28e3bb33f9ed62f9d03ea958e7e254e7b40014f3c2c3f511a; snapshot_sha256=9b029c9517396a8d997df32dc9f96ebbad7b75f0821df65a9e256aa574e8afc8
-- Behavior: 直接实现账单通知服务并写入代码，未进行 PM 需求收敛。仅作对比，不影响 with_skill 断言判定。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2c9610bcc27c8c480be3a4506b94682924ad1bb0ce1f3f95bfb12428326c37eb; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=b6e9fc12e0660d7b2bd1b58af589f59ea1a6b50577599e4f0d919407b1fe4025; snapshot_sha256=caa3c317bb79188eb4b87a9aa6ef924fc04f63f7369d1a188eacf205a293417f
+- Behavior: 直接实现账单通知模块并交付代码，未进入 PM 需求收敛流程。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-17-scope-guard-unenabled-general/eval_metadata.json
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-17-scope-guard-unenabled-general/eval_metadata.json
@@ -3,7 +3,9 @@
   "eval_name": "scope-guard-unenabled-general",
   "workspace_root": "agents/product_manager/test/pm-agent/evals/workspace/eval-17-scope-guard-unenabled-general",
   "fixture_context": [],
-  "skill_dependencies": [],
+  "skill_dependencies": [
+    "agents/product_manager/skills/idea-to-spec"
+  ],
   "runtime_isolation": {
     "processes": "not_used",
     "ports": "not_used",

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-18-scope-guard-explicit-invocation/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-18-scope-guard-explicit-invocation/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-18-scope-guard-explicit-invocation`.
 - Identity schema: `2`
-- target_skill_sha256: `28ec452f7594200030ea15ffdc8d5edc9ae2298318457884574b818964824cf6`
+- target_skill_sha256: `cec475406cc49b4c9cebbfe9c62f8f1a19fc3e7ced9282825f8f2930bab1478a`
 - eval_definition_sha256: `fbd5b3a5e4c0be83eacf913e76dfe890f776915d3d24ba4fd45c191e31196a40`
 - metadata_sha256: `d008e123b4ee70f7bf43fcaf109d74c9d72e4654db9631f703b1f4b299706113`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `3a5175573f5c12faf8ef17031068ea4a3554be3c63ea98a9f0e35a5de2fe7ef6`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `495fc0f825d65d1e7057e4dc84ea777d069a48dcb665a6ab231607b5f4f53d34`
-- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
+- Repository HEAD: `133a65e3c3b501be88257e9d3a557af4d5ccd242`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `561948022d6f471d6801c1e0d382cc70e538542dca320632f699ef9189b2a512`
+- Skill overlay SHA-256: `6ef9504e39a31fcbe8fbf27603399dd657878f1891b55f001c87ffcd613b4b43`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,19 +33,19 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `explicit_invocation_proceeds` | PASS | with_skill explicitly used pm-agent, identified the request as outside PM/product-engineering scope, and honestly stopped without inventing a PM route or owner. |
-| `classifies_general_request` | PASS | with_skill handled the general file-organization request through PM entry classification and honestly declared that no PM route applied; it did not skip classification to perform file operations. |
+| `explicit_invocation_proceeds` | PASS | with_skill 直接读取并遵循 pm-agent 的入口协议，明确判定该请求是本地文件整理、不属于 PM/工程研发或下游角色，并诚实停在该边界；未伪造分类或执行移动。 |
+| `classifies_general_request` | PASS | with_skill 在执行文件操作前完成了 pm-agent 入口判定与范围分类，说明该请求不属于现有 PM/下游类别，并因目录不可访问而停止，未跳过分类直接操作。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=495fc0f825d65d1e7057e4dc84ea777d069a48dcb665a6ab231607b5f4f53d34; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=ce0ae9c95932bc15d3b629aec9002c4ca36c86678c6dd758ad613d9b969206c9; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Honest PM classification: local file organization has no matching PM route, so execution stopped at the PM boundary.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=495fc0f825d65d1e7057e4dc84ea777d069a48dcb665a6ab231607b5f4f53d34; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=d1cf598700baced7cc9b59c7657290a15e33ee4d8cdc260e454c7a865c08cf3b; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 识别并使用了显式点名的 pm-agent，诚实判定本地文件整理不属于其 PM/工程范围，在目标目录不可访问时安全停止且未发生变更。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=495fc0f825d65d1e7057e4dc84ea777d069a48dcb665a6ab231607b5f4f53d34; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=7e4d9233ad8d09595773b0835bfddd1887e4305ff0b8b9de97dbcce70b84290f; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Fresh baseline reported pm-agent unavailable and stopped without PM classification.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=495fc0f825d65d1e7057e4dc84ea777d069a48dcb665a6ab231607b5f4f53d34; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=1fb87984c9ee101ae58414606f99339b2b6de58e09adcfa5e6696e7417471dc8; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 未使用 pm-agent，直接以能力不可用和 Downloads 不可访问为由拒绝；可作为新鲜基线对照。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-18-scope-guard-explicit-invocation/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-18-scope-guard-explicit-invocation/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-18-scope-guard-explicit-invocation`.
 - Identity schema: `2`
-- target_skill_sha256: `cec475406cc49b4c9cebbfe9c62f8f1a19fc3e7ced9282825f8f2930bab1478a`
+- target_skill_sha256: `a37bf10fca64a8e15e6213ecdd45b65783814d307c78fd8d8ce6ab45b20effef`
 - eval_definition_sha256: `fbd5b3a5e4c0be83eacf913e76dfe890f776915d3d24ba4fd45c191e31196a40`
 - metadata_sha256: `d008e123b4ee70f7bf43fcaf109d74c9d72e4654db9631f703b1f4b299706113`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `3a5175573f5c12faf8ef17031068ea4a3554be3c63ea98a9f0e35a5de2fe7ef6`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `495fc0f825d65d1e7057e4dc84ea777d069a48dcb665a6ab231607b5f4f53d34`
-- Repository HEAD: `133a65e3c3b501be88257e9d3a557af4d5ccd242`
+- Repository HEAD: `3f5e81c4837ef85284a7d5381575e40267796c92`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `6ef9504e39a31fcbe8fbf27603399dd657878f1891b55f001c87ffcd613b4b43`
+- Skill overlay SHA-256: `b63527fcaf0019710c1759725af4572c6d06eff41061de787b57dc1dae12ee7c`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,19 +33,19 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `explicit_invocation_proceeds` | PASS | with_skill 直接读取并遵循 pm-agent 的入口协议，明确判定该请求是本地文件整理、不属于 PM/工程研发或下游角色，并诚实停在该边界；未伪造分类或执行移动。 |
-| `classifies_general_request` | PASS | with_skill 在执行文件操作前完成了 pm-agent 入口判定与范围分类，说明该请求不属于现有 PM/下游类别，并因目录不可访问而停止，未跳过分类直接操作。 |
+| `explicit_invocation_proceeds` | PASS | With-skill trace shows it read and applied pm-agent's entry rules, recognized the explicit invocation, honestly determined the request was outside PM's product/engineering scope, and performed no contradictory routing or file mutation. |
+| `classifies_general_request` | PASS | With-skill trace explicitly records the classification as local file organization outside PM's categories and says it will not invent new_feature or delivery routing; it did not skip classification to execute file operations. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=495fc0f825d65d1e7057e4dc84ea777d069a48dcb665a6ab231607b5f4f53d34; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=d1cf598700baced7cc9b59c7657290a15e33ee4d8cdc260e454c7a865c08cf3b; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 识别并使用了显式点名的 pm-agent，诚实判定本地文件整理不属于其 PM/工程范围，在目标目录不可访问时安全停止且未发生变更。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=495fc0f825d65d1e7057e4dc84ea777d069a48dcb665a6ab231607b5f4f53d34; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=81e25b33d580b5a083000609564f27d16ae32b9620ab0050bc7bcac8f4fc45ce; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Used pm-agent, classified the explicitly invoked request honestly as outside PM scope, and stopped without unsupported file operations because Downloads was unavailable.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=495fc0f825d65d1e7057e4dc84ea777d069a48dcb665a6ab231607b5f4f53d34; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=1fb87984c9ee101ae58414606f99339b2b6de58e09adcfa5e6696e7417471dc8; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 未使用 pm-agent，直接以能力不可用和 Downloads 不可访问为由拒绝；可作为新鲜基线对照。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=495fc0f825d65d1e7057e4dc84ea777d069a48dcb665a6ab231607b5f4f53d34; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=916b7d46f32c52bb1b9ecfd40f51d98917fcbf3e5872a5e6261935a3e2fb0390; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Reported pm-agent was unavailable and Downloads was inaccessible; it did not perform PM classification.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-18-scope-guard-explicit-invocation/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-18-scope-guard-explicit-invocation/comparison.md
@@ -13,18 +13,18 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-18-scope-guard-explicit-invocation`.
 - Identity schema: `2`
-- target_skill_sha256: `f9ea1bade234ebfd780e1e4773d4808a60f7baa61920e5859daea2b146c1ce93`
-- eval_definition_sha256: `c9288fa3642ba9620547b9cef097cb305dbbd76229e2d8a01a3398cb410b16ae`
-- metadata_sha256: `9bbacd8d1d30aecb1b4dd5b9add9750bc75aa04b90825b7bca13141ac06f87e8`
+- target_skill_sha256: `28ec452f7594200030ea15ffdc8d5edc9ae2298318457884574b818964824cf6`
+- eval_definition_sha256: `fbd5b3a5e4c0be83eacf913e76dfe890f776915d3d24ba4fd45c191e31196a40`
+- metadata_sha256: `d008e123b4ee70f7bf43fcaf109d74c9d72e4654db9631f703b1f4b299706113`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
 - runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
 - judge_schema_sha256: `3a5175573f5c12faf8ef17031068ea4a3554be3c63ea98a9f0e35a5de2fe7ef6`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `495fc0f825d65d1e7057e4dc84ea777d069a48dcb665a6ab231607b5f4f53d34`
-- Repository HEAD: `2ac10136f4ed18048058361915e66c52b4e038c5`
+- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `84ad07662e525000bb3bbf1da6aa3f2d49322c424326b70644431a72cdb52c55`
+- Skill overlay SHA-256: `561948022d6f471d6801c1e0d382cc70e538542dca320632f699ef9189b2a512`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,19 +33,19 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `explicit_invocation_proceeds` | PASS | With-skill output explicitly states classification was completed, identifies the request as local file operation outside PM/downstream categories, and keeps it in PM without a scope-guard rejection. |
-| `classifies_general_request` | PASS | With-skill output honestly states that no PM category or downstream role matches; it does not invent a request type or owner and does not skip classification. |
+| `explicit_invocation_proceeds` | PASS | with_skill explicitly used pm-agent, identified the request as outside PM/product-engineering scope, and honestly stopped without inventing a PM route or owner. |
+| `classifies_general_request` | PASS | with_skill handled the general file-organization request through PM entry classification and honestly declared that no PM route applied; it did not skip classification to perform file operations. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=495fc0f825d65d1e7057e4dc84ea777d069a48dcb665a6ab231607b5f4f53d34; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=85e440b132673bfc7ff0492b789bc76defa98f87df5c995bdb5b6afa356a3b82; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Explicit pm-agent invocation proceeds to classification and honestly keeps the general file-operation request in PM.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=495fc0f825d65d1e7057e4dc84ea777d069a48dcb665a6ab231607b5f4f53d34; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=ce0ae9c95932bc15d3b629aec9002c4ca36c86678c6dd758ad613d9b969206c9; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Honest PM classification: local file organization has no matching PM route, so execution stopped at the PM boundary.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=495fc0f825d65d1e7057e4dc84ea777d069a48dcb665a6ab231607b5f4f53d34; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=be9a0257816740672ca0afcade327f98a596a8b04dd01cb510243a55c1cb789c; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Fresh baseline stops because pm-agent and ~/Downloads are unavailable, without entering the required classification flow.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=495fc0f825d65d1e7057e4dc84ea777d069a48dcb665a6ab231607b5f4f53d34; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=7e4d9233ad8d09595773b0835bfddd1887e4305ff0b8b9de97dbcce70b84290f; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline reported pm-agent unavailable and stopped without PM classification.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-18-scope-guard-explicit-invocation/eval_metadata.json
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-18-scope-guard-explicit-invocation/eval_metadata.json
@@ -3,9 +3,7 @@
   "eval_name": "scope-guard-explicit-invocation",
   "workspace_root": "agents/product_manager/test/pm-agent/evals/workspace/eval-18-scope-guard-explicit-invocation",
   "fixture_context": [],
-  "skill_dependencies": [
-    "agents/product_manager/skills/idea-to-spec"
-  ],
+  "skill_dependencies": [],
   "runtime_isolation": {
     "processes": "not_used",
     "ports": "not_used",

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-19-scope-guard-enabled-general/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-19-scope-guard-enabled-general/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `fe6bcb3f9a810e8ec07d6cd151b927dd0790270b275bdd2a0170bbc91573f2d5` from `agents/product_manager/test/pm-agent/evals/workspace/eval-19-scope-guard-enabled-general`.
 - Identity schema: `2`
-- target_skill_sha256: `28ec452f7594200030ea15ffdc8d5edc9ae2298318457884574b818964824cf6`
+- target_skill_sha256: `cec475406cc49b4c9cebbfe9c62f8f1a19fc3e7ced9282825f8f2930bab1478a`
 - eval_definition_sha256: `ee3671589f95fa8a892847eb388a153411b54b14444f1f7420faa0785c1aa02b`
 - metadata_sha256: `b685d83a8e82816d2f4d521a041ae8452f619db60e5a55ebbccd97b0160d2ffb`
 - fixture_sha256: `fe6bcb3f9a810e8ec07d6cd151b927dd0790270b275bdd2a0170bbc91573f2d5`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `6b0ff1b76e8b03f7712d3dcd168848aec48a65be2655318b04e40fdedd5925d2`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `9d2abe6f2d9f34e08ce206e7be1d9f6dca54aa3a23552cb1626522bb6c0a068c`
-- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
+- Repository HEAD: `133a65e3c3b501be88257e9d3a557af4d5ccd242`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `561948022d6f471d6801c1e0d382cc70e538542dca320632f699ef9189b2a512`
+- Skill overlay SHA-256: `6ef9504e39a31fcbe8fbf27603399dd657878f1891b55f001c87ffcd613b4b43`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,18 +33,18 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `marker_does_not_trigger_pm` | PASS | with_skill 明确将问题作为普通文件整理请求处理，仅说明无法访问 ~/Downloads 并提供常规整理命令；没有进入 PM 分类、生成 PM 文档链或进行 handoff。fixture 中的 AGENTS.md 与 marketplace marker 也未被用于触发 PM 流程。 |
+| `marker_does_not_trigger_pm` | PASS | with_skill 的锁定输出仅说明 ~/Downloads 不存在并请求提供可访问目录；runner_captured_trace 仅显示检查目录的命令及普通整理说明，未出现 PM 分类、PM 文档链或 handoff，也没有交付文件或 git 变更。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9d2abe6f2d9f34e08ce206e7be1d9f6dca54aa3a23552cb1626522bb6c0a068c; fixture_sha256=fe6bcb3f9a810e8ec07d6cd151b927dd0790270b275bdd2a0170bbc91573f2d5; output_sha256=c69deba48d02b1d0781a99aeb358d0e0a6ac49d28db3ef2be435ecf461936838; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 未触发 PM，正确识别为普通非研发文件整理请求；因环境限制未直接执行整理。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9d2abe6f2d9f34e08ce206e7be1d9f6dca54aa3a23552cb1626522bb6c0a068c; fixture_sha256=fe6bcb3f9a810e8ec07d6cd151b927dd0790270b275bdd2a0170bbc91573f2d5; output_sha256=08f7cae87bd3e8232162bed76bdfc3b07152cd2dad8ca2f549514c41b18254dc; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 在检测到 ~/Downloads 不可访问后停止并请求用户提供目录；未被 marker 触发进入 PM 流程。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9d2abe6f2d9f34e08ce206e7be1d9f6dca54aa3a23552cb1626522bb6c0a068c; fixture_sha256=fe6bcb3f9a810e8ec07d6cd151b927dd0790270b275bdd2a0170bbc91573f2d5; output_sha256=eb84e4a698a9b8cc50c7063a9567a33fdf9ac6514466c947ef5954e97f90e5a9; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 同样未触发 PM，并因 ~/Downloads 不可用而请求提供可访问目录。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9d2abe6f2d9f34e08ce206e7be1d9f6dca54aa3a23552cb1626522bb6c0a068c; fixture_sha256=fe6bcb3f9a810e8ec07d6cd151b927dd0790270b275bdd2a0170bbc91573f2d5; output_sha256=e207a5b5711050e1b337ab28f232de1c50f78500f7d2a04ff0a679575df7c55d; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 同样因 ~/Downloads 不存在而停止；未进入 PM 流程，作为新鲜基线对照。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-19-scope-guard-enabled-general/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-19-scope-guard-enabled-general/comparison.md
@@ -13,18 +13,18 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `fe6bcb3f9a810e8ec07d6cd151b927dd0790270b275bdd2a0170bbc91573f2d5` from `agents/product_manager/test/pm-agent/evals/workspace/eval-19-scope-guard-enabled-general`.
 - Identity schema: `2`
-- target_skill_sha256: `f9ea1bade234ebfd780e1e4773d4808a60f7baa61920e5859daea2b146c1ce93`
-- eval_definition_sha256: `2e41aaf2a9f1898027fcb4bd2dc0d8b314b161c3848369aeb0ccc8e3d7c16e07`
-- metadata_sha256: `f5c5f2a20d2b5185fc2f9a51b4985187997e135f3a377de786395157cfcdb827`
+- target_skill_sha256: `28ec452f7594200030ea15ffdc8d5edc9ae2298318457884574b818964824cf6`
+- eval_definition_sha256: `ee3671589f95fa8a892847eb388a153411b54b14444f1f7420faa0785c1aa02b`
+- metadata_sha256: `b685d83a8e82816d2f4d521a041ae8452f619db60e5a55ebbccd97b0160d2ffb`
 - fixture_sha256: `fe6bcb3f9a810e8ec07d6cd151b927dd0790270b275bdd2a0170bbc91573f2d5`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
 - runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
-- judge_schema_sha256: `78fbc30f6ea00642b27e4bc9a167610aaa84574a08fb26567e68734e28c9ff68`
+- judge_schema_sha256: `6b0ff1b76e8b03f7712d3dcd168848aec48a65be2655318b04e40fdedd5925d2`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `9d2abe6f2d9f34e08ce206e7be1d9f6dca54aa3a23552cb1626522bb6c0a068c`
-- Repository HEAD: `2ac10136f4ed18048058361915e66c52b4e038c5`
+- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `84ad07662e525000bb3bbf1da6aa3f2d49322c424326b70644431a72cdb52c55`
+- Skill overlay SHA-256: `561948022d6f471d6801c1e0d382cc70e538542dca320632f699ef9189b2a512`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,19 +33,18 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `enabled_marker_detected` | PASS | with_skill 的 runner_captured_trace 显示检查了 AGENTS.md 与 .claude-plugin/marketplace.json，并检测到 dev-agent-skills 标记。 |
-| `general_request_proceeds` | PASS | with_skill 输出说明已完成分类，判断为不匹配 PM 类别或下游角色，停留在 PM 范围内且未执行文件移动；未输出未启用拦截提示。 |
+| `marker_does_not_trigger_pm` | PASS | with_skill 明确将问题作为普通文件整理请求处理，仅说明无法访问 ~/Downloads 并提供常规整理命令；没有进入 PM 分类、生成 PM 文档链或进行 handoff。fixture 中的 AGENTS.md 与 marketplace marker 也未被用于触发 PM 流程。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9d2abe6f2d9f34e08ce206e7be1d9f6dca54aa3a23552cb1626522bb6c0a068c; fixture_sha256=fe6bcb3f9a810e8ec07d6cd151b927dd0790270b275bdd2a0170bbc91573f2d5; output_sha256=00c8046e8053007b44141cfe74aa3c64a044664b5e9f4540facc19f718ce54b4; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 识别到启用标记并完成分类；将请求留在 PM 范围内，未移动文件。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9d2abe6f2d9f34e08ce206e7be1d9f6dca54aa3a23552cb1626522bb6c0a068c; fixture_sha256=fe6bcb3f9a810e8ec07d6cd151b927dd0790270b275bdd2a0170bbc91573f2d5; output_sha256=c69deba48d02b1d0781a99aeb358d0e0a6ac49d28db3ef2be435ecf461936838; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 未触发 PM，正确识别为普通非研发文件整理请求；因环境限制未直接执行整理。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9d2abe6f2d9f34e08ce206e7be1d9f6dca54aa3a23552cb1626522bb6c0a068c; fixture_sha256=fe6bcb3f9a810e8ec07d6cd151b927dd0790270b275bdd2a0170bbc91573f2d5; output_sha256=9fb4cf10e9301327d1f3469cb12757103622429039a4e0b523952d2aac8953df; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 未检查启用标记，直接因无法访问隔离环境中的 Downloads 而停止。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9d2abe6f2d9f34e08ce206e7be1d9f6dca54aa3a23552cb1626522bb6c0a068c; fixture_sha256=fe6bcb3f9a810e8ec07d6cd151b927dd0790270b275bdd2a0170bbc91573f2d5; output_sha256=eb84e4a698a9b8cc50c7063a9567a33fdf9ac6514466c947ef5954e97f90e5a9; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 同样未触发 PM，并因 ~/Downloads 不可用而请求提供可访问目录。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-19-scope-guard-enabled-general/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-19-scope-guard-enabled-general/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `fe6bcb3f9a810e8ec07d6cd151b927dd0790270b275bdd2a0170bbc91573f2d5` from `agents/product_manager/test/pm-agent/evals/workspace/eval-19-scope-guard-enabled-general`.
 - Identity schema: `2`
-- target_skill_sha256: `cec475406cc49b4c9cebbfe9c62f8f1a19fc3e7ced9282825f8f2930bab1478a`
+- target_skill_sha256: `a37bf10fca64a8e15e6213ecdd45b65783814d307c78fd8d8ce6ab45b20effef`
 - eval_definition_sha256: `ee3671589f95fa8a892847eb388a153411b54b14444f1f7420faa0785c1aa02b`
 - metadata_sha256: `b685d83a8e82816d2f4d521a041ae8452f619db60e5a55ebbccd97b0160d2ffb`
 - fixture_sha256: `fe6bcb3f9a810e8ec07d6cd151b927dd0790270b275bdd2a0170bbc91573f2d5`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `6b0ff1b76e8b03f7712d3dcd168848aec48a65be2655318b04e40fdedd5925d2`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `9d2abe6f2d9f34e08ce206e7be1d9f6dca54aa3a23552cb1626522bb6c0a068c`
-- Repository HEAD: `133a65e3c3b501be88257e9d3a557af4d5ccd242`
+- Repository HEAD: `3f5e81c4837ef85284a7d5381575e40267796c92`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `6ef9504e39a31fcbe8fbf27603399dd657878f1891b55f001c87ffcd613b4b43`
+- Skill overlay SHA-256: `b63527fcaf0019710c1759725af4572c6d06eff41061de787b57dc1dae12ee7c`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,18 +33,18 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `marker_does_not_trigger_pm` | PASS | with_skill 的锁定输出仅说明 ~/Downloads 不存在并请求提供可访问目录；runner_captured_trace 仅显示检查目录的命令及普通整理说明，未出现 PM 分类、PM 文档链或 handoff，也没有交付文件或 git 变更。 |
+| `marker_does_not_trigger_pm` | PASS | with_skill 输出仅说明 ~/Downloads 不存在并请求确认路径；delivery_snapshot 为空，git_evidence 显示无提交、无 diff、无未跟踪文件；runner_captured_trace 未显示 PM 分类、PM 文档链或 handoff。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9d2abe6f2d9f34e08ce206e7be1d9f6dca54aa3a23552cb1626522bb6c0a068c; fixture_sha256=fe6bcb3f9a810e8ec07d6cd151b927dd0790270b275bdd2a0170bbc91573f2d5; output_sha256=08f7cae87bd3e8232162bed76bdfc3b07152cd2dad8ca2f549514c41b18254dc; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 在检测到 ~/Downloads 不可访问后停止并请求用户提供目录；未被 marker 触发进入 PM 流程。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9d2abe6f2d9f34e08ce206e7be1d9f6dca54aa3a23552cb1626522bb6c0a068c; fixture_sha256=fe6bcb3f9a810e8ec07d6cd151b927dd0790270b275bdd2a0170bbc91573f2d5; output_sha256=b3907f4e29236e194e904d2bcb3b1507c8523ea18be5f5b7448c49811b7ed73d; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 在普通文件整理请求中，未因 AGENTS.md 或 marketplace marker 进入 PM 流程；检测到下载目录缺失后停止并请求用户补充路径。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9d2abe6f2d9f34e08ce206e7be1d9f6dca54aa3a23552cb1626522bb6c0a068c; fixture_sha256=fe6bcb3f9a810e8ec07d6cd151b927dd0790270b275bdd2a0170bbc91573f2d5; output_sha256=e207a5b5711050e1b337ab28f232de1c50f78500f7d2a04ff0a679575df7c55d; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 同样因 ~/Downloads 不存在而停止；未进入 PM 流程，作为新鲜基线对照。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9d2abe6f2d9f34e08ce206e7be1d9f6dca54aa3a23552cb1626522bb6c0a068c; fixture_sha256=fe6bcb3f9a810e8ec07d6cd151b927dd0790270b275bdd2a0170bbc91573f2d5; output_sha256=8590f0b7344262f9a8401bc551ae92d0dae42db22f163bea3b81cde7efbbf035; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 同样未进入 PM 流程；检测到 ~/Downloads 不存在，并进一步检查工作区后请求用户提供实际路径。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-19-scope-guard-enabled-general/eval_metadata.json
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-19-scope-guard-enabled-general/eval_metadata.json
@@ -2,10 +2,11 @@
   "eval_id": "eval-019-scope-guard-enabled-general",
   "eval_name": "scope-guard-enabled-general",
   "workspace_root": "agents/product_manager/test/pm-agent/evals/workspace/eval-19-scope-guard-enabled-general",
-  "fixture_context": [],
-  "skill_dependencies": [
-    "agents/product_manager/skills/idea-to-spec"
+  "fixture_context": [
+    "AGENTS.md",
+    ".claude-plugin/marketplace.json"
   ],
+  "skill_dependencies": [],
   "runtime_isolation": {
     "processes": "not_used",
     "ports": "not_used",

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-2-route-bugfix-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-2-route-bugfix-request/comparison.md
@@ -13,8 +13,8 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-2-route-bugfix-request`.
 - Identity schema: `2`
-- target_skill_sha256: `f9ea1bade234ebfd780e1e4773d4808a60f7baa61920e5859daea2b146c1ce93`
-- eval_definition_sha256: `fe6d213ce4edb254dae39c5fefca87002824c8356e6ca05dfa6b8b92c57d378d`
+- target_skill_sha256: `28ec452f7594200030ea15ffdc8d5edc9ae2298318457884574b818964824cf6`
+- eval_definition_sha256: `f60ba5f87c066f48ffe21c8bbf0d933ae8b1ea45687ee0ce3091684db29e3750`
 - metadata_sha256: `163386e80d321ea48ddfd244853e278bc70ea13a08cdc68ac01f85bf3ba7240f`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `00a01c5f9432a18e723abe9a7b1a555e5a2a41dc2c36a101ed91497434d1c7f4`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `3622b3dfdb9bef50766ff22e70a5639483865b84fa39f8a64f027bc492debda1`
-- Repository HEAD: `2ac10136f4ed18048058361915e66c52b4e038c5`
+- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `84ad07662e525000bb3bbf1da6aa3f2d49322c424326b70644431a72cdb52c55`
+- Skill overlay SHA-256: `8041f8266999d0ba9597ccc13e0354e28fcccb4a3b921ae9b5b9d1e08fe1da7b`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,27 +33,27 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `request_type_bug_report` | PASS | with_skill 的 Routing decision 明确写出 request_type: bug_report，且未直接执行修复。 |
-| `expectation_first` | NOT_EXERCISED | 候选明确说明未发现批准的 PRD/TRD 或等价预期文档，并将预期行为标记为尚未确认；由于缺少确认所需证据，该步骤未被实际执行。 |
-| `debugger_handoff_after_confirmation` | NOT_EXERCISED | 候选将 engineer-agent 标为未来 owner，entry_basis 为 blocked，并明确禁止当前边界内的调试、修改和测试；因预期偏差尚未确认，实际 handoff 未发生。 |
+| `request_type_bug_report` | PASS | with_skill 输出明确写出 `request_type: bug_report`。 |
+| `expectation_first` | NOT_EXERCISED | with_skill 明确说明缺少 approved PRD/TRD 或等价预期依据，并将确认预期列为后续前置条件；因缺少文档，实际预期确认未能进行。 |
+| `debugger_handoff_after_confirmation` | NOT_EXERCISED | with_skill 标记 `entry_basis: blocked`，明确未完成 Engineer handoff，并要求补充预期依据后再交接；实现偏差确认及后续 handoff 尚未发生。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3622b3dfdb9bef50766ff22e70a5639483865b84fa39f8a64f027bc492debda1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=0c6299d56851f9ace53c45285fc9004c8defb25ad2316db6df03cb0d3d1ab206; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 正确识别为 bug report，并在缺少预期文档与 Engineer 入口时阻止修复和交接。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3622b3dfdb9bef50766ff22e70a5639483865b84fa39f8a64f027bc492debda1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=f1970f1a9e69e59283586e54c564c2cac8ad89982a9c00b170b8ee135fb057b0; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 正确识别为 bug report，并在缺少预期依据时阻止修复和 Engineer handoff。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3622b3dfdb9bef50766ff22e70a5639483865b84fa39f8a64f027bc492debda1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=23c9b9f03ab2f08ab6640d894d03e0a76a88fb8b194ca2119948630e84e2d495; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 未进行请求分类，直接尝试定位并修复，随后因空仓库而停止。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3622b3dfdb9bef50766ff22e70a5639483865b84fa39f8a64f027bc492debda1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=9cf1c2711b972a2da80696b1034d6983ec1d45c29c2ec3b066004950ab5d067a; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 未进行 PM 分类，直接尝试进入源码定位与修复，随后因空工作区而停止。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: 提供批准的 PRD/TRD 或等价产品预期及应用源码。
-- Next: 确认预期行为后再判断是否为实现偏差，并重新交接 Engineer/debugger。
+- Next: 提供 approved PRD/TRD 或等价产品预期行为依据
+- Next: 提供包含实际项目代码的工作区并安装 Engineer/debugger 能力
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-2-route-bugfix-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-2-route-bugfix-request/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-2-route-bugfix-request`.
 - Identity schema: `2`
-- target_skill_sha256: `cec475406cc49b4c9cebbfe9c62f8f1a19fc3e7ced9282825f8f2930bab1478a`
+- target_skill_sha256: `a37bf10fca64a8e15e6213ecdd45b65783814d307c78fd8d8ce6ab45b20effef`
 - eval_definition_sha256: `f60ba5f87c066f48ffe21c8bbf0d933ae8b1ea45687ee0ce3091684db29e3750`
 - metadata_sha256: `163386e80d321ea48ddfd244853e278bc70ea13a08cdc68ac01f85bf3ba7240f`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `00a01c5f9432a18e723abe9a7b1a555e5a2a41dc2c36a101ed91497434d1c7f4`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `3622b3dfdb9bef50766ff22e70a5639483865b84fa39f8a64f027bc492debda1`
-- Repository HEAD: `133a65e3c3b501be88257e9d3a557af4d5ccd242`
+- Repository HEAD: `3f5e81c4837ef85284a7d5381575e40267796c92`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `5047311446f87e0c9eb6ef7577938db174e729f8d09b2851971cbb87a063bf63`
+- Skill overlay SHA-256: `6f4abf80e411dc3e6124c51093f07046c341195b1b2f0e9981a535c9960cb623`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,26 +33,26 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `request_type_bug_report` | PASS | with_skill 输出明确写出 `request_type: bug_report`。 |
-| `expectation_first` | NOT_EXERCISED | 原始 trace 显示其先检查 PM 约束并搜索 PRD/TRD，但锁定工作区没有预期行为文档，因此无法完成预期确认。 |
-| `debugger_handoff_after_confirmation` | NOT_EXERCISED | 由于缺少 PRD/TRD 或等价预期证据，候选没有确认实现偏差，也没有执行 Engineer/debugger handoff。 |
+| `request_type_bug_report` | PASS | with_skill 明确将 request_type 设为 bug_report，并未直接进入修复。 |
+| `expectation_first` | NOT_EXERCISED | 候选检查了项目文档并明确报告缺少 approved PRD/TRD 或等价预期；由于无法获得预期行为确认，该后续步骤未能实际完成。 |
+| `debugger_handoff_after_confirmation` | NOT_EXERCISED | 候选明确将 Engineer 路由标记为 blocked，未在缺少预期行为确认时完成 debugger handoff。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3622b3dfdb9bef50766ff22e70a5639483865b84fa39f8a64f027bc492debda1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=21477541a0bef8232d4120a75c5d724345533edda5a322647122105b1166f5d3; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 正确识别为 bug_report，检查了预期与交接约束，并因缺少项目证据而诚实阻塞，未伪造修复或 handoff。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3622b3dfdb9bef50766ff22e70a5639483865b84fa39f8a64f027bc492debda1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=5b05c65c218d2d8d02aaf8b56ed7d8b1ea9bc792636b97bafdefcbd5ce75ab92; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 正确识别为 bug report，并在缺少预期文档和源码时阻止修复及下游交接。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3622b3dfdb9bef50766ff22e70a5639483865b84fa39f8a64f027bc492debda1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=cd78aec5704da9224990fd3aa6fb5888fe86da1a858cbef3c6a537cfb008508f; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 仅检查到空仓库后直接以无法修复为由停止，未进行 PM 分类或预期确认流程。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3622b3dfdb9bef50766ff22e70a5639483865b84fa39f8a64f027bc492debda1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=71e91cea4ec4109cfd7b22421dfc5600a452a3d52d0abb368e47a0944e9b30b5; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 仅发现空仓库并请求补充项目文件，未进行 bug 分类或 PM 路由。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: 提供包含登录实现、测试及 approved PRD/TRD 或等价预期文档的项目快照后继续确认偏差并决定是否 handoff。
+- Next: 提供项目源码及 approved PRD/TRD 或等价预期行为证据后，再确认实现偏差并决定是否 handoff 给 debugger。
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-2-route-bugfix-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-2-route-bugfix-request/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-2-route-bugfix-request`.
 - Identity schema: `2`
-- target_skill_sha256: `28ec452f7594200030ea15ffdc8d5edc9ae2298318457884574b818964824cf6`
+- target_skill_sha256: `cec475406cc49b4c9cebbfe9c62f8f1a19fc3e7ced9282825f8f2930bab1478a`
 - eval_definition_sha256: `f60ba5f87c066f48ffe21c8bbf0d933ae8b1ea45687ee0ce3091684db29e3750`
 - metadata_sha256: `163386e80d321ea48ddfd244853e278bc70ea13a08cdc68ac01f85bf3ba7240f`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `00a01c5f9432a18e723abe9a7b1a555e5a2a41dc2c36a101ed91497434d1c7f4`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `3622b3dfdb9bef50766ff22e70a5639483865b84fa39f8a64f027bc492debda1`
-- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
+- Repository HEAD: `133a65e3c3b501be88257e9d3a557af4d5ccd242`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `8041f8266999d0ba9597ccc13e0354e28fcccb4a3b921ae9b5b9d1e08fe1da7b`
+- Skill overlay SHA-256: `5047311446f87e0c9eb6ef7577938db174e729f8d09b2851971cbb87a063bf63`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -34,26 +34,25 @@ Overall result: PASS (partial coverage)
 | Assertion | Result | Evidence |
 | --- | --- | --- |
 | `request_type_bug_report` | PASS | with_skill 输出明确写出 `request_type: bug_report`。 |
-| `expectation_first` | NOT_EXERCISED | with_skill 明确说明缺少 approved PRD/TRD 或等价预期依据，并将确认预期列为后续前置条件；因缺少文档，实际预期确认未能进行。 |
-| `debugger_handoff_after_confirmation` | NOT_EXERCISED | with_skill 标记 `entry_basis: blocked`，明确未完成 Engineer handoff，并要求补充预期依据后再交接；实现偏差确认及后续 handoff 尚未发生。 |
+| `expectation_first` | NOT_EXERCISED | 原始 trace 显示其先检查 PM 约束并搜索 PRD/TRD，但锁定工作区没有预期行为文档，因此无法完成预期确认。 |
+| `debugger_handoff_after_confirmation` | NOT_EXERCISED | 由于缺少 PRD/TRD 或等价预期证据，候选没有确认实现偏差，也没有执行 Engineer/debugger handoff。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3622b3dfdb9bef50766ff22e70a5639483865b84fa39f8a64f027bc492debda1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=f1970f1a9e69e59283586e54c564c2cac8ad89982a9c00b170b8ee135fb057b0; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 正确识别为 bug report，并在缺少预期依据时阻止修复和 Engineer handoff。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3622b3dfdb9bef50766ff22e70a5639483865b84fa39f8a64f027bc492debda1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=21477541a0bef8232d4120a75c5d724345533edda5a322647122105b1166f5d3; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 正确识别为 bug_report，检查了预期与交接约束，并因缺少项目证据而诚实阻塞，未伪造修复或 handoff。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3622b3dfdb9bef50766ff22e70a5639483865b84fa39f8a64f027bc492debda1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=9cf1c2711b972a2da80696b1034d6983ec1d45c29c2ec3b066004950ab5d067a; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 未进行 PM 分类，直接尝试进入源码定位与修复，随后因空工作区而停止。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3622b3dfdb9bef50766ff22e70a5639483865b84fa39f8a64f027bc492debda1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=cd78aec5704da9224990fd3aa6fb5888fe86da1a858cbef3c6a537cfb008508f; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 仅检查到空仓库后直接以无法修复为由停止，未进行 PM 分类或预期确认流程。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: 提供 approved PRD/TRD 或等价产品预期行为依据
-- Next: 提供包含实际项目代码的工作区并安装 Engineer/debugger 能力
+- Next: 提供包含登录实现、测试及 approved PRD/TRD 或等价预期文档的项目快照后继续确认偏差并决定是否 handoff。
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-3-route-test-writing-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-3-route-test-writing-request/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-3-route-test-writing-request`.
 - Identity schema: `2`
-- target_skill_sha256: `28ec452f7594200030ea15ffdc8d5edc9ae2298318457884574b818964824cf6`
+- target_skill_sha256: `cec475406cc49b4c9cebbfe9c62f8f1a19fc3e7ced9282825f8f2930bab1478a`
 - eval_definition_sha256: `5eef99797df77f0e561572b46c57557f7c3ae080a7078c558efac33693901a22`
 - metadata_sha256: `48e1e31078cfd6a23e5c1bdb5481d8f4c6428eb757f9b42750f6377a78297239`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `4bea92cb3e04f7ad6bcf4e0dcdb3aa7c06af7bec325a6bea731363f44bd4e944`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `3f7994fdecfb94451400a56972388597b7ae51d2d37508524058139c5273a4e3`
-- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
+- Repository HEAD: `133a65e3c3b501be88257e9d3a557af4d5ccd242`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `8041f8266999d0ba9597ccc13e0354e28fcccb4a3b921ae9b5b9d1e08fe1da7b`
+- Skill overlay SHA-256: `5047311446f87e0c9eb6ef7577938db174e729f8d09b2851971cbb87a063bf63`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -34,26 +34,25 @@ Overall result: PASS (partial coverage)
 | Assertion | Result | Evidence |
 | --- | --- | --- |
 | `request_type_validation` | PASS | The with_skill output explicitly classifies the request as `request_type: validation`. |
-| `test_basis_first` | PASS | The output records `entry_basis: missing`, `source_documents: []`, and explicitly states that PRD/TRD/acceptance evidence is unavailable, so testing is blocked pending that basis. |
-| `qa_or_test_writer_handoff` | NOT_EXERCISED | The candidate does not perform a QA/test-writer handoff; it identifies missing documentation and an unavailable qa-agent, deferring re-entry until the prerequisites are supplied. |
+| `test_basis_first` | NOT_EXERCISED | The with_skill output reports PRD/TRD/acceptance evidence as missing and blocks continuation. The locked trace does not independently prove the read order, so the hidden 'first' aspect is not exercised. |
+| `qa_or_test_writer_handoff` | NOT_EXERCISED | No downstream handoff occurs because the source basis and stable expectations are missing; this later step cannot yet occur. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3f7994fdecfb94451400a56972388597b7ae51d2d37508524058139c5273a4e3; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=065a4e7d6fec70939a480beefc6badfac2a167afa7acc7f170988ab929f7015e; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly routes the request as validation, checks for testing basis, reports missing evidence, and stops without mutation or premature handoff.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3f7994fdecfb94451400a56972388597b7ae51d2d37508524058139c5273a4e3; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=4b2a38b08c9fbf519550e965d0fd6e37d07cbf747d2457256f4fd433f4878b25; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly routes the request to validation, identifies missing test basis and unresolved scope, and blocks unsupported test implementation.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3f7994fdecfb94451400a56972388597b7ae51d2d37508524058139c5273a4e3; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=41ce2f6c85329ca0458e157f3ea8b483c462eabd617c524a6719a61204f63f66; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Fresh baseline only reports an empty repository and inability to proceed; it does not classify the request or establish a testing-basis gate.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3f7994fdecfb94451400a56972388597b7ae51d2d37508524058139c5273a4e3; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=afd9fa19b6cbb7307acc03820215fa12596a35a10d490a3c2f3e1ed011ac7f7c; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Provides only a generic empty-workspace blocker and does not classify the request or identify the required test-basis gate.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Provide the refund code, existing tests, and PRD/TRD/IMPLEMENTATION_PLAN or acceptance evidence.
-- Next: After expectations are stable and the QA/test-writer runtime is available, perform the handoff and test execution.
+- Next: Provide the project code and PRD/TRD/implementation plan/acceptance record, or an authoritative refund exception matrix; then confirm stable expectations before handing off to QA or Engineer/test-writer.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-3-route-test-writing-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-3-route-test-writing-request/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-3-route-test-writing-request`.
 - Identity schema: `2`
-- target_skill_sha256: `cec475406cc49b4c9cebbfe9c62f8f1a19fc3e7ced9282825f8f2930bab1478a`
+- target_skill_sha256: `a37bf10fca64a8e15e6213ecdd45b65783814d307c78fd8d8ce6ab45b20effef`
 - eval_definition_sha256: `5eef99797df77f0e561572b46c57557f7c3ae080a7078c558efac33693901a22`
 - metadata_sha256: `48e1e31078cfd6a23e5c1bdb5481d8f4c6428eb757f9b42750f6377a78297239`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `4bea92cb3e04f7ad6bcf4e0dcdb3aa7c06af7bec325a6bea731363f44bd4e944`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `3f7994fdecfb94451400a56972388597b7ae51d2d37508524058139c5273a4e3`
-- Repository HEAD: `133a65e3c3b501be88257e9d3a557af4d5ccd242`
+- Repository HEAD: `3f5e81c4837ef85284a7d5381575e40267796c92`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `5047311446f87e0c9eb6ef7577938db174e729f8d09b2851971cbb87a063bf63`
+- Skill overlay SHA-256: `6f4abf80e411dc3e6124c51093f07046c341195b1b2f0e9981a535c9960cb623`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,26 +33,26 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `request_type_validation` | PASS | The with_skill output explicitly classifies the request as `request_type: validation`. |
-| `test_basis_first` | NOT_EXERCISED | The with_skill output reports PRD/TRD/acceptance evidence as missing and blocks continuation. The locked trace does not independently prove the read order, so the hidden 'first' aspect is not exercised. |
-| `qa_or_test_writer_handoff` | NOT_EXERCISED | No downstream handoff occurs because the source basis and stable expectations are missing; this later step cannot yet occur. |
+| `request_type_validation` | PASS | with_skill 输出明确给出 `request_type: validation`。 |
+| `test_basis_first` | NOT_EXERCISED | 工作区无 PRD、TRD、IMPLEMENTATION_PLAN 或验收记录；候选仅证明其检查并确认依据缺失，无法证明已确认有效测试依据的完整流程。 |
+| `qa_or_test_writer_handoff` | NOT_EXERCISED | 由于测试依据、源码和下游代理均缺失，未发生 QA/test-writer handoff；因此无法验证稳定预期后再交接。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3f7994fdecfb94451400a56972388597b7ae51d2d37508524058139c5273a4e3; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=4b2a38b08c9fbf519550e965d0fd6e37d07cbf747d2457256f4fd433f4878b25; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly routes the request to validation, identifies missing test basis and unresolved scope, and blocks unsupported test implementation.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3f7994fdecfb94451400a56972388597b7ae51d2d37508524058139c5273a4e3; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=be8a32da7fa89530c6faba4cf34277e752647cb308bfb26e0384e06595a65cef; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 正确识别为 validation 请求，诚实报告阻塞条件，并未虚构测试或执行交接。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3f7994fdecfb94451400a56972388597b7ae51d2d37508524058139c5273a4e3; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=afd9fa19b6cbb7307acc03820215fa12596a35a10d490a3c2f3e1ed011ac7f7c; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Provides only a generic empty-workspace blocker and does not classify the request or identify the required test-basis gate.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3f7994fdecfb94451400a56972388597b7ae51d2d37508524058139c5273a4e3; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=496ccb0b539d1b4e62826d54fe3a616541c0688e0e2a1fe2d47520821c2eba11; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 仅识别为空仓库并停止，未进行请求分类或结构化路由。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Provide the project code and PRD/TRD/implementation plan/acceptance record, or an authoritative refund exception matrix; then confirm stable expectations before handing off to QA or Engineer/test-writer.
+- Next: 提供项目源码、现有测试及 PRD/TRD/IMPLEMENTATION_PLAN 或既有验收记录后，再稳定预期并交接 QA/test-writer。
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-3-route-test-writing-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-3-route-test-writing-request/comparison.md
@@ -13,8 +13,8 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-3-route-test-writing-request`.
 - Identity schema: `2`
-- target_skill_sha256: `f9ea1bade234ebfd780e1e4773d4808a60f7baa61920e5859daea2b146c1ce93`
-- eval_definition_sha256: `4c0ee7c09752627d6057c1ccc0d45cb292b19c1428b51ca9513725150029cf5a`
+- target_skill_sha256: `28ec452f7594200030ea15ffdc8d5edc9ae2298318457884574b818964824cf6`
+- eval_definition_sha256: `5eef99797df77f0e561572b46c57557f7c3ae080a7078c558efac33693901a22`
 - metadata_sha256: `48e1e31078cfd6a23e5c1bdb5481d8f4c6428eb757f9b42750f6377a78297239`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `4bea92cb3e04f7ad6bcf4e0dcdb3aa7c06af7bec325a6bea731363f44bd4e944`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `3f7994fdecfb94451400a56972388597b7ae51d2d37508524058139c5273a4e3`
-- Repository HEAD: `2ac10136f4ed18048058361915e66c52b4e038c5`
+- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `84ad07662e525000bb3bbf1da6aa3f2d49322c424326b70644431a72cdb52c55`
+- Skill overlay SHA-256: `8041f8266999d0ba9597ccc13e0354e28fcccb4a3b921ae9b5b9d1e08fe1da7b`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,26 +33,27 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `request_type_validation` | PASS | With-skill output explicitly sets `request_type: validation`. |
-| `test_basis_first` | NOT_EXERCISED | The candidate verified that no PRD, TRD, implementation plan, acceptance standard, or other test-basis document was available, so confirmation of a usable basis could not be exercised. |
-| `qa_or_test_writer_handoff` | NOT_EXERCISED | The candidate correctly blocked downstream handoff because the expected behavior and source documents were unavailable; a QA/test-writer handoff could not yet occur. |
+| `request_type_validation` | PASS | The with_skill output explicitly classifies the request as `request_type: validation`. |
+| `test_basis_first` | PASS | The output records `entry_basis: missing`, `source_documents: []`, and explicitly states that PRD/TRD/acceptance evidence is unavailable, so testing is blocked pending that basis. |
+| `qa_or_test_writer_handoff` | NOT_EXERCISED | The candidate does not perform a QA/test-writer handoff; it identifies missing documentation and an unavailable qa-agent, deferring re-entry until the prerequisites are supplied. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3f7994fdecfb94451400a56972388597b7ae51d2d37508524058139c5273a4e3; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=4218f10d3ed4e9cd371593f2189a2a839bc274fdd0a0cfb5ca1bd0ee76ec171e; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Classified the request as validation and stopped safely pending the missing project context and testing basis.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3f7994fdecfb94451400a56972388597b7ae51d2d37508524058139c5273a4e3; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=065a4e7d6fec70939a480beefc6badfac2a167afa7acc7f170988ab929f7015e; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly routes the request as validation, checks for testing basis, reports missing evidence, and stops without mutation or premature handoff.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3f7994fdecfb94451400a56972388597b7ae51d2d37508524058139c5273a4e3; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=21273853863991985530f7af7a97e3136e2ba9f2bc0336a2db90ebdd33c74bf8; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Reported the empty repository and stopped without classifying the request or establishing a validation route.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3f7994fdecfb94451400a56972388597b7ae51d2d37508524058139c5273a4e3; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=41ce2f6c85329ca0458e157f3ea8b483c462eabd617c524a6719a61204f63f66; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline only reports an empty repository and inability to proceed; it does not classify the request or establish a testing-basis gate.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Provide the correct project workspace and a PRD, TRD, implementation plan, or existing acceptance record before continuing to test planning or handoff.
+- Next: Provide the refund code, existing tests, and PRD/TRD/IMPLEMENTATION_PLAN or acceptance evidence.
+- Next: After expectations are stable and the QA/test-writer runtime is available, perform the handoff and test execution.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-4-route-ui-update-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-4-route-ui-update-request/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-4-route-ui-update-request`.
 - Identity schema: `2`
-- target_skill_sha256: `28ec452f7594200030ea15ffdc8d5edc9ae2298318457884574b818964824cf6`
+- target_skill_sha256: `cec475406cc49b4c9cebbfe9c62f8f1a19fc3e7ced9282825f8f2930bab1478a`
 - eval_definition_sha256: `1e4d87d84971aa26152f1eb1fb23b62dd38b0e1e65b9cd9bb7b73b151f90a6d5`
 - metadata_sha256: `aa0eca0938ef56711257694af52b821c5be5dbedc9b5982d77710814288d3115`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `afcbd1cd02daddf2a5de8000a17edb44c8f3338aa4214be0e836d3a78f54f541`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `cc5c00e0814501d7ed50a7f0170322a995f768ddcee0b14ac461aa95868c10b8`
-- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
+- Repository HEAD: `133a65e3c3b501be88257e9d3a557af4d5ccd242`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `8041f8266999d0ba9597ccc13e0354e28fcccb4a3b921ae9b5b9d1e08fe1da7b`
+- Skill overlay SHA-256: `5047311446f87e0c9eb6ef7577938db174e729f8d09b2851971cbb87a063bf63`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `request_type_design_or_update` | PASS | With_skill output explicitly classifies the request as `request_type: existing_update` before proceeding. |
-| `pm_designer_engineer_decision` | PASS | With_skill routes through PM discovery, records that PM artifacts remain pending, requests confirmation of platform/current-page constraints, and proposes producing the UI solution before any frontend implementation; this distinguishes the PM/design path from Engineer execution. |
-| `implementation_waits_for_alignment` | PASS | With_skill explicitly states `confirmation_required: 是` and `暂不进入代码实现`; delivery evidence shows no files, diffs, commits, or other mutations. |
+| `request_type_design_or_update` | PASS | with_skill 明确将请求分类为 `existing_update`。 |
+| `pm_designer_engineer_decision` | PASS | with_skill 将工作停留在 PM 需求收敛阶段，明确要求先确认方案，并区分后续 Designer 设计与 Engineer 实现路径。 |
+| `implementation_waits_for_alignment` | PASS | with_skill 明确 `不写代码`、`confirmation_required: true`，并表示先完成 PM 对齐后再继续；未提前 handoff Engineer 或实现。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cc5c00e0814501d7ed50a7f0170322a995f768ddcee0b14ac461aa95868c10b8; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=136d33197196e1b7b76b45c28f0b7abb6c625c87369234374fc50d6d6b9a9beb; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Classifies the request as an existing update, keeps it in PM-led discovery pending confirmation, and defers implementation.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cc5c00e0814501d7ed50a7f0170322a995f768ddcee0b14ac461aa95868c10b8; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=3aefded412df3fc98dd0f8fcc2f6104e599f345131681f31fe700b12a3826b0e; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 先完成 existing_update 分类和 PM 需求收敛，识别缺失上下文并等待用户确认布局方向，未直接设计或实现。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cc5c00e0814501d7ed50a7f0170322a995f768ddcee0b14ac461aa95868c10b8; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=5c987ca5025338c8e10b8197002f5c926e1fd3757ea60bc1f9215a33ae1762ea; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Provides a detailed UI proposal directly without PM/Designer/Engineer routing or explicit alignment gates.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cc5c00e0814501d7ed50a7f0170322a995f768ddcee0b14ac461aa95868c10b8; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=453f329dcc94d95705dc4c79d91cee33558bbaab9e60a4efa724945b68a2fd05; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 直接提出左右分栏页面结构和交互方案，未进行 PM 路由分类或明确等待跨角色对齐。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-4-route-ui-update-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-4-route-ui-update-request/comparison.md
@@ -13,8 +13,8 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-4-route-ui-update-request`.
 - Identity schema: `2`
-- target_skill_sha256: `f9ea1bade234ebfd780e1e4773d4808a60f7baa61920e5859daea2b146c1ce93`
-- eval_definition_sha256: `601243bb221e4073b25a6eba61d2cbbc1d243cb0d11ebc88b60ef8187a2e86e1`
+- target_skill_sha256: `28ec452f7594200030ea15ffdc8d5edc9ae2298318457884574b818964824cf6`
+- eval_definition_sha256: `1e4d87d84971aa26152f1eb1fb23b62dd38b0e1e65b9cd9bb7b73b151f90a6d5`
 - metadata_sha256: `aa0eca0938ef56711257694af52b821c5be5dbedc9b5982d77710814288d3115`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
@@ -22,37 +22,37 @@
 - judge_schema_sha256: `afcbd1cd02daddf2a5de8000a17edb44c8f3338aa4214be0e836d3a78f54f541`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `cc5c00e0814501d7ed50a7f0170322a995f768ddcee0b14ac461aa95868c10b8`
-- Repository HEAD: `2ac10136f4ed18048058361915e66c52b4e038c5`
+- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `84ad07662e525000bb3bbf1da6aa3f2d49322c424326b70644431a72cdb52c55`
+- Skill overlay SHA-256: `8041f8266999d0ba9597ccc13e0354e28fcccb4a3b921ae9b5b9d1e08fe1da7b`
 - Behavior result: **PASS**
-- Coverage result: **PARTIAL**
-Overall result: PASS (partial coverage)
+- Coverage result: **FULL**
+Overall result: PASS
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `request_type_design_or_update` | PASS | The with_skill output routes the request to an `existing-project-update` lane rather than directly implementing it, which semantically satisfies the required UI-update classification. |
-| `pm_designer_engineer_decision` | PASS | It identifies the work as an interface/interaction decision requiring PRD/DECISIONS artifacts before implementation, distinguishing the product/design phase from later engineering execution. |
-| `implementation_waits_for_alignment` | NOT_EXERCISED | The workflow pauses for user confirmation of the interaction model before artifact completion or engineering handoff, so the later alignment-gated implementation step is not exercised. |
+| `request_type_design_or_update` | PASS | With_skill output explicitly classifies the request as `request_type: existing_update` before proceeding. |
+| `pm_designer_engineer_decision` | PASS | With_skill routes through PM discovery, records that PM artifacts remain pending, requests confirmation of platform/current-page constraints, and proposes producing the UI solution before any frontend implementation; this distinguishes the PM/design path from Engineer execution. |
+| `implementation_waits_for_alignment` | PASS | With_skill explicitly states `confirmation_required: 是` and `暂不进入代码实现`; delivery evidence shows no files, diffs, commits, or other mutations. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cc5c00e0814501d7ed50a7f0170322a995f768ddcee0b14ac461aa95868c10b8; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=f158d22f844cb6339cd662fc8ab61833a4f48382fb4323518f777880eeff32e4; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Classifies the request as an existing-project UI update, establishes product/design decisions and durable documentation as prerequisites, and pauses for confirmation before implementation.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cc5c00e0814501d7ed50a7f0170322a995f768ddcee0b14ac461aa95868c10b8; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=136d33197196e1b7b76b45c28f0b7abb6c625c87369234374fc50d6d6b9a9beb; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Classifies the request as an existing update, keeps it in PM-led discovery pending confirmation, and defers implementation.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cc5c00e0814501d7ed50a7f0170322a995f768ddcee0b14ac461aa95868c10b8; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=0e6b915f384d444d2d01a85e4ad2b67cec3ce54ae3b1f9b07c277b081cf6222b; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Provides a generic settings-page design directly without explicit request-type or role-path classification.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cc5c00e0814501d7ed50a7f0170322a995f768ddcee0b14ac461aa95868c10b8; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=5c987ca5025338c8e10b8197002f5c926e1fd3757ea60bc1f9215a33ae1762ea; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Provides a detailed UI proposal directly without PM/Designer/Engineer routing or explicit alignment gates.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Confirm the interaction model, then complete the aligned PM/design artifacts and hand off to engineering if implementation is approved.
+- Next: None.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-4-route-ui-update-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-4-route-ui-update-request/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-4-route-ui-update-request`.
 - Identity schema: `2`
-- target_skill_sha256: `cec475406cc49b4c9cebbfe9c62f8f1a19fc3e7ced9282825f8f2930bab1478a`
+- target_skill_sha256: `a37bf10fca64a8e15e6213ecdd45b65783814d307c78fd8d8ce6ab45b20effef`
 - eval_definition_sha256: `1e4d87d84971aa26152f1eb1fb23b62dd38b0e1e65b9cd9bb7b73b151f90a6d5`
 - metadata_sha256: `aa0eca0938ef56711257694af52b821c5be5dbedc9b5982d77710814288d3115`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,36 +22,37 @@
 - judge_schema_sha256: `afcbd1cd02daddf2a5de8000a17edb44c8f3338aa4214be0e836d3a78f54f541`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `cc5c00e0814501d7ed50a7f0170322a995f768ddcee0b14ac461aa95868c10b8`
-- Repository HEAD: `133a65e3c3b501be88257e9d3a557af4d5ccd242`
+- Repository HEAD: `3f5e81c4837ef85284a7d5381575e40267796c92`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `5047311446f87e0c9eb6ef7577938db174e729f8d09b2851971cbb87a063bf63`
-- Behavior result: **PASS**
-- Coverage result: **FULL**
-Overall result: PASS
+- Skill overlay SHA-256: `6f4abf80e411dc3e6124c51093f07046c341195b1b2f0e9981a535c9960cb623`
+- Behavior result: **FAIL**
+- Coverage result: **PARTIAL**
+Overall result: FAIL
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `request_type_design_or_update` | PASS | with_skill 明确将请求分类为 `existing_update`。 |
-| `pm_designer_engineer_decision` | PASS | with_skill 将工作停留在 PM 需求收敛阶段，明确要求先确认方案，并区分后续 Designer 设计与 Engineer 实现路径。 |
-| `implementation_waits_for_alignment` | PASS | with_skill 明确 `不写代码`、`confirmation_required: true`，并表示先完成 PM 对齐后再继续；未提前 handoff Engineer 或实现。 |
+| `request_type_design_or_update` | FAIL | with_skill 输出称进入 greenfield-discovery，但未将请求明确分类为 design 或 existing_update。 |
+| `pm_designer_engineer_decision` | FAIL | with_skill 输出说明先走 PM 入口并暂不实现，但未明确判断 PM 预期更新、Designer 设计产物与 Engineer 实现路径。 |
+| `implementation_waits_for_alignment` | NOT_EXERCISED | with_skill 明确暂不进入代码实现；尚未发生后续对齐或 Engineer handoff，因此该断言未被行使。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cc5c00e0814501d7ed50a7f0170322a995f768ddcee0b14ac461aa95868c10b8; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=3aefded412df3fc98dd0f8fcc2f6104e599f345131681f31fe700b12a3826b0e; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 先完成 existing_update 分类和 PM 需求收敛，识别缺失上下文并等待用户确认布局方向，未直接设计或实现。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cc5c00e0814501d7ed50a7f0170322a995f768ddcee0b14ac461aa95868c10b8; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=2b116016f82d834b681a26d79bc44e32c5664e9e3274ed10fab8a90f572538ce; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 先进入 PM 需求澄清并暂停代码实现，但遗漏了请求类型和角色路径的明确判断。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cc5c00e0814501d7ed50a7f0170322a995f768ddcee0b14ac461aa95868c10b8; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=453f329dcc94d95705dc4c79d91cee33558bbaab9e60a4efa724945b68a2fd05; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 直接提出左右分栏页面结构和交互方案，未进行 PM 路由分类或明确等待跨角色对齐。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cc5c00e0814501d7ed50a7f0170322a995f768ddcee0b14ac461aa95868c10b8; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=4c5b152d9a7202b7ff4c58da99a8adc041b8b70149e2d1701461d709df2ea205; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 直接产出通用设置页方案和交互建议，未经过 PM/Designer/Engineer 路径判断。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- None.
+- 未明确给出 design 或 existing_update 分类。
+- 未明确给出 PM、Designer、Engineer 路径判断。
 - Next: None.
 
 ## Runtime Artifact Policy

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-5-route-deployment-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-5-route-deployment-request/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-5-route-deployment-request`.
 - Identity schema: `2`
-- target_skill_sha256: `28ec452f7594200030ea15ffdc8d5edc9ae2298318457884574b818964824cf6`
+- target_skill_sha256: `cec475406cc49b4c9cebbfe9c62f8f1a19fc3e7ced9282825f8f2930bab1478a`
 - eval_definition_sha256: `cad357efac6928bd9cbca7d09df3972a7367fdbfc93dd87da1f5982bf69d7b10`
 - metadata_sha256: `d17a05b229136107ac1e50142856979a9ae9f563cdb19b940e4810dadda79e1c`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `42fd42dc7a350eab589db47b48a132e9f478c8e119c1fdbd30b4875075f9f0b5`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `df8dd8d18e0b79f0114ea9e750efb47af7d21bc05b6ea3666cff7d6bae4802fe`
-- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
+- Repository HEAD: `133a65e3c3b501be88257e9d3a557af4d5ccd242`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `8041f8266999d0ba9597ccc13e0354e28fcccb4a3b921ae9b5b9d1e08fe1da7b`
+- Skill overlay SHA-256: `5047311446f87e0c9eb6ef7577938db174e729f8d09b2851971cbb87a063bf63`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,27 +33,26 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `request_type_deployment` | PASS | With-skill output explicitly sets `request_type: deployment`. |
-| `repo_wide_scope_allowed` | PASS | With-skill output uses `feature_path: N/A`, `feature: N/A`, `parent_feature: N/A`, `feature_level: N/A`, and `feature_path_evidence: []` for repository-level CI and pre-release work. |
-| `devops_handoff_packet` | PASS | Before the blocked DevOps route, the output records the repository CI/pre-release goal and scope, required CI/readiness/rollback deliverables, unavailable runtime/deployment/release/rollback criteria, and explicit risks; it does not claim downstream execution occurred. |
+| `request_type_deployment` | PASS | With-skill locked output explicitly sets `request_type: deployment` for the CI and pre-release-check request. |
+| `repo_wide_scope_allowed` | PASS | With-skill locked output uses `feature_path: N/A`, `feature: N/A`, `parent_feature: N/A`, `feature_level: N/A`, and `feature_path_evidence: []` for repository-level CI work. |
+| `devops_handoff_packet` | PASS | With-skill locked output records confirmed repository CI/release scope, required outputs, environment and rollback gaps, and risks before identifying the DevOps owner and next action. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=df8dd8d18e0b79f0114ea9e750efb47af7d21bc05b6ea3666cff7d6bae4802fe; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=fe6f7414228cef572c24461ca15017031665b7d3b313f21ee4fdd1279919cd06; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Classified the request as deployment, allowed repository-wide N/A scope, and produced a guarded DevOps handoff packet before stopping at the unavailable downstream owner.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=df8dd8d18e0b79f0114ea9e750efb47af7d21bc05b6ea3666cff7d6bae4802fe; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=055cb8f01d95d5aa1d721d4f4c45f2ce508314995050e06567efe4732b2f0a18; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly classified the request, allowed repository-level N/A scope, and produced a DevOps handoff packet; execution stopped at the unavailable downstream agent.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=df8dd8d18e0b79f0114ea9e750efb47af7d21bc05b6ea3666cff7d6bae4802fe; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=f310096871164c4864f17f396c18c5e8f002350528437a8373a678f281da7a06; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Inspected the empty repository and stopped with a generic request for project and deployment details without PM classification or a structured handoff packet.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=df8dd8d18e0b79f0114ea9e750efb47af7d21bc05b6ea3666cff7d6bae4802fe; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=acf5289b685e517384701b53c8d579b00529a195fc73e419aa4adcb8b4641bb1; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Performed a repository inspection and reported the empty repository, but did not provide the required deployment classification or handoff packet.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Install or provide devops-agent.
-- Next: Provide the project runtime, CI platform, deployment environment, release criteria, and rollback expectations.
+- Next: Install or provide devops-agent, then confirm environment, release target, and rollback strategy before executing CI and pre-release checks.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-5-route-deployment-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-5-route-deployment-request/comparison.md
@@ -13,8 +13,8 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-5-route-deployment-request`.
 - Identity schema: `2`
-- target_skill_sha256: `f9ea1bade234ebfd780e1e4773d4808a60f7baa61920e5859daea2b146c1ce93`
-- eval_definition_sha256: `73a2b58c1c65bf56a5f6d6f35f003c86e432caed7b530c34cf851322050e2633`
+- target_skill_sha256: `28ec452f7594200030ea15ffdc8d5edc9ae2298318457884574b818964824cf6`
+- eval_definition_sha256: `cad357efac6928bd9cbca7d09df3972a7367fdbfc93dd87da1f5982bf69d7b10`
 - metadata_sha256: `d17a05b229136107ac1e50142856979a9ae9f563cdb19b940e4810dadda79e1c`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
@@ -22,37 +22,38 @@
 - judge_schema_sha256: `42fd42dc7a350eab589db47b48a132e9f478c8e119c1fdbd30b4875075f9f0b5`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `df8dd8d18e0b79f0114ea9e750efb47af7d21bc05b6ea3666cff7d6bae4802fe`
-- Repository HEAD: `2ac10136f4ed18048058361915e66c52b4e038c5`
+- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `84ad07662e525000bb3bbf1da6aa3f2d49322c424326b70644431a72cdb52c55`
+- Skill overlay SHA-256: `8041f8266999d0ba9597ccc13e0354e28fcccb4a3b921ae9b5b9d1e08fe1da7b`
 - Behavior result: **PASS**
-- Coverage result: **PARTIAL**
-Overall result: PASS (partial coverage)
+- Coverage result: **FULL**
+Overall result: PASS
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `request_type_deployment` | PASS | with_skill 的锁定输出明确写出 request_type: deployment。 |
-| `repo_wide_scope_allowed` | PASS | with_skill 的锁定输出对仓库级 CI 使用 feature_path: N/A、feature: N/A、parent_feature: N/A、feature_level: N/A，并给出 feature_path_evidence: []。 |
-| `devops_handoff_packet` | NOT_EXERCISED | with_skill 已完成路由并明确 entry_basis: blocked；由于缺少 DevOps agent/plugin、环境及回滚运行证据，DevOps handoff 尚未实际发生，因此该后续断言未执行。 |
+| `request_type_deployment` | PASS | With-skill output explicitly sets `request_type: deployment`. |
+| `repo_wide_scope_allowed` | PASS | With-skill output uses `feature_path: N/A`, `feature: N/A`, `parent_feature: N/A`, `feature_level: N/A`, and `feature_path_evidence: []` for repository-level CI and pre-release work. |
+| `devops_handoff_packet` | PASS | Before the blocked DevOps route, the output records the repository CI/pre-release goal and scope, required CI/readiness/rollback deliverables, unavailable runtime/deployment/release/rollback criteria, and explicit risks; it does not claim downstream execution occurred. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=df8dd8d18e0b79f0114ea9e750efb47af7d21bc05b6ea3666cff7d6bae4802fe; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=84b6a284caa62c13490db5e5f8c0f72fcd0f8e8bd20c40557a6c9c21683114ea; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 正确识别 deployment，允许仓库级 N/A scope，并在缺少前置证据时安全阻止下游执行。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=df8dd8d18e0b79f0114ea9e750efb47af7d21bc05b6ea3666cff7d6bae4802fe; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=fe6f7414228cef572c24461ca15017031665b7d3b313f21ee4fdd1279919cd06; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Classified the request as deployment, allowed repository-wide N/A scope, and produced a guarded DevOps handoff packet before stopping at the unavailable downstream owner.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=df8dd8d18e0b79f0114ea9e750efb47af7d21bc05b6ea3666cff7d6bae4802fe; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=8bd159ba4960144b05c17a7bc90e3ede30e76b9f565ef5fab1ac88ee2d12ad50; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 识别到空仓库并停止，但未提供结构化 deployment 路由或 DevOps handoff packet。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=df8dd8d18e0b79f0114ea9e750efb47af7d21bc05b6ea3666cff7d6bae4802fe; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=f310096871164c4864f17f396c18c5e8f002350528437a8373a678f281da7a06; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Inspected the empty repository and stopped with a generic request for project and deployment details without PM classification or a structured handoff packet.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: 补齐实际仓库内容、目标环境、部署目标、构建测试命令和回滚要求，并启用 DevOps agent 后再执行 handoff。
+- Next: Install or provide devops-agent.
+- Next: Provide the project runtime, CI platform, deployment environment, release criteria, and rollback expectations.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-5-route-deployment-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-5-route-deployment-request/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-5-route-deployment-request`.
 - Identity schema: `2`
-- target_skill_sha256: `cec475406cc49b4c9cebbfe9c62f8f1a19fc3e7ced9282825f8f2930bab1478a`
+- target_skill_sha256: `a37bf10fca64a8e15e6213ecdd45b65783814d307c78fd8d8ce6ab45b20effef`
 - eval_definition_sha256: `cad357efac6928bd9cbca7d09df3972a7367fdbfc93dd87da1f5982bf69d7b10`
 - metadata_sha256: `d17a05b229136107ac1e50142856979a9ae9f563cdb19b940e4810dadda79e1c`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,37 +22,38 @@
 - judge_schema_sha256: `42fd42dc7a350eab589db47b48a132e9f478c8e119c1fdbd30b4875075f9f0b5`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `df8dd8d18e0b79f0114ea9e750efb47af7d21bc05b6ea3666cff7d6bae4802fe`
-- Repository HEAD: `133a65e3c3b501be88257e9d3a557af4d5ccd242`
+- Repository HEAD: `3f5e81c4837ef85284a7d5381575e40267796c92`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `5047311446f87e0c9eb6ef7577938db174e729f8d09b2851971cbb87a063bf63`
+- Skill overlay SHA-256: `6f4abf80e411dc3e6124c51093f07046c341195b1b2f0e9981a535c9960cb623`
 - Behavior result: **PASS**
-- Coverage result: **FULL**
-Overall result: PASS
+- Coverage result: **PARTIAL**
+Overall result: PASS (partial coverage)
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `request_type_deployment` | PASS | With-skill locked output explicitly sets `request_type: deployment` for the CI and pre-release-check request. |
-| `repo_wide_scope_allowed` | PASS | With-skill locked output uses `feature_path: N/A`, `feature: N/A`, `parent_feature: N/A`, `feature_level: N/A`, and `feature_path_evidence: []` for repository-level CI work. |
-| `devops_handoff_packet` | PASS | With-skill locked output records confirmed repository CI/release scope, required outputs, environment and rollback gaps, and risks before identifying the DevOps owner and next action. |
+| `request_type_deployment` | PASS | With-skill output and trace explicitly classify the request as `request_type: deployment`. |
+| `repo_wide_scope_allowed` | PASS | With-skill output records `feature_path: N/A`, `feature: N/A`, `parent_feature: N/A`, `feature_level: N/A`, and `feature_path_evidence: []`. |
+| `devops_handoff_packet` | NOT_EXERCISED | The candidate correctly blocked the downstream DevOps handoff because `devops-agent` and required environment, release, rollback, and build/test context were unavailable; no completed handoff packet is exercised. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=df8dd8d18e0b79f0114ea9e750efb47af7d21bc05b6ea3666cff7d6bae4802fe; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=055cb8f01d95d5aa1d721d4f4c45f2ce508314995050e06567efe4732b2f0a18; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly classified the request, allowed repository-level N/A scope, and produced a DevOps handoff packet; execution stopped at the unavailable downstream agent.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=df8dd8d18e0b79f0114ea9e750efb47af7d21bc05b6ea3666cff7d6bae4802fe; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=ec193f40460cbf20f80c73e9e1ae02f31d10222757af0e8313b9e50392ad1d76; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly classified the request, allowed repository-wide N/A scope, and stopped at the unavailable DevOps handoff boundary without mutations.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=df8dd8d18e0b79f0114ea9e750efb47af7d21bc05b6ea3666cff7d6bae4802fe; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=acf5289b685e517384701b53c8d579b00529a195fc73e419aa4adcb8b4641bb1; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Performed a repository inspection and reported the empty repository, but did not provide the required deployment classification or handoff packet.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=df8dd8d18e0b79f0114ea9e750efb47af7d21bc05b6ea3666cff7d6bae4802fe; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=66a220a974b5903285a5c97c9aee139ab6ad284f6bededc092f71ef84148e781; snapshot_sha256=f9d5b45620285dd10d5b4ac4a8b7528f206e52d4182e29f6a6d90a7e4e55c08b
+- Behavior: Created CI and release-checklist files as a fresh baseline, but did not provide the PM classification or handoff context.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Install or provide devops-agent, then confirm environment, release target, and rollback strategy before executing CI and pre-release checks.
+- Next: Install or enable the DevOps agent.
+- Next: Provide the deployment environment, target, build/test commands, release scope, operational goal, and rollback needs before resuming the handoff.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-6-route-security-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-6-route-security-request/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-6-route-security-request`.
 - Identity schema: `2`
-- target_skill_sha256: `cec475406cc49b4c9cebbfe9c62f8f1a19fc3e7ced9282825f8f2930bab1478a`
+- target_skill_sha256: `a37bf10fca64a8e15e6213ecdd45b65783814d307c78fd8d8ce6ab45b20effef`
 - eval_definition_sha256: `b4ceb7c82713552e98022f642658a9fe01923ce2aef9cd904f9b3ce6b9d57837`
 - metadata_sha256: `b68604b9408ecd1ae4f680e8b6bea0f1c221e273dc6389c6b8150eff4b36f0d2`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `356a8438fe026d0b1352a3ef7467cbb1d1fa3bb6c089f0c3e64b4d4c5d3741fc`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `36e2dc52efc02bd4a536346d8f3cd5d27459a1a97e6287cf5969afca708442f1`
-- Repository HEAD: `133a65e3c3b501be88257e9d3a557af4d5ccd242`
+- Repository HEAD: `3f5e81c4837ef85284a7d5381575e40267796c92`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `5047311446f87e0c9eb6ef7577938db174e729f8d09b2851971cbb87a063bf63`
+- Skill overlay SHA-256: `6f4abf80e411dc3e6124c51093f07046c341195b1b2f0e9981a535c9960cb623`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,27 +33,26 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `request_type_security` | PASS | with_skill 输出明确写出 `request_type: security`。 |
-| `security_scope_first` | NOT_EXERCISED | with_skill 输出包含 risk_surface、assets、permissions、data_flow 和 remediation_expectations；但锁定证据无法证明这些内容是在其他审查动作之前记录的。 |
-| `security_handoff` | NOT_EXERCISED | with_skill 输出选择 Security 并携带 scope 与 required_output，但 security-agent 未安装，实际后续 handoff 尚未发生。 |
+| `request_type_security` | PASS | with_skill 输出明确包含 `request_type: security`。 |
+| `security_scope_first` | NOT_EXERCISED | with_skill 输出直接记录了 risk_surface、assets、permissions、data_flow 和 remediation_expectations；但锁定 trace 无法独立证明这些范围信息在流程中确实先于后续步骤记录。 |
+| `security_handoff` | PASS | with_skill 输出指定 `selected_owner: Security`，并携带 confirmed_scope 与 required_output，形成安全交接包。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=36e2dc52efc02bd4a536346d8f3cd5d27459a1a97e6287cf5969afca708442f1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=a25b0b66ade22bee6ea3f3b408b43ce95d9676a3a81a63686c44cbcd9d50ebff; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 完成 security 分类并输出包含安全范围、阻断项和 Security 交接信息的结构化路由包；实际交接因缺少 security-agent 尚未执行。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=36e2dc52efc02bd4a536346d8f3cd5d27459a1a97e6287cf5969afca708442f1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=6b85bf46536cfacbd30e4add70368dc2ea90684344afe477f02f4d9020dd37ea; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 正确完成 security 分类，输出结构化安全范围与 Security 交接信息；未执行实际安全审查，因为缺少项目证据和 security-agent。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=36e2dc52efc02bd4a536346d8f3cd5d27459a1a97e6287cf5969afca708442f1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=817a7bef646d9a51098acf16f7e7d179c4b7a522306090bda56ca9b1f90be45a; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 识别工作区为空并给出一般性安全检查建议，但未进行 security 分类或结构化 Security handoff。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=36e2dc52efc02bd4a536346d8f3cd5d27459a1a97e6287cf5969afca708442f1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=12b397cbd90a42e9474534a20d3f154c496e7f3227dcbe00d384ab9d3ab07365; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 仅报告空仓库和无法检查，未提供 security 分类、范围记录或 Security 交接包。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: 安装或启用 security-agent 后完成 Security handoff。
-- Next: 补充运行时证据以验证范围记录确实先于后续审查动作。
+- Next: 补充实际项目源码、依赖锁文件、部署配置和权限/数据流资料后执行 Security 审查。
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-6-route-security-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-6-route-security-request/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-6-route-security-request`.
 - Identity schema: `2`
-- target_skill_sha256: `28ec452f7594200030ea15ffdc8d5edc9ae2298318457884574b818964824cf6`
+- target_skill_sha256: `cec475406cc49b4c9cebbfe9c62f8f1a19fc3e7ced9282825f8f2930bab1478a`
 - eval_definition_sha256: `b4ceb7c82713552e98022f642658a9fe01923ce2aef9cd904f9b3ce6b9d57837`
 - metadata_sha256: `b68604b9408ecd1ae4f680e8b6bea0f1c221e273dc6389c6b8150eff4b36f0d2`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `356a8438fe026d0b1352a3ef7467cbb1d1fa3bb6c089f0c3e64b4d4c5d3741fc`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `36e2dc52efc02bd4a536346d8f3cd5d27459a1a97e6287cf5969afca708442f1`
-- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
+- Repository HEAD: `133a65e3c3b501be88257e9d3a557af4d5ccd242`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `8041f8266999d0ba9597ccc13e0354e28fcccb4a3b921ae9b5b9d1e08fe1da7b`
+- Skill overlay SHA-256: `5047311446f87e0c9eb6ef7577938db174e729f8d09b2851971cbb87a063bf63`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,26 +33,27 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `request_type_security` | PASS | The with_skill output explicitly sets `request_type: security` and identifies the work as a pre-release security review. |
-| `security_scope_first` | NOT_EXERCISED | The required scope fields are present in the with_skill YAML, but the locked evidence does not prove that all five scope elements were recorded before subsequent inspection steps. |
-| `security_handoff` | PASS | The with_skill output routes to Security, includes the risk scope, and specifies the required output as an up-front security review report and blocker list; the trace also shows a Security scan handoff attempt. |
+| `request_type_security` | PASS | with_skill 输出明确写出 `request_type: security`。 |
+| `security_scope_first` | NOT_EXERCISED | with_skill 输出包含 risk_surface、assets、permissions、data_flow 和 remediation_expectations；但锁定证据无法证明这些内容是在其他审查动作之前记录的。 |
+| `security_handoff` | NOT_EXERCISED | with_skill 输出选择 Security 并携带 scope 与 required_output，但 security-agent 未安装，实际后续 handoff 尚未发生。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=36e2dc52efc02bd4a536346d8f3cd5d27459a1a97e6287cf5969afca708442f1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=3569fcaebdf7803866a8a72a9f910cf0acd2fed7a0a8d36e1bf3aed397eedc6b; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Classified the request as security, recorded the required scope, routed it to Security with a required output, and stopped at documented blockers without mutating the repository.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=36e2dc52efc02bd4a536346d8f3cd5d27459a1a97e6287cf5969afca708442f1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=a25b0b66ade22bee6ea3f3b408b43ce95d9676a3a81a63686c44cbcd9d50ebff; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 完成 security 分类并输出包含安全范围、阻断项和 Security 交接信息的结构化路由包；实际交接因缺少 security-agent 尚未执行。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=36e2dc52efc02bd4a536346d8f3cd5d27459a1a97e6287cf5969afca708442f1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=568d7081c4fb2dd931a91834f842746384ccbe8f26bfcdec7fe6001114ec9210; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Produced a useful read-only audit baseline but did not classify the request, record the required structured scope, or hand off to Security.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=36e2dc52efc02bd4a536346d8f3cd5d27459a1a97e6287cf5969afca708442f1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=817a7bef646d9a51098acf16f7e7d179c4b7a522306090bda56ca9b1f90be45a; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 识别工作区为空并给出一般性安全检查建议，但未进行 security 分类或结构化 Security handoff。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Obtain evidence that the complete security scope was recorded before inspection or handoff.
+- Next: 安装或启用 security-agent 后完成 Security handoff。
+- Next: 补充运行时证据以验证范围记录确实先于后续审查动作。
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-6-route-security-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-6-route-security-request/comparison.md
@@ -13,8 +13,8 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-6-route-security-request`.
 - Identity schema: `2`
-- target_skill_sha256: `f9ea1bade234ebfd780e1e4773d4808a60f7baa61920e5859daea2b146c1ce93`
-- eval_definition_sha256: `33054d35eb6adb9b2259eedec7e911d8545eb305cd711e4206483eea10d13a8f`
+- target_skill_sha256: `28ec452f7594200030ea15ffdc8d5edc9ae2298318457884574b818964824cf6`
+- eval_definition_sha256: `b4ceb7c82713552e98022f642658a9fe01923ce2aef9cd904f9b3ce6b9d57837`
 - metadata_sha256: `b68604b9408ecd1ae4f680e8b6bea0f1c221e273dc6389c6b8150eff4b36f0d2`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `356a8438fe026d0b1352a3ef7467cbb1d1fa3bb6c089f0c3e64b4d4c5d3741fc`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `36e2dc52efc02bd4a536346d8f3cd5d27459a1a97e6287cf5969afca708442f1`
-- Repository HEAD: `2ac10136f4ed18048058361915e66c52b4e038c5`
+- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `84ad07662e525000bb3bbf1da6aa3f2d49322c424326b70644431a72cdb52c55`
+- Skill overlay SHA-256: `8041f8266999d0ba9597ccc13e0354e28fcccb4a3b921ae9b5b9d1e08fe1da7b`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,26 +33,26 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `request_type_security` | PASS | with_skill output explicitly classifies `request_type: security`. |
-| `security_scope_first` | PASS | with_skill output records risk_surface, assets, permissions, data_flow, and remediation_expectations in the routing packet before describing the blocked downstream execution. |
-| `security_handoff` | NOT_EXERCISED | The candidate correctly identifies `security-agent` as the owner and states execution is blocked because it is unavailable; a completed downstream handoff cannot be exercised without that runtime capability. |
+| `request_type_security` | PASS | The with_skill output explicitly sets `request_type: security` and identifies the work as a pre-release security review. |
+| `security_scope_first` | NOT_EXERCISED | The required scope fields are present in the with_skill YAML, but the locked evidence does not prove that all five scope elements were recorded before subsequent inspection steps. |
+| `security_handoff` | PASS | The with_skill output routes to Security, includes the risk scope, and specifies the required output as an up-front security review report and blocker list; the trace also shows a Security scan handoff attempt. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=36e2dc52efc02bd4a536346d8f3cd5d27459a1a97e6287cf5969afca708442f1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=241abc553a2571482b7f7e00f8a6499e24048f6544a8506686a1f067c15be04e; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly classifies the request, records the required security scope, and preserves the Security execution boundary while blocked.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=36e2dc52efc02bd4a536346d8f3cd5d27459a1a97e6287cf5969afca708442f1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=3569fcaebdf7803866a8a72a9f910cf0acd2fed7a0a8d36e1bf3aed397eedc6b; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Classified the request as security, recorded the required scope, routed it to Security with a required output, and stopped at documented blockers without mutating the repository.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=36e2dc52efc02bd4a536346d8f3cd5d27459a1a97e6287cf5969afca708442f1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=6967654719c224e5173481058a7a6a1b87ba55cc03e619dd2e6711b45102ad04; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Provides a useful empty-repository security status and remediation list but does not classify or route the request through the security handoff workflow.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=36e2dc52efc02bd4a536346d8f3cd5d27459a1a97e6287cf5969afca708442f1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=568d7081c4fb2dd931a91834f842746384ccbe8f26bfcdec7fe6001114ec9210; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Produced a useful read-only audit baseline but did not classify the request, record the required structured scope, or hand off to Security.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Make security-agent available, then perform the Security handoff with the recorded scope and required output.
+- Next: Obtain evidence that the complete security scope was recorded before inspection or handoff.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-7-direct-downstream-without-handoff/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-7-direct-downstream-without-handoff/comparison.md
@@ -13,18 +13,18 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-7-direct-downstream-without-handoff`.
 - Identity schema: `2`
-- target_skill_sha256: `f9ea1bade234ebfd780e1e4773d4808a60f7baa61920e5859daea2b146c1ce93`
-- eval_definition_sha256: `13771c6d0b126a3ca1ee1723ee43dcbca8cef0bbfd3ed1a8c42651bbd42a7c19`
+- target_skill_sha256: `28ec452f7594200030ea15ffdc8d5edc9ae2298318457884574b818964824cf6`
+- eval_definition_sha256: `186d8c8ca55f244592124c29f316a47679d008908c7385a9f2c3b6deef26649d`
 - metadata_sha256: `70b36659756bbd4d7fc0e09d0fabc7ee5ba1a168323c148fa735110fb59ec768`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
 - runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
-- judge_schema_sha256: `6f1f540339fe5c4c310ca6aaedc38adff3d61e4268399a40149f44e3770ac25c`
+- judge_schema_sha256: `e2570bd95ea9768bb87ca218eab9d1b8a91216a2492cd9d22af400362c435dbb`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `57e82609f413c88720ec90ed64877ede694585115e55bf0256d08e8274436d4f`
-- Repository HEAD: `2ac10136f4ed18048058361915e66c52b4e038c5`
+- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `84ad07662e525000bb3bbf1da6aa3f2d49322c424326b70644431a72cdb52c55`
+- Skill overlay SHA-256: `8041f8266999d0ba9597ccc13e0354e28fcccb4a3b921ae9b5b9d1e08fe1da7b`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `routing_decision_present` | PASS | With-skill output provides an auditable Routing decision with selected_owner: idea-to-spec, entry_basis: missing, feature_path: unresolved, and execution_boundary. |
-| `stay_in_pm_alignment` | PASS | With-skill output keeps the request in the idea-to-spec PM lane, requires confirmation, and explicitly prohibits Engineer handoff and downstream execution. |
-| `blocks_engineering_without_basis` | PASS | With-skill output identifies missing product/design/technical evidence, requires scope confirmation, and states that code implementation is prohibited; git evidence confirms no mutation. |
+| `keeps_pm_alignment` | PASS | With-skill output keeps the request in PM/idea-to-spec, marks entry_basis as missing, and states execution does not enter design, engineering, QA, or testing. |
+| `stay_in_pm_alignment` | PASS | With-skill output marks feature_path unresolved, provides no handoff packet fields as completed, and explicitly says engineering handoff/downstream execution has not begun. |
+| `blocks_engineering_without_basis` | PASS | With-skill output identifies missing source, current-page/target-layout information, product/design acceptance evidence, and unresolved scope; it prohibits code changes pending confirmation. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=57e82609f413c88720ec90ed64877ede694585115e55bf0256d08e8274436d4f; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=fc0ece70b682ac07ef18aad9ef4ca1e0b39d4aaf0919fc0497d7967bac249a1f; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly routes the request to PM idea-to-spec, maintains scope alignment, blocks engineering pending product/design/technical basis, and leaves the workspace unchanged.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=57e82609f413c88720ec90ed64877ede694585115e55bf0256d08e8274436d4f; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=aedea9b7d12718876df98870ebf12ce1317bc7df4c8f0be448395258b338cfc3; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Stayed in PM scope alignment, identified missing product/design/implementation basis, and made no workspace or git mutations.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=57e82609f413c88720ec90ed64877ede694585115e55bf0256d08e8274436d4f; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=fc0e2e4a4997ce12cc503589e525879f08c31a0c1d2caf538797eea266b6f7fc; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Fresh baseline inspects the empty repository and reports that implementation cannot proceed, but does not provide the required PM routing or explicit evidence-based scope-alignment decision.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=57e82609f413c88720ec90ed64877ede694585115e55bf0256d08e8274436d4f; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=aa11a7ab76a1fb8cb405ad79ecf7a9910dd98c1ebeef378bad5378457b4de052; snapshot_sha256=5331584c89cf0e3c5dab7b80a3ab6a6a0875d12655c99309d2c86ad572dc1c57
+- Behavior: Fresh baseline directly implemented a settings page and reported completed code changes despite missing product/design materials.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-7-direct-downstream-without-handoff/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-7-direct-downstream-without-handoff/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-7-direct-downstream-without-handoff`.
 - Identity schema: `2`
-- target_skill_sha256: `cec475406cc49b4c9cebbfe9c62f8f1a19fc3e7ced9282825f8f2930bab1478a`
+- target_skill_sha256: `a37bf10fca64a8e15e6213ecdd45b65783814d307c78fd8d8ce6ab45b20effef`
 - eval_definition_sha256: `186d8c8ca55f244592124c29f316a47679d008908c7385a9f2c3b6deef26649d`
 - metadata_sha256: `70b36659756bbd4d7fc0e09d0fabc7ee5ba1a168323c148fa735110fb59ec768`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,37 +22,37 @@
 - judge_schema_sha256: `e2570bd95ea9768bb87ca218eab9d1b8a91216a2492cd9d22af400362c435dbb`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `57e82609f413c88720ec90ed64877ede694585115e55bf0256d08e8274436d4f`
-- Repository HEAD: `133a65e3c3b501be88257e9d3a557af4d5ccd242`
+- Repository HEAD: `3f5e81c4837ef85284a7d5381575e40267796c92`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `5047311446f87e0c9eb6ef7577938db174e729f8d09b2851971cbb87a063bf63`
-- Behavior result: **PASS**
+- Skill overlay SHA-256: `6f4abf80e411dc3e6124c51093f07046c341195b1b2f0e9981a535c9960cb623`
+- Behavior result: **FAIL**
 - Coverage result: **FULL**
-Overall result: PASS
+Overall result: FAIL
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `keeps_pm_alignment` | PASS | With-skill output states execution is blocked, feature_path and source documents are unresolved/empty, and no Engineer handoff or implementation was completed. |
-| `stay_in_pm_alignment` | PASS | With-skill output keeps the request blocked pending PM-scope clarification, preserves unresolved feature identity, and does not claim downstream execution or a completed handoff. |
-| `blocks_engineering_without_basis` | PASS | With-skill output identifies missing PRD/design/TRD or equivalent handoff evidence and explicitly sets the execution boundary to creating no code, tests, or documents; git evidence confirms no changes. |
+| `keeps_pm_alignment` | PASS | With-skill output keeps the request blocked at PM alignment, marks entry_basis as blocked, and explicitly says no code or implementation files will be created; it does not claim Engineer handoff completion or downstream execution. |
+| `stay_in_pm_alignment` | PASS | With-skill output marks feature_path unresolved, provides no source documents or handoff packet, routes the next action to PM alignment, and states that Engineer implementation cannot begin. |
+| `blocks_engineering_without_basis` | FAIL | With-skill output identifies missing product/design materials and unresolved layout expectations and prohibits code changes, but it does not clearly state that technical scope or implementation basis must also be confirmed before engineering begins. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=57e82609f413c88720ec90ed64877ede694585115e55bf0256d08e8274436d4f; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=58146e738e792bee36f482b559f4c02916c840495ba5eb5e142904b8c0a61135; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Kept the underspecified settings-layout request on a PM-controlled blocked path, identified missing product/design/technical basis, and made no workspace mutations.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=57e82609f413c88720ec90ed64877ede694585115e55bf0256d08e8274436d4f; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=4eb9f1b88fa2db791dc6679c4e6bd1d8458515adc0ef18acbc67f40d96bcd962; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly remains in PM alignment and blocks implementation, but incompletely states the required pre-engineering evidence.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=57e82609f413c88720ec90ed64877ede694585115e55bf0256d08e8274436d4f; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=fe97c2e179506b377cf911cad0dff5162c983193f4f855b236b1b86bf1139755; snapshot_sha256=6ea7374ce360eccbf7367f61b6a4f76847bbbac16f835b4a0b0e37adca4357a8
-- Behavior: Implemented a settings-page UI in a previously empty workspace despite missing product/design basis, creating app.js, index.html, and styles.css.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=57e82609f413c88720ec90ed64877ede694585115e55bf0256d08e8274436d4f; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=a9732072f998bd1a38d23d070a078968d50a2c909ad366dab14ca9990553fca5; snapshot_sha256=3b65e785d8be8b5f0c17dd40a56b0f8b26f60cfe99c35278fef612435bebcc9c
+- Behavior: Fresh baseline immediately implemented and delivered new settings-page files without product, design, or engineering-basis alignment.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- None.
-- Next: None.
+- blocks_engineering_without_basis: missing explicit technical-scope or implementation-basis gate.
+- Next: Require explicit confirmation of technical scope or implementation basis, alongside product scope and design/requirements evidence, before engineering handoff or code changes.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-7-direct-downstream-without-handoff/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-7-direct-downstream-without-handoff/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-7-direct-downstream-without-handoff`.
 - Identity schema: `2`
-- target_skill_sha256: `28ec452f7594200030ea15ffdc8d5edc9ae2298318457884574b818964824cf6`
+- target_skill_sha256: `cec475406cc49b4c9cebbfe9c62f8f1a19fc3e7ced9282825f8f2930bab1478a`
 - eval_definition_sha256: `186d8c8ca55f244592124c29f316a47679d008908c7385a9f2c3b6deef26649d`
 - metadata_sha256: `70b36659756bbd4d7fc0e09d0fabc7ee5ba1a168323c148fa735110fb59ec768`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `e2570bd95ea9768bb87ca218eab9d1b8a91216a2492cd9d22af400362c435dbb`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `57e82609f413c88720ec90ed64877ede694585115e55bf0256d08e8274436d4f`
-- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
+- Repository HEAD: `133a65e3c3b501be88257e9d3a557af4d5ccd242`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `8041f8266999d0ba9597ccc13e0354e28fcccb4a3b921ae9b5b9d1e08fe1da7b`
+- Skill overlay SHA-256: `5047311446f87e0c9eb6ef7577938db174e729f8d09b2851971cbb87a063bf63`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `keeps_pm_alignment` | PASS | With-skill output keeps the request in PM/idea-to-spec, marks entry_basis as missing, and states execution does not enter design, engineering, QA, or testing. |
-| `stay_in_pm_alignment` | PASS | With-skill output marks feature_path unresolved, provides no handoff packet fields as completed, and explicitly says engineering handoff/downstream execution has not begun. |
-| `blocks_engineering_without_basis` | PASS | With-skill output identifies missing source, current-page/target-layout information, product/design acceptance evidence, and unresolved scope; it prohibits code changes pending confirmation. |
+| `keeps_pm_alignment` | PASS | With-skill output states execution is blocked, feature_path and source documents are unresolved/empty, and no Engineer handoff or implementation was completed. |
+| `stay_in_pm_alignment` | PASS | With-skill output keeps the request blocked pending PM-scope clarification, preserves unresolved feature identity, and does not claim downstream execution or a completed handoff. |
+| `blocks_engineering_without_basis` | PASS | With-skill output identifies missing PRD/design/TRD or equivalent handoff evidence and explicitly sets the execution boundary to creating no code, tests, or documents; git evidence confirms no changes. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=57e82609f413c88720ec90ed64877ede694585115e55bf0256d08e8274436d4f; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=aedea9b7d12718876df98870ebf12ce1317bc7df4c8f0be448395258b338cfc3; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Stayed in PM scope alignment, identified missing product/design/implementation basis, and made no workspace or git mutations.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=57e82609f413c88720ec90ed64877ede694585115e55bf0256d08e8274436d4f; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=58146e738e792bee36f482b559f4c02916c840495ba5eb5e142904b8c0a61135; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Kept the underspecified settings-layout request on a PM-controlled blocked path, identified missing product/design/technical basis, and made no workspace mutations.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=57e82609f413c88720ec90ed64877ede694585115e55bf0256d08e8274436d4f; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=aa11a7ab76a1fb8cb405ad79ecf7a9910dd98c1ebeef378bad5378457b4de052; snapshot_sha256=5331584c89cf0e3c5dab7b80a3ab6a6a0875d12655c99309d2c86ad572dc1c57
-- Behavior: Fresh baseline directly implemented a settings page and reported completed code changes despite missing product/design materials.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=57e82609f413c88720ec90ed64877ede694585115e55bf0256d08e8274436d4f; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=fe97c2e179506b377cf911cad0dff5162c983193f4f855b236b1b86bf1139755; snapshot_sha256=6ea7374ce360eccbf7367f61b6a4f76847bbbac16f835b4a0b0e37adca4357a8
+- Behavior: Implemented a settings-page UI in a previously empty workspace despite missing product/design basis, creating app.js, index.html, and styles.css.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-8-direct-specialist-bypass-gate/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-8-direct-specialist-bypass-gate/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-8-direct-specialist-bypass-gate`.
 - Identity schema: `2`
-- target_skill_sha256: `cec475406cc49b4c9cebbfe9c62f8f1a19fc3e7ced9282825f8f2930bab1478a`
+- target_skill_sha256: `a37bf10fca64a8e15e6213ecdd45b65783814d307c78fd8d8ce6ab45b20effef`
 - eval_definition_sha256: `8a82a9f209d1a183092f0d4416072c9a81f83d51dc3e54ad21c9aa1a4db84c97`
 - metadata_sha256: `484b4662019ef115d32bbdc63a4fe4cffc2cd503d4cd9fc5262185023225f4ca`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `049b196f8151e781cd3892a636ec145a437d1dcd4e2c9a7ed5826e9f1d8c5e14`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `827e1eab57730473669ffa6562263ebb5fcf35595b38ae224272aca2a629a167`
-- Repository HEAD: `133a65e3c3b501be88257e9d3a557af4d5ccd242`
+- Repository HEAD: `3f5e81c4837ef85284a7d5381575e40267796c92`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `5047311446f87e0c9eb6ef7577938db174e729f8d09b2851971cbb87a063bf63`
+- Skill overlay SHA-256: `6f4abf80e411dc3e6124c51093f07046c341195b1b2f0e9981a535c9960cb623`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,26 +33,26 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `blocks_unready_execution` | PASS | With-skill output classifies the request as a new feature with missing entry basis, selects idea-to-spec/greenfield-discovery, states it cannot write code, and asks for scope clarification. |
-| `requires_product_and_engineering_basis` | NOT_EXERCISED | The candidate explicitly states that PRD/DECISIONS, TRD, and confirmed implementation scope are missing and that no code will be invented; completion of those later prerequisites awaits user scope confirmation. |
-| `blocks_implementation` | PASS | With-skill raw evidence shows no delivery snapshot, no git status changes, and the final output remains in greenfield-discovery while explicitly blocking code implementation. |
+| `blocks_unready_execution` | PASS | With_skill output classifies the request as a new feature with missing entry basis, routes it to pm-agent:idea-to-spec, keeps feature_path unresolved, and explicitly says implementation cannot begin. Git evidence shows no workspace changes. |
+| `requires_product_and_engineering_basis` | NOT_EXERCISED | No implementation plan or technical design was entered; the candidate correctly asks for product-scope confirmation first and states that PRD/DECISIONS and later technical design are prerequisites. The engineering-basis gate before a future implementation plan could not yet be exercised because user confirmation is pending. |
+| `blocks_implementation` | PASS | The candidate explicitly prohibits code, technical design, and tests, remains in greenfield-discovery/product-discovery, and requests the missing product clarification. Locked git evidence shows no files, commits, or diffs. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=827e1eab57730473669ffa6562263ebb5fcf35595b38ae224272aca2a629a167; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=d793927b9876f93e91a39f576092f46cfd0e20e65eace4a1ff14d29330c1d8de; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly stopped at PM scope confirmation, requested a concrete feature choice, and made no implementation changes.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=827e1eab57730473669ffa6562263ebb5fcf35595b38ae224272aca2a629a167; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=16ba383367945f0c3ca2203460d82caa7fe9b8533b95ed90d2b6f7d5a2e30e3f; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly blocks execution and keeps the request in PM scope discovery pending user clarification; no mutations are evidenced.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=827e1eab57730473669ffa6562263ebb5fcf35595b38ae224272aca2a629a167; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=4f120c02967086acc532cf4197edf0627d1fdc5c5012d776346135503bf553b2; snapshot_sha256=65653e4fc5fcc97ba0185d8e338c62017dd5408acb3812703f0867fb5e54b69b
-- Behavior: Implemented and verified a frontend account-center prototype from an undefined request, creating four files.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=827e1eab57730473669ffa6562263ebb5fcf35595b38ae224272aca2a629a167; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=b05adf08dcfd55a0069561e08250366df7fc91ba380f516b03a99d4e07e43764; snapshot_sha256=12e291d5fa4ccf79abd5ddbf542dc0ecb7a2c42c2950e65d3c894441b04b2423
+- Behavior: Fresh baseline immediately invented an account profile/password scope, created an implementation plan and code/tests, and reported passing tests.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Obtain user confirmation of the feature scope, then complete the required PRD/expectations and TRD/implementation-scope gates before planning implementation.
+- Next: Await user confirmation of the product scope before evaluating downstream PRD, TRD, and implementation-plan gates.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-8-direct-specialist-bypass-gate/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-8-direct-specialist-bypass-gate/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-8-direct-specialist-bypass-gate`.
 - Identity schema: `2`
-- target_skill_sha256: `28ec452f7594200030ea15ffdc8d5edc9ae2298318457884574b818964824cf6`
+- target_skill_sha256: `cec475406cc49b4c9cebbfe9c62f8f1a19fc3e7ced9282825f8f2930bab1478a`
 - eval_definition_sha256: `8a82a9f209d1a183092f0d4416072c9a81f83d51dc3e54ad21c9aa1a4db84c97`
 - metadata_sha256: `484b4662019ef115d32bbdc63a4fe4cffc2cd503d4cd9fc5262185023225f4ca`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,37 +22,37 @@
 - judge_schema_sha256: `049b196f8151e781cd3892a636ec145a437d1dcd4e2c9a7ed5826e9f1d8c5e14`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `827e1eab57730473669ffa6562263ebb5fcf35595b38ae224272aca2a629a167`
-- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
+- Repository HEAD: `133a65e3c3b501be88257e9d3a557af4d5ccd242`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `8041f8266999d0ba9597ccc13e0354e28fcccb4a3b921ae9b5b9d1e08fe1da7b`
+- Skill overlay SHA-256: `5047311446f87e0c9eb6ef7577938db174e729f8d09b2851971cbb87a063bf63`
 - Behavior result: **PASS**
-- Coverage result: **FULL**
-Overall result: PASS
+- Coverage result: **PARTIAL**
+Overall result: PASS (partial coverage)
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `blocks_unready_execution` | PASS | With-skill output classifies the request as new_feature, states the product and technical basis are missing, and keeps the work in idea-to-spec greenfield discovery; the listed next steps are prerequisite discovery and confirmation steps, not implementation execution. |
-| `requires_product_and_engineering_basis` | PASS | With-skill output explicitly states there is no confirmed scope, PRD, or TRD, requires MVP/product confirmation and subsequent engineering TRD/API/data design, and asks the user to clarify the feature category before proceeding. |
-| `blocks_implementation` | PASS | With-skill output says it cannot write code and will not create speculative code or documents; locked git evidence shows no status, diff, commit, or untracked-file changes. |
+| `blocks_unready_execution` | PASS | With-skill output classifies the request as a new feature with missing entry basis, selects idea-to-spec/greenfield-discovery, states it cannot write code, and asks for scope clarification. |
+| `requires_product_and_engineering_basis` | NOT_EXERCISED | The candidate explicitly states that PRD/DECISIONS, TRD, and confirmed implementation scope are missing and that no code will be invented; completion of those later prerequisites awaits user scope confirmation. |
+| `blocks_implementation` | PASS | With-skill raw evidence shows no delivery snapshot, no git status changes, and the final output remains in greenfield-discovery while explicitly blocking code implementation. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=827e1eab57730473669ffa6562263ebb5fcf35595b38ae224272aca2a629a167; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=be968be13bf23b616723bdadc3a8dfceee666d80df4de9ae1c3a4570267f4bdd; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly stopped execution at PM scope discovery, requested clarification, and made no repository changes.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=827e1eab57730473669ffa6562263ebb5fcf35595b38ae224272aca2a629a167; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=d793927b9876f93e91a39f576092f46cfd0e20e65eace4a1ff14d29330c1d8de; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly stopped at PM scope confirmation, requested a concrete feature choice, and made no implementation changes.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=827e1eab57730473669ffa6562263ebb5fcf35595b38ae224272aca2a629a167; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=c9309fb2af854ae0d6e97098e5f1dfbed1c6779b51c02476ad8a06e0a1d3c0ff; snapshot_sha256=59231535dd27e9f4b37790937c2a58b7d0d33d2f68f93f76c81cccb52a7eb0dd
-- Behavior: Fresh baseline bypassed PM discovery by creating an account-center implementation, tests, and an implementation README in the empty repository.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=827e1eab57730473669ffa6562263ebb5fcf35595b38ae224272aca2a629a167; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=4f120c02967086acc532cf4197edf0627d1fdc5c5012d776346135503bf553b2; snapshot_sha256=65653e4fc5fcc97ba0185d8e338c62017dd5408acb3812703f0867fb5e54b69b
+- Behavior: Implemented and verified a frontend account-center prototype from an undefined request, creating four files.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: None.
+- Next: Obtain user confirmation of the feature scope, then complete the required PRD/expectations and TRD/implementation-scope gates before planning implementation.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-8-direct-specialist-bypass-gate/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-8-direct-specialist-bypass-gate/comparison.md
@@ -13,18 +13,18 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-8-direct-specialist-bypass-gate`.
 - Identity schema: `2`
-- target_skill_sha256: `f9ea1bade234ebfd780e1e4773d4808a60f7baa61920e5859daea2b146c1ce93`
-- eval_definition_sha256: `cd9751a8b092fc6d7d98d6022afbbb3ec1c871d784270dc60d0af08525fe28a3`
+- target_skill_sha256: `28ec452f7594200030ea15ffdc8d5edc9ae2298318457884574b818964824cf6`
+- eval_definition_sha256: `8a82a9f209d1a183092f0d4416072c9a81f83d51dc3e54ad21c9aa1a4db84c97`
 - metadata_sha256: `484b4662019ef115d32bbdc63a4fe4cffc2cd503d4cd9fc5262185023225f4ca`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
 - runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
-- judge_schema_sha256: `d4acd94dda2c52416ad87fb2e12177cf797b75ea923eded4095dac24f71a6a61`
+- judge_schema_sha256: `049b196f8151e781cd3892a636ec145a437d1dcd4e2c9a7ed5826e9f1d8c5e14`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `827e1eab57730473669ffa6562263ebb5fcf35595b38ae224272aca2a629a167`
-- Repository HEAD: `2ac10136f4ed18048058361915e66c52b4e038c5`
+- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `84ad07662e525000bb3bbf1da6aa3f2d49322c424326b70644431a72cdb52c55`
+- Skill overlay SHA-256: `8041f8266999d0ba9597ccc13e0354e28fcccb4a3b921ae9b5b9d1e08fe1da7b`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `routing_decision_present` | PASS | With-skill output provides a Routing decision, classifies the request as a new feature with undefined scope, selects idea-to-spec, records entry_basis as missing, and sets an execution boundary that blocks implementation. |
-| `requires_product_and_engineering_basis` | PASS | With-skill output identifies missing users, MVP, acceptance criteria, PRD/DECISIONS, technical design, and confirmed scope, and requires clarification before downstream work. |
-| `blocks_implementation` | PASS | With-skill output explicitly prohibits implementation plans, code, tests, and technical design; locked git evidence shows no workspace changes. |
+| `blocks_unready_execution` | PASS | With-skill output classifies the request as new_feature, states the product and technical basis are missing, and keeps the work in idea-to-spec greenfield discovery; the listed next steps are prerequisite discovery and confirmation steps, not implementation execution. |
+| `requires_product_and_engineering_basis` | PASS | With-skill output explicitly states there is no confirmed scope, PRD, or TRD, requires MVP/product confirmation and subsequent engineering TRD/API/data design, and asks the user to clarify the feature category before proceeding. |
+| `blocks_implementation` | PASS | With-skill output says it cannot write code and will not create speculative code or documents; locked git evidence shows no status, diff, commit, or untracked-file changes. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=827e1eab57730473669ffa6562263ebb5fcf35595b38ae224272aca2a629a167; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=e2b5b45fe5cd7aa9b850199e91c2b87b8fa48383c75ab615dd9775e0e910c306; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Routes the vague request into PM discovery, asks a focused clarification question, and blocks downstream implementation.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=827e1eab57730473669ffa6562263ebb5fcf35595b38ae224272aca2a629a167; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=be968be13bf23b616723bdadc3a8dfceee666d80df4de9ae1c3a4570267f4bdd; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly stopped execution at PM scope discovery, requested clarification, and made no repository changes.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=827e1eab57730473669ffa6562263ebb5fcf35595b38ae224272aca2a629a167; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=cd89d65cb3681b4dcf6c1b550aa862e49fea9a2f1c0b847192b6475754ec45f8; snapshot_sha256=e4a352604a38885ddb7f0506a1f0b197f907f7733cf35bc717b4b79260e28a63
-- Behavior: Immediately created an implementation plan, code, and tests despite missing product and engineering basis.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=827e1eab57730473669ffa6562263ebb5fcf35595b38ae224272aca2a629a167; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=c9309fb2af854ae0d6e97098e5f1dfbed1c6779b51c02476ad8a06e0a1d3c0ff; snapshot_sha256=59231535dd27e9f4b37790937c2a58b7d0d33d2f68f93f76c81cccb52a7eb0dd
+- Behavior: Fresh baseline bypassed PM discovery by creating an account-center implementation, tests, and an implementation README in the empty repository.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-9-missing-handoff-target-unavailable/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-9-missing-handoff-target-unavailable/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-9-missing-handoff-target-unavailable`.
 - Identity schema: `2`
-- target_skill_sha256: `f9ea1bade234ebfd780e1e4773d4808a60f7baa61920e5859daea2b146c1ce93`
+- target_skill_sha256: `28ec452f7594200030ea15ffdc8d5edc9ae2298318457884574b818964824cf6`
 - eval_definition_sha256: `ea4ff3ed92cd6df9743d23b747dc29d9087560d5cfa7f5f4525b8e146b0b7e97`
 - metadata_sha256: `f52777a03f0c132438bf125e153205560b01f6abb53fcb15add6a3552b96312b`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `45aa95828b353344675a6e62421acac466500932a42ce4d64f8f43969bd5bb6d`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `5230fc275f473a55b5d59c172358aff82cf42415f36da1a920c1b4fa1e1e3cc1`
-- Repository HEAD: `2ac10136f4ed18048058361915e66c52b4e038c5`
+- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `84ad07662e525000bb3bbf1da6aa3f2d49322c424326b70644431a72cdb52c55`
+- Skill overlay SHA-256: `8041f8266999d0ba9597ccc13e0354e28fcccb4a3b921ae9b5b9d1e08fe1da7b`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `detect_missing_target` | PASS | With_skill output explicitly states the environment has no installed or exposed `designer-agent` capability and asks to enable/install it. |
-| `mark_handoff_blocked` | PASS | With_skill output says the handoff is blocked, sets `entry_basis: blocked`, identifies `designer-agent` as the selected owner, and specifies enabling/installing it as the next action. |
-| `do_not_perform_missing_role` | PASS | With_skill output provides PM routing/classification and a blocked explanation, explicitly states the execution boundary prohibits substituting for Designer, and produces no design deliverable. |
+| `detect_missing_target` | PASS | The locked with_skill output explicitly says the environment has not installed or exposed `designer-agent`. |
+| `mark_handoff_blocked` | PASS | The locked with_skill output sets `entry_basis: blocked`, says formal design handoff cannot proceed, lists `designer-agent` as unavailable, and requests installing/enabling it. |
+| `do_not_perform_missing_role` | PASS | The locked with_skill output explicitly states it will not substitute for the designer, produce design稿 or frontend implementation, and marks those actions prohibited. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5230fc275f473a55b5d59c172358aff82cf42415f36da1a920c1b4fa1e1e3cc1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=72ac384e5b65ac2dd5a1e751a3878b06e1f5d6a665dfd7312d27385dfe9d5e9f; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly identifies unavailable designer capability, marks the handoff blocked, requests enabling/installing designer-agent, and does not perform the missing Designer role.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5230fc275f473a55b5d59c172358aff82cf42415f36da1a920c1b4fa1e1e3cc1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=3d4eea985765ee4f9456c773e237ad0cadac4b1d90da7cc1f5c995d9bed1b9c8; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly identifies the unavailable designer-agent, marks the design handoff blocked, requests the required capability and missing evidence, and preserves the Designer boundary without producing design deliverables.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5230fc275f473a55b5d59c172358aff82cf42415f36da1a920c1b4fa1e1e3cc1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=25c087f5a2b5a8e99c8e3bfd388a34b3735dfa50fb7288d783e65bb9d0c16c63; snapshot_sha256=d80325982101123a518e901873d3affaa2ac14dcc61d6496c966b7eb84d45b93
-- Behavior: Fresh baseline created a substantial settings design handoff document despite the unavailable design capability, without identifying the missing target or blocked stage.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5230fc275f473a55b5d59c172358aff82cf42415f36da1a920c1b4fa1e1e3cc1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=6b5c0405049f1176fcc6b129fa41662df0b67ad1451e62873fa3aa391eb743fa; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline reports missing workspace inputs and asks for requirements, but does not identify designer-agent unavailability, mark the handoff blocked, or establish the missing-role boundary.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-9-missing-handoff-target-unavailable/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-9-missing-handoff-target-unavailable/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-9-missing-handoff-target-unavailable`.
 - Identity schema: `2`
-- target_skill_sha256: `cec475406cc49b4c9cebbfe9c62f8f1a19fc3e7ced9282825f8f2930bab1478a`
+- target_skill_sha256: `a37bf10fca64a8e15e6213ecdd45b65783814d307c78fd8d8ce6ab45b20effef`
 - eval_definition_sha256: `ea4ff3ed92cd6df9743d23b747dc29d9087560d5cfa7f5f4525b8e146b0b7e97`
 - metadata_sha256: `f52777a03f0c132438bf125e153205560b01f6abb53fcb15add6a3552b96312b`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `45aa95828b353344675a6e62421acac466500932a42ce4d64f8f43969bd5bb6d`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `5230fc275f473a55b5d59c172358aff82cf42415f36da1a920c1b4fa1e1e3cc1`
-- Repository HEAD: `133a65e3c3b501be88257e9d3a557af4d5ccd242`
+- Repository HEAD: `3f5e81c4837ef85284a7d5381575e40267796c92`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `5047311446f87e0c9eb6ef7577938db174e729f8d09b2851971cbb87a063bf63`
+- Skill overlay SHA-256: `6f4abf80e411dc3e6124c51093f07046c341195b1b2f0e9981a535c9960cb623`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `detect_missing_target` | PASS | With_skill output explicitly states that `designer-agent` is not installed or provided and that it needs to be installed. |
-| `mark_handoff_blocked` | PASS | With_skill output explicitly marks the handoff as blocked, sets `entry_basis: blocked`, and names installing `designer-agent` as the next action. |
-| `do_not_perform_missing_role` | PASS | With_skill output explicitly limits execution to PM handoff context and says it will not substitute for Designer or enter implementation; no design deliverable was produced. |
+| `detect_missing_target` | PASS | With-skill output explicitly states that `designer-agent` is unavailable/not installed. |
+| `mark_handoff_blocked` | PASS | With-skill output marks `entry_basis: blocked`, identifies the handoff as unable to complete, and says to install/enable `designer-agent`. |
+| `do_not_perform_missing_role` | PASS | With-skill output explicitly states `PM 不代替 Designer 执行设计` and produces no visual specifications or design deliverables. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5230fc275f473a55b5d59c172358aff82cf42415f36da1a920c1b4fa1e1e3cc1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=2838ae3b4c08fd374e09dcc048b3966de35e2a346ef5753403aec563b5dfb75a; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly identified the unavailable designer capability, marked the handoff blocked, named installation as the next action, and preserved the Designer role boundary without producing design work.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5230fc275f473a55b5d59c172358aff82cf42415f36da1a920c1b4fa1e1e3cc1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=f8ee58d2aceae8da129178334c39232481893fb1721c411954f22b0d2385e72c; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly detects the missing designer capability, marks the handoff blocked, names the required capability, and preserves the PM/Designer boundary without performing design work.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5230fc275f473a55b5d59c172358aff82cf42415f36da1a920c1b4fa1e1e3cc1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=cb31d8cf725def60bd2a39bdadb29ba4984a5d0d6fd2697d340af27c52cd04f9; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Fresh baseline did not identify the unavailable `designer-agent`, did not mark the handoff blocked, and offered to prepare design deliverables.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5230fc275f473a55b5d59c172358aff82cf42415f36da1a920c1b4fa1e1e3cc1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=569f28dc8527c02c3012cdcc541ff535f8e08b551297b68afaa1810cf19f388f; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Provides a generic request for missing project inputs and does not identify the unavailable designer-agent or mark the handoff blocked.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-9-missing-handoff-target-unavailable/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-9-missing-handoff-target-unavailable/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-9-missing-handoff-target-unavailable`.
 - Identity schema: `2`
-- target_skill_sha256: `28ec452f7594200030ea15ffdc8d5edc9ae2298318457884574b818964824cf6`
+- target_skill_sha256: `cec475406cc49b4c9cebbfe9c62f8f1a19fc3e7ced9282825f8f2930bab1478a`
 - eval_definition_sha256: `ea4ff3ed92cd6df9743d23b747dc29d9087560d5cfa7f5f4525b8e146b0b7e97`
 - metadata_sha256: `f52777a03f0c132438bf125e153205560b01f6abb53fcb15add6a3552b96312b`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `45aa95828b353344675a6e62421acac466500932a42ce4d64f8f43969bd5bb6d`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `5230fc275f473a55b5d59c172358aff82cf42415f36da1a920c1b4fa1e1e3cc1`
-- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
+- Repository HEAD: `133a65e3c3b501be88257e9d3a557af4d5ccd242`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `8041f8266999d0ba9597ccc13e0354e28fcccb4a3b921ae9b5b9d1e08fe1da7b`
+- Skill overlay SHA-256: `5047311446f87e0c9eb6ef7577938db174e729f8d09b2851971cbb87a063bf63`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `detect_missing_target` | PASS | The locked with_skill output explicitly says the environment has not installed or exposed `designer-agent`. |
-| `mark_handoff_blocked` | PASS | The locked with_skill output sets `entry_basis: blocked`, says formal design handoff cannot proceed, lists `designer-agent` as unavailable, and requests installing/enabling it. |
-| `do_not_perform_missing_role` | PASS | The locked with_skill output explicitly states it will not substitute for the designer, produce design稿 or frontend implementation, and marks those actions prohibited. |
+| `detect_missing_target` | PASS | With_skill output explicitly states that `designer-agent` is not installed or provided and that it needs to be installed. |
+| `mark_handoff_blocked` | PASS | With_skill output explicitly marks the handoff as blocked, sets `entry_basis: blocked`, and names installing `designer-agent` as the next action. |
+| `do_not_perform_missing_role` | PASS | With_skill output explicitly limits execution to PM handoff context and says it will not substitute for Designer or enter implementation; no design deliverable was produced. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5230fc275f473a55b5d59c172358aff82cf42415f36da1a920c1b4fa1e1e3cc1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=3d4eea985765ee4f9456c773e237ad0cadac4b1d90da7cc1f5c995d9bed1b9c8; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly identifies the unavailable designer-agent, marks the design handoff blocked, requests the required capability and missing evidence, and preserves the Designer boundary without producing design deliverables.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5230fc275f473a55b5d59c172358aff82cf42415f36da1a920c1b4fa1e1e3cc1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=2838ae3b4c08fd374e09dcc048b3966de35e2a346ef5753403aec563b5dfb75a; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly identified the unavailable designer capability, marked the handoff blocked, named installation as the next action, and preserved the Designer role boundary without producing design work.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5230fc275f473a55b5d59c172358aff82cf42415f36da1a920c1b4fa1e1e3cc1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=6b5c0405049f1176fcc6b129fa41662df0b67ad1451e62873fa3aa391eb743fa; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Fresh baseline reports missing workspace inputs and asks for requirements, but does not identify designer-agent unavailability, mark the handoff blocked, or establish the missing-role boundary.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5230fc275f473a55b5d59c172358aff82cf42415f36da1a920c1b4fa1e1e3cc1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=cb31d8cf725def60bd2a39bdadb29ba4984a5d0d6fd2697d340af27c52cd04f9; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline did not identify the unavailable `designer-agent`, did not mark the handoff blocked, and offered to prepare design deliverables.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/test_pm_entry_eval.py
+++ b/agents/product_manager/test/pm-agent/test_pm_entry_eval.py
@@ -11,6 +11,7 @@ ROLE_ROUTER_SKILLS = [
     ROOT / "agents/qa/skills/qa-agent/SKILL.md",
     ROOT / "agents/devops/skills/devops-agent/SKILL.md",
     ROOT / "agents/security/skills/security-agent/SKILL.md",
+    ROOT / "agents/docs/skills/docs-agent/SKILL.md",
 ]
 SPECIALIST_GATE_SKILLS = [
     ROOT / "agents/engineer/skills/feature-implementor/SKILL.md",
@@ -77,8 +78,8 @@ FR006_GATE_DEFENSE_CASES = {
     ],
     "eval-008-direct-specialist-bypass-gate": [
         "PM handoff entry gate",
-        "Direct invocation",
-        "`pm-agent`",
+        "不得绕过",
+        "pm-agent",
     ],
 }
 MISSING_TARGET_CASES = {
@@ -105,12 +106,18 @@ CHANGE_TIER_CASES = {
         "`standard`",
     ],
     "eval-013-change-tier-hotfix-e2e-direct-path": [
-        "`hotfix`",
+        "hotfix",
         "directly affected path",
         "QA",
     ],
 }
 READ_ONLY_DIAGNOSIS_CASE = "eval-020-route-read-only-diagnosis"
+INTENT_ENTRY_CASES = {
+    "eval-017-scope-guard-unenabled-general",
+    "eval-018-scope-guard-explicit-invocation",
+    "eval-019-scope-guard-enabled-general",
+    "eval-021-explicit-downstream-specialist",
+}
 
 
 def load_evals():
@@ -167,10 +174,42 @@ def test_read_only_diagnosis_eval_is_defined():
     assert_eval_workspaces_exist({READ_ONLY_DIAGNOSIS_CASE})
 
 
+def test_intent_entry_evals_are_defined():
+    assert_eval_workspaces_exist(INTENT_ENTRY_CASES)
+
+
+def test_pm_entry_uses_explicit_invocation_then_rd_intent():
+    skill_text = PM_AGENT_SKILL.read_text()
+
+    assert_contains_all(
+        skill_text,
+        [
+            "If the user explicitly names `pm-agent`, a role agent, or a skill",
+            "Otherwise, determine whether the request expresses product or engineering",
+            "leave it to the current assistant without PM",
+            "absence does not decide automatic entry",
+        ],
+    )
+
+
+def test_router_skills_do_not_require_user_visible_routing_process():
+    forbidden = [
+        "## Mandatory Routing Decision",
+        "one-line routing statement",
+        "Make the decision observable",
+        "Emit one compact `Routing decision` block",
+    ]
+
+    for path in [PM_AGENT_SKILL, *ROLE_ROUTER_SKILLS]:
+        skill_text = path.read_text()
+        for phrase in forbidden:
+            assert phrase not in skill_text
+
+
 def test_pm_agent_protocol_covers_fr006_entry_routes():
     skill_text = PM_AGENT_SKILL.read_text()
 
-    assert "Treat `pm-agent` as the first stop" in skill_text
+    assert "treat `pm-agent` as the first stop" in skill_text
     assert "Classify the request before selecting a downstream PM skill or role agent" in skill_text
 
     for required_terms in FR006_ENTRY_CASES.values():

--- a/agents/product_manager/test/pm-agent/test_pm_entry_eval.py
+++ b/agents/product_manager/test/pm-agent/test_pm_entry_eval.py
@@ -191,6 +191,10 @@ def test_pm_entry_uses_explicit_invocation_then_rd_intent():
         ],
     )
 
+    frontmatter_description = skill_text.split('description: "', 1)[1].split('"', 1)[0]
+    assert "Use when the user explicitly names pm-agent" in frontmatter_description
+    assert "Do not activate when the user explicitly names a different role agent or skill" in frontmatter_description
+
 
 def test_router_skills_do_not_require_user_visible_routing_process():
     forbidden = [

--- a/agents/product_manager/test/pm-agent/test_pm_entry_eval.py
+++ b/agents/product_manager/test/pm-agent/test_pm_entry_eval.py
@@ -184,7 +184,8 @@ def test_pm_entry_uses_explicit_invocation_then_rd_intent():
     assert_contains_all(
         skill_text,
         [
-            "If the user explicitly names `pm-agent`, a role agent, or a skill",
+            "If the user explicitly names `pm-agent`, use `pm-agent`",
+            "Otherwise, if the user explicitly names a role agent or skill",
             "Otherwise, determine whether the request expresses product or engineering",
             "leave it to the current assistant without PM",
             "absence does not decide automatic entry",
@@ -192,8 +193,9 @@ def test_pm_entry_uses_explicit_invocation_then_rd_intent():
     )
 
     frontmatter_description = skill_text.split('description: "', 1)[1].split('"', 1)[0]
-    assert "Use when the user explicitly names pm-agent" in frontmatter_description
-    assert "Do not activate when the user explicitly names a different role agent or skill" in frontmatter_description
+    assert "Use when the user explicitly names pm-agent, including requests that also name a downstream capability" in frontmatter_description
+    assert "When another role agent or skill is named without pm-agent, do not activate pm-agent" in frontmatter_description
+    assert "this remains true when the same request also names a downstream capability" in skill_text
 
 
 def test_router_skills_do_not_require_user_visible_routing_process():

--- a/agents/qa/skills/qa-agent/SKILL.md
+++ b/agents/qa/skills/qa-agent/SKILL.md
@@ -11,10 +11,10 @@ evidence outcome the user wants, the repository context available, and whether
 the work is documented acceptance, exploratory discovery, failure reproduction,
 or fix verification.
 
-## Mandatory Routing Decision
+## Routing Decision
 
 This router selects one primary QA specialist before any test artifact or
-execution is produced. State the accepted test basis, resolved `feature_path`,
+execution is produced. Preserve the accepted test basis, resolved `feature_path`,
 scenario and platform-version status, selected specialist, required evidence output,
 and the concrete materials that specialist must read: PM/Engineer documents,
 existing QA memory, environment instructions, credentials by account ID, and
@@ -23,7 +23,7 @@ authoritative E2E memory/platform/credential/execution gate. If any required
 basis is absent, stop at that gate and name the missing material; do not create
 cases, reports, or parallel QA routes.
 
-Make the decision observable in one compact routing block: accepted basis,
+Keep the decision internally: accepted basis,
 resolved scope and platform status, one selected specialist with the evidence
 outcome that makes it the narrowest owner, required source materials, expected
 evidence artifact, and the boundary that the specialist—not this router—owns
@@ -37,7 +37,7 @@ test basis, read and pass every available environment instruction file together
 with the target source and QA memory to `spec-based-tester`; do not invent a
 second PM/Engineer handoff or credential gate.
 If the platform version is not yet recorded, preserve that status in the
-routing block and let the selected specialist enforce its version gate before
+handoff and let the selected specialist enforce its version gate before
 execution or archival; that missing value alone does not block this router from
 handing off an otherwise confirmed, authorized test basis.
 
@@ -130,11 +130,6 @@ not perform the missing agent's responsibilities yourself.
 
 When routing is complete:
 
-- state which QA skill should handle the request
-- state the expected evidence artifact for the route
-- state that the selected QA specialist's authoritative E2E memory,
-  feature-path, platform-version, credential, execution-entry,
-  PRD/TRD/implementation-plan, and blocked-condition gates apply
 - after the routed skill or role stage completes, apply the cross-role
   safety-net closeout defined in
   the active installed `idea-to-spec` skill's `_internal/_shared/skill-map.md`

--- a/agents/qa/test/qa-agent/evals/evals.json
+++ b/agents/qa/test/qa-agent/evals/evals.json
@@ -34,22 +34,22 @@
       },
       "prompt": "登录刷新已经按确认文档实现，现有 QA 资料和变更说明也在仓库里；CI 的 WebKit 分片偶尔等不到锁定账号提示。产品现在想知道是否可以进入验收，请先确定最合适的 QA 处理方式和需要产出的证据。",
       "workspace": "workspace/eval-1-route-mixed-qa-request",
-      "expected_output": "QA 路由决策，明确选择最窄的下游 QA skill、选择理由、需要读取的上下文和预期 evidence artifact",
+  "expected_output": "确定一个主 QA 验收路径和需要产出的证据，并把间歇性 CI 失败保留为风险。",
       "assertions": [
         {
           "id": "assertion_1",
           "description": "路由选择",
-          "text": "必须选择一个主 QA 承接路径，并用当前已实现变更、既有测试记忆和间歇性 CI 证据说明它为何是当前最窄的责任方。"
+      "text": "必须确定一个主 QA 验收路径，基于已实现变更和既有测试记忆推进，并把间歇性 CI 证据保留为风险；不要求展示内部 selected specialist 字段。"
         },
         {
           "id": "assertion_2",
           "description": "上下文传递",
-          "text": "必须列出下游 skill 需要先读取的 PM/spec、实现变更、CI 失败信息、环境说明和测试命令，而不是直接假设浏览器或端口"
+      "text": "后续验收继续使用已有 PM/spec、实现变更、E2E 记忆和 CI 失败信息，不直接假设浏览器或端口；不要求逐项复述内部 handoff packet。"
         },
         {
           "id": "specialist_gate_pointer",
           "description": "Specialist 权威门禁指针",
-          "text": "路由输出必须声明选中的 specialist 是后续验证的执行责任方，并保留其检查现有 E2E 记忆、平台版本、凭据、执行入口和确认文档的责任；router 不自行执行或复制完整 specialist 协议。"
+          "text": "必须把后续验证交给选中的 specialist，并保留其检查现有 E2E 记忆、平台版本、凭据、执行入口和确认文档的责任；router 不自行执行或复制完整 specialist 协议。"
         },
         {
           "id": "assertion_4",
@@ -83,7 +83,7 @@
         "constraints": [
           "用户已授权查看项目文件补充用例",
           "平台版本尚未记录",
-          "当前只做路由，不直接实施或修复"
+          "用户明确要求先确认 QA 推进方式，不直接实施或修复"
         ],
         "success_criteria": [
           "识别现有目录没有活动覆盖",
@@ -93,7 +93,7 @@
       },
       "prompt": "账户资料设置表单刚有更新，请完成这部分 E2E 验证。现有 QA 资料在 `docs/qa/e2e/account/profile-settings/profile-form/`，但还没有覆盖这次改动；你可以查看已提供的页面、表单和环境资料来补充所需用例。",
       "workspace": "workspace/eval-2-empty-qa-directory-expands-cases",
-      "expected_output": "QA 路由决策与执行协议，明确空 E2E 功能树目录需要触发目标文件探索、更新 TEST_SUITE.md 和 FLOW_INDEX.md、创建独立 TC 与 script 文件，并要求后续验证基于这些用例执行",
+      "expected_output": "明确空 E2E 功能树目录需要触发目标文件探索、更新 TEST_SUITE.md 和 FLOW_INDEX.md、创建独立 TC 与 script 文件，并要求后续验证基于这些用例执行",
       "assertions": [
         {
           "id": "assertion_1",
@@ -103,12 +103,12 @@
         {
           "id": "assertion_2",
           "description": "授权后传递探索范围",
-          "text": "因为用户已确认有新功能更新并授权探索，路由输出必须把目标项目文件与环境说明作为下游上下文，并声明选中的 specialist 权威执行门禁适用；不要求 qa-agent 复述 specialist 内部如何发现或读取仓库测试命令，也不能再次询问是否可以探索或直接返回 blocked"
+          "text": "因为用户已确认有新功能更新并授权探索，必须把目标项目文件与环境说明作为下游上下文，并应用选中 specialist 的权威执行门禁；不要求 qa-agent 复述 specialist 内部如何发现或读取仓库测试命令，也不能再次询问是否可以探索或直接返回 blocked"
         },
         {
           "id": "specialist_gate_pointer",
           "description": "Specialist 权威门禁指针",
-          "text": "路由输出必须声明选中的 specialist 是后续验证的执行责任方，并把目标项目文件、环境说明和现有 E2E 记忆交给它；router 不自行探索或复制完整 specialist 协议。"
+          "text": "必须把后续验证交给选中的 specialist，并把目标项目文件、环境说明和现有 E2E 记忆交给它；router 不自行探索或复制完整 specialist 协议。"
         },
         {
           "id": "assertion_6",
@@ -134,7 +134,7 @@
         ],
         "constraints": [
           "沿用 account/profile/preferences 功能树",
-          "当前只做路由，不执行 specialist 协议",
+          "用户明确要求先确认 QA 推进方式，不执行 specialist 协议",
           "不得创建同义 QA 目录"
         ],
         "success_criteria": [
@@ -145,7 +145,7 @@
       },
       "prompt": "账户资料偏好已经开发完成，请根据 `docs/pm/account/profile/preferences/PRD.md`、对应 TRD 和现有 QA 目录更新并执行 E2E 验收。请先确定由哪类 QA 工作承接，并说明当前材料是否足够。",
       "workspace": "workspace/eval-3-feature-path-missing-plan-blocked",
-      "expected_output": "QA 路由决策必须识别 feature_path account/profile/preferences，读取同路径 PRD/TRD 和 QA 功能树，但因为缺少 docs/engineer/account/profile/preferences/IMPLEMENTATION_PLAN.md 而 blocked，不创建、更新或执行 E2E acceptance TC",
+      "expected_output": "识别 feature_path account/profile/preferences，读取同路径 PRD/TRD 和 QA 功能树，但因为缺少 docs/engineer/account/profile/preferences/IMPLEMENTATION_PLAN.md 而 blocked，不创建、更新或执行 E2E acceptance TC",
       "assertions": [
         {
           "id": "reads_same_feature_path",
@@ -155,7 +155,7 @@
         {
           "id": "specialist_gate_pointer",
           "description": "Specialist 权威门禁指针",
-          "text": "路由输出必须声明选中的 specialist 是后续验证的执行责任方，并客观指出当前缺少已确认实施计划而不能执行；router 不自行创建、更新或运行 E2E 资产。"
+          "text": "必须把后续验证交给选中的 specialist，并客观指出当前缺少已确认实施计划而不能执行；router 不自行创建、更新或运行 E2E 资产。"
         },
         {
           "id": "keeps_single_route",

--- a/agents/qa/test/qa-agent/evals/workspace/eval-1-route-mixed-qa-request/comparison.md
+++ b/agents/qa/test/qa-agent/evals/workspace/eval-1-route-mixed-qa-request/comparison.md
@@ -13,18 +13,18 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `c9268123afd7a11d5bd4ac6d14865261ea2db8883ff6a745cea96f843ec5dbd5` from `agents/qa/test/qa-agent/evals/workspace/eval-1-route-mixed-qa-request`.
 - Identity schema: `2`
-- target_skill_sha256: `23a4457fc9bf10be6976d98ea55607b47c6c623db1e20d5c73160d9f386c2a36`
-- eval_definition_sha256: `2ad0a90eac7fca1f06d238ff5d3d06535381ddd810d8a9e8e9e423ce29483f2c`
+- target_skill_sha256: `87273b18e32710512ee493a3e80a098f8b357ae29e71e4e0a6f3bdb4e8e38c08`
+- eval_definition_sha256: `0c9c4e17aa3aba15319c1b891ee6bf6eebad63436a6c10edd0a500e765aa29f6`
 - metadata_sha256: `718fcc57ee1abd91d0d7551c46ebe8546481fa4f027452b86db232f30d15ab47`
 - fixture_sha256: `c9268123afd7a11d5bd4ac6d14865261ea2db8883ff6a745cea96f843ec5dbd5`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
 - runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
 - judge_schema_sha256: `f4aaec46995456a39da2b489696e387a78408415038edddd6412ca13bedbc20a`
-- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
-- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
-- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
-- Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
+- Prompt SHA-256: `d32b34f557a9af42827fae115c24f25ec47fe1e0fcda62e092dc3afa3789c767`
+- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
 - Repository worktree state: **DIRTY**
+- Skill overlay SHA-256: `8e73acbd41a735f43f1f03a7222bf46710fac8290789ae5f94fc114c9a9ac613`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,28 +33,28 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `assertion_1` | PASS | 选择 qa-agent:spec-based-tester，并以已确认的 PRD/TRD/IMPLEMENTATION_PLAN、变更说明、QA 记忆及 CI WebKit 间歇性失败说明其为最窄责任方。 |
-| `assertion_2` | PASS | 列出了 PM/Engineer 文档、QA suite/flow、环境说明、账号凭据状态、QA application URL 和 npm test -- login 执行入口。 |
-| `specialist_gate_pointer` | PASS | 明确由 spec-based-tester 负责 preflight、执行和证据归档，并将平台版本、环境 URL、账号、执行入口及确认文档核验留给 specialist；router 声明不执行测试或创建报告。 |
-| `assertion_4` | PASS | 声明了每个 TC 的 result.md、testcase.snapshot.md，以及按平台版本归档的 feature-update 汇总报告，并包含 PASS/FAIL/BLOCKED、风险和验收建议。 |
-| `assertion_5` | PASS | 仅选择一个下游 specialist；将 CI 超时保留为风险项，不直接认定为 confirmed bug 或改走 bug 分析。 |
+| `assertion_1` | PASS | with_skill 明确选择一个主路径：进入验收准备/QA 路由，选择 spec-based-tester，并将 WebKit 超时保留为风险。 |
+| `assertion_2` | PASS | with_skill 传递了 PM/Engineer 文档、实现变更、QA 套件/流程记忆、CI 失败信息和 npm test -- login 执行入口，同时保留环境、凭据、平台版本缺口，未假设浏览器或端口。 |
+| `specialist_gate_pointer` | PASS | with_skill 明确将后续执行和最终判定交给 qa-agent:spec-based-tester，并列出其需检查的平台版本、环境、账号、执行入口及相关资料；同时说明 router 不执行测试。 |
+| `assertion_4` | PASS | with_skill 声明了每个 TC 的 result.md、testcase.snapshot.md、feature-update 汇总报告、需求—执行结果矩阵、阻塞项和风险等产物结构。 |
+| `assertion_5` | PASS | with_skill 只选择一个下游 specialist，明确不是 bug-analyzer，并将 WebKit 间歇性超时作为风险记录而非 confirmed bug。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=d32b34f557a9af42827fae115c24f25ec47fe1e0fcda62e092dc3afa3789c767; fixture_sha256=c9268123afd7a11d5bd4ac6d14865261ea2db8883ff6a745cea96f843ec5dbd5; output_sha256=bd70db8423d67b7cdf9bcdddbd87fce0fe3986f5eb5ad950c1026b0f7236bf76; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 完整完成单一路由、上下文传递、specialist 门禁指针、证据产物和风险边界控制。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=d32b34f557a9af42827fae115c24f25ec47fe1e0fcda62e092dc3afa3789c767; fixture_sha256=c9268123afd7a11d5bd4ac6d14865261ea2db8883ff6a745cea96f843ec5dbd5; output_sha256=11eba24a5736bed601b9714c44030b13e4c72a7f08dc84d9518760f49f1f9f32; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 完成单一路由选择、上下文传递、specialist 权威门禁指针和结构化证据产物声明；未执行测试。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=d32b34f557a9af42827fae115c24f25ec47fe1e0fcda62e092dc3afa3789c767; fixture_sha256=c9268123afd7a11d5bd4ac6d14865261ea2db8883ff6a745cea96f843ec5dbd5; output_sha256=98b752b49faa7867014a55089cfb6394ff3302e17b5754af52c60e47e57d1fef; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 提供了合理 QA 建议和证据清单，但未明确单一 specialist 路由及其责任边界。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=d32b34f557a9af42827fae115c24f25ec47fe1e0fcda62e092dc3afa3789c767; fixture_sha256=c9268123afd7a11d5bd4ac6d14865261ea2db8883ff6a745cea96f843ec5dbd5; output_sha256=99c03ee60d4647bb341e295721407c1aa897401c87321b123576dc933080a0e1; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 给出合理的 QA 准备建议和证据清单，但未提供 specialist 路由与权威门禁指针。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: None.
+- Next: 由 spec-based-tester 在取得平台版本、凭据、环境和可执行入口后继续验证。
 
 ## Runtime Artifact Policy
 

--- a/agents/qa/test/qa-agent/evals/workspace/eval-2-empty-qa-directory-expands-cases/comparison.md
+++ b/agents/qa/test/qa-agent/evals/workspace/eval-2-empty-qa-directory-expands-cases/comparison.md
@@ -13,18 +13,18 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `870f233236f82c3cf594816a5771878c8e388e11eeb3846cf269bf436f0fb100` from `agents/qa/test/qa-agent/evals/workspace/eval-2-empty-qa-directory-expands-cases`.
 - Identity schema: `2`
-- target_skill_sha256: `23a4457fc9bf10be6976d98ea55607b47c6c623db1e20d5c73160d9f386c2a36`
-- eval_definition_sha256: `1252f49c3e393535dba5cc481c5c3100fe9a709aa3de1773196b4edb5900ada3`
+- target_skill_sha256: `87273b18e32710512ee493a3e80a098f8b357ae29e71e4e0a6f3bdb4e8e38c08`
+- eval_definition_sha256: `191bfa99acdac3657f309157a88a7fec7c17e9d659acf0a1a21ab3c03782508a`
 - metadata_sha256: `bf12045623474ece32b13073fc8cb963c9b4f673ab0fe9f0cf0dc0ad649d4ef6`
 - fixture_sha256: `870f233236f82c3cf594816a5771878c8e388e11eeb3846cf269bf436f0fb100`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
 - runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
 - judge_schema_sha256: `d61853152f0f59bd847f0aa3394c1f282e4bb9275d56c9fb66462de58118346d`
-- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
-- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
-- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
-- Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
+- Prompt SHA-256: `068467ca9228748a58aa1065f9a150e3f5b012d5ddc3cefa3e5b130984c9cc4a`
+- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
 - Repository worktree state: **DIRTY**
+- Skill overlay SHA-256: `c61dc207829993f3cf5c3bb3c732dc39c76754cabec6f70bf1bd90a868f073f6`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,27 +33,27 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `assertion_1` | PASS | With-skill routing identified the existing QA directory as containing no executable cases/scripts/results, and did not fall back to another QA directory. |
-| `assertion_2` | PASS | The routing block recorded the confirmed feature update and bounded exploration authority, passed source, QA memory, environment, credential-reference, and execution-entry context to spec-based-tester, and preserved the specialist gate without re-asking. |
-| `specialist_gate_pointer` | PASS | The output selected spec-based-tester as the specialist execution owner and preserved its authoritative E2E gates and handoff boundary. |
-| `assertion_6` | PASS | Exactly one narrow route, spec-based-tester, was selected; no parallel QA skill execution or implementation repair was performed. |
+| `assertion_1` | PASS | with_skill identifies the target QA memory as having no executable cases/scripts or historical results/reports and retains the correct nested feature path. |
+| `assertion_2` | PASS | with_skill carries the target source files, environment instructions, credential reference, feature flag, execution entry, and specialist gate context without re-asking for authorization or returning blocked. |
+| `specialist_gate_pointer` | PASS | with_skill explicitly hands follow-up case creation, execution, and evidence archival to spec-based-tester, while preserving QA memory and environment context. |
+| `assertion_6` | PASS | with_skill selects only spec-based-tester as the primary route, keeps execution within QA ownership, and makes no implementation changes. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=068467ca9228748a58aa1065f9a150e3f5b012d5ddc3cefa3e5b130984c9cc4a; fixture_sha256=870f233236f82c3cf594816a5771878c8e388e11eeb3846cf269bf436f0fb100; output_sha256=66f7ca854b4ab8f80940e75ff69cb5a6f576f720df18173556a3ef398388add8; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly routed to spec-based-tester, identified the empty QA baseline, and stopped at documented specialist gates without creating artifacts or claiming execution.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=068467ca9228748a58aa1065f9a150e3f5b012d5ddc3cefa3e5b130984c9cc4a; fixture_sha256=870f233236f82c3cf594816a5771878c8e388e11eeb3846cf269bf436f0fb100; output_sha256=e50cb74d44e52847e3922bd8c28ee0aede73d6fbce43fbda3434832d48e718ff; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly routes the authorized validation request to spec-based-tester with the required scope, source materials, QA memory condition, environment gate, and ownership boundary.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=068467ca9228748a58aa1065f9a150e3f5b012d5ddc3cefa3e5b130984c9cc4a; fixture_sha256=870f233236f82c3cf594816a5771878c8e388e11eeb3846cf269bf436f0fb100; output_sha256=ef7cb515ee5428e1fc9ce875bfcb9a69af6c75f50fc5410172f983f8cf74dd4a; snapshot_sha256=c3d8793c9df408a0e72dea96b2099affb95eb1ccff78983f842ae3023e3c81bd
-- Behavior: Created QA suite and flow artifacts despite the empty baseline and bypassed the required routing/specialist gate.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=068467ca9228748a58aa1065f9a150e3f5b012d5ddc3cefa3e5b130984c9cc4a; fixture_sha256=870f233236f82c3cf594816a5771878c8e388e11eeb3846cf269bf436f0fb100; output_sha256=86bf6d6d38c1b0b08caad8f2ea729854723de9fcc78e197fee180c1944597b47; snapshot_sha256=7fa49c17cb23077ce09c2431f1edd376f1924b860443c5779001b77070f74199
+- Behavior: Created QA artifacts directly and reported browser checks blocked; it did not provide the specialist-routing behavior.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Provide the missing specialist-gate materials before continuing E2E case generation or execution.
+- Next: None.
 
 ## Runtime Artifact Policy
 

--- a/agents/qa/test/qa-agent/evals/workspace/eval-3-feature-path-missing-plan-blocked/comparison.md
+++ b/agents/qa/test/qa-agent/evals/workspace/eval-3-feature-path-missing-plan-blocked/comparison.md
@@ -13,18 +13,18 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `39ecc1af9722a7aadd83ae04a9403edca1017d45bde6a98a57d2d87ccb7702dc` from `agents/qa/test/qa-agent/evals/workspace/eval-3-feature-path-missing-plan-blocked`.
 - Identity schema: `2`
-- target_skill_sha256: `23a4457fc9bf10be6976d98ea55607b47c6c623db1e20d5c73160d9f386c2a36`
-- eval_definition_sha256: `ffa490cd1f58367914b109adc50e94706c92cbf66e7c95942ae329d3f9a191c7`
+- target_skill_sha256: `87273b18e32710512ee493a3e80a098f8b357ae29e71e4e0a6f3bdb4e8e38c08`
+- eval_definition_sha256: `ec357d7e216245f12726027da14d7981d249bcac4a9eff1a2ed19f5ffc8af4f2`
 - metadata_sha256: `aa798ca118679678c2fef882d4726badd357a387202dcb387aceaa4b86696bd0`
 - fixture_sha256: `39ecc1af9722a7aadd83ae04a9403edca1017d45bde6a98a57d2d87ccb7702dc`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
 - runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
 - judge_schema_sha256: `7c827cee8609863280607c031efdc95a92d32b851664d68126eccd9d66c1f27a`
-- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
-- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
-- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
-- Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
+- Prompt SHA-256: `094ec5b09f42125c7ea3b42f7f8365ddf4bd40bef6652060cfeb7ff368908608`
+- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
 - Repository worktree state: **DIRTY**
+- Skill overlay SHA-256: `8bdd2e06aa5b2802048e58c95086ce3578e5b5c6997eaafa30b5cfbddd879d53`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `reads_same_feature_path` | PASS | Trace directly shows reads of docs/pm/account/profile/preferences/PRD.md, docs/engineer/account/profile/preferences/TRD.md, and the same-path QA TEST_SUITE.md/FLOW_INDEX.md; output sets feature_path to account/profile/preferences, and git evidence shows no QA-tree mutation. |
-| `specialist_gate_pointer` | PASS | Output selects spec-based-tester as execution_owner, identifies the missing same-path IMPLEMENTATION_PLAN.md gate, states execution cannot proceed, and says the router will not create cases, reports, or execute E2E. |
-| `keeps_single_route` | PASS | Output names exactly one narrow route, spec-based-tester; trace shows no specialist execution or implementation changes, and git status/diff are empty. |
+| `reads_same_feature_path` | PASS | Trace shows direct reads of the same-path PRD, TRD, and QA directory; the handoff preserves feature_path account/profile/preferences and the QA path. |
+| `specialist_gate_pointer` | PASS | The output selects spec-based-tester, identifies the missing IMPLEMENTATION_PLAN.md and blocked execution, and states that execution/assets belong to the specialist; trace shows no file-change or E2E execution event. |
+| `keeps_single_route` | PASS | Only one QA route, spec-based-tester, is selected; the trace contains no parallel QA route, specialist execution, or implementation repair. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=094ec5b09f42125c7ea3b42f7f8365ddf4bd40bef6652060cfeb7ff368908608; fixture_sha256=39ecc1af9722a7aadd83ae04a9403edca1017d45bde6a98a57d2d87ccb7702dc; output_sha256=06f9f4af97f02368c19f8973eb8d596e2b83732f604d6656ceb402b2e7460ef7; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly routed the request to spec-based-tester, preserved the same feature path, enforced the implementation-plan gate, and stopped before specialist execution or asset mutation.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=094ec5b09f42125c7ea3b42f7f8365ddf4bd40bef6652060cfeb7ff368908608; fixture_sha256=39ecc1af9722a7aadd83ae04a9403edca1017d45bde6a98a57d2d87ccb7702dc; output_sha256=129bc5ac1e11162e87317fc340802f641c4f53108da5ac01cec37a51f1956738; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Routes the request to the single narrow spec-based-tester specialist, preserves the feature path and QA context, and stops at the specialist gate with explicit blockers.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=094ec5b09f42125c7ea3b42f7f8365ddf4bd40bef6652060cfeb7ff368908608; fixture_sha256=39ecc1af9722a7aadd83ae04a9403edca1017d45bde6a98a57d2d87ccb7702dc; output_sha256=444ffd214d2a441168ca23f1a78935f48b823493fe0c6aa08eef863ab5fb0c4d; snapshot_sha256=fb6494026fd90bf01ffd204ca76948cecfc2d4d60758403e4a300ee582f68fa9
-- Behavior: Fresh baseline edited QA assets and performed execution probing without the specialist gate or single-route handoff.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=094ec5b09f42125c7ea3b42f7f8365ddf4bd40bef6652060cfeb7ff368908608; fixture_sha256=39ecc1af9722a7aadd83ae04a9403edca1017d45bde6a98a57d2d87ccb7702dc; output_sha256=b4adf397744257f7612029915c44f0a3f92b91ecace8e52c274b0ee2e6a77fa1; snapshot_sha256=04c5884ef54cdb3169b505d9cf6e41c54a8e87f3aef84ac34eaa589ea34dd9d5
+- Behavior: Fresh baseline updated QA files and reported blocked E2E execution, but did not provide the specialist-gated single-route behavior.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/security/skills/security-agent/SKILL.md
+++ b/agents/security/skills/security-agent/SKILL.md
@@ -10,9 +10,9 @@ visibility: internal
 based on whether the user needs broad application review, focused auth review,
 dependency risk analysis, or privacy/data-handling mapping.
 
-## Mandatory Routing Decision
+## Routing Decision
 
-Before any review, state the accepted security entry basis, selected specialist
+Before any review, preserve the accepted security entry basis, selected specialist
 or ordered chain, preserved risk surface and evidence, and remediation owner.
 Preserve every requested component of the handoff packet's `required_output`
 instead of shortening it to a filename or generic report, and explicitly
@@ -26,7 +26,7 @@ decide explicitly whether the verified conclusion changes product behavior,
 formal documentation facts, operational facts, or release readiness; if so,
 return the evidence to `pm-agent` for issue classification before any follow-up
 Docs, Engineer, DevOps, or release work.
-If routing has not yet produced a verified Security-owned conclusion, record
+If routing has not yet produced a verified Security-owned conclusion, preserve
 `pm_escalation: not_applicable_yet`. Security never sends a conclusion directly
 to `docs-agent` and never creates the PM tracking issue itself.
 
@@ -125,8 +125,6 @@ do not perform the missing agent's responsibilities yourself.
 
 When routing is complete:
 
-- state which security skill should handle the request
-- if relevant, state the follow-up security chain
 - make the expected output clear as a structured review or risk report, not an
   implementation patch
 - for feature-scoped work, state the expected report path under

--- a/agents/security/test/security-agent/evals/evals.json
+++ b/agents/security/test/security-agent/evals/evals.json
@@ -31,7 +31,7 @@
       },
       "prompt": "登录和权限模型重构准备上线，最担心 admin 越权，同时也要确认依赖有没有已知风险。相关产品范围、变更摘要和依赖清单都在仓库里；请先安排最合适的安全审查顺序和每一步的证据交付。",
       "workspace": "workspace/eval-1-route-auth-release-risk",
-      "expected_output": "安全路由决策，明确 authz-reviewer 是当前主 route，dependency-risk-auditor 是后续，并保持证据型安全输出边界。",
+      "expected_output": "明确 authz-reviewer 是当前主要工作，dependency-risk-auditor 是后续，并保持证据型安全输出边界。",
       "assertions": [
         {
           "id": "routes_primary_to_authz",

--- a/agents/security/test/security-agent/evals/workspace/eval-1-route-auth-release-risk/comparison.md
+++ b/agents/security/test/security-agent/evals/workspace/eval-1-route-auth-release-risk/comparison.md
@@ -13,18 +13,18 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `6becbc324dd17ee4f5ba7cdf2d867ad58ae183800d34e6d3eb510323380d49a0` from `agents/security/test/security-agent/evals/workspace/eval-1-route-auth-release-risk`.
 - Identity schema: `2`
-- target_skill_sha256: `f9c706626daa220552f758703ae64d133ee8d82358801e24309850f00386ef65`
-- eval_definition_sha256: `86d9cf5b5d192be02693890eee51825a1b00e0750fd5f2d88fdcc91b3fe08ad7`
+- target_skill_sha256: `5c1776fcba11e4a564f6d8bef4826b23a262e7433780174f7756ea89d40a2136`
+- eval_definition_sha256: `d5973b25612b7e076dab35db16f38a088f965995470b2ae2a1e956ac49b1959d`
 - metadata_sha256: `10861a3430f4e9df517502c7dede98b52c06228662db21b0d8914dd6b558a77c`
 - fixture_sha256: `6becbc324dd17ee4f5ba7cdf2d867ad58ae183800d34e6d3eb510323380d49a0`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
 - runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
 - judge_schema_sha256: `d09f4cbeb933e811c934cf8e665fe7675560abe0fc34d7865e0c67a56b1f4b12`
-- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
-- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
-- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
-- Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
+- Prompt SHA-256: `5a4bc456b36f0fe19e8d15843877f0c9ef8daed9d99b67bdcc85d65720c79c5b`
+- Repository HEAD: `2f950c46c67111058957774f796ccf97ae616d36`
 - Repository worktree state: **DIRTY**
+- Skill overlay SHA-256: `a9c69f3b86e02ca2f703b7da58237c4caab46ae028402c3524fc126377a613bc`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,29 +33,29 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `routes_primary_to_authz` | PASS | With-skill output explicitly selects `authz-reviewer` first for authentication, roles, sensitive routes, and admin cross-tenant risk. |
-| `names_dependency_followup` | PASS | With-skill output explicitly schedules `dependency-risk-auditor` after the authorization review. |
-| `collects_security_context` | PASS | It names login sessions, the role matrix, sensitive routes, tenant isolation, existing tests, dependency manifests/lockfiles, and dependency trees as review inputs or evidence. |
-| `structured_risk_output` | PASS | It specifies structured security reports, permission matrices, evidence, risk levels, and remediation recommendations, and says the output is not an implementation patch. |
-| `hands_off_remediation` | PASS | It hands code fixes to `engineer-agent` and dependency/build/deployment fixes to `devops-agent`. |
-| `evaluates_escalation_to_pm_at_closeout` | NOT_EXERCISED | The workflow stops before specialist execution and asks for confirmation. It records escalation as not applicable yet and describes PM handoff/no direct Docs handoff or self-filed issue, but no confirmed closeout conclusion exists to exercise the full closeout assertion. |
+| `routes_primary_to_authz` | PASS | with_skill 明确将 `authz-reviewer` 作为第一个步骤，并聚焦 admin 越权、角色和认证边界。 |
+| `names_dependency_followup` | PASS | with_skill 将 `dependency-risk-auditor` 列为第二步，专门审查 express 及依赖供应链风险。 |
+| `collects_security_context` | PASS | with_skill 指定认证流程、角色矩阵、敏感路由、测试证据、实现代码及 package/锁文件和扫描结果作为下游输入。 |
+| `structured_risk_output` | PASS | with_skill 声明交付结构化 security review/risk report，包含风险矩阵、证据、修复建议和上线结论，且不是实现补丁。 |
+| `hands_off_remediation` | PASS | with_skill 将应用代码修复交给应用工程团队，将依赖、构建或部署修复交给平台工程团队，语义上对应 engineer-agent/devops-agent remediation handoff。 |
+| `evaluates_escalation_to_pm_at_closeout` | NOT_EXERCISED | with_skill 已完成路由规划并等待用户确认后进入审查；closeout 阶段尚未发生，因此无法执行最终的 PM escalation 评估。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5a4bc456b36f0fe19e8d15843877f0c9ef8daed9d99b67bdcc85d65720c79c5b; fixture_sha256=6becbc324dd17ee4f5ba7cdf2d867ad58ae183800d34e6d3eb510323380d49a0; output_sha256=68d4737dd6e8ff17c963804c8e73bc17c630ed4516db101f4118364575d246a3; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Routes the request through PM security context to `authz-reviewer`, then `dependency-risk-auditor`, with structured evidence and remediation handoffs; pauses for confirmation before execution.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5a4bc456b36f0fe19e8d15843877f0c9ef8daed9d99b67bdcc85d65720c79c5b; fixture_sha256=6becbc324dd17ee4f5ba7cdf2d867ad58ae183800d34e6d3eb510323380d49a0; output_sha256=753230d8b14d64b0d110fed79248e7f4eff18cec557102f32456e0fef5a269c3; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 正确完成安全审查路由：authz-reviewer 主审、dependency-risk-auditor 后续，并给出上下文、结构化产物、remediation handoff 和条件性 PM 交接规则；等待用户确认进入下一步。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5a4bc456b36f0fe19e8d15843877f0c9ef8daed9d99b67bdcc85d65720c79c5b; fixture_sha256=6becbc324dd17ee4f5ba7cdf2d867ad58ae183800d34e6d3eb510323380d49a0; output_sha256=4b622c800ab60e894fce5f540d2ef81778d1c774c5df635d38418d3df715a1f8; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Provides a useful generic security review sequence and evidence checklist, but does not establish the specialist route/handoff workflow shown by the with-skill lane.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5a4bc456b36f0fe19e8d15843877f0c9ef8daed9d99b67bdcc85d65720c79c5b; fixture_sha256=6becbc324dd17ee4f5ba7cdf2d867ad58ae183800d34e6d3eb510323380d49a0; output_sha256=3627f0f2b4c6d177ae76d565124c835b46fe059c009f0c897b1d74c83f3cbbd2; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 给出较完整的通用安全审查计划和证据要求，但未明确使用 authz-reviewer 与 dependency-risk-auditor 路由。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: After user confirmation, execute the `authz-reviewer` step; assess closeout escalation only after a confirmed review conclusion exists.
+- Next: 获得用户确认后执行 authz-reviewer；完成后再进行 dependency-risk-auditor 和 closeout escalation 评估。
 
 ## Runtime Artifact Policy
 

--- a/docs/README.codex.md
+++ b/docs/README.codex.md
@@ -55,9 +55,9 @@ flowchart TD
 - `agents/` 镜像到 `~/.agents/skills/.dev-agent-skills/agents/`
 - selected skills 以相对软链暴露到 `~/.agents/skills/<skill-name>`
 
-Personal 安装的 skill 在宿主可见的每个项目中都可被发现。未启用
-dev-agent-skills 的项目中，`pm-agent` 的使用范围判定会拦截一般对话、本机
-环境操作与通用文件处理（只提示一句并停止）；项目向请求与显式点名仍正常执行。
+Personal 安装的 skill 在宿主可见的每个项目中都可被发现。显式点名
+`pm-agent`、role agent 或 skill 时始终使用该能力并保留其既有门禁；未显式点名时，
+研发意图进入 `pm-agent`，普通非研发请求由当前助手处理。
 
 ### Project
 
@@ -68,8 +68,7 @@ dev-agent-skills 的项目中，`pm-agent` 的使用范围判定会拦截一般�
 - selected skills 以相对软链暴露到 `<project>/.agents/skills/<skill-name>`
 
 Project 安装把 skill 保持在项目目录内，天然隔离其他项目；项目内的
-`.agents/skills/.dev-agent-skills/.dev-agent-skills-mirror.json` 同时作为
-`pm-agent` 使用范围判定的启用标记。若需要最严格的隔离，优先选择本层级。
+`.agents/skills/.dev-agent-skills/.dev-agent-skills-mirror.json` 记录安装镜像。若需要最严格的隔离，优先选择本层级。
 
 两种安装方式都保持仓库内的 `agents/*/skills/*` 目录不变，用于兼容 Claude marketplace。
 

--- a/docs/engineer/repository-governance/pm-single-entry/IMPLEMENTATION_PLAN.md
+++ b/docs/engineer/repository-governance/pm-single-entry/IMPLEMENTATION_PLAN.md
@@ -161,8 +161,8 @@ GitHub CI 与 Codex Review 状态。
 - [x] 受影响 eval 与 deterministic tests 已更新。
 - [x] `skills-lock.json` 已刷新。
 - [x] 本地合同、确定性测试与本次目标 fresh paired eval 通过；既有无关 FAIL 保留。
-- [ ] 单一 PR 已创建，CI 和 Codex Review 已完成。
-- [ ] PR 未合并，已通知维护者确认。
+- [x] 单一 PR #283 已创建；CI 4/4 通过，review/comment/thread 核对无待处理项。
+- [x] PR 已标记 Ready 且未合并，等待维护者确认合并。
 
 ## 10. 风险
 
@@ -193,4 +193,6 @@ GitHub CI 与 Codex Review 状态。
   README 中文措辞问题已修复并 fresh/静态复核。
 - `residual_risks`：Docs eval-004、005、006 的既有 skill 缺陷仍按 fresh FAIL 保存，超出
   #281/#282 范围，后续应独立处理。
-- `next_owner`：创建单一 draft PR，等待 GitHub CI 与 review；不得自动合并。
+- `delivery`：PR #283 已标记 Ready；GitHub CI 4/4 通过，PR 为 `MERGEABLE/CLEAN`，
+  review、comment 和 unresolved thread 均为空。
+- `next_owner`：维护者审阅并明确确认是否合并 PR #283；不得自动合并。

--- a/docs/engineer/repository-governance/pm-single-entry/IMPLEMENTATION_PLAN.md
+++ b/docs/engineer/repository-governance/pm-single-entry/IMPLEMENTATION_PLAN.md
@@ -132,7 +132,7 @@ owner 或等价过程信息的句子。分类表、gate 指针、specialist entr
 预计整个 PR 净改约 500–900 行，以删除和改写为主，不新增抽象。若明显超出该量级，先
 停止实施并核对是否误触 specialist gate、handoff schema、无关 skill 或新的输出协议。
 
-实际暂存 diff 为新增 1729 行、删除 1776 行、raw net -47 行；其中约 500 行来自将上一轮
+最终实施 diff 为新增 1733 行、删除 1775 行、raw net -42 行；其中约 500 行来自将上一轮
 活动计划忠实复制到新归档文件。排除这份已批准的机械归档后，主体净改约 -548 行，符合
 预期量级，未发现范围扩张。
 
@@ -187,7 +187,7 @@ GitHub CI 与 Codex Review 状态。
   存在的 FAIL；eval-004 已恢复为原有单一 entry-basis 缺陷，没有新增 handoff/输出断言
   回归。本次需求引入的 FAIL 为 0。
 - `scope_review`：共享 handoff contract、specialist gate、eval runtime 和 release 流程均
-  未修改；raw net -47 行，排除约 500 行忠实计划归档后主体净改约 -548 行，未新增输出
+  未修改；raw net -42 行，排除约 500 行忠实计划归档后主体净改约 -548 行，未新增输出
   协议或抽象。
 - `independent_validation`：独立只读验收提出的下游显式调用覆盖、Docs eval-004 断言和
   README 中文措辞问题已修复并 fresh/静态复核。

--- a/docs/engineer/repository-governance/pm-single-entry/IMPLEMENTATION_PLAN.md
+++ b/docs/engineer/repository-governance/pm-single-entry/IMPLEMENTATION_PLAN.md
@@ -1,7 +1,7 @@
 ---
 title: "研发意图入口与路由过程收敛实施计划"
 type: IMPLEMENTATION_PLAN
-version: "0.2.0"
+version: "0.3.0"
 status: "Implemented"
 author: "Neplich Codex"
 date: "2026-08-14"
@@ -20,6 +20,9 @@ related_issues:
   - "https://github.com/Neplich/dev-agent-skills/issues/281"
   - "https://github.com/Neplich/dev-agent-skills/issues/282"
 changelog:
+  - version: "0.3.0"
+    date: "2026-08-14"
+    changes: "处理 Codex Review 三项 P2：排除其他显式能力触发 PM、移除 eval prompt 答案泄漏、更新 Kimi 入口说明；22 项受影响 fresh eval 通过"
   - version: "0.2.0"
     date: "2026-08-14"
     changes: "完成研发意图入口、显式调用优先、7 个 router 输出收敛、42 条 fresh paired eval、确定性验证与独立验收"
@@ -132,8 +135,8 @@ owner 或等价过程信息的句子。分类表、gate 指针、specialist entr
 预计整个 PR 净改约 500–900 行，以删除和改写为主，不新增抽象。若明显超出该量级，先
 停止实施并核对是否误触 specialist gate、handoff schema、无关 skill 或新的输出协议。
 
-最终实施 diff 为新增 1733 行、删除 1775 行、raw net -42 行；其中约 500 行来自将上一轮
-活动计划忠实复制到新归档文件。排除这份已批准的机械归档后，主体净改约 -548 行，符合
+最终实施 diff 为新增 1750 行、删除 1780 行、raw net -30 行；其中 424 行来自将上一轮
+活动计划忠实复制到新归档文件。排除这份已批准的机械归档后，主体净改约 -454 行，接近
 预期量级，未发现范围扩张。
 
 ## 8. 验证命令
@@ -187,12 +190,15 @@ GitHub CI 与 Codex Review 状态。
   存在的 FAIL；eval-004 已恢复为原有单一 entry-basis 缺陷，没有新增 handoff/输出断言
   回归。本次需求引入的 FAIL 为 0。
 - `scope_review`：共享 handoff contract、specialist gate、eval runtime 和 release 流程均
-  未修改；raw net -42 行，排除约 500 行忠实计划归档后主体净改约 -548 行，未新增输出
+  未修改；raw net -30 行，排除 424 行忠实计划归档后主体净改约 -454 行，未新增输出
   协议或抽象。
 - `independent_validation`：独立只读验收提出的下游显式调用覆盖、Docs eval-004 断言和
   README 中文措辞问题已修复并 fresh/静态复核。
+- `review_followup`：Codex Review 三项 P2 已处理：PM discovery metadata 明确排除其他
+  被点名能力，Docs eval-001 prompt 恢复为自然请求，英文 Kimi 安装说明改为意图入口；
+  PM 21 项与 Docs eval-001 共 22 项 fresh comparison 均 PASS 或 partial coverage。
 - `residual_risks`：Docs eval-004、005、006 的既有 skill 缺陷仍按 fresh FAIL 保存，超出
   #281/#282 范围，后续应独立处理。
-- `delivery`：PR #283 已标记 Ready；GitHub CI 4/4 通过，PR 为 `MERGEABLE/CLEAN`，
-  review、comment 和 unresolved thread 均为空。
+- `delivery`：PR #283 已标记 Ready；首轮 GitHub CI 4/4 通过。Codex Review 三条 P2
+  已在同一 PR 修复，等待更新后的 CI 与线程复核后执行已获授权的 squash merge。
 - `next_owner`：维护者审阅并明确确认是否合并 PR #283；不得自动合并。

--- a/docs/engineer/repository-governance/pm-single-entry/IMPLEMENTATION_PLAN.md
+++ b/docs/engineer/repository-governance/pm-single-entry/IMPLEMENTATION_PLAN.md
@@ -1,421 +1,196 @@
 ---
-title: "PM 唯一入口 Batch 4 实施计划"
+title: "研发意图入口与路由过程收敛实施计划"
 type: IMPLEMENTATION_PLAN
-version: "0.4.0"
+version: "0.2.0"
 status: "Implemented"
 author: "Neplich Codex"
-date: "2026-07-05"
-last_updated: "2026-07-05"
+date: "2026-08-14"
+last_updated: "2026-08-14"
 generated_by: "feature-implementor"
 feature: "pm-single-entry"
 feature_path: "repository-governance/pm-single-entry"
 parent_feature: "repository-governance"
 feature_level: "2"
-implementation_scope: "eval-contract-closeout"
+change_tier: "major"
+implementation_scope: "intent-routing-output"
+previous_plan_archive: "docs/engineer/repository-governance/pm-single-entry/archive/IMPLEMENTATION_PLAN-eval-contract-closeout.md"
 related_prd: "docs/pm/repository-governance/pm-single-entry/PRD.md"
 related_trd: "docs/engineer/repository-governance/pm-single-entry/TRD.md"
-related_issue: "https://github.com/Neplich/dev-agent-skills/issues/52"
 related_issues:
-  - "https://github.com/Neplich/dev-agent-skills/issues/55"
-  - "https://github.com/Neplich/dev-agent-skills/issues/59"
-  - "https://github.com/Neplich/dev-agent-skills/issues/60"
-  - "https://github.com/Neplich/dev-agent-skills/issues/61"
-  - "https://github.com/Neplich/dev-agent-skills/issues/62"
+  - "https://github.com/Neplich/dev-agent-skills/issues/281"
+  - "https://github.com/Neplich/dev-agent-skills/issues/282"
 changelog:
-  - version: "0.4.0"
-    date: "2026-07-05"
-    changes: "Batch 4 实施完成：补齐 PM entry eval 全量、missing handoff target 与 change_tier eval 覆盖，并增加非 PM skill internal visibility contract"
-  - version: "0.3.12"
-    date: "2026-07-05"
-    changes: "Codex Review 修复：designer-agent 移除缺 PM handoff 的非持久设计建议绕过"
-  - version: "0.3.11"
-    date: "2026-07-05"
-    changes: "Codex Review 修复：AGENTS 仓库级 PM-first 规则保留 project-bootstrap 显式 skip-PM scaffold 例外"
-  - version: "0.3.10"
-    date: "2026-07-05"
-    changes: "Codex Review 修复：DevOps 与 Security router 的 PM handoff gate 前移到 routing 前"
-  - version: "0.3.9"
-    date: "2026-07-05"
-    changes: "Codex Review 修复：更新 Batch 3 验证记录中的 pytest 计数"
-  - version: "0.3.8"
-    date: "2026-07-05"
-    changes: "Codex Review 修复：FR-006 场景 7-8 comparison 不再把未运行 fresh validation 的 eval 标为 PASS"
-  - version: "0.3.7"
-    date: "2026-07-05"
-    changes: "Codex Review 修复：同日 last_updated 例外只接受顶层 frontmatter changelog key"
-  - version: "0.3.6"
-    date: "2026-07-05"
-    changes: "Codex Review 修复：同日 last_updated 例外只匹配 frontmatter changelog block，并补回归测试"
-  - version: "0.3.5"
-    date: "2026-07-05"
-    changes: "Codex Review 修复：同日 last_updated 例外只扫描 frontmatter changelog entry"
-  - version: "0.3.4"
-    date: "2026-07-05"
-    changes: "Codex Review 修复：同日 last_updated 例外必须同时匹配 changelog version 与 date"
-  - version: "0.3.3"
-    date: "2026-07-05"
-    changes: "Codex Review 修复：FR-006 场景 8 不再把已存在 IMPLEMENTATION_PLAN 当作 feature-implementor 入口前置条件"
-  - version: "0.3.2"
-    date: "2026-07-05"
-    changes: "Codex Review 修复：engineer-agent router 按 specialist entry basis 放行 trd-gen 与 project-bootstrap 合法路径，并补 deterministic 断言"
-  - version: "0.3.1"
-    date: "2026-07-05"
-    changes: "实施完成：下游 gate 指针化与 specialist 权威副本统一、入口 SKILL.md 瘦身、FR-006 场景 7-8 eval 与 deterministic pytest 补齐"
-  - version: "0.3.0"
-    date: "2026-07-05"
-    changes: "规划 Batch 3：下游 gate 指针化与去重、feature-implementor / idea-to-spec 正文瘦身、防绕过 eval 场景 7-8"
-  - version: "0.2.5"
-    date: "2026-07-05"
-    changes: "Batch 2 已完成并合并：补齐 PM 入口分类、handoff packet、FR-006 场景 1-6 和 Codex Review 修复"
+  - version: "0.2.0"
+    date: "2026-08-14"
+    changes: "完成研发意图入口、显式调用优先、7 个 router 输出收敛、42 条 fresh paired eval、确定性验证与独立验收"
+  - version: "0.1.0"
+    date: "2026-08-14"
+    changes: "规划意图优先入口与 7 个 router 路由过程输出收敛；归档前一轮 eval-contract-closeout 计划"
 ---
 
-# PM 唯一入口 Batch 4 实施计划
+# 研发意图入口与路由过程收敛实施计划
 
-## 1. 实施上下文
+## 1. 对齐与门禁
 
-本计划继续实施 issue #52 的最终 Batch 4：在 Batch 1 完成公开发现面收口、Batch 2 完成
-`pm-agent` 高召回分类与 handoff packet、Batch 3 完成下游 gate 去重和 SKILL.md 瘦身后，
-收尾 PM-only 入口 eval、#62 missing handoff target eval、#55 FR-008 变更分级 eval 和可机器
-检查的 internal visibility contract。
-
-本批 `change_tier` 自判为 `major`：它修改 eval 契约、deterministic pytest、repository
-contract 脚本和本实施计划。用户已明确确认继续 Batch 4；实施已完成。
-
-```mermaid
-flowchart TD
-    U["用户直接请求下游"] --> R["role router"]
-    U --> S["specialist"]
-    R --> G1{"有 PM handoff packet 或等效已确认文档链？"}
-    S --> G2{"specialist 入口 gate 通过？"}
-    G1 -->|"否"| PM["回 pm-agent 分类"]
-    G1 -->|"是"| P["只保留 gate 指针并继续路由"]
-    G2 -->|"否"| PM
-    G2 -->|"是"| X["按 specialist 协议执行"]
-```
-
-来源文档：
-
-- PRD：`docs/pm/repository-governance/pm-single-entry/PRD.md`
-- TRD：`docs/engineer/repository-governance/pm-single-entry/TRD.md`
-- 分级与归档契约：`AGENTS.md`
-- 关联 issue：#52、#55、#59、#60、#61、#62
-
-## 2. 当前门禁状态
-
-| 门禁 | 状态 | 证据 |
-| --- | --- | --- |
-| PRD 对齐 | 已完成 | PM single-entry PRD 覆盖 FR-006；change-tier PRD 覆盖 FR-008；#62 留有 missing target eval 要求 |
-| TRD 对齐 | 已完成 | PM single-entry TRD 第 8 节定义 Batch 4：eval 全量、contract 收尾、durable comparison 更新 |
-| Feature path | 已解析 | `repository-governance/pm-single-entry` |
-| 设计输入 | 不适用 | 本批为 skill / 文档契约变更，不涉及 UI |
-| Archive gate | 继续更新当前计划 | PR #73 已合并，维护者明确进入最后 Batch 4；本 feature 连续分批实施仍使用当前活跃计划，不新建归档 |
-| Sub-agent 写计划 | 不启用 | 当前任务是单一实施计划更新；主进程保留 PRD/TRD/AGENTS 约束并在用户确认后实施 |
-
-## 3. 范围
-
-### 3.1 计划修改文件
-
-| 类别 | 路径 | 实际操作 |
-| --- | --- | --- |
-| 仓库契约 | `AGENTS.md` | 收敛为 PM 唯一入口与 gate 指针声明；保留变更分级、QA E2E、archive 等仓库级规则，不复制 specialist 操作步骤 |
-| Role router | `agents/engineer/skills/engineer-agent/SKILL.md` | 把 Existing Feature Alignment Gate 改为轻量指针；新增直接用户请求无 PM handoff 时回 PM 的统一规则 |
-| Role router | `agents/designer/skills/designer-agent/SKILL.md` | Feature Path Gate 指针化；直接设计请求无 PM handoff 时回 PM |
-| Role router | `agents/qa/skills/qa-agent/SKILL.md` | QA / E2E gate 指针化；保留 QA 路由摘要，完整 E2E 执行门禁下沉到 QA specialist 入口 |
-| Role router | `agents/devops/skills/devops-agent/SKILL.md` | Feature Path Gate 指针化；repo-wide DevOps handoff 继续允许 `N/A` feature scope |
-| Role router | `agents/security/skills/security-agent/SKILL.md` | Feature Path Gate 指针化；安全 review 无 PM handoff 时回 PM |
-| Specialist gate | `agents/engineer/skills/feature-implementor/SKILL.md` | 保留并压缩 PRD alignment、UI design handoff、plan/archive/closeout gate；作为实现类 gate 权威副本 |
-| Specialist gate | `agents/engineer/skills/debugger/SKILL.md` | 保留 expected-behavior / repair gate；无 PM handoff 或等效文档链时回 PM |
-| Specialist gate | `agents/engineer/skills/project-bootstrap/SKILL.md`、`trd-gen/SKILL.md`、`test-writer/SKILL.md` | 保留各自最小前置门禁；避免复制 PM packet 字段清单 |
-| QA specialist gate | `agents/qa/skills/spec-based-tester/SKILL.md`、`exploratory-tester/SKILL.md`、`bug-analyzer/SKILL.md`、`regression-suite/SKILL.md` | 保留 E2E / feature-scoped QA 的完整门禁；`qa-agent` 只指向这些权威副本 |
-| 其他 specialist gate | Designer / DevOps / Security specialist `SKILL.md` | 只在已有 feature-path gate 处统一 PM handoff 与回 PM wording；不新增重复大段 gate |
-| 正文瘦身样本 | `agents/product_manager/skills/idea-to-spec/SKILL.md` | 目标压到约 150 行；保留入口协议，阶段细节与示例下沉 `_internal` |
-| 正文瘦身样本 | `agents/engineer/skills/feature-implementor/SKILL.md` | 目标压到约 150 行；gate 必须留在 SKILL.md，阶段执行细节下沉 `_internal` |
-| 内部模块 | `agents/product_manager/skills/idea-to-spec/_internal/**`、`agents/engineer/skills/feature-implementor/_internal/**` | 承接从 SKILL.md 移出的阶段流程、模板和输出约定 |
-| Eval | `agents/product_manager/test/pm-agent/evals/evals.json` 与 workspace | 补齐 FR-006 场景 7-8 的 durable eval 定义、workspace、comparison |
-| Eval | `agents/product_manager/test/pm-agent/evals/evals.json` 与 workspace | Batch 4 补齐 #62 missing handoff target 与 #55 FR-008 change_tier 场景 9-13，更新 1-8 comparison 的 post-merge fresh validation 状态 |
-| Pytest | `agents/product_manager/test/pm-agent/test_pm_entry_eval.py` | 增加防绕过 deterministic 断言 |
-| Pytest | `agents/product_manager/test/pm-agent/test_pm_entry_eval.py` | Batch 4 增加 missing target、hotfix fast lane、standard full gate、hotfix abuse blocked、hotfix E2E direct-path deterministic 断言 |
-| Contract | `scripts/check_repository_contract.py` | 兼容同一天内连续 Batch 修改同一实施计划时的 `version` / `last_updated` 检查，避免要求写未来日期 |
-| Contract | `scripts/check_repository_contract.py` | Batch 4 增加 PM-only public entry 静态检查：除 `pm-agent` 外所有 skill 必须声明 `visibility: internal` |
-| Lock | `skills-lock.json` | 重算所有被修改 skill 目录的 `computedHash` |
-
-### 3.2 明确不做
-
-- 不修改 marketplace / README / installer 公开发现面；这些已由 Batch 1 完成。
-- 不重新设计 PM handoff packet 字段；字段权威定义沿用 Batch 2 的 PM `_internal` 共享契约。
-- 不新增 release CI、GitHub ruleset 或运行时强制拦截。
-- 不执行 PR 合并；PR 创建后仍等待 Codex Review、CI 和维护者确认。
-
-## 4. 实施顺序
-
-### 4.1 Gate 去重与指针化
-
-1. 先建立 gate 家族清单：
-   - PM handoff packet 字段：权威副本在 PM `_internal` 共享契约。
-   - 实现前 PRD/TRD/plan gate：权威副本在 `feature-implementor/SKILL.md`。
-   - bug repair expected-behavior gate：权威副本在 `debugger/SKILL.md`。
-   - bootstrap settled-spec gate：权威副本在 `project-bootstrap/SKILL.md`。
-   - QA E2E / feature-scoped validation gate：权威副本在 QA specialist `SKILL.md`。
-   - DevOps / Security / Designer feature path gate：权威副本在对应 specialist `SKILL.md`。
-2. 更新 5 个 role router：
-   - 只保留“PM handoff packet 或等效已确认文档链”的入口判断。
-   - 没有 PM handoff 的直接用户请求，统一回 `pm-agent` 分类。
-   - 具体执行 gate 只引用 specialist 权威副本，不复制步骤。
-3. 更新 `AGENTS.md`：
-   - 保留仓库级结论和路径规则。
-   - 删除或压缩与 specialist gate 重复的操作性步骤。
-   - 指向本 feature 的 TRD / specialist gate 作为执行细节来源。
-
-### 4.2 Specialist gate 统一
-
-1. 按 TRD 6.2 统一三段判断顺序：
-   - 显式 PM handoff packet 完整时执行。
-   - 无 packet 但存在等效已确认文档链时执行。
-   - 二者都没有时不执行本 skill 协议，回 `pm-agent` 分类。
-2. 保留各 specialist 的专业 gate：
-   - `feature-implementor` 不直接接新需求、改功能或“帮我实现”原始请求。
-   - `debugger` 不直接修未对齐预期的 bug。
-   - QA specialist 不在预期未确认时固化 E2E 预期。
-3. 避免在每个 specialist 重复 PM packet 字段清单；只引用 PM `_internal` 权威定义。
-
-### 4.3 SKILL.md 瘦身
-
-1. `feature-implementor/SKILL.md`：
-   - 保留 frontmatter、职责、使用/拒绝条件、关键 gate、高层 phase、输出边界。
-   - 将上下文读取细节、计划模板、实现步骤、自检模板、handoff 模板下沉到现有
-     `_internal/planner`、`_internal/implementor`、`_internal/reviewer` 和 `_internal/_shared`
-     模块。
-   - gate 不下沉；只压缩文案。
-2. `idea-to-spec/SKILL.md`：
-   - 保留 Non-Negotiable Protocol、Operating Modes、Execution Lanes、Internal Routing
-     Contract、Feature Document Memory 和高层 phases。
-   - 将 workspace detection、lane playbooks、phase 细节、deliverable shapes、examples 下沉到
-     `_internal/orchestration`、`_internal/gen` 和 `_internal/_shared`。
-3. 目标：
-   - 两个样本入口文件各自约 150 行。
-   - 如果 `feature-implementor` 因 gate 必须留在入口文件导致略超，必须在 closeout 记录行数和原因。
-
-### 4.4 Eval 场景 7-8
-
-新增 FR-006 防绕过覆盖：
-
-| 场景 | 验证点 |
+| 项 | 结果 |
 | --- | --- |
-| `eval-007-direct-downstream-without-handoff` | 直接点名 role router / downstream agent 且无 PM handoff packet 时，应回 `pm-agent` 分类 |
-| `eval-008-direct-specialist-bypass-gate` | 绕过 router 直接触发 `feature-implementor` 等 specialist 时，specialist gate 仍执行并阻止直接实现 |
+| PRD | `docs/pm/repository-governance/pm-single-entry/PRD.md` v1.1.0，覆盖 #281 与 #282 |
+| TRD | `docs/engineer/repository-governance/pm-single-entry/TRD.md` v1.1.0，实施面和验证策略已确认 |
+| Feature path | `repository-governance/pm-single-entry`，PRD/TRD/计划一致 |
+| Change tier | `major`：修改默认入口、7 个 router、发现面、文档与 eval 契约 |
+| Archive gate | 旧 `eval-contract-closeout` 计划已按批准归档，新计划通过 `previous_plan_archive` 回链 |
+| 计划与实施门禁 | Neplich 已于 2026-08-14 明确批准文档、归档、计划和实施，可直接执行至 PR 合并前 |
+| PR 策略 | 全部变更放在同一个 PR；PR 不自动合并，合并前向维护者确认 |
 
-Deterministic pytest 至少检查：
+## 2. 成功标准
 
-- eval 定义、workspace、`comparison.md` 存在且符合 durable artifact 策略。
-- role router SKILL.md 含统一 direct-request guardrail。
-- `feature-implementor` / `debugger` / QA specialist 含无 handoff 回 PM 的 gate 行为。
+1. 未显式点名能力时，研发请求进入 `pm-agent`，普通非研发请求不进入。
+2. 显式点名 `pm-agent`、role agent 或 skill 时，无条件使用被点名能力，其既有 gate 继续执行。
+3. docs、PRD、TRD、代码和 marker 仅作为进入 PM 后的上下文与门禁证据。
+4. 7 个 router 不再强制展示“已路由到”、routing decision、routing block/YAML、selected
+   specialist、owner 等过程信息。
+5. 内部分类、specialist gate、handoff packet schema 与职责边界没有变化。
+6. 静态契约、确定性测试和 fresh paired eval 得到可审计证据；本次目标不新增
+   FAIL，既有无关 FAIL 如实保留。CI 和 PR review 在 PR 阶段继续核对。
+7. 创建单一 PR 并停在合并前等待维护者确认。
 
-Fresh subagent validation 仍按仓库 eval 门禁执行；若本批实际运行，则同步更新对应
-`comparison.md`。
+## 3. 计划文件范围
 
-### 4.5 Contract 同日更新兼容
+### 3.1 PM 入口、发现描述和文档
 
-当前 `check_repository_contract.py` 要求 implementation plan 的 `version` 变化时
-`last_updated` 字符串也必须变化，但 `last_updated` 又只能使用 `YYYY-MM-DD`。当 Batch 2 与
-Batch 3 在同一天连续推进时，真实日期不能变化，不能通过写未来日期绕过。本批需要把该
-校验调整为：同一天内只要 `version` 已更新、changelog 含对应版本条目，就接受
-`last_updated` 保持当天日期。
+| 路径或类别 | 操作 |
+| --- | --- |
+| `agents/product_manager/skills/pm-agent/SKILL.md` | 调整判定顺序；保留显式调用；后置上下文检查；删除强制路由输出 |
+| `.claude-plugin/marketplace.json` 与 PM plugin description | 同步“研发意图默认入口 + 显式调用”发现语义 |
+| `AGENTS.md` | 替换与目标冲突的旧 Scope Guard / 默认入口文案 |
+| `README.md`、`README_zh.md`、`.codex/INSTALL.md`、`docs/README.codex.md` | 仅更新直接描述旧触发语义的内容 |
+| `agents/product_manager/README.md`、`README_zh.md` | 同步 PM 入口说明 |
 
-## 5. Hash 重算
+### 3.2 七个 router
 
-所有修改过的 skill 目录在提交前重算 `skills-lock.json`。命令：
+修改以下 router 的 `SKILL.md`：
+
+- `agents/product_manager/skills/pm-agent/SKILL.md`
+- `agents/designer/skills/designer-agent/SKILL.md`
+- `agents/engineer/skills/engineer-agent/SKILL.md`
+- `agents/qa/skills/qa-agent/SKILL.md`
+- `agents/devops/skills/devops-agent/SKILL.md`
+- `agents/security/skills/security-agent/SKILL.md`
+- `agents/docs/skills/docs-agent/SKILL.md`
+
+每个文件只删除或改写强制显式输出 routing block、routing decision、selected specialist、
+owner 或等价过程信息的句子。分类表、gate 指针、specialist entry basis、handoff 和边界规则
+保持原样。
+
+### 3.3 必要 PRD 文档
+
+- 更新本 feature 的 PRD/TRD 与本实施计划。
+- 仅当 router 自身既有 PRD 明确要求用户侧展示路由过程时，才同步改写对应要求。
+- 不因为 SKILL.md 文案删除而扩写新的 router 输出协议。
+
+### 3.4 Eval、确定性测试和 lock
+
+| 类别 | 操作 |
+| --- | --- |
+| PM entry eval | 新增或改造“无 docs 的研发请求”“有 docs 的非研发请求”“显式调用优先”场景 |
+| Router eval | 删除要求 routing block/decision 的 prompt 和断言，保留正确分流、gate、边界与任务结果断言 |
+| Durable comparison | 仅根据本轮 fresh paired 结果更新实际受影响的 `comparison.md` |
+| Deterministic tests | 覆盖入口三分支，静态确认 7 router 无强制输出要求且 handoff/gate 未丢失 |
+| `skills-lock.json` | 重算本 PR 修改过的 skill 目录 `computedHash` |
+
+## 4. 明确禁区
+
+- specialist gate 逻辑；
+- PM handoff packet 字段 schema、必填性和 owner 映射；
+- 无关 agent、skills、eval 与文档；
+- release 版本、tag、release notes 和发布流程；
+- 新的隐藏路由协议、输出抽象、配置项或运行时机制；
+- PR 合并。
+
+## 5. 实施顺序
+
+1. 更新 PM 自动入口判断与发现描述。
+2. 同步 AGENTS、用户文档和 PM Agent README 中直接冲突的旧规则。
+3. 删除 7 个 router 的强制路由过程输出要求。
+4. 核对受影响 router PRD，只同步实际冲突的既有要求。
+5. 由 `skill-eval-runner` 更新受影响 eval、workspace、deterministic tests 和 comparison。
+6. 重算 `skills-lock.json` 中受影响 skill hash。
+7. 执行静态契约、确定性测试和 fresh paired eval，修复本次范围内失败。
+8. 对照 PRD/TRD、计划文件表和禁区审查最终 diff。
+9. 创建一个工作 PR，等待 CI 与 Codex Review；处理意见后停在合并前通知维护者。
+
+## 6. 分工
+
+`subagent_split: enabled`
+
+- 实现：由独立 subagent 按第 3～5 节实施，不能修改禁区。
+- 验证：由另一独立 subagent 审查 diff、执行静态契约与确定性测试，并核对 fresh eval 证据。
+- 主进程：整合文档与实现、处理冲突、确认范围、创建 PR，并在合并前向维护者交付。
+
+## 7. 规模预期
+
+预计整个 PR 净改约 500–900 行，以删除和改写为主，不新增抽象。若明显超出该量级，先
+停止实施并核对是否误触 specialist gate、handoff schema、无关 skill 或新的输出协议。
+
+实际暂存 diff 为新增 1729 行、删除 1776 行、raw net -47 行；其中约 500 行来自将上一轮
+活动计划忠实复制到新归档文件。排除这份已批准的机械归档后，主体净改约 -548 行，符合
+预期量级，未发现范围扩张。
+
+## 8. 验证命令
 
 ```bash
-uv run python - <<'EOF'
-import json, importlib.util, sys
-from pathlib import Path
-spec = importlib.util.spec_from_file_location("checker", "scripts/check_repository_contract.py")
-m = importlib.util.module_from_spec(spec)
-sys.modules[spec.name] = m
-spec.loader.exec_module(m)
-root = Path(".")
-lock_path = root / "skills-lock.json"
-lock = json.loads(lock_path.read_text())
-for name, entry in lock["skills"].items():
-    entry["computedHash"] = m.compute_tracked_directory_hash(root, entry["source"])
-lock_path.write_text(json.dumps(lock, indent=2, ensure_ascii=False) + "\n")
-print("refreshed", len(lock["skills"]), "hashes")
-EOF
+uv run scripts/check_repository_contract.py
+uv run scripts/check_eval_contract.py
+uv run scripts/check_eval_artifacts.py
+uv run scripts/check_doc_contract.py
+uv run --with pytest pytest <受影响的确定性测试>
+git diff --check
 ```
 
-## 6. 验证结果
+静态检查通过后，由 `skill-eval-runner` 对实际受影响的 PM entry 与 router eval 执行 fresh
+paired validation，最多 10 workers，并根据真实结果更新 durable `comparison.md`。随后检查
+GitHub CI 与 Codex Review 状态。
 
-| 验证项 | 命令 |
+## 9. 验收清单
+
+- [x] PM 自动入口按显式调用、研发意图、非研发直处三分支运行。
+- [x] 项目上下文不再作为自动触发首要依据。
+- [x] 7 个 router 的强制路由过程输出要求全部移除。
+- [x] Specialist gate 与 handoff schema 未被删除或改义。
+- [x] 必要发现描述、用户文档和 router PRD 已同步。
+- [x] 受影响 eval 与 deterministic tests 已更新。
+- [x] `skills-lock.json` 已刷新。
+- [x] 本地合同、确定性测试与本次目标 fresh paired eval 通过；既有无关 FAIL 保留。
+- [ ] 单一 PR 已创建，CI 和 Codex Review 已完成。
+- [ ] PR 未合并，已通知维护者确认。
+
+## 10. 风险
+
+| 风险 | 控制 |
 | --- | --- |
-| diff 空白检查 | `git diff --check` -> PASS |
-| 行数检查 | `wc -l agents/engineer/skills/feature-implementor/SKILL.md agents/product_manager/skills/idea-to-spec/SKILL.md` -> `feature-implementor` 152 行、`idea-to-spec` 147 行 |
-| 仓库契约 | `uv run scripts/check_repository_contract.py` -> PASS |
-| eval 契约 | `uv run scripts/check_eval_contract.py` -> PASS |
-| eval 产物策略 | `uv run scripts/check_eval_artifacts.py` -> PASS |
-| pm-agent eval pytest | `uv run --with pytest pytest agents/product_manager/test/pm-agent/test_pm_entry_eval.py -q` -> 11 passed |
-| CI 同款 pytest | `uv run --with pytest pytest agents/product_manager/test/idea-to-spec agents/product_manager/test/pm-agent agents/qa/test/test_qa_run_eval.py agents/designer/test/test_designer_run_eval.py agents/devops/test/test_devops_run_eval.py agents/test_eval_contract.py` -> 97 passed |
+| 意图判断过宽或过窄 | 相反场景成对 eval，不依赖 marker 作为断言代理 |
+| 显式调用被拒绝 | 单独覆盖显式点名 PM 与下游能力的场景 |
+| 删除输出要求时误删路由行为 | 独立验证 subagent 对比 gate、handoff 和 specialist 路由表 |
+| comparison 与真实运行不一致 | 只接受本轮 fresh paired 证据，不手工复制旧结论 |
+| PR 范围漂移 | 最终逐项对照第 3、4 节与 `git diff --name-only` |
 
-## 7. 风险与缓解
+## 11. Closeout 记录
 
-| 风险 | 缓解 |
-| --- | --- |
-| gate 过度指针化导致直接触发 specialist 时失去拦截 | gate 权威副本必须留在 specialist `SKILL.md`，不移入 `_internal` |
-| router 指针太弱导致合法 handoff 被反复拉回 PM | role router 保留 PM handoff packet / 等效文档链放行条件 |
-| #60 瘦身删除了必要上下文 | 只下沉阶段细节与模板，不删除职责、gate、输出边界 |
-| QA E2E gate 在 router 和 specialist 间漂移 | `qa-agent` 只保留路由和指针；QA specialist 保留执行门禁 |
-| eval 场景 7-8 只测文本、不测行为 | 本批先补 deterministic 防回退；fresh subagent validation 如执行则更新 durable comparison |
-| 同一天连续批次导致 `last_updated` 无法变化 | 小范围调整 repository contract，不写未来日期 |
-
-## 8. 完成标准
-
-- Batch 4 计划范围内文件已更新，未触碰 Batch 1 / Batch 2 已完成的公开发现面和 PM packet 字段定义。
-- `feature-implementor` 与 `idea-to-spec` 入口文件显著瘦身，并记录最终行数。
-- FR-006 场景 7-8 eval 定义、workspace、comparison 和 pytest 覆盖已补齐。
-- FR-006 场景 1-8 eval 定义与 deterministic pytest 全量覆盖已保留。
-- #62 missing handoff target eval 场景已补齐，断言目标 agent 未安装时 blocked 且不代行职责。
-- #55 FR-008 change_tier eval 场景已补齐，覆盖 hotfix fast lane、standard full gate、hotfix 滥用阻断和 hotfix QA 直接影响路径。
-- repository contract 已校验非 PM skill 的 `visibility: internal` 声明。
-- Batch 4 未修改 skill 目录，未产生新的 `skills-lock.json` 更新。
-- 本地验证命令全部通过。
-- PR 创建后通过 GitHub CI 和 Codex Review；如 Codex Review 提出问题，只追加 commit 修复并再次触发一次 `@codex review`。
-
-## 9. Batch 2 已合并摘要
-
-Batch 2 PR #72 已合并到 `main`，完成 `pm-agent` 高召回入口、请求分类、handoff packet
-权威定义、FR-006 场景 1-6 eval 和多轮 Codex Review 修复。本批从该合并后基线继续，不再
-重复修改 Batch 2 已确认的 PM packet 字段。
-
-## 10. 实施 Closeout
-
-最终状态：Batch 4 本地实施完成，进入 PR、CI 和 Codex Review 阶段。
-
-已完成变更：
-
-- `AGENTS.md` 增加 PM 唯一入口与下游 gate 指针规则，不复制 PM packet 字段或 specialist 操作步骤。
-- 5 个 role router 改为轻量 PM handoff entry gate；直接用户请求缺少 PM handoff 或等效文档链时回 `pm-agent` 分类。
-- Engineer、Designer、QA、DevOps、Security specialist 入口补齐 PM handoff gate，专业 gate 保留在对应 specialist 作为权威副本。
-- `feature-implementor/SKILL.md` 瘦身至 152 行；因实现类 gate 必须保留在入口文件，略高于 150 行目标。
-- `idea-to-spec/SKILL.md` 瘦身至 147 行；阶段细节保留在 `_internal` 模块。
-- 新增 FR-006 场景 7-8 eval、workspace、durable `comparison.md`，并扩展 pm-agent deterministic pytest。
-- 新增 Batch 4 eval 场景 9-13：missing handoff target、hotfix fast lane、standard full gate、hotfix 滥用阻断和 hotfix QA 直接影响路径。
-- 更新 FR-006 场景 1-8 durable `comparison.md` 的 next-step 说明，明确 fresh with/without-skill validation 转入 Batch 4 合并后的集中 skill-eval 阶段。
-- `scripts/check_repository_contract.py` 增加 internal visibility 静态检查，确保除 `pm-agent` 外的 skill 均声明 `visibility: internal`。
-- `scripts/check_repository_contract.py` 兼容同日连续批次更新 implementation plan 时的 `version` / `last_updated` 合法状态。
-- Batch 4 本地验证通过：repository contract、eval contract、eval artifacts、pm-agent eval pytest 11 passed、CI 同款 pytest 97 passed。
-- Batch 3 已全量重算 `skills-lock.json`；Batch 4 未修改 skill 目录，未产生新的 `skills-lock.json` 更新。
-
-未运行项：
-
-- Fresh Codex subagent validation 未在本 PR 执行；本批只补 deterministic eval / contract coverage 与 durable comparison 状态记录。维护者已安排 Batch 4 合并后集中执行受影响 skill 的 fresh subagent validation，并重新生成 without-skill baseline、同步更新 comparison。
-
-剩余风险：
-
-- 本批是 eval 与 contract 收尾，行为执行仍依赖后续集中 fresh validation 和实际 agent 调用遵循这些入口 gate。
-- `feature-implementor` 入口文件保留 152 行，是为了不把关键实现 gate 下沉到 `_internal` 后降低直接触发时的拦截强度。
-
-下一 owner：
-
-- 维护者 / PR 流程：等待 GitHub CI、Codex Review 和维护者确认后再合并；若 Codex Review 提出问题，只追加 commit 修复并再次触发一次 `@codex review`。
-
-## 11. Codex Review 修复记录
-
-2026-07-05 Codex Review 对提交 `7de025d` 提出两条 P2：
-
-- `engineer-agent` 不应在用户明确 skip PM 并请求 `project-bootstrap` scaffold 时，先于 specialist override 把请求拉回 PM。
-- `engineer-agent` 不应把 `trd-gen` 路径要求成 PRD + TRD + confirmed implementation plan；TRD 创建路径应允许 confirmed PM docs + stable feature path 作为 specialist entry basis。
-
-修复结果：
-
-- `engineer-agent/SKILL.md` 的 PM handoff entry gate 改为按 selected specialist entry basis 判断。
-- 明确 `trd-gen` 可从 confirmed PM documents 与 stable feature path 进入，即使 Engineer TRD 尚不存在。
-- 明确 `project-bootstrap` 在用户显式 skip PM and scaffold anyway 时可进入 specialist，由 specialist 自己处理 override 和最小 stack question。
-- `test_pm_entry_eval.py` 新增 deterministic 断言覆盖这两个合法路径。
-
-2026-07-05 Codex Review 对提交 `5b8c500` 提出一条 P2：
-
-- FR-006 场景 8 的断言不应要求等价 PRD/TRD/IMPLEMENTATION_PLAN 文档链；`feature-implementor` 合法入口是在 PM scope 和 TRD 已确认后创建 `IMPLEMENTATION_PLAN.md`。
-
-修复结果：
-
-- `eval-008-direct-specialist-bypass-gate` 改为要求 PM handoff packet，或等价已确认 PRD/TRD 与当前 implementation scope。
-- 场景 8 durable `comparison.md` 明确已存在 `IMPLEMENTATION_PLAN.md` 不是首次进入 `feature-implementor` planning 的前置条件。
-
-2026-07-05 Codex Review 对提交 `37ba7e6` 提出一条 P2：
-
-- 同日 `last_updated` 例外只检查 changelog version 会让跨日遗漏 `last_updated` 的计划也通过；需要同时校验 changelog entry date。
-
-修复结果：
-
-- `markdown_changelog_has_version_date` 现在按 changelog entry 同时匹配 `version` 和 `date`。
-- `validate_implementation_plan_metadata` 只有在当前 `last_updated` 与 changelog entry date 一致时才豁免同日连续版本更新。
-
-2026-07-05 Codex Review 对提交 `1a43cb4` 提出一条 P2：
-
-- version/date 匹配不应扫描整篇 Markdown，正文示例里的 changelog 片段不能充当 frontmatter changelog entry。
-
-修复结果：
-
-- 新增 `markdown_frontmatter_block`，只提取 Markdown frontmatter。
-- 同日 `last_updated` 例外改为调用 `markdown_frontmatter_changelog_has_version_date`，只在 frontmatter changelog entry 中匹配 version/date。
-
-2026-07-05 Codex Review 对提交 `ed8a35d` 提出一条 P2：
-
-- frontmatter 中其他 `version/date` 列表仍可能被误当作 changelog entry；同日例外必须限制到 `changelog:` block。
-
-修复结果：
-
-- 新增 `markdown_frontmatter_changelog_block`，只提取 frontmatter 中的 `changelog:` 子块。
-- 同日 `last_updated` 例外只在该 changelog block 内匹配 version/date。
-- `agents/test_eval_contract.py` 新增回归测试，验证 frontmatter 其他列表和正文 fenced YAML 示例不会触发同日例外。
-
-2026-07-05 Codex Review 对提交 `f986e07` 提出一条 P2：
-
-- 嵌套 frontmatter map 中的 `changelog:` 不应被当成顶层 canonical changelog；同日例外只能接受顶层 `changelog:` key。
-
-修复结果：
-
-- `markdown_frontmatter_changelog_block` 改为只匹配无缩进的顶层 `changelog:`。
-- `agents/test_eval_contract.py` 补充嵌套 `release_metadata.changelog` 不会触发同日例外的回归断言。
-
-2026-07-05 Codex Review 对提交 `84308bc` 提出一条 P2：
-
-- 新增 eval 7/8 的 durable `comparison.md` 不应在 fresh Codex subagent validation 与新 baseline 尚未运行时写成 `PASS`。
-
-修复结果：
-
-- eval 7/8 的 `Latest result` 改为 `PARTIAL`，明确当前只有 deterministic Batch 3 gate 覆盖。
-- eval 7/8 的 coverage gap 记录 fresh subagent validation 与 without-skill baseline 仍待 Batch 4 授权执行。
-
-2026-07-05 Codex Review 对提交 `11192f1` 提出一条 P3：
-
-- 实施计划中的验证计数仍记录为 `6 passed` / `91 passed`，与当前测试套件和 closeout 摘要不一致。
-
-修复结果：
-
-- Batch 3 验证结果更新为 pm-agent eval pytest `7 passed`、CI 同款 pytest `93 passed`。
-
-2026-07-05 Codex Review 对提交 `c92e326` 提出两条 P2：
-
-- `devops-agent` 的 PM handoff gate 位于 Available Skills / Routing Signals / Default Routes / Escalation Rules 之后，可能先选择 DevOps specialist 再检查 PM handoff。
-- `security-agent` 的 PM handoff gate 同样位于 routing 内容之后，可能先选择 Security specialist 再检查 PM handoff。
-
-修复结果：
-
-- `devops-agent/SKILL.md` 将 PM Handoff Entry Gate 前移到 Role Boundary 后、Available Skills 前。
-- `security-agent/SKILL.md` 将 PM Handoff Entry Gate 前移到 Role Boundary 后、Available Skills 前。
-
-2026-07-05 Codex Review 对提交 `4760557` 提出一条 P2：
-
-- 仓库级 `AGENTS.md` 的 PM-first 规则没有保留 `project-bootstrap` 显式 skip-PM scaffold override，可能先于 specialist gate 把合法 starter scaffold 路径拉回 PM。
-
-修复结果：
-
-- `AGENTS.md` 的直接调用下游规则补充唯一例外：用户直接请求 `project-bootstrap` 且明确要求跳过 PM 并立即 scaffold 时，可进入 `project-bootstrap` 的最小脚手架 override。
-
-2026-07-05 Codex Review 对提交 `ee4ccc9` 提出一条 P2：
-
-- `designer-agent` 的 PM handoff gate 已要求缺少 handoff/docs 时回 `pm-agent`，但 Escalation Rules 仍允许缺 PM docs 的直接设计请求进入最窄 design skill 做非持久建议，形成绕过。
-
-修复结果：
-
-- `designer-agent/SKILL.md` 移除缺 PM docs 的非持久设计建议 bypass；缺少 PM handoff context 或等效已确认 PM/design 文档时，先回 `pm-agent` 分类再选择 design skill。
+- `changed_files`：PM 入口和发现描述、7 个 role router、直接冲突的用户/角色文档与
+  PRD/TRD、入口与 router eval、42 份 fresh comparison、PM 确定性测试、7 个 skill
+  lock hash，以及上一轮计划归档。
+- `commands_and_results`：repository/eval/artifact/doc 四项 contract 全部 PASS；独立全仓
+  pytest `318 passed, 6 subtests passed`；`git diff --check` PASS；`tmp/eval-runs/` 已清理。
+- `fresh_eval_results`：7 个既有 router 的 41 项 affected-target regression 已完成；新增
+  `eval-021-explicit-downstream-specialist` fresh PASS。PM 21 项无 FAIL，Designer、Engineer、
+  QA、DevOps、Security router 无 FAIL。Docs router 保留 eval-004、005、006 三项变更前已
+  存在的 FAIL；eval-004 已恢复为原有单一 entry-basis 缺陷，没有新增 handoff/输出断言
+  回归。本次需求引入的 FAIL 为 0。
+- `scope_review`：共享 handoff contract、specialist gate、eval runtime 和 release 流程均
+  未修改；raw net -47 行，排除约 500 行忠实计划归档后主体净改约 -548 行，未新增输出
+  协议或抽象。
+- `independent_validation`：独立只读验收提出的下游显式调用覆盖、Docs eval-004 断言和
+  README 中文措辞问题已修复并 fresh/静态复核。
+- `residual_risks`：Docs eval-004、005、006 的既有 skill 缺陷仍按 fresh FAIL 保存，超出
+  #281/#282 范围，后续应独立处理。
+- `next_owner`：创建单一 draft PR，等待 GitHub CI 与 review；不得自动合并。

--- a/docs/engineer/repository-governance/pm-single-entry/IMPLEMENTATION_PLAN.md
+++ b/docs/engineer/repository-governance/pm-single-entry/IMPLEMENTATION_PLAN.md
@@ -1,7 +1,7 @@
 ---
 title: "研发意图入口与路由过程收敛实施计划"
 type: IMPLEMENTATION_PLAN
-version: "0.3.0"
+version: "0.4.0"
 status: "Implemented"
 author: "Neplich Codex"
 date: "2026-08-14"
@@ -20,6 +20,9 @@ related_issues:
   - "https://github.com/Neplich/dev-agent-skills/issues/281"
   - "https://github.com/Neplich/dev-agent-skills/issues/282"
 changelog:
+  - version: "0.4.0"
+    date: "2026-08-14"
+    changes: "处理 Codex Review 双点名优先级 P2：显式点名 pm-agent 时优先 PM，仅在未点名 PM 时直达其他显式能力；PM 21 项 fresh eval 无 FAIL"
   - version: "0.3.0"
     date: "2026-08-14"
     changes: "处理 Codex Review 三项 P2：排除其他显式能力触发 PM、移除 eval prompt 答案泄漏、更新 Kimi 入口说明；22 项受影响 fresh eval 通过"
@@ -135,8 +138,8 @@ owner 或等价过程信息的句子。分类表、gate 指针、specialist entr
 预计整个 PR 净改约 500–900 行，以删除和改写为主，不新增抽象。若明显超出该量级，先
 停止实施并核对是否误触 specialist gate、handoff schema、无关 skill 或新的输出协议。
 
-最终实施 diff 为新增 1750 行、删除 1780 行、raw net -30 行；其中 424 行来自将上一轮
-活动计划忠实复制到新归档文件。排除这份已批准的机械归档后，主体净改约 -454 行，接近
+最终实施 diff 为新增 1754 行、删除 1775 行、raw net -21 行；其中 424 行来自将上一轮
+活动计划忠实复制到新归档文件。排除这份已批准的机械归档后，主体净改约 -445 行，接近
 预期量级，未发现范围扩张。
 
 ## 8. 验证命令
@@ -190,15 +193,17 @@ GitHub CI 与 Codex Review 状态。
   存在的 FAIL；eval-004 已恢复为原有单一 entry-basis 缺陷，没有新增 handoff/输出断言
   回归。本次需求引入的 FAIL 为 0。
 - `scope_review`：共享 handoff contract、specialist gate、eval runtime 和 release 流程均
-  未修改；raw net -30 行，排除 424 行忠实计划归档后主体净改约 -454 行，未新增输出
+  未修改；raw net -21 行，排除 424 行忠实计划归档后主体净改约 -445 行，未新增输出
   协议或抽象。
 - `independent_validation`：独立只读验收提出的下游显式调用覆盖、Docs eval-004 断言和
   README 中文措辞问题已修复并 fresh/静态复核。
-- `review_followup`：Codex Review 三项 P2 已处理：PM discovery metadata 明确排除其他
-  被点名能力，Docs eval-001 prompt 恢复为自然请求，英文 Kimi 安装说明改为意图入口；
-  PM 21 项与 Docs eval-001 共 22 项 fresh comparison 均 PASS 或 partial coverage。
+- `review_followup`：Codex Review 首轮三项 P2 已处理：PM discovery metadata 明确排除其他
+  被点名能力，Docs eval-001 prompt 恢复为自然请求，英文 Kimi 安装说明改为意图入口。
+  后续 P2 已明确双点名优先级：点名 `pm-agent` 时使用 PM，即使同时点名下游能力；仅在
+  未点名 PM 时直达其他显式能力。更新后 PM 21 项 fresh comparison 无 FAIL，Docs
+  eval-001 fresh PASS。
 - `residual_risks`：Docs eval-004、005、006 的既有 skill 缺陷仍按 fresh FAIL 保存，超出
   #281/#282 范围，后续应独立处理。
-- `delivery`：PR #283 已标记 Ready；首轮 GitHub CI 4/4 通过。Codex Review 三条 P2
-  已在同一 PR 修复，等待更新后的 CI 与线程复核后执行已获授权的 squash merge。
-- `next_owner`：维护者审阅并明确确认是否合并 PR #283；不得自动合并。
+- `delivery`：PR #283 已标记 Ready；此前 GitHub CI 4/4 通过。Codex Review 意见均已在
+  同一 PR 修复，维护者已明确授权合并；等待最终提交的 CI 与线程复核后执行 squash merge。
+- `next_owner`：主进程完成最终 CI 与 review thread 复核后执行已获授权的 squash merge。

--- a/docs/engineer/repository-governance/pm-single-entry/TRD.md
+++ b/docs/engineer/repository-governance/pm-single-entry/TRD.md
@@ -1,11 +1,11 @@
 ---
-title: "PM 唯一对外入口与下游编排 TRD"
+title: "PM 研发意图入口与路由过程收敛 TRD"
 type: TRD
-version: "1.0.1"
-status: Draft
+version: "1.1.0"
+status: Approved
 author: "Neplich Codex"
 date: "2026-07-05"
-last_updated: "2026-08-11"
+last_updated: "2026-08-14"
 generated_by: "trd-gen"
 feature: "pm-single-entry"
 feature_path: "repository-governance/pm-single-entry"
@@ -13,23 +13,23 @@ parent_feature: "repository-governance"
 feature_level: "2"
 related_prd: "docs/pm/repository-governance/pm-single-entry/PRD.md"
 related_issue: "https://github.com/Neplich/dev-agent-skills/issues/52"
+related_issues:
+  - "https://github.com/Neplich/dev-agent-skills/issues/281"
+  - "https://github.com/Neplich/dev-agent-skills/issues/282"
 related_docs:
   - "AGENTS.md"
-  - "docs/pm/repository-governance/pm-single-entry/PRD.md"
   - ".claude-plugin/marketplace.json"
-  - ".codex/INSTALL.md"
-  - "docs/README.codex.md"
   - "agents/product_manager/skills/pm-agent/SKILL.md"
+  - "agents/designer/skills/designer-agent/SKILL.md"
   - "agents/engineer/skills/engineer-agent/SKILL.md"
-  - "agents/engineer/skills/feature-implementor/SKILL.md"
-  - "agents/engineer/skills/debugger/SKILL.md"
-  - "docs/engineer/repository-governance/feature-path-contract/TRD.md"
-  - "https://github.com/Neplich/dev-agent-skills/issues/61"
-  - "https://github.com/Neplich/dev-agent-skills/issues/59"
-  - "https://github.com/Neplich/dev-agent-skills/issues/60"
-  - "https://github.com/Neplich/dev-agent-skills/issues/55"
-  - "https://github.com/Neplich/dev-agent-skills/pull/68"
+  - "agents/qa/skills/qa-agent/SKILL.md"
+  - "agents/devops/skills/devops-agent/SKILL.md"
+  - "agents/security/skills/security-agent/SKILL.md"
+  - "agents/docs/skills/docs-agent/SKILL.md"
 changelog:
+  - version: "1.1.0"
+    date: "2026-08-14"
+    changes: "对齐 #281 与 #282：定义意图优先的 PM 自动入口顺序，并以最小删除方式移除 7 个 router 的强制路由过程输出"
   - version: "1.0.1"
     date: "2026-07-05"
     changes: "实施拆分修正：5 个 role router description 弱化明确排入 Batch 1；skills-lock.json 刷新改为随每个修改 skill 目录的批次同 PR 执行，Batch 4 只保留收尾项"
@@ -38,285 +38,134 @@ changelog:
     changes: "初始版本：平台约束分析、#61 入口策略决策记录、description 分工契约、handoff packet 校验规则和实施分批计划"
 ---
 
-# PM 唯一对外入口与下游编排 TRD
+# PM 研发意图入口与路由过程收敛 TRD
 
-## 1. 来源上下文
+## 1. 技术目标
 
-本 TRD 承接 `docs/pm/repository-governance/pm-single-entry/PRD.md`、GitHub issue #52 和
-issue #61。PM 范围已明确：`pm-agent` 收口为唯一对外公开入口，6 个下游 role agent 和
-32 个 specialist skills 内部化为 PM 编排下的下游能力，并对平台无法完全阻止的直接触发
-路径建立防绕过机制。
-
-本 TRD 只定义技术契约、平台约束分析、架构决策、影响范围和验证策略，**不进入实现**。
-实现推迟到在途 PR #57 / #64 / #65 / #66 / #67 / #68 合并完成后进行，因为本 feature 的
-实施面（`AGENTS.md`、多个 SKILL.md、marketplace.json、eval fixtures）与这些在途 PR 大量
-重叠，先行实现会造成大面积冲突。届时由 `feature-implementor` 基于本 TRD 生成
-`docs/engineer/repository-governance/pm-single-entry/IMPLEMENTATION_PLAN.md`，确认后再
-分批进入实施。
-
-## 2. 技术概览
+本轮只修改 skill 的入口判断顺序和 router 的强制输出文案：
 
 ```mermaid
-flowchart TD
-    subgraph Public["公开发现面（收口后）"]
-        PM["pm-agent（唯一推荐入口，高召回 description）"]
-    end
-    subgraph Internal["内部/下游能力（description 弱化）"]
-        R1["engineer-agent / designer-agent / qa-agent / devops-agent / security-agent / docs-agent（router）"]
-        S1["32 个 specialist skills"]
-    end
-    U["用户请求"] --> PM
-    PM -->|"分类 + change_tier + handoff packet"| R1
-    R1 --> S1
-    U -.->|"平台无法完全阻止的直接触发"| S1
-    S1 --> G{"入口 gate：packet 或已确认文档链？"}
-    G -->|"否"| PM
-    G -->|"是"| X["按协议执行"]
+flowchart LR
+    U["用户请求"] --> X{"显式点名？"}
+    X -->|"是"| N["调用被点名能力"]
+    X -->|"否"| D{"产品或工程研发意图？"}
+    D -->|"是"| P["pm-agent 分类"]
+    D -->|"否"| H["当前助手处理"]
+    P --> G["既有上下文、gate 与 handoff 流程"]
 ```
 
-三层机制协同：
+不新增分类服务、隐藏路由协议或输出包装层。内部 handoff packet 和 specialist gate 保持
+现状；#282 仅删除现有 skill 文档中强制用户可见 routing block 的要求。
 
-1. **发现面收口**：文档与 marketplace/skill description 只把 `pm-agent` 描述为用户入口；
-   下游 description 弱化为「handoff 后使用」，移除用户侧触发短语。
-2. **PM 编排**：`pm-agent` 高召回捕获全部用户侧起点，分类、判级（`change_tier`）后携带
-   标准化 handoff packet 交给下游。
-3. **纵深防御**：specialist 内保留入口 gate 作为唯一权威 gate 副本；即使 description 弱化后
-   仍被直接命中，无凭据请求依然被拉回 PM。
+## 2. 入口判定顺序
 
-## 3. 平台约束分析
+### 2.1 显式调用
 
-### 3.1 Claude Code / Codex 的 skill discovery 机制
+1. 判断用户是否显式点名已安装的 `pm-agent`、role agent 或 skill。
+2. 若已点名，使用被点名能力，并继续执行该能力自身的入口 gate。
+3. 不用“是否为研发请求”覆盖或取消显式调用。
 
-| 平台 | 发现机制 | 能否「物理隐藏」非 PM skill |
+### 2.2 自动入口
+
+未显式点名时：
+
+1. 判断请求是否属于现有 PM 覆盖的产品或工程研发意图。
+2. 属于研发意图时进入 `pm-agent`。
+3. 不属于研发意图时由当前助手直接处理，不进入 PM 分类。
+4. 只有进入 PM 后，才读取 docs、PRD、TRD、代码、项目 marker 和 handoff 证据，完成
+   request type、feature path、change tier 与下游 gate 判断。
+
+## 3. Router 输出变更
+
+修改以下 7 个 router：
+
+| Router | 技术动作 |
+| --- | --- |
+| `pm-agent` | 删除强制输出 routing decision、route、owner 或 packet 展示的要求 |
+| `designer-agent` | 删除 mandatory routing block / selected specialist 展示要求 |
+| `engineer-agent` | 删除 mandatory routing block / selected specialist 展示要求 |
+| `qa-agent` | 删除 mandatory routing block / selected specialist 展示要求 |
+| `devops-agent` | 删除 mandatory routing block / selected specialist 展示要求 |
+| `security-agent` | 删除 mandatory routing block / selected specialist 展示要求 |
+| `docs-agent` | 删除 mandatory routing block / selected specialist 展示要求 |
+
+删除仅覆盖用户侧显式输出要求。下列内容不得改变：
+
+- router 的分类与 specialist 选择条件；
+- PM 与下游入口 gate；
+- handoff packet 字段名称、必填性和 owner 映射；
+- specialist entry basis 与职责边界；
+- auto-continue、安全升级和 closeout 规则。
+
+## 4. 精确实施面
+
+| 同步面 | 路径或类别 | 预期改动 |
 | --- | --- | --- |
-| Claude Code（marketplace 安装） | `.claude-plugin/marketplace.json` 按 plugin 注册 skill 目录；每个 skill 的 frontmatter `name` + `description` 常驻 harness 上下文，模型基于 description 自主选择触发。 | 否。只要 skill 被 plugin 注册并安装，它的 description 就进入模型可选集。marketplace schema 没有已确认的 `internal`/`hidden` 可见性字段可依赖；把 skill 移出注册表则 PM 编排也无法调用它，违背「保留下游能力」的目标。 |
-| Codex（`.codex/INSTALL.md` symlink 安装） | 把 `agents/*/skills/*` 逐个 symlink 到 `.agents/skills/<skill-name>`，Codex 原生 skill discovery 读取每个 SKILL.md 的 frontmatter。 | 否。安装模型是「整 agent 目录的全部 skill 都链接」，不链接则 PM 编排同样调用不到；Codex 侧也没有 per-skill 可见性开关。 |
+| PM 入口 | `agents/product_manager/skills/pm-agent/SKILL.md` | 显式调用优先；自动入口按研发意图；上下文检查后置；删除强制路由过程输出 |
+| 发现描述 | `pm-agent` frontmatter、`.claude-plugin/marketplace.json` PM description、必要 plugin description | 将“任意新请求/项目 marker 触发”收窄为研发意图默认入口，并保留显式调用 |
+| 仓库规则 | `AGENTS.md` | 同步 PM 默认入口判定，删除与新目标冲突的旧 Scope Guard 文案 |
+| 用户文档 | 根 README 中英文版、`.codex/INSTALL.md`、`docs/README.codex.md`、PM Agent README 中英文版 | 仅改写直接描述旧自动入口规则的段落 |
+| Role router | 7 个 router `SKILL.md` | 删除强制显式 routing block / decision / owner 输出要求 |
+| PRD 文档 | 受影响 router 的既有 skill PRD | 仅在存在“必须展示路由过程”的已批准要求时同步删除或改写 |
+| Eval | PM 入口与 7 个 router 的 `evals.json`、workspace、受影响 durable `comparison.md` | 用真实任务请求验证入口与最终行为，不再断言 routing block |
+| Deterministic tests | PM entry、router routing 与契约相关 pytest | 固定三分支入口判断，防止误删 gate/handoff |
+| Lock | `skills-lock.json` | 重算本 PR 修改过的 skill 目录 hash |
 
-结论：**两个平台都无法在保留下游可编排能力的前提下物理隐藏非 PM skill**。凡安装即
-可被模型直接选中，这是必须接受的平台事实（与 #61 的观察一致）。
+## 5. Eval 策略
 
-### 3.2 FR-001 降级策略选项与取舍
+Eval 的编写、静态校验和 fresh paired 执行遵循项目 `skill-eval-runner`：
 
-| 选项 | 做法 | 优点 | 缺点 | 结论 |
-| --- | --- | --- | --- | --- |
-| A. internal-only 标记 | 在 SKILL.md frontmatter 增加自定义字段（如 `visibility: internal`）并在文档中声明语义。 | 声明清晰，可被 contract 脚本校验。 | 两个平台的 harness 都不消费该字段，对模型选择行为无实际影响；不隐藏 slash 命令，也不阻止用户显式直调。 | 采用，但仅作为**声明层**：供文档、contract 脚本和 reviewer 使用，表达下游不是默认入口，不指望平台执行。 |
-| B. frontmatter 触发描述弱化 | 非 PM skill 的 description 移除用户侧触发短语，改写为「Downstream capability. Invoked via pm-agent handoff...」类弱触发表述。 | 直接作用于模型选择概率，是平台机制内唯一能真正降低直接命中率的手段；同时缩减常驻上下文（#61 的 10KB 问题）。 | 无法降为零：用户显式点名 skill 名称时仍会命中；弱化过度可能影响 PM 编排链路内的合法调用。 | 采用，作为**主降级手段**。description 保留 skill 职责描述与「handoff 后使用」定位，只删用户侧起点短语。 |
-| C. 触发后强制回 PM | specialist 入口保留 gate：无 PM handoff packet（或等效已确认文档链）时不执行，输出回 `pm-agent` 的引导。 | 不依赖平台机制，绕过路径的最终兜底；gate 行为可被 eval 验证。 | 依赖模型遵循 SKILL.md 指令，属于行为层约束而非硬拦截；增加 specialist 入口文件少量篇幅。 | 采用，作为**纵深防御**。gate 全文唯一副本放 specialist（与 #59 对齐）。 |
+1. PM 自动入口至少覆盖：
+   - 无 docs、但有明确研发意图；
+   - 有 docs、但属于普通非研发请求；
+   - 显式点名 `pm-agent` 处理非研发请求；
+   - 显式点名下游 agent 或 specialist，仍进入被点名能力的既有 gate。
+2. Router eval 删除“只做路由”“输出 routing decision”等测试化 prompt 和相关字段断言，
+   改用真实任务请求。
+3. 保留正确 specialist 选择、入口门禁、职责边界和最终任务结果的语义断言。
+4. Fresh paired eval 使用新的 with-skill 与 baseline 执行；只由真实结果更新受影响的
+   `comparison.md`，不手工复用旧结论。
 
-**推荐降级策略 = A（声明）+ B（主手段）+ C（兜底）三层叠加。** 残余风险：模型仍可能
-无视弱化 description 与 gate 指令直接执行；该风险无法在平台机制内消除，通过 FR-006 的
-防绕过 eval 持续监测，并在 eval 回归时修正 description 或 gate 文案。
+## 6. Deterministic 验证
 
-## 4. #61 入口策略决策记录（ADR 性质）
+静态和确定性测试至少证明：
 
-### 4.1 决策
+- `pm-agent` 的显式调用判断先于研发意图判断；
+- 自动入口不再以 docs、PRD/TRD、代码或 marker 为首要触发依据；
+- 非研发且未显式点名的请求不进入 PM；
+- 7 个 router 不再要求输出 routing block、routing decision 或 selected owner；
+- specialist gate、handoff schema 和 owner 映射仍存在且内容未变；
+- 修改过的 skill hash 与 `skills-lock.json` 一致。
 
-**采用「PM 收口 + specialist description 弱化（#61 方案 B 语义）+ specialist 内 gate 保留
-作为纵深防御」的组合策略。**
-
-- 对外入口层面按 #52 收口：`pm-agent` 是默认入口，6 个 role router 与 32 个
-  specialist 标记为非默认入口，用户显式直达下游仍是受支持路径。
-- description 分工按方案 B 语义执行于 specialist 与 role router 两层：用户侧起点短语
-  全部收敛到 `pm-agent` description（高召回）；role router description 收敛为「PM handoff
-  后的角色内分流」；specialist description 收敛为「router/PM 编排下的执行模块」弱触发
-  表述，删除与上游重叠的 trigger phrases。
-- 同时承认平台无法完全阻止直接触发（3.1 节结论），specialist 内保留入口 gate 作为
-  纵深防御：无 handoff packet 或等效已确认文档链时拉回 PM。
-
-### 4.2 为什么不采用纯方案 A（接受双入口，gate 唯一副本放 specialist）
-
-方案 A 的前提是「接受 harness 直接触发 specialist，不与之对抗」，让 router 与 specialist
-各自面向用户维持一套触发短语。该前提与 #52 的核心目标直接冲突：
-
-1. **#52 要求用户侧起点统一进入 PM**。方案 A 下「实现这个功能」仍直接命中
-   `feature-implementor`，即使 gate 能拦住无凭据请求，用户体验也是「先命中错误 skill，
-   再被 gate 弹回」，而不是「一开始就进入 PM 分类」；且 gate 只能拦截该 specialist 协议
-   内定义的凭据缺失，无法完成 PM 侧的请求分类、change_tier 判级和跨角色编排。
-2. **方案 A 保留双份 description 成本**。router 与 specialist 继续各自维护用户侧触发短语，
-   #61 指出的约 10KB 常驻上下文与短语重叠漂移问题只被缓解、没有被消除。
-3. **方案 A 的「router 被绕过也无所谓」只对单角色内部路由成立**。跨角色的入口判断
-   （bug 是预期问题还是实现偏离、测试依据是否已确认）本来就不在 specialist gate 的职责
-   内，双入口会让这些判断没有稳定的执行点。
-
-同时不采用**纯方案 B**（仅弱化、无 gate）：3.1 节已论证平台无法保证弱化后不被直接
-命中，没有 gate 的纯方案 B 会让绕过路径完全失守；方案 B 的已知缺点（用户说「实现
-这个功能」可能触发不到任何 skill）由 `pm-agent` 高召回 description 承接——该短语收敛
-到 PM 而不是凭空删除，用户请求仍有明确归宿。
-
-即：本决策 = 方案 B 的 description 语义 + 方案 A 中「gate 唯一副本放 specialist」的架构
-遗产，二者在 PM 收口框架下不再互斥。
-
-### 4.3 对 #59（gate 去重）的约束
-
-- gate 全文的**唯一权威副本放 specialist**（gate 的执行者），这一点沿用 #61 方案 A 的
-  实施步骤 1，与本决策兼容：纵深防御要求 gate 不依赖 router 是否被经过。
-- `AGENTS.md` 层收敛为一句契约声明 + 指向 specialist 权威副本的引用；role router 层留
-  轻量指针（「入口凭据校验见 specialist gate」），不再复制全文。
-- #59 去重时**不得把 gate 从 specialist 迁移到 router 或 AGENTS.md**，否则纵深防御失效。
-- PM handoff packet 的字段定义（PRD FR-005）唯一权威副本放 PM skill 的 handoff
-  contract（`_internal/_shared/skill-map.md` 一类共享模块）；下游 gate 按引用校验字段，
-  不复制字段清单全文。
-
-### 4.4 对 #60（SKILL.md 瘦身）的约束
-
-- 瘦身以「router description 压缩 + 细节下沉 `_internal`」为方向，与本决策一致；role
-  router SKILL.md 退化为轻量路由表的目标（≤100 行 / description 约 300 字符）继续成立。
-- specialist SKILL.md 瘦身时，**入口 gate（凭据校验 + 回 PM 引导）必须留在 SKILL.md
-  入口文件内**，不得下沉到 `_internal` 按需加载——gate 必须在 skill 被触发的第一时间
-  生效，而 `_internal` 模块只有模型主动读取才生效。
-- description 弱化改写与 #60 的 description 压缩合并为同一次编辑，避免两轮 PR 都动
-  39 个 frontmatter。
-
-## 5. Description 分工契约
-
-| 层 | Description 职责 | 允许内容 | 禁止内容 |
-| --- | --- | --- | --- |
-| `pm-agent` | 唯一用户入口，高召回。 | PRD FR-002 十类用户侧起点的代表性短语（新需求、变更、bug、工程诉求、设计、测试、部署、安全、GitHub 状态、正式文档）；「意图模糊、需要分流」的宽泛表述。 | 无（上限受 harness description 长度与上下文成本约束，实现时控制总长）。 |
-| Role router（6 个） | PM handoff 后的角色内分流。 | 角色能力枚举 + 「invoked after pm-agent handoff / PM 编排下使用」定位；目标约 300 字符。 | 用户侧第一人称起点短语（「帮我实现」「修一下」「测一下」等）。 |
-| Specialist（32 个） | 编排下的执行模块，弱触发。 | 单一职责描述 + 上游入口声明（由哪个 router/PM 场景进入）。 | 与 PM / router 重叠的 trigger phrases；「Use when the user asks...」类用户起点表述（改为「Use when routed from ...」语义）。 |
-
-marketplace.json 的 7 个 plugin description 同步改写：`pm-agent` plugin 描述为 entry
-dispatcher，其余 6 个 plugin 描述为 downstream role capability。
-
-## 6. Handoff packet 与下游入口校验
-
-### 6.1 Packet 契约
-
-字段定义见 PRD FR-005（`request_type`、`change_tier`、feature path 五元组、
-`source_documents`、`scope_decision`、`downstream_owner`、`required_output`、
-`blockers_risks`）。技术要求：
-
-- packet 以结构化块（YAML 或等效清单）出现在 PM handoff 输出中，字段名固定，便于
-  下游 gate 与 eval 语义断言识别。
-- feature path 五元组遵循 `docs/engineer/repository-governance/feature-path-contract/TRD.md`
-  的解析与校验规则。
-- `change_tier` 判定标准衔接变更分级契约（issue #55 / PR #68）。本 TRD 基于的 main 尚未
-  合入该契约：合入后以 `AGENTS.md` 的分级定义为唯一来源；未合入期间按 issue #55 的
-  hotfix / standard / major 定义执行，字段语义不变。
-
-### 6.2 下游入口 gate 行为
-
-specialist（及 role router）入口 gate 的统一判定顺序：
-
-1. 请求携带显式 PM handoff packet → 校验必填字段完整性后执行；字段缺失按缺口回 PM。
-2. 无 packet，但存在等效已确认文档链（如已确认的
-   `docs/pm/{feature_path}/PRD.md` + `docs/engineer/{feature_path}/TRD.md` +
-   已确认 `IMPLEMENTATION_PLAN.md`，且请求范围未超出文档预期）→ 视为已获编排凭据，
-   可执行；这是避免「重复拉回 PM」的合法快捷路径（PRD US-004）。
-3. 二者皆无 → 不执行本 skill 协议，输出回 `pm-agent` 的引导（说明拉回原因与 PM 将做
-   的分类），不产出实现、测试预期或修复。
-
-特例强化（沿用 PRD FR-004）：`feature-implementor` 对新需求原始请求、`debugger` 对
-未对齐预期的 bug 报告、`qa-agent` 对未确认预期的 E2E 更新，均落入第 3 类。
-
-## 7. 影响文件范围
-
-实现阶段应覆盖下列类别，具体拆分见第 8 节：
-
-| 优先级 | 路径 | 预期改动 |
-| --- | --- | --- |
-| P0 | `README.md`、`README_zh.md`、`.codex/INSTALL.md`、`docs/README.codex.md` | 推荐 `pm-agent` 为默认入口；下游定位为 PM 编排能力，同时保留显式直达路径。 |
-| P0 | `.claude-plugin/marketplace.json` | 7 个 plugin description 收口；skill 列表保持不变。 |
-| P0 | `agents/product_manager/skills/pm-agent/SKILL.md` | description 高召回扩写；路由协议增加请求分类表、change_tier 判级、handoff packet 组装。 |
-| P0 | PM `_internal` 共享模块（skill-map / handoff contract） | packet 字段唯一权威定义；下游 owner 映射。 |
-| P0 | 6 个 role router SKILL.md | description 弱化为 handoff 后使用；gate 全文改指针。 |
-| P0 | 32 个 specialist SKILL.md frontmatter | description 弱触发改写 + `visibility: internal` 声明字段。 |
-| P0 | `agents/engineer/skills/feature-implementor/SKILL.md`、`debugger/SKILL.md`、`agents/qa/skills/qa-agent/SKILL.md` 等 | 入口 gate 按 6.2 判定顺序统一改写（gate 唯一副本，#59 协同）。 |
-| P0 | `AGENTS.md` | PM 唯一入口契约声明 + gate 指针化（#59 协同）。 |
-| P0 | `skills-lock.json` | 随每个修改 skill 目录的批次在同一 PR 内重算受影响 `computedHash`（见第 8 节）。 |
-| P1 | `agents/**/test/**/evals/`（PM 入口与防绕过 eval） | 新增/改造 FR-006 的 9 类场景，含「绕过 router 直接触发」用例。 |
-| P1 | `scripts/check_repository_contract.py` | 校验 description 分工（specialist 无用户侧触发短语）、`visibility` 字段、packet 字段定义唯一性（可行范围内的静态检查）。 |
-
-## 8. 实施拆分（后续 PR 分批计划)
-
-**前置依赖：在途 PR #57（归档门禁）、#64（相对路径）、#65（_internal 结构）、#66（跨
-Agent 依赖）、#67（feature-catalog）、#68（change_tier 契约）全部合并后再开始实现**，
-因为它们与本 feature 的实施面（AGENTS.md、SKILL.md、eval fixtures）大量重叠。
-
-| 批次 | 内容 | 依赖 | 验证 |
-| --- | --- | --- | --- |
-| Batch 1: 发现面收口 | marketplace.json plugin description、README / README_zh / `.codex/INSTALL.md` / `docs/README.codex.md`、6 个 role router SKILL.md frontmatter description 弱化、specialist frontmatter description 弱化 + `visibility: internal`（与 #60 的 description 压缩合并执行）。router description 与 marketplace / specialist description 同批收口，因为三者同属 Claude/Codex 的直接 discovery 输入，任何一层单独遗留都会保持公开触发面；弱化语义按第 5 节契约执行：保留角色能力枚举与「invoked after pm-agent handoff / PM 编排下使用」的内部编排定位，删除用户侧触发短语，并指向 `pm-agent` 作为用户入口。 | 在途 PR 全部合并。 | 三个契约脚本 + pytest；description 分工静态审查。 |
-| Batch 2: PM router 重写 | pm-agent SKILL.md 高召回 description、请求分类协议、change_tier 判级、handoff packet 组装；PM `_internal` handoff contract 权威定义。 | Batch 1；#68 已合入（change_tier 定义来源）。 | 契约脚本 + PM 入口 eval（FR-006 场景 1-6、9；交付 fast lane 见 eval-010）。 |
-| Batch 3: 下游 gate 统一与 #59 去重 | 6 个 role router gate 指针化（description 弱化已在 Batch 1 完成，本批只动 gate 正文）、specialist gate 按 6.2 改写为唯一副本、AGENTS.md 契约声明；与 #59 gate 归位同一批执行。 | Batch 2。 | 契约脚本 + 防绕过 eval（FR-006 场景 7-8）。 |
-| Batch 4: eval 与 contract 收尾 | PM-only 入口 eval 全量、`check_repository_contract.py` 新校验、durable `comparison.md` 更新。 | Batch 1-3。 | 三个契约脚本 + pytest + fresh subagent validation。 |
-
-与相关 issue 的执行顺序：#59（gate 去重）在 Batch 3 内协同完成；#60（SKILL.md 瘦身）
-的 description 部分并入 Batch 1，正文瘦身可与 Batch 3 同批或紧随其后；均不得先于本
-feature 的决策单独改动 gate 位置或 description 分工。
-
-`skills-lock.json` 刷新不单独成批：Batch 1-3 都会修改 tracked skill 目录，而每批 PR 必须
-通过 `repository-contract`（`check_repository_contract.py` 会按目录 tracked 文件实时重算
-每个 skill 的 `computedHash`），推迟刷新会让首个改动 SKILL.md 的批次因 stale lock 直接
-失败。因此**每个修改 skill 目录的批次必须在同一 PR 内同步重算并更新受影响 skill 的
-`computedHash`**；Batch 4 不再承担 lock 刷新，只保留真正的收尾项（eval 全量、contract
-新校验、durable `comparison.md`）。
-
-每批次为独立 PR，均需通过 PR 必跑校验顺序
-`repository-contract -> eval-contract -> python-tests`，涉及 skill 行为的批次在合并前手动
-触发 eval workflow。
-
-## 9. 验证策略
-
-实施完成后按以下顺序验证：
+执行命令：
 
 ```bash
 uv run scripts/check_repository_contract.py
 uv run scripts/check_eval_contract.py
 uv run scripts/check_eval_artifacts.py
-uv run --extra test pytest
+uv run scripts/check_doc_contract.py
+uv run --with pytest pytest <受影响的确定性测试>
+git diff --check
 ```
 
-针对本契约的静态检查与人工审查入口：
+涉及模型行为的 router eval 在静态检查通过后执行 fresh paired validation，最多 10 workers。
 
-```bash
-# specialist description 不应再包含用户侧触发短语（示例抽查）
-rg -n '实现这个功能|帮我实现|修一下|补测试' agents/*/skills/*/SKILL.md
-# 下游 role agent 与 specialist 的 visibility 声明
-rg -n 'visibility:' agents/*/skills/*/SKILL.md
-# 用户文档只推荐 pm-agent 入口
-rg -n 'pm-agent' README.md README_zh.md .codex/INSTALL.md docs/README.codex.md
-```
+## 7. 实施约束
 
-本 TRD 阶段不声称上述命令已经运行；命令是实施完成后的验证入口。行为层验证依赖
-FR-006 的 eval：每次实际执行 skill eval 或 fresh Codex subagent validation 后，必须在同一
-轮变更中更新对应 durable `comparison.md`。
+- 所有变更放在同一个 PR 内。
+- 以删除或改写现有规则为主，不新增分类器抽象、输出协议、配置项或公共包装函数。
+- 预计净改约 500–900 行；明显超出时停止并重新核对范围。
+- 不改 specialist gate 逻辑、handoff 字段 schema、无关 skills 或 release 版本。
+- 不自动合并 PR；创建 PR、通过本地验证并等待 CI/Codex Review 后，在合并前交由维护者确认。
 
-## 10. 发布与回滚
+## 8. 回滚
 
-本变更是文档、description 和 eval 契约升级，不新增运行时服务。按第 8 节分批 PR 合入；
-回滚方式是普通 git revert。注意 Batch 1（description 弱化）与 Batch 3（gate 归位）之间
-存在依赖：若只回滚 Batch 3 而保留 Batch 1，specialist 将处于「弱触发但 gate 仍三层复制」
-的中间态，功能不受损；若只回滚 Batch 1 而保留 Batch 3，需确认 router 指针仍能指向有效
-gate 副本。
+本变更没有数据迁移或运行时状态。若入口判断或 router 行为回归，整体 revert 本 PR 即可；
+不得只回滚 lockfile 或 eval 产物，避免 skill 内容与验证证据失配。
 
-## 11. 安全与隐私
+## 9. 已确认决策
 
-本变更不引入凭据、账号、token、cookie 或 SSH key。handoff packet 只携带仓库内文档
-路径、issue/PR 引用和范围决策，不得写入本地绝对路径、用户私有目录或任何账号信息。
-
-## 12. 风险、假设和待确认问题
-
-| 类型 | 内容 | Owner | Blocking |
-| --- | --- | --- | --- |
-| Risk | 平台机制不阻止用户显式直达下游；gate 属于行为层约束，模型可能不遵循。 | Engineer | No（通过 eval 持续监测，残余风险已在 3.2 节声明） |
-| Risk | specialist description 弱化过度导致 PM 编排链路内合法调用失败。 | Engineer | Yes（Batch 1 需 eval 覆盖 handoff 放行场景后才可合并） |
-| Risk | 在途 PR 合并顺序变化导致实施基线漂移。 | Maintainer | Yes（实现开始前重校 TRD 第 7、8 节的文件清单） |
-| Decision | 入口策略：PM 收口 + specialist description 弱化（#61 方案 B 语义）+ specialist 内 gate 纵深防御；不采用纯方案 A，理由见 4.2。 | Maintainer | No |
-| Decision | gate 唯一权威副本放 specialist（约束 #59）；gate 不得随 #60 瘦身下沉到 `_internal`。 | Maintainer | No |
-| Decision | `visibility: internal` 仅为声明层字段，不依赖平台执行。 | Maintainer | No |
-| Assumption | `change_tier` 定义以 issue #55 / PR #68 为来源；合入后以 `AGENTS.md` 为唯一权威。 | Maintainer | No |
-| Open Question | `check_repository_contract.py` 对「specialist 无用户侧触发短语」的静态校验粒度（关键词黑名单 vs 人工审查），在实施计划阶段确定。 | Engineer | No |
-| Open Question | Claude Code marketplace schema 未来若提供官方 skill 可见性字段，是否迁移 `visibility` 声明。 | Maintainer | No |
-
-## 13. Feature-Implementor 交接条件
-
-- Confirmed PRD path: `docs/pm/repository-governance/pm-single-entry/PRD.md`
-- Confirmed TRD path: `docs/engineer/repository-governance/pm-single-entry/TRD.md`
-- Expected implementation plan path:
-  `docs/engineer/repository-governance/pm-single-entry/IMPLEMENTATION_PLAN.md`
-- Precondition: 在途 PR #57 / #64 / #65 / #66 / #67 / #68 已全部合并，且已按合并后基线
-  重校本 TRD 第 7、8 节。
-- Boundary: 本 TRD 不进入实现，不修改 SKILL.md、marketplace.json、skills-lock.json、
-  AGENTS.md、eval 或 contract 脚本。
-- Required next step: `feature-implementor` 基于本 TRD 按第 8 节分批生成详细实施计划，
-  用户确认后再进入实施。
+- 入口语义、文档更新、归档、新计划和实施门禁已由 Neplich 于 2026-08-14 批准。
+- #281 使用“显式调用优先、未显式调用按研发意图判断”。
+- #282 只删除 skill 流程内的强制路由过程输出要求。
+- 内部分类、gate 与 handoff 契约不改。

--- a/docs/engineer/repository-governance/pm-single-entry/archive/IMPLEMENTATION_PLAN-eval-contract-closeout.md
+++ b/docs/engineer/repository-governance/pm-single-entry/archive/IMPLEMENTATION_PLAN-eval-contract-closeout.md
@@ -1,0 +1,424 @@
+---
+title: "PM 唯一入口 Batch 4 实施计划"
+type: IMPLEMENTATION_PLAN
+version: "0.4.0"
+status: "Archived"
+author: "Neplich Codex"
+date: "2026-07-05"
+last_updated: "2026-07-05"
+generated_by: "feature-implementor"
+feature: "pm-single-entry"
+feature_path: "repository-governance/pm-single-entry"
+parent_feature: "repository-governance"
+feature_level: "2"
+implementation_scope: "eval-contract-closeout"
+archived_at: "2026-08-14"
+archive_approved_by: "Neplich"
+source_plan: "docs/engineer/repository-governance/pm-single-entry/IMPLEMENTATION_PLAN.md"
+related_prd: "docs/pm/repository-governance/pm-single-entry/PRD.md"
+related_trd: "docs/engineer/repository-governance/pm-single-entry/TRD.md"
+related_issue: "https://github.com/Neplich/dev-agent-skills/issues/52"
+related_issues:
+  - "https://github.com/Neplich/dev-agent-skills/issues/55"
+  - "https://github.com/Neplich/dev-agent-skills/issues/59"
+  - "https://github.com/Neplich/dev-agent-skills/issues/60"
+  - "https://github.com/Neplich/dev-agent-skills/issues/61"
+  - "https://github.com/Neplich/dev-agent-skills/issues/62"
+changelog:
+  - version: "0.4.0"
+    date: "2026-07-05"
+    changes: "Batch 4 实施完成：补齐 PM entry eval 全量、missing handoff target 与 change_tier eval 覆盖，并增加非 PM skill internal visibility contract"
+  - version: "0.3.12"
+    date: "2026-07-05"
+    changes: "Codex Review 修复：designer-agent 移除缺 PM handoff 的非持久设计建议绕过"
+  - version: "0.3.11"
+    date: "2026-07-05"
+    changes: "Codex Review 修复：AGENTS 仓库级 PM-first 规则保留 project-bootstrap 显式 skip-PM scaffold 例外"
+  - version: "0.3.10"
+    date: "2026-07-05"
+    changes: "Codex Review 修复：DevOps 与 Security router 的 PM handoff gate 前移到 routing 前"
+  - version: "0.3.9"
+    date: "2026-07-05"
+    changes: "Codex Review 修复：更新 Batch 3 验证记录中的 pytest 计数"
+  - version: "0.3.8"
+    date: "2026-07-05"
+    changes: "Codex Review 修复：FR-006 场景 7-8 comparison 不再把未运行 fresh validation 的 eval 标为 PASS"
+  - version: "0.3.7"
+    date: "2026-07-05"
+    changes: "Codex Review 修复：同日 last_updated 例外只接受顶层 frontmatter changelog key"
+  - version: "0.3.6"
+    date: "2026-07-05"
+    changes: "Codex Review 修复：同日 last_updated 例外只匹配 frontmatter changelog block，并补回归测试"
+  - version: "0.3.5"
+    date: "2026-07-05"
+    changes: "Codex Review 修复：同日 last_updated 例外只扫描 frontmatter changelog entry"
+  - version: "0.3.4"
+    date: "2026-07-05"
+    changes: "Codex Review 修复：同日 last_updated 例外必须同时匹配 changelog version 与 date"
+  - version: "0.3.3"
+    date: "2026-07-05"
+    changes: "Codex Review 修复：FR-006 场景 8 不再把已存在 IMPLEMENTATION_PLAN 当作 feature-implementor 入口前置条件"
+  - version: "0.3.2"
+    date: "2026-07-05"
+    changes: "Codex Review 修复：engineer-agent router 按 specialist entry basis 放行 trd-gen 与 project-bootstrap 合法路径，并补 deterministic 断言"
+  - version: "0.3.1"
+    date: "2026-07-05"
+    changes: "实施完成：下游 gate 指针化与 specialist 权威副本统一、入口 SKILL.md 瘦身、FR-006 场景 7-8 eval 与 deterministic pytest 补齐"
+  - version: "0.3.0"
+    date: "2026-07-05"
+    changes: "规划 Batch 3：下游 gate 指针化与去重、feature-implementor / idea-to-spec 正文瘦身、防绕过 eval 场景 7-8"
+  - version: "0.2.5"
+    date: "2026-07-05"
+    changes: "Batch 2 已完成并合并：补齐 PM 入口分类、handoff packet、FR-006 场景 1-6 和 Codex Review 修复"
+---
+
+# PM 唯一入口 Batch 4 实施计划
+
+## 1. 实施上下文
+
+本计划继续实施 issue #52 的最终 Batch 4：在 Batch 1 完成公开发现面收口、Batch 2 完成
+`pm-agent` 高召回分类与 handoff packet、Batch 3 完成下游 gate 去重和 SKILL.md 瘦身后，
+收尾 PM-only 入口 eval、#62 missing handoff target eval、#55 FR-008 变更分级 eval 和可机器
+检查的 internal visibility contract。
+
+本批 `change_tier` 自判为 `major`：它修改 eval 契约、deterministic pytest、repository
+contract 脚本和本实施计划。用户已明确确认继续 Batch 4；实施已完成。
+
+```mermaid
+flowchart TD
+    U["用户直接请求下游"] --> R["role router"]
+    U --> S["specialist"]
+    R --> G1{"有 PM handoff packet 或等效已确认文档链？"}
+    S --> G2{"specialist 入口 gate 通过？"}
+    G1 -->|"否"| PM["回 pm-agent 分类"]
+    G1 -->|"是"| P["只保留 gate 指针并继续路由"]
+    G2 -->|"否"| PM
+    G2 -->|"是"| X["按 specialist 协议执行"]
+```
+
+来源文档：
+
+- PRD：`docs/pm/repository-governance/pm-single-entry/PRD.md`
+- TRD：`docs/engineer/repository-governance/pm-single-entry/TRD.md`
+- 分级与归档契约：`AGENTS.md`
+- 关联 issue：#52、#55、#59、#60、#61、#62
+
+## 2. 当前门禁状态
+
+| 门禁 | 状态 | 证据 |
+| --- | --- | --- |
+| PRD 对齐 | 已完成 | PM single-entry PRD 覆盖 FR-006；change-tier PRD 覆盖 FR-008；#62 留有 missing target eval 要求 |
+| TRD 对齐 | 已完成 | PM single-entry TRD 第 8 节定义 Batch 4：eval 全量、contract 收尾、durable comparison 更新 |
+| Feature path | 已解析 | `repository-governance/pm-single-entry` |
+| 设计输入 | 不适用 | 本批为 skill / 文档契约变更，不涉及 UI |
+| Archive gate | 继续更新当前计划 | PR #73 已合并，维护者明确进入最后 Batch 4；本 feature 连续分批实施仍使用当前活跃计划，不新建归档 |
+| Sub-agent 写计划 | 不启用 | 当前任务是单一实施计划更新；主进程保留 PRD/TRD/AGENTS 约束并在用户确认后实施 |
+
+## 3. 范围
+
+### 3.1 计划修改文件
+
+| 类别 | 路径 | 实际操作 |
+| --- | --- | --- |
+| 仓库契约 | `AGENTS.md` | 收敛为 PM 唯一入口与 gate 指针声明；保留变更分级、QA E2E、archive 等仓库级规则，不复制 specialist 操作步骤 |
+| Role router | `agents/engineer/skills/engineer-agent/SKILL.md` | 把 Existing Feature Alignment Gate 改为轻量指针；新增直接用户请求无 PM handoff 时回 PM 的统一规则 |
+| Role router | `agents/designer/skills/designer-agent/SKILL.md` | Feature Path Gate 指针化；直接设计请求无 PM handoff 时回 PM |
+| Role router | `agents/qa/skills/qa-agent/SKILL.md` | QA / E2E gate 指针化；保留 QA 路由摘要，完整 E2E 执行门禁下沉到 QA specialist 入口 |
+| Role router | `agents/devops/skills/devops-agent/SKILL.md` | Feature Path Gate 指针化；repo-wide DevOps handoff 继续允许 `N/A` feature scope |
+| Role router | `agents/security/skills/security-agent/SKILL.md` | Feature Path Gate 指针化；安全 review 无 PM handoff 时回 PM |
+| Specialist gate | `agents/engineer/skills/feature-implementor/SKILL.md` | 保留并压缩 PRD alignment、UI design handoff、plan/archive/closeout gate；作为实现类 gate 权威副本 |
+| Specialist gate | `agents/engineer/skills/debugger/SKILL.md` | 保留 expected-behavior / repair gate；无 PM handoff 或等效文档链时回 PM |
+| Specialist gate | `agents/engineer/skills/project-bootstrap/SKILL.md`、`trd-gen/SKILL.md`、`test-writer/SKILL.md` | 保留各自最小前置门禁；避免复制 PM packet 字段清单 |
+| QA specialist gate | `agents/qa/skills/spec-based-tester/SKILL.md`、`exploratory-tester/SKILL.md`、`bug-analyzer/SKILL.md`、`regression-suite/SKILL.md` | 保留 E2E / feature-scoped QA 的完整门禁；`qa-agent` 只指向这些权威副本 |
+| 其他 specialist gate | Designer / DevOps / Security specialist `SKILL.md` | 只在已有 feature-path gate 处统一 PM handoff 与回 PM wording；不新增重复大段 gate |
+| 正文瘦身样本 | `agents/product_manager/skills/idea-to-spec/SKILL.md` | 目标压到约 150 行；保留入口协议，阶段细节与示例下沉 `_internal` |
+| 正文瘦身样本 | `agents/engineer/skills/feature-implementor/SKILL.md` | 目标压到约 150 行；gate 必须留在 SKILL.md，阶段执行细节下沉 `_internal` |
+| 内部模块 | `agents/product_manager/skills/idea-to-spec/_internal/**`、`agents/engineer/skills/feature-implementor/_internal/**` | 承接从 SKILL.md 移出的阶段流程、模板和输出约定 |
+| Eval | `agents/product_manager/test/pm-agent/evals/evals.json` 与 workspace | 补齐 FR-006 场景 7-8 的 durable eval 定义、workspace、comparison |
+| Eval | `agents/product_manager/test/pm-agent/evals/evals.json` 与 workspace | Batch 4 补齐 #62 missing handoff target 与 #55 FR-008 change_tier 场景 9-13，更新 1-8 comparison 的 post-merge fresh validation 状态 |
+| Pytest | `agents/product_manager/test/pm-agent/test_pm_entry_eval.py` | 增加防绕过 deterministic 断言 |
+| Pytest | `agents/product_manager/test/pm-agent/test_pm_entry_eval.py` | Batch 4 增加 missing target、hotfix fast lane、standard full gate、hotfix abuse blocked、hotfix E2E direct-path deterministic 断言 |
+| Contract | `scripts/check_repository_contract.py` | 兼容同一天内连续 Batch 修改同一实施计划时的 `version` / `last_updated` 检查，避免要求写未来日期 |
+| Contract | `scripts/check_repository_contract.py` | Batch 4 增加 PM-only public entry 静态检查：除 `pm-agent` 外所有 skill 必须声明 `visibility: internal` |
+| Lock | `skills-lock.json` | 重算所有被修改 skill 目录的 `computedHash` |
+
+### 3.2 明确不做
+
+- 不修改 marketplace / README / installer 公开发现面；这些已由 Batch 1 完成。
+- 不重新设计 PM handoff packet 字段；字段权威定义沿用 Batch 2 的 PM `_internal` 共享契约。
+- 不新增 release CI、GitHub ruleset 或运行时强制拦截。
+- 不执行 PR 合并；PR 创建后仍等待 Codex Review、CI 和维护者确认。
+
+## 4. 实施顺序
+
+### 4.1 Gate 去重与指针化
+
+1. 先建立 gate 家族清单：
+   - PM handoff packet 字段：权威副本在 PM `_internal` 共享契约。
+   - 实现前 PRD/TRD/plan gate：权威副本在 `feature-implementor/SKILL.md`。
+   - bug repair expected-behavior gate：权威副本在 `debugger/SKILL.md`。
+   - bootstrap settled-spec gate：权威副本在 `project-bootstrap/SKILL.md`。
+   - QA E2E / feature-scoped validation gate：权威副本在 QA specialist `SKILL.md`。
+   - DevOps / Security / Designer feature path gate：权威副本在对应 specialist `SKILL.md`。
+2. 更新 5 个 role router：
+   - 只保留“PM handoff packet 或等效已确认文档链”的入口判断。
+   - 没有 PM handoff 的直接用户请求，统一回 `pm-agent` 分类。
+   - 具体执行 gate 只引用 specialist 权威副本，不复制步骤。
+3. 更新 `AGENTS.md`：
+   - 保留仓库级结论和路径规则。
+   - 删除或压缩与 specialist gate 重复的操作性步骤。
+   - 指向本 feature 的 TRD / specialist gate 作为执行细节来源。
+
+### 4.2 Specialist gate 统一
+
+1. 按 TRD 6.2 统一三段判断顺序：
+   - 显式 PM handoff packet 完整时执行。
+   - 无 packet 但存在等效已确认文档链时执行。
+   - 二者都没有时不执行本 skill 协议，回 `pm-agent` 分类。
+2. 保留各 specialist 的专业 gate：
+   - `feature-implementor` 不直接接新需求、改功能或“帮我实现”原始请求。
+   - `debugger` 不直接修未对齐预期的 bug。
+   - QA specialist 不在预期未确认时固化 E2E 预期。
+3. 避免在每个 specialist 重复 PM packet 字段清单；只引用 PM `_internal` 权威定义。
+
+### 4.3 SKILL.md 瘦身
+
+1. `feature-implementor/SKILL.md`：
+   - 保留 frontmatter、职责、使用/拒绝条件、关键 gate、高层 phase、输出边界。
+   - 将上下文读取细节、计划模板、实现步骤、自检模板、handoff 模板下沉到现有
+     `_internal/planner`、`_internal/implementor`、`_internal/reviewer` 和 `_internal/_shared`
+     模块。
+   - gate 不下沉；只压缩文案。
+2. `idea-to-spec/SKILL.md`：
+   - 保留 Non-Negotiable Protocol、Operating Modes、Execution Lanes、Internal Routing
+     Contract、Feature Document Memory 和高层 phases。
+   - 将 workspace detection、lane playbooks、phase 细节、deliverable shapes、examples 下沉到
+     `_internal/orchestration`、`_internal/gen` 和 `_internal/_shared`。
+3. 目标：
+   - 两个样本入口文件各自约 150 行。
+   - 如果 `feature-implementor` 因 gate 必须留在入口文件导致略超，必须在 closeout 记录行数和原因。
+
+### 4.4 Eval 场景 7-8
+
+新增 FR-006 防绕过覆盖：
+
+| 场景 | 验证点 |
+| --- | --- |
+| `eval-007-direct-downstream-without-handoff` | 直接点名 role router / downstream agent 且无 PM handoff packet 时，应回 `pm-agent` 分类 |
+| `eval-008-direct-specialist-bypass-gate` | 绕过 router 直接触发 `feature-implementor` 等 specialist 时，specialist gate 仍执行并阻止直接实现 |
+
+Deterministic pytest 至少检查：
+
+- eval 定义、workspace、`comparison.md` 存在且符合 durable artifact 策略。
+- role router SKILL.md 含统一 direct-request guardrail。
+- `feature-implementor` / `debugger` / QA specialist 含无 handoff 回 PM 的 gate 行为。
+
+Fresh subagent validation 仍按仓库 eval 门禁执行；若本批实际运行，则同步更新对应
+`comparison.md`。
+
+### 4.5 Contract 同日更新兼容
+
+当前 `check_repository_contract.py` 要求 implementation plan 的 `version` 变化时
+`last_updated` 字符串也必须变化，但 `last_updated` 又只能使用 `YYYY-MM-DD`。当 Batch 2 与
+Batch 3 在同一天连续推进时，真实日期不能变化，不能通过写未来日期绕过。本批需要把该
+校验调整为：同一天内只要 `version` 已更新、changelog 含对应版本条目，就接受
+`last_updated` 保持当天日期。
+
+## 5. Hash 重算
+
+所有修改过的 skill 目录在提交前重算 `skills-lock.json`。命令：
+
+```bash
+uv run python - <<'EOF'
+import json, importlib.util, sys
+from pathlib import Path
+spec = importlib.util.spec_from_file_location("checker", "scripts/check_repository_contract.py")
+m = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = m
+spec.loader.exec_module(m)
+root = Path(".")
+lock_path = root / "skills-lock.json"
+lock = json.loads(lock_path.read_text())
+for name, entry in lock["skills"].items():
+    entry["computedHash"] = m.compute_tracked_directory_hash(root, entry["source"])
+lock_path.write_text(json.dumps(lock, indent=2, ensure_ascii=False) + "\n")
+print("refreshed", len(lock["skills"]), "hashes")
+EOF
+```
+
+## 6. 验证结果
+
+| 验证项 | 命令 |
+| --- | --- |
+| diff 空白检查 | `git diff --check` -> PASS |
+| 行数检查 | `wc -l agents/engineer/skills/feature-implementor/SKILL.md agents/product_manager/skills/idea-to-spec/SKILL.md` -> `feature-implementor` 152 行、`idea-to-spec` 147 行 |
+| 仓库契约 | `uv run scripts/check_repository_contract.py` -> PASS |
+| eval 契约 | `uv run scripts/check_eval_contract.py` -> PASS |
+| eval 产物策略 | `uv run scripts/check_eval_artifacts.py` -> PASS |
+| pm-agent eval pytest | `uv run --with pytest pytest agents/product_manager/test/pm-agent/test_pm_entry_eval.py -q` -> 11 passed |
+| CI 同款 pytest | `uv run --with pytest pytest agents/product_manager/test/idea-to-spec agents/product_manager/test/pm-agent agents/qa/test/test_qa_run_eval.py agents/designer/test/test_designer_run_eval.py agents/devops/test/test_devops_run_eval.py agents/test_eval_contract.py` -> 97 passed |
+
+## 7. 风险与缓解
+
+| 风险 | 缓解 |
+| --- | --- |
+| gate 过度指针化导致直接触发 specialist 时失去拦截 | gate 权威副本必须留在 specialist `SKILL.md`，不移入 `_internal` |
+| router 指针太弱导致合法 handoff 被反复拉回 PM | role router 保留 PM handoff packet / 等效文档链放行条件 |
+| #60 瘦身删除了必要上下文 | 只下沉阶段细节与模板，不删除职责、gate、输出边界 |
+| QA E2E gate 在 router 和 specialist 间漂移 | `qa-agent` 只保留路由和指针；QA specialist 保留执行门禁 |
+| eval 场景 7-8 只测文本、不测行为 | 本批先补 deterministic 防回退；fresh subagent validation 如执行则更新 durable comparison |
+| 同一天连续批次导致 `last_updated` 无法变化 | 小范围调整 repository contract，不写未来日期 |
+
+## 8. 完成标准
+
+- Batch 4 计划范围内文件已更新，未触碰 Batch 1 / Batch 2 已完成的公开发现面和 PM packet 字段定义。
+- `feature-implementor` 与 `idea-to-spec` 入口文件显著瘦身，并记录最终行数。
+- FR-006 场景 7-8 eval 定义、workspace、comparison 和 pytest 覆盖已补齐。
+- FR-006 场景 1-8 eval 定义与 deterministic pytest 全量覆盖已保留。
+- #62 missing handoff target eval 场景已补齐，断言目标 agent 未安装时 blocked 且不代行职责。
+- #55 FR-008 change_tier eval 场景已补齐，覆盖 hotfix fast lane、standard full gate、hotfix 滥用阻断和 hotfix QA 直接影响路径。
+- repository contract 已校验非 PM skill 的 `visibility: internal` 声明。
+- Batch 4 未修改 skill 目录，未产生新的 `skills-lock.json` 更新。
+- 本地验证命令全部通过。
+- PR 创建后通过 GitHub CI 和 Codex Review；如 Codex Review 提出问题，只追加 commit 修复并再次触发一次 `@codex review`。
+
+## 9. Batch 2 已合并摘要
+
+Batch 2 PR #72 已合并到 `main`，完成 `pm-agent` 高召回入口、请求分类、handoff packet
+权威定义、FR-006 场景 1-6 eval 和多轮 Codex Review 修复。本批从该合并后基线继续，不再
+重复修改 Batch 2 已确认的 PM packet 字段。
+
+## 10. 实施 Closeout
+
+最终状态：Batch 4 本地实施完成，进入 PR、CI 和 Codex Review 阶段。
+
+已完成变更：
+
+- `AGENTS.md` 增加 PM 唯一入口与下游 gate 指针规则，不复制 PM packet 字段或 specialist 操作步骤。
+- 5 个 role router 改为轻量 PM handoff entry gate；直接用户请求缺少 PM handoff 或等效文档链时回 `pm-agent` 分类。
+- Engineer、Designer、QA、DevOps、Security specialist 入口补齐 PM handoff gate，专业 gate 保留在对应 specialist 作为权威副本。
+- `feature-implementor/SKILL.md` 瘦身至 152 行；因实现类 gate 必须保留在入口文件，略高于 150 行目标。
+- `idea-to-spec/SKILL.md` 瘦身至 147 行；阶段细节保留在 `_internal` 模块。
+- 新增 FR-006 场景 7-8 eval、workspace、durable `comparison.md`，并扩展 pm-agent deterministic pytest。
+- 新增 Batch 4 eval 场景 9-13：missing handoff target、hotfix fast lane、standard full gate、hotfix 滥用阻断和 hotfix QA 直接影响路径。
+- 更新 FR-006 场景 1-8 durable `comparison.md` 的 next-step 说明，明确 fresh with/without-skill validation 转入 Batch 4 合并后的集中 skill-eval 阶段。
+- `scripts/check_repository_contract.py` 增加 internal visibility 静态检查，确保除 `pm-agent` 外的 skill 均声明 `visibility: internal`。
+- `scripts/check_repository_contract.py` 兼容同日连续批次更新 implementation plan 时的 `version` / `last_updated` 合法状态。
+- Batch 4 本地验证通过：repository contract、eval contract、eval artifacts、pm-agent eval pytest 11 passed、CI 同款 pytest 97 passed。
+- Batch 3 已全量重算 `skills-lock.json`；Batch 4 未修改 skill 目录，未产生新的 `skills-lock.json` 更新。
+
+未运行项：
+
+- Fresh Codex subagent validation 未在本 PR 执行；本批只补 deterministic eval / contract coverage 与 durable comparison 状态记录。维护者已安排 Batch 4 合并后集中执行受影响 skill 的 fresh subagent validation，并重新生成 without-skill baseline、同步更新 comparison。
+
+剩余风险：
+
+- 本批是 eval 与 contract 收尾，行为执行仍依赖后续集中 fresh validation 和实际 agent 调用遵循这些入口 gate。
+- `feature-implementor` 入口文件保留 152 行，是为了不把关键实现 gate 下沉到 `_internal` 后降低直接触发时的拦截强度。
+
+下一 owner：
+
+- 维护者 / PR 流程：等待 GitHub CI、Codex Review 和维护者确认后再合并；若 Codex Review 提出问题，只追加 commit 修复并再次触发一次 `@codex review`。
+
+## 11. Codex Review 修复记录
+
+2026-07-05 Codex Review 对提交 `7de025d` 提出两条 P2：
+
+- `engineer-agent` 不应在用户明确 skip PM 并请求 `project-bootstrap` scaffold 时，先于 specialist override 把请求拉回 PM。
+- `engineer-agent` 不应把 `trd-gen` 路径要求成 PRD + TRD + confirmed implementation plan；TRD 创建路径应允许 confirmed PM docs + stable feature path 作为 specialist entry basis。
+
+修复结果：
+
+- `engineer-agent/SKILL.md` 的 PM handoff entry gate 改为按 selected specialist entry basis 判断。
+- 明确 `trd-gen` 可从 confirmed PM documents 与 stable feature path 进入，即使 Engineer TRD 尚不存在。
+- 明确 `project-bootstrap` 在用户显式 skip PM and scaffold anyway 时可进入 specialist，由 specialist 自己处理 override 和最小 stack question。
+- `test_pm_entry_eval.py` 新增 deterministic 断言覆盖这两个合法路径。
+
+2026-07-05 Codex Review 对提交 `5b8c500` 提出一条 P2：
+
+- FR-006 场景 8 的断言不应要求等价 PRD/TRD/IMPLEMENTATION_PLAN 文档链；`feature-implementor` 合法入口是在 PM scope 和 TRD 已确认后创建 `IMPLEMENTATION_PLAN.md`。
+
+修复结果：
+
+- `eval-008-direct-specialist-bypass-gate` 改为要求 PM handoff packet，或等价已确认 PRD/TRD 与当前 implementation scope。
+- 场景 8 durable `comparison.md` 明确已存在 `IMPLEMENTATION_PLAN.md` 不是首次进入 `feature-implementor` planning 的前置条件。
+
+2026-07-05 Codex Review 对提交 `37ba7e6` 提出一条 P2：
+
+- 同日 `last_updated` 例外只检查 changelog version 会让跨日遗漏 `last_updated` 的计划也通过；需要同时校验 changelog entry date。
+
+修复结果：
+
+- `markdown_changelog_has_version_date` 现在按 changelog entry 同时匹配 `version` 和 `date`。
+- `validate_implementation_plan_metadata` 只有在当前 `last_updated` 与 changelog entry date 一致时才豁免同日连续版本更新。
+
+2026-07-05 Codex Review 对提交 `1a43cb4` 提出一条 P2：
+
+- version/date 匹配不应扫描整篇 Markdown，正文示例里的 changelog 片段不能充当 frontmatter changelog entry。
+
+修复结果：
+
+- 新增 `markdown_frontmatter_block`，只提取 Markdown frontmatter。
+- 同日 `last_updated` 例外改为调用 `markdown_frontmatter_changelog_has_version_date`，只在 frontmatter changelog entry 中匹配 version/date。
+
+2026-07-05 Codex Review 对提交 `ed8a35d` 提出一条 P2：
+
+- frontmatter 中其他 `version/date` 列表仍可能被误当作 changelog entry；同日例外必须限制到 `changelog:` block。
+
+修复结果：
+
+- 新增 `markdown_frontmatter_changelog_block`，只提取 frontmatter 中的 `changelog:` 子块。
+- 同日 `last_updated` 例外只在该 changelog block 内匹配 version/date。
+- `agents/test_eval_contract.py` 新增回归测试，验证 frontmatter 其他列表和正文 fenced YAML 示例不会触发同日例外。
+
+2026-07-05 Codex Review 对提交 `f986e07` 提出一条 P2：
+
+- 嵌套 frontmatter map 中的 `changelog:` 不应被当成顶层 canonical changelog；同日例外只能接受顶层 `changelog:` key。
+
+修复结果：
+
+- `markdown_frontmatter_changelog_block` 改为只匹配无缩进的顶层 `changelog:`。
+- `agents/test_eval_contract.py` 补充嵌套 `release_metadata.changelog` 不会触发同日例外的回归断言。
+
+2026-07-05 Codex Review 对提交 `84308bc` 提出一条 P2：
+
+- 新增 eval 7/8 的 durable `comparison.md` 不应在 fresh Codex subagent validation 与新 baseline 尚未运行时写成 `PASS`。
+
+修复结果：
+
+- eval 7/8 的 `Latest result` 改为 `PARTIAL`，明确当前只有 deterministic Batch 3 gate 覆盖。
+- eval 7/8 的 coverage gap 记录 fresh subagent validation 与 without-skill baseline 仍待 Batch 4 授权执行。
+
+2026-07-05 Codex Review 对提交 `11192f1` 提出一条 P3：
+
+- 实施计划中的验证计数仍记录为 `6 passed` / `91 passed`，与当前测试套件和 closeout 摘要不一致。
+
+修复结果：
+
+- Batch 3 验证结果更新为 pm-agent eval pytest `7 passed`、CI 同款 pytest `93 passed`。
+
+2026-07-05 Codex Review 对提交 `c92e326` 提出两条 P2：
+
+- `devops-agent` 的 PM handoff gate 位于 Available Skills / Routing Signals / Default Routes / Escalation Rules 之后，可能先选择 DevOps specialist 再检查 PM handoff。
+- `security-agent` 的 PM handoff gate 同样位于 routing 内容之后，可能先选择 Security specialist 再检查 PM handoff。
+
+修复结果：
+
+- `devops-agent/SKILL.md` 将 PM Handoff Entry Gate 前移到 Role Boundary 后、Available Skills 前。
+- `security-agent/SKILL.md` 将 PM Handoff Entry Gate 前移到 Role Boundary 后、Available Skills 前。
+
+2026-07-05 Codex Review 对提交 `4760557` 提出一条 P2：
+
+- 仓库级 `AGENTS.md` 的 PM-first 规则没有保留 `project-bootstrap` 显式 skip-PM scaffold override，可能先于 specialist gate 把合法 starter scaffold 路径拉回 PM。
+
+修复结果：
+
+- `AGENTS.md` 的直接调用下游规则补充唯一例外：用户直接请求 `project-bootstrap` 且明确要求跳过 PM 并立即 scaffold 时，可进入 `project-bootstrap` 的最小脚手架 override。
+
+2026-07-05 Codex Review 对提交 `ee4ccc9` 提出一条 P2：
+
+- `designer-agent` 的 PM handoff gate 已要求缺少 handoff/docs 时回 `pm-agent`，但 Escalation Rules 仍允许缺 PM docs 的直接设计请求进入最窄 design skill 做非持久建议，形成绕过。
+
+修复结果：
+
+- `designer-agent/SKILL.md` 移除缺 PM docs 的非持久设计建议 bypass；缺少 PM handoff context 或等效已确认 PM/design 文档时，先回 `pm-agent` 分类再选择 design skill。

--- a/docs/pm/agents/designer-agent/skills/designer-agent/PRD.md
+++ b/docs/pm/agents/designer-agent/skills/designer-agent/PRD.md
@@ -5,11 +5,11 @@ feature: "skill-designer-agent"
 feature_path: "agents/designer-agent/skills/designer-agent"
 parent_feature: "agents/designer-agent/skills"
 feature_level: "4"
-version: "1.1.0"
+version: "1.2.0"
 status: Draft
 author: "Neplich Codex"
 date: "2026-06-12"
-last_updated: "2026-06-24"
+last_updated: "2026-08-14"
 generated_by: "prd-gen"
 related_docs:
   - "agents/designer/README.md"
@@ -23,6 +23,9 @@ related_docs:
   - "docs/pm/agent-collaboration/frontend-ui-routing-contract/PRD.md"
   - "docs/engineer/agent-collaboration/frontend-ui-routing-contract/TRD.md"
 changelog:
+  - version: "1.2.0"
+    date: "2026-08-14"
+    changes: "Remove mandatory user-visible router selection explanation"
   - version: "1.1.0"
     date: "2026-06-24"
     changes: "Add Engineer-sourced UI maintenance design handoff"
@@ -126,7 +129,7 @@ Error flow: 如果必要上下文无法满足，输出 blocked reason、missing 
 
 - 输出先给结论、产物和证据，再说明限制和下一步。
 - 对需要用户确认的事项只问当前最小阻塞问题。
-- Dispatcher 选择 skill 时应说明选择理由；specialist 自身不需要把“正在使用某 skill”作为产品强制要求，除非 SKILL.md 明确要求。
+- Dispatcher 内部选择 skill 并保留交接依据；不把选择过程作为用户侧强制输出。
 
 ## 数据模型
 

--- a/docs/pm/agents/devops-agent/skills/devops-agent/PRD.md
+++ b/docs/pm/agents/devops-agent/skills/devops-agent/PRD.md
@@ -5,11 +5,11 @@ feature: "skill-devops-agent"
 feature_path: "agents/devops-agent/skills/devops-agent"
 parent_feature: "agents/devops-agent/skills"
 feature_level: "4"
-version: "1.0.0"
+version: "1.1.0"
 status: Draft
 author: "Neplich Codex"
 date: "2026-06-12"
-last_updated: "2026-06-23"
+last_updated: "2026-08-14"
 generated_by: "prd-gen"
 related_docs:
   - "agents/devops/README.md"
@@ -18,6 +18,9 @@ related_docs:
   - ".claude-plugin/marketplace.json"
   - "agents/devops/test/devops-agent/evals/evals.json"
 changelog:
+  - version: "1.1.0"
+    date: "2026-08-14"
+    changes: "Remove mandatory user-visible router selection explanation"
   - version: "1.0.0"
     date: "2026-06-12"
     changes: "Initial version"
@@ -123,7 +126,7 @@ Error flow: 如果必要上下文无法满足，输出 blocked reason、missing 
 
 - 输出先给结论、产物和证据，再说明限制和下一步。
 - 对需要用户确认的事项只问当前最小阻塞问题。
-- Dispatcher 选择 skill 时应说明选择理由；specialist 自身不需要把“正在使用某 skill”作为产品强制要求，除非 SKILL.md 明确要求。
+- Dispatcher 内部选择 skill 并保留交接依据；不把选择过程作为用户侧强制输出。
 
 ## 数据模型
 

--- a/docs/pm/agents/engineer-agent/skills/engineer-agent/PRD.md
+++ b/docs/pm/agents/engineer-agent/skills/engineer-agent/PRD.md
@@ -5,11 +5,11 @@ feature: "skill-engineer-agent"
 feature_path: "agents/engineer-agent/skills/engineer-agent"
 parent_feature: "agents/engineer-agent/skills"
 feature_level: "4"
-version: "1.2.0"
+version: "1.3.0"
 status: Draft
 author: "Neplich Codex"
 date: "2026-06-12"
-last_updated: "2026-08-01"
+last_updated: "2026-08-14"
 generated_by: "prd-gen"
 related_docs:
   - "agents/engineer/README.md"
@@ -22,6 +22,9 @@ related_docs:
   - ".claude-plugin/marketplace.json"
   - "agents/engineer/test/engineer-agent/evals/evals.json"
 changelog:
+  - version: "1.3.0"
+    date: "2026-08-14"
+    changes: "Remove mandatory user-visible router selection explanation"
   - version: "1.2.0"
     date: "2026-06-24"
     changes: "Add frontend UI implementation routing and Designer handoff"
@@ -137,7 +140,7 @@ Error flow: 如果必要上下文无法满足，输出 blocked reason、missing 
 
 - 输出先给结论、产物和证据，再说明限制和下一步。
 - 对需要用户确认的事项只问当前最小阻塞问题。
-- Dispatcher 选择 skill 时应说明选择理由；specialist 自身不需要把“正在使用某 skill”作为产品强制要求，除非 SKILL.md 明确要求。
+- Dispatcher 内部选择 skill 并保留交接依据；不把选择过程作为用户侧强制输出。
 
 ## 数据模型
 

--- a/docs/pm/agents/pm-agent/skills/pm-agent/PRD.md
+++ b/docs/pm/agents/pm-agent/skills/pm-agent/PRD.md
@@ -5,11 +5,11 @@ feature: "skill-pm-agent"
 feature_path: "agents/pm-agent/skills/pm-agent"
 parent_feature: "agents/pm-agent/skills"
 feature_level: "4"
-version: "1.0.0"
+version: "1.1.0"
 status: Draft
 author: "Neplich Codex"
 date: "2026-06-12"
-last_updated: "2026-08-06"
+last_updated: "2026-08-14"
 generated_by: "prd-gen"
 related_docs:
   - "agents/product_manager/README.md"
@@ -21,6 +21,9 @@ related_docs:
   - "docs/engineer/repository-governance/feature-path-contract/TRD.md"
   - "docs/engineer/repository-governance/feature-path-contract/IMPLEMENTATION_PLAN.md"
 changelog:
+  - version: "1.1.0"
+    date: "2026-08-14"
+    changes: "Align intent-based entry and remove mandatory user-visible routing explanation"
   - version: "1.0.0"
     date: "2026-06-12"
     changes: "Initial version"
@@ -128,7 +131,7 @@ Error flow: 如果必要上下文无法满足，输出 blocked reason、missing 
 
 - 输出先给结论、产物和证据，再说明限制和下一步。
 - 对需要用户确认的事项只问当前最小阻塞问题。
-- Dispatcher 选择 skill 时应说明选择理由；specialist 自身不需要把“正在使用某 skill”作为产品强制要求，除非 SKILL.md 明确要求。
+- Dispatcher 内部选择 skill 并保留分类依据；不把选择过程作为用户侧强制输出。
 
 ## 数据模型
 

--- a/docs/pm/agents/qa-agent/skills/qa-agent/PRD.md
+++ b/docs/pm/agents/qa-agent/skills/qa-agent/PRD.md
@@ -5,11 +5,11 @@ feature: "skill-qa-agent"
 feature_path: "agents/qa-agent/skills/qa-agent"
 parent_feature: "agents/qa-agent/skills"
 feature_level: "4"
-version: "1.0.0"
+version: "1.1.0"
 status: Draft
 author: "Neplich Codex"
 date: "2026-06-12"
-last_updated: "2026-06-23"
+last_updated: "2026-08-14"
 generated_by: "prd-gen"
 related_docs:
   - "agents/qa/README.md"
@@ -23,6 +23,9 @@ related_docs:
   - "docs/engineer/repository-governance/feature-path-contract/TRD.md"
   - "docs/engineer/repository-governance/feature-path-contract/IMPLEMENTATION_PLAN.md"
 changelog:
+  - version: "1.1.0"
+    date: "2026-08-14"
+    changes: "Remove mandatory user-visible route decision output"
   - version: "1.0.0"
     date: "2026-06-12"
     changes: "Initial version"
@@ -70,7 +73,7 @@ changelog:
 | FR-S01 | Trigger Matching | `qa-agent` 必须作为 `qa-agent` 的入口 dispatcher，选择一个最窄下游 specialist。 | P0 | 匹配场景与 parent dispatcher 和 `qa-agent` SKILL.md 一致。 |
 | FR-S02 | Context Intake | 路由级 QA evidence outcome；E2E 硬门禁包括平台版本、凭据/环境、同一 `feature_path` 的 PRD/TRD alignment、确认的 IMPLEMENTATION_PLAN。 | P0 | 路径不清、缺 plan 或文档不一致时 blocked 并说明 next owner；可推导上下文不应被写成硬门槛。 |
 | FR-S03 | Workflow Execution | 必须按当前实现工作流执行，并保留已实现的 gate、phase 或 mode。 | P0 | Mermaid 流程和工作流条目覆盖关键阶段。 |
-| FR-S04 | Artifact Output | route decision、选择理由、expected evidence artifact、上下文清单、E2E 执行协议、风险/阻塞/交接说明。 | P0 | 未阻塞时产出指定 artifact；blocked 时说明原因、缺口和 next owner。 |
+| FR-S04 | Artifact Output | expected evidence artifact、上下文清单、E2E 执行协议、风险/阻塞/交接说明；路由选择过程仅内部保留。 | P0 | 未阻塞时产出指定 artifact；blocked 时说明原因、缺口和 next owner。 |
 | FR-S05 | Boundary Guard | 不接管 `qa-agent` 之外角色的职责；不在上下文不足时伪造结论。 | P0 | 越界事项转交 owning skill/agent，不在本 skill 内扩大范围。 |
 | FR-S06 | Handoff | QA specialist、engineer-agent、pm-agent、release owner。 | P0 | Handoff 目标具体到 skill/agent/owner，并携带输入包、证据和期望结果。 |
 | FR-S07 | Traceability | PRD 必须引用执行契约来源。 | P1 | related_docs、Dependencies、API Touchpoints 能覆盖关键实现来源。 |
@@ -114,7 +117,7 @@ flowchart LR
     Decision --> exploratory_tester["exploratory-tester"]
     Decision --> bug_analyzer["bug-analyzer"]
     Decision --> regression_suite["regression-suite"]
-    Decision --> Output["route decision、选择理由、expected evidence artifact、上下文清单、E2E 执行协议、风险/阻塞/交接说明。"]
+    Decision --> Output["expected evidence artifact、上下文清单、E2E 执行协议、风险/阻塞/交接说明。"]
     Output --> Handoff["QA specialist、engineer-agent、pm-agent、release owner。"]
 ```
 
@@ -126,7 +129,7 @@ Error flow: 如果必要上下文无法满足，输出 blocked reason、missing 
 
 - 输出先给结论、产物和证据，再说明限制和下一步。
 - 对需要用户确认的事项只问当前最小阻塞问题。
-- Dispatcher 选择 skill 时应说明选择理由；specialist 自身不需要把“正在使用某 skill”作为产品强制要求，除非 SKILL.md 明确要求。
+- Dispatcher 内部选择 skill 并保留交接依据；不把选择过程作为用户侧强制输出。
 
 ## 数据模型
 

--- a/docs/pm/agents/security-agent/skills/security-agent/PRD.md
+++ b/docs/pm/agents/security-agent/skills/security-agent/PRD.md
@@ -5,11 +5,11 @@ feature: "skill-security-agent"
 feature_path: "agents/security-agent/skills/security-agent"
 parent_feature: "agents/security-agent/skills"
 feature_level: "4"
-version: "1.0.0"
+version: "1.1.0"
 status: Draft
 author: "Neplich Codex"
 date: "2026-06-12"
-last_updated: "2026-06-23"
+last_updated: "2026-08-14"
 generated_by: "prd-gen"
 related_docs:
   - "agents/security/README.md"
@@ -18,6 +18,9 @@ related_docs:
   - ".claude-plugin/marketplace.json"
   - "agents/security/test/security-agent/evals/evals.json"
 changelog:
+  - version: "1.1.0"
+    date: "2026-08-14"
+    changes: "Remove mandatory user-visible router selection explanation"
   - version: "1.0.0"
     date: "2026-06-12"
     changes: "Initial version"
@@ -123,7 +126,7 @@ Error flow: 如果必要上下文无法满足，输出 blocked reason、missing 
 
 - 输出先给结论、产物和证据，再说明限制和下一步。
 - 对需要用户确认的事项只问当前最小阻塞问题。
-- Dispatcher 选择 skill 时应说明选择理由；specialist 自身不需要把“正在使用某 skill”作为产品强制要求，除非 SKILL.md 明确要求。
+- Dispatcher 内部选择 skill 并保留交接依据；不把选择过程作为用户侧强制输出。
 
 ## 数据模型
 

--- a/docs/pm/repository-governance/pm-single-entry/PRD.md
+++ b/docs/pm/repository-governance/pm-single-entry/PRD.md
@@ -1,17 +1,20 @@
 ---
-title: "PM 唯一对外入口与下游编排 PRD"
+title: "PM 研发意图入口与路由过程收敛 PRD"
 type: PRD
-version: "1.0.0"
-status: Draft
+version: "1.1.0"
+status: Approved
 author: "Neplich Codex"
 date: "2026-07-05"
-last_updated: "2026-08-11"
+last_updated: "2026-08-14"
 generated_by: "prd-gen"
 feature: "pm-single-entry"
 feature_path: "repository-governance/pm-single-entry"
 parent_feature: "repository-governance"
 feature_level: "2"
 related_issue: "https://github.com/Neplich/dev-agent-skills/issues/52"
+related_issues:
+  - "https://github.com/Neplich/dev-agent-skills/issues/281"
+  - "https://github.com/Neplich/dev-agent-skills/issues/282"
 related_docs:
   - "AGENTS.md"
   - "README.md"
@@ -20,276 +23,123 @@ related_docs:
   - ".codex/INSTALL.md"
   - "docs/README.codex.md"
   - "agents/product_manager/skills/pm-agent/SKILL.md"
+  - "agents/designer/skills/designer-agent/SKILL.md"
   - "agents/engineer/skills/engineer-agent/SKILL.md"
-  - "agents/engineer/skills/feature-implementor/SKILL.md"
-  - "agents/engineer/skills/debugger/SKILL.md"
-  - "docs/pm/repository-governance/feature-path-contract/PRD.md"
-  - "https://github.com/Neplich/dev-agent-skills/issues/61"
-  - "https://github.com/Neplich/dev-agent-skills/issues/59"
-  - "https://github.com/Neplich/dev-agent-skills/issues/60"
-  - "https://github.com/Neplich/dev-agent-skills/issues/55"
+  - "agents/qa/skills/qa-agent/SKILL.md"
+  - "agents/devops/skills/devops-agent/SKILL.md"
+  - "agents/security/skills/security-agent/SKILL.md"
+  - "agents/docs/skills/docs-agent/SKILL.md"
 changelog:
+  - version: "1.1.0"
+    date: "2026-08-14"
+    changes: "对齐 #281 与 #282：自动入口改为研发意图优先，保留显式调用，并移除 router 强制展示路由过程的要求"
   - version: "1.0.0"
     date: "2026-07-05"
     changes: "初始版本：定义 PM 唯一对外入口、高召回触发、统一路由编排、下游内部化和防绕过需求"
 ---
 
-# PM 唯一对外入口与下游编排 PRD
+# PM 研发意图入口与路由过程收敛 PRD
 
-## 1. 背景与动机
+## 1. 当前状态
 
-本仓库当前将 7 个入口 dispatcher skills 和 32 个 specialist skills 一起暴露在
-`.claude-plugin/marketplace.json` 和 Codex skill discovery 中。即使 README 建议优先调用
-入口 agent，用户的新需求、问题反馈、修复诉求或上线准备仍可能直接命中
-`engineer-agent`、`feature-implementor`、`debugger`、`qa-agent` 等下游能力，绕过 PM 侧的
-统一需求判断、范围确认、PRD/TRD 对齐和跨角色编排（issue #52）。
+`pm-agent` 是研发协作请求的默认入口，负责分类、范围确认、变更分级和下游 handoff。
+当前自动触发规则仍把项目目录、文档或 marker 作为入口判断依据，导致两类偏差：没有
+PRD/TRD 的明确研发请求可能无法进入 PM，而处于已启用项目中的普通非研发请求可能被
+强制分类。同时，7 个 role router 仍要求向用户显式输出 routing decision 或 routing block，
+把内部流程信息暴露为用户交付内容。
 
-这与现实协作模型不一致：实际项目里，用户提出的新需求、问题反馈、变更想法、测试诉求、
-部署诉求或安全诉求，都应先从 PM 侧进入，由 PM 判断它是新需求、现有功能变更、缺陷、
-验证、部署、安全审查，还是需要继续澄清，再编排到下游角色。
+本轮处理 GitHub issue #281 与 #282，只调整自动入口判断和 router 的强制输出要求。
+既有内部分类、门禁、handoff packet 与 specialist 职责边界保持不变。
 
-issue #61 为「防绕过」需求提供了直接证据：39 个 skill 的 frontmatter description 全部常驻
-harness 上下文（router 类普遍 500-670 字符，合计约 10KB），且 router 与 specialist 的触发
-短语大量重叠。例如「实现这个功能」同时出现在 `engineer-agent`（router）和
-`feature-implementor`（specialist）的 description 中。harness 层由模型基于 description 自主
-选择 skill，完全可能直接命中 specialist、跳过 router，router 精心设计的路由前置检查
-（Existing Feature Alignment Gate、PM Handoff Guardrail 等）随之被绕开。当前的实际缓解
-方式是把 gate 复制进 specialist，功能上兜住了，但造成 issue #59 描述的三层重复维护。
+## 2. 目标
 
-本 PRD 更新并覆盖早先的「6 个 role-based agent 对外入口」方案。新的目标是：`pm-agent`
-是唯一对外公开入口；其他 role agent 和 specialist skills 都变成 PM 编排下的内部/下游能力，
-同时正面回答 #61 提出的双入口架构决策问题。
+1. 未显式点名能力时，按用户请求是否属于产品或工程研发意图决定是否进入 `pm-agent`。
+2. 用户显式点名 `pm-agent`、role agent 或 skill 时，无条件使用被点名能力。
+3. 项目文档、代码和 marker 只在进入 PM 后作为上下文与门禁证据，不作为自动触发的
+   首要依据。
+4. 删除 7 个 router 强制向用户展示路由过程的要求，让用户回答聚焦任务本身。
+5. 保留内部分类、门禁、handoff packet 字段和 specialist 执行规则。
 
-## 2. 目标与非目标
+## 3. 非目标
 
-### 目标
+1. 不修改 specialist gate 逻辑或 handoff packet schema。
+2. 不新增隐藏路由协议、输出抽象、配置项或运行时机制。
+3. 不讨论宿主或系统层的具体输出行为；本需求只约束仓库内 skill 流程。
+4. 不改变显式调用语义，不以请求是否属于研发意图拒绝用户明确点名的能力。
+5. 不增加新的 agent、skill 或 release 版本。
 
-1. 对外只推荐和公开 `pm-agent` 作为唯一用户入口。
-2. `pm-agent` 扩大触发范围，能捕获近似、模糊、不完整的需求和问题表达（高召回）。
-3. `pm-agent` 负责统一路由和编排：需求澄清、范围判断、feature_path 解析、PM 文档更新、
-   下游角色 handoff、执行状态追踪。
-4. `engineer-agent`、`designer-agent`、`qa-agent`、`devops-agent`、`security-agent`、
-   `docs-agent` 不再作为用户公开入口，而是 PM handoff 后的下游 role capability。
-5. 32 个 specialist skills 保留目录和协议能力，但定位为 role agent 或 PM 编排下的内部
-   执行模块，不再面向用户直接触发。
-6. 防止「用户提了一个新需求，直接被 `engineer-agent` / `feature-implementor` 响应并进入
-   实现」的路径；承认平台无法完全阻止直接触发时，提供明确的纵深防御与降级策略。
-7. 消除 router 与 specialist 触发描述的重叠（#61），让路由竞争行为可预期、gate 不因入口
-   不同而失效。
-
-### 非目标
-
-1. 不删除或迁移任何 specialist skill 目录；协议能力全部保留。
-2. 不改变 PRD、TRD、实施计划、QA E2E 等既有文档契约的职责边界。
-3. 不在本 feature 内实现 #59 的 gate 去重和 #60 的 SKILL.md 瘦身，但本 PRD 的决策会约束
-   它们的方向（见 FR-004 与 TRD 决策记录）。
-4. 不承诺在 Claude Code / Codex 平台机制上「物理隐藏」非 PM skill；只承诺发现面收口与
-   行为层防绕过（降级策略在 TRD 中明确）。
-5. 不引入新的运行时服务或 CI 强制拦截；防绕过通过文档契约、description 分工和 eval 保障。
-
-## 3. 用户画像
-
-| 用户画像 | 描述 | 核心诉求 | 痛点 |
-| --- | --- | --- | --- |
-| 终端用户 | 在自己项目里安装本 marketplace 的开发者。 | 说一句需求就能被正确编排，不需要先学 39 个 skill 的分工。 | 直接命中下游 skill 后跳过范围确认，产出与预期不符。 |
-| 仓库维护者 | 维护 Agent skill 行为、文档契约和 eval 的人。 | 路由竞争行为可预期，治理规则不因入口不同而失效。 | router/specialist 描述重叠，gate 被绕过时只能靠三层复制兜底。 |
-| Skill 作者 | 维护单个 agent 或 specialist skill 的人。 | description 分工清晰，改一处不用同步多处。 | 触发短语互相抄写，改任意一条要检查多个文件。 |
-| 下游 Agent 使用者 | 已有明确 PM handoff、需要执行下游能力的用户。 | 携带 handoff packet 时下游直接承接，不被反复拉回 PM。 | 收口过严会让明确的执行请求也被强制绕路。 |
-
-## 4. 用户故事与场景
-
-| ID | 用户故事 | 优先级 | 验收标准 |
-| --- | --- | --- | --- |
-| US-001 | 作为终端用户，我说「做一个新功能」时希望先进入需求澄清，而不是直接被写代码。 | P0 | 请求命中 `pm-agent`，PM 完成分类和范围确认后才 handoff Engineer，`feature-implementor` 不直接响应。 |
-| US-002 | 作为终端用户，我报告一个 bug 时希望先确认预期，而不是被直接「修掉」。 | P0 | 请求命中 `pm-agent`，先做预期分类（预期冲突回 PM，实现偏离 handoff debugger）。 |
-| US-003 | 作为终端用户，我提出部署/安全/测试诉求时希望 PM 记录目标、范围和风险后再编排。 | P0 | 请求命中 `pm-agent`，分类后按 handoff packet 交给 DevOps/Security/QA。 |
-| US-004 | 作为携带已确认 handoff 的用户，我希望下游直接承接，不被重复拉回 PM。 | P0 | 请求携带明确 PM handoff packet（或等效已确认文档链）时，下游 role agent 直接执行。 |
-| US-005 | 作为维护者，我希望用户直接点名下游 agent/specialist 时有可预期的防绕过行为。 | P0 | 无 handoff packet 的直接触发默认回 `pm-agent` 分类；specialist 内 gate 保留作为纵深防御。 |
-| US-006 | 作为 Skill 作者，我希望 router 和 specialist 的 description 不再互相抄触发词。 | P0 | specialist description 收敛为弱触发表述，router/PM description 承担用户侧短语；无重叠触发短语。 |
-| US-007 | 作为维护者，我希望 eval 能持续验证 PM-only 入口和防绕过行为不回退。 | P0 | PM 入口 eval 覆盖 FR-006 列举的用户起点场景与直接点名下游的防绕过场景。 |
-
-## 5. 功能需求
-
-### FR-001: PM agent 是唯一公开入口（P0）
-
-- `README.md`、`README_zh.md`、`.codex/INSTALL.md`、`docs/README.codex.md` 等安装与使用
-  文档只把 `pm-agent` 描述为用户可直接调用的入口；其余 role agent 和 specialist 均描述为
-  「PM 编排下的下游/内部能力」。
-- `.claude-plugin/marketplace.json` 的 plugin 与 skill description 收口公开发现面：非 PM 入口
-  的描述改写为 handoff 后使用的定位，不再包含用户侧第一人称触发短语。
-- Codex 安装逻辑（symlink 安装模型）保持 skill 目录完整安装（下游能力仍需可被 PM 编排
-  调用），但安装文档的「可直接调用入口」只列 `pm-agent`。
-- 平台限制导致无法完全隐藏其他 agent / specialist（Claude Code 与 Codex 的 skill discovery
-  均基于 frontmatter description，凡安装即可被模型选中）；降级策略必须在 TRD 中明确，
-  候选包括：internal-only 标记、frontmatter 触发描述弱化、触发后强制回 PM。
-
-验收标准：用户文档中唯一被推荐直接调用的入口是 `pm-agent`；TRD 有明确的平台约束
-分析和降级策略决策。
-
-### FR-002: PM agent 高召回触发（P0）
-
-`pm-agent` 的 description / routing contract 必须覆盖所有用户侧起点，而不只覆盖传统产品
-工作：
-
-- 新想法、新功能、新模块、空仓库产品形态。
-- 现有功能行为调整、体验调整、规则变更、文案变更。
-- 用户报告问题、bug、异常现象、失败日志、CI 失败。
-- 「帮我实现 / 改一下 / 修一下 / 补测试 / 提 PR」等工程诉求。
-- 设计、页面、交互、视觉系统诉求。
-- 验收、冒烟、复测、回归、探索测试诉求。
-- 部署、CI/CD、环境变量、Docker/Helm、发布、回滚、runbook 诉求。
-- 安全、权限、登录、依赖、secrets、隐私、数据流、webhook/upload 等风险诉求。
-- GitHub issue / PR / milestone / release / changelog / roadmap / repo status 诉求。
-- 正式文档站 bootstrap、功能/部署/发版后的同步、存量回填、图文用户操作手册、站内
-  Release Notes、发版审计诉求。
-
-验收标准：`pm-agent` description 覆盖上述十类起点的代表性短语；FR-006 的 eval 场景全部
-命中 `pm-agent`。
-
-### FR-003: PM 先分类，再 handoff（P0）
-
-`pm-agent` 必须先把请求分类，而不是直接放行到下游：
-
-| 请求类型 | PM 处理 | Handoff 条件 |
-| --- | --- | --- |
-| 新需求或范围未定 | 停留在 PM，走 `idea-to-spec` / PRD / DECISIONS。 | PRD/范围确认后才 handoff Engineer。 |
-| 现有功能变更 | 先走 PM existing-project-update，更新 PRD 或产品决策。 | PRD 更新后同步 TRD，再 handoff。 |
-| 用户报告 bug | 先判断是否与现有 PRD/TRD 预期冲突。 | 预期不清或变更诉求回 PM；确认实现偏离后 handoff Engineer/debugger。 |
-| 设计诉求 | 先确认是设计产物需求还是前端实现需求。 | 设计产物 handoff Designer；前端实现需 PM/TRD/设计对齐后 handoff Engineer。 |
-| 测试诉求 | 先确认测试依据（PRD/TRD/已确认实施计划）。 | 预期未确认不得让 QA 或 test-writer 固化新预期。 |
-| 部署/运维/安全诉求 | PM 记录目标、范围和风险。 | 记录完成后 handoff DevOps/Security。 |
-| 正式文档诉求 | PM 确认范围（bootstrap / sync / 手册 / Release Notes / audit）。 | 确认后 handoff Docs（docs-agent）。 |
-| 已完成工作交付 | 确认变更范围和验证状态。 | 确认后 handoff Engineer/delivery，不得绕过状态确认。 |
-
-分类时同步判定变更等级（`change_tier`，衔接 issue #55 / PR #68 的变更分级契约）：
-`hotfix` 与交付/状态查询类请求走 fast lane，分类后立即放行；新需求、预期变更、范围不清
-一律留在 PM。
-
-验收标准：每类请求都有明确的 PM 处理动作与 handoff 条件；fast lane 不跳过分类本身。
-
-### FR-004: 下游 agent 不直接响应用户入口（P0）
-
-- 6 个下游 role agent（Engineer、Designer、QA、DevOps、Security、Docs）的公开触发描述
-  调整为「PM handoff 后使用」；specialist 的 description 移除与用户侧起点重叠的触发短语，
-  改为弱触发表述（#61 方案 B 语义应用于 specialist 层）。
-- 用户直接点名下游 agent 或 specialist 时，默认先回到 `pm-agent` 做入口分类，除非该请求
-  已携带明确、已确认的 PM handoff packet（或等效的已确认 PRD/TRD/实施计划文档链）。
-- `feature-implementor` 不得直接响应「新需求 / 改功能 / 做个功能 / 帮我实现」等用户原始
-  请求。
-- `debugger` 不得直接响应用户报告的 bug 并进入修复；必须先有 PM/PRD/TRD 预期对齐或
-  PM handoff。
-- `qa-agent` 不得在预期未确认时直接生成或更新 E2E 预期。
-- 承认平台无法完全阻止直接触发：specialist 内的入口校验 gate 保留作为纵深防御（deep
-  defense），即使 description 弱化后仍被直接命中，gate 依然执行并把无凭据请求拉回 PM。
-  该决策同时约束 #59（gate 去重时唯一权威副本放 specialist，router/PM 留指针）和 #60
-  （SKILL.md 瘦身不得把入口 gate 摘除出 specialist 入口文件）。
-
-验收标准：无 handoff packet 的直接触发在行为上回到 PM 分类；specialist description 不再
-包含用户侧原始触发短语；gate 在绕过 router 直接触发场景下仍然执行。
-
-### FR-005: PM handoff packet 标准化（P0）
-
-PM handoff 到下游角色时必须携带结构化输入：
-
-| 字段 | 说明 |
-| --- | --- |
-| `request_type` | new_feature / existing_update / bug_report / validation / deployment / security / delivery / status / formal_docs 等。 |
-| `change_tier` | hotfix / standard / major（衔接 issue #55 / PR #68 的变更分级契约；契约未合入前由 PM 按同一定义判级）。 |
-| `feature_path` / `feature` / `parent_feature` / `feature_level` / `feature_path_evidence` | 功能归属主键与证据，遵循 feature-path-contract。 |
-| `source_documents` | PRD / DECISIONS / TRD / design docs / issue / PR / release context。 |
-| `scope_decision` | 本次范围、非目标、是否改变已批准预期。 |
-| `downstream_owner` | Designer / Engineer / QA / DevOps / Security / Docs / delivery 等。 |
-| `required_output` | 下游需要产出的文档、计划、实现、报告或验证证据。 |
-| `blockers_risks` | 缺失文档、未确认决策、平台限制、验证风险。 |
-
-验收标准：packet 字段被文档化；下游 agent 把 packet（或等效已确认文档链）作为入口
-校验依据。
-
-### FR-006: Eval 覆盖 PM-only 入口（P0）
-
-需要新增或改造 eval，验证以下路径：
-
-1. 用户说「做一个新功能」，命中 `pm-agent`，不会直接进 `feature-implementor`。
-2. 用户说「帮我修这个 bug」，命中 `pm-agent`，先做预期分类，再 handoff debugger。
-3. 用户说「帮我补测试」，命中 `pm-agent`，先确认测试依据，再 handoff QA 或
-   Engineer/test-writer。
-4. 用户说「更新前端 UI」，命中 `pm-agent`，再判断 PM / Designer / Engineer 路径。
-5. 用户说「部署一下 / 配 CI / 上线前检查」，命中 `pm-agent`，再 handoff DevOps。
-6. 用户说「看下权限 / 依赖漏洞 / secrets 风险」，命中 `pm-agent`，再 handoff Security。
-7. 用户直接调用下游 agent 或 specialist 时，如果没有 PM handoff packet，应被拉回 PM 分类。
-8. 绕过 router 直接触发 specialist 时（#61 场景），specialist 内 gate 仍然执行。
-9. 用户说「搭个文档站 / 同步正式文档 / 写用户手册」，命中 `pm-agent`，再 handoff Docs。
-
-验收标准：eval 使用 schema `1.0` 与语义断言；实际执行后更新 durable `comparison.md`。
-
-## 6. 用户流程
+## 4. 用户流程
 
 ```mermaid
 flowchart TD
-    U["用户请求（任意起点）"] --> PM["pm-agent 入口分类"]
-    PM --> C{"请求类型 + change_tier"}
-    C -->|新需求 / 范围未定| Spec["idea-to-spec: PRD / DECISIONS"]
-    C -->|现有功能变更| Update["PM existing-project-update -> 同步 TRD"]
-    C -->|bug 报告| Align{"与 PRD/TRD 预期冲突？"}
-    Align -->|预期不清 / 预期变更| Spec
-    Align -->|实现偏离| HE["handoff Engineer / debugger"]
-    C -->|设计诉求| DQ{"设计产物 or 前端实现？"}
-    DQ -->|设计产物| HD["handoff Designer"]
-    DQ -->|前端实现| HE
-    C -->|测试诉求| TQ{"测试依据已确认？"}
-    TQ -->|否| Spec
-    TQ -->|是| HQ["handoff QA / test-writer"]
-    C -->|部署 / 安全| HO["记录目标范围风险 -> handoff DevOps / Security"]
-    C -->|正式文档| HF["handoff Docs（bootstrap / sync / 手册 / release notes / audit）"]
-    C -->|交付 / 状态 (fast lane)| HL["确认范围与验证状态 -> handoff delivery / github-reader"]
-    Spec --> Packet["PM handoff packet"]
-    Update --> Packet
-    Packet --> Down["下游 role agent / specialist 执行"]
-    Direct["用户直接点名下游 / specialist"] --> Guard{"携带 handoff packet 或已确认文档链？"}
-    Guard -->|否| PM
-    Guard -->|是| Down
+    U["用户请求"] --> E{"显式点名 agent 或 skill？"}
+    E -->|"是"| S["使用被点名能力"]
+    E -->|"否"| I{"属于产品或工程研发意图？"}
+    I -->|"是"| PM["进入 pm-agent"]
+    I -->|"否"| A["当前助手直接处理"]
+    PM --> C["读取项目文档、代码与 marker 作为上下文和门禁证据"]
 ```
 
-## 7. 验收标准
+## 5. 功能需求
 
-| ID | 验收标准 | 验证方式 |
+### FR-010：自动入口按研发意图判断
+
+- 未显式点名能力时，先判断请求是否属于产品或工程研发工作。
+- 研发意图包括新产品或功能、需求变更、bug、代码实现、测试、设计交付、部署、发布、
+  安全审查、正式项目文档和研发项目状态等现有 PM 分类范围。
+- 属于研发意图时进入 `pm-agent`；不属于研发意图时由当前助手直接处理。
+- 自动判断不以当前目录是否启用 dev-agent-skills、是否存在 `docs/`、PRD、TRD、代码或
+  marker 为首要条件。
+
+### FR-011：显式调用始终生效
+
+- 用户显式点名 `pm-agent`、任一 role agent 或任一 skill 时，使用被点名能力。
+- 显式点名优先于自动入口判断，不因请求内容被判断为非研发而拒绝调用。
+- 被点名能力内部原有 gate 和职责边界继续执行，本需求不提供绕过门禁的权限。
+
+### FR-012：项目上下文后置
+
+- 进入 `pm-agent` 后，继续读取项目文档、代码、marker 和已确认 handoff 作为分类、
+  `feature_path`、`change_tier` 与 specialist gate 的证据。
+- 上述证据只影响进入 PM 后如何处理，不决定未显式请求是否应进入 PM。
+
+### FR-013：移除 router 强制路由过程输出
+
+- `pm-agent`、Designer、Engineer、QA、DevOps、Security、Docs 共 7 个 router 不再要求
+  显式输出“已路由到”、`Routing decision`、routing block、YAML、selected specialist、
+  owner 或同类内部过程信息。
+- 仅删除“必须向用户展示”的要求，不重新定义新的用户输出协议。
+- router 的内部选择规则、入口门禁、handoff 数据和 specialist 路由表保持不变。
+
+## 6. 验收场景
+
+| ID | 场景 | 期望 |
 | --- | --- | --- |
-| AC-001 | 用户文档只把 `pm-agent` 描述为公开入口。 | 审查 README / README_zh / `.codex/INSTALL.md` / `docs/README.codex.md`。 |
-| AC-002 | 新需求、功能变更、bug、测试、部署、安全、交付、正式文档请求默认先进入 PM 分类和编排。 | PM 入口 eval（FR-006 场景 1-6；交付 fast lane 见 eval-010；正式文档场景 9 对应 eval 待补充）。 |
-| AC-003 | 无 PM handoff packet 时，下游 role agent / specialist 不直接承接用户原始请求。 | 防绕过 eval（FR-006 场景 7-8）。 |
-| AC-004 | `feature-implementor` 不直接响应用户新需求并进入实现。 | `feature-implementor` eval 与 gate 审查。 |
-| AC-005 | PM handoff packet 字段被文档化，并被下游 agent 作为入口校验依据。 | 审查 PM skill-map / handoff contract 与下游 SKILL.md。 |
-| AC-006 | PM-only 入口 eval 覆盖主要用户侧起点和防绕过场景。 | `check_eval_contract.py` + fresh subagent validation + `comparison.md`。 |
-| AC-007 | repository contract、eval contract、eval artifacts 检查通过。 | 三个契约脚本 + pytest。 |
-| AC-008 | 平台无法完全隐藏非 PM skills 时，TRD 明确残余风险和降级策略。 | 审查 `docs/engineer/repository-governance/pm-single-entry/TRD.md`。 |
-| AC-009 | router 与 specialist 的 description 不再互相抄触发词（#61）。 | description 分工审查 + 绕过 eval。 |
+| AC-010 | 无 PRD/TRD 的目录中请求实现新功能 | 自动进入 `pm-agent` |
+| AC-011 | 有完整项目文档的目录中请求处理普通非研发事项 | 不自动进入 `pm-agent` |
+| AC-012 | 用户显式点名 `pm-agent` 处理非研发请求 | 使用 `pm-agent`，其内部规则照常执行 |
+| AC-013 | 用户显式点名下游 role agent 或 specialist | 使用被点名能力，其入口 gate 照常执行 |
+| AC-014 | 研发请求完成 router 分类 | 用户侧结果不因 skill 契约被强制包含 routing block 或 routing decision |
+| AC-015 | 删除强制输出要求后执行下游流程 | 内部 gate、handoff 字段和职责边界保持不变 |
 
-## 8. 发布计划与里程碑
+## 7. 发布边界
 
-| Phase | Scope | Owner |
-| --- | --- | --- |
-| PRD/TRD（本次交付） | 固化需求、平台约束分析、#61 入口策略决策和实施拆分。 | PM / Engineer |
-| Implementation Plan | 待在途 PR（#57/#64/#65/#66/#67/#68）合并后，由 `feature-implementor` 产出。 | Engineer |
-| 实施批次 | 按 TRD 第 8 节分批 PR 实施。 | Engineer |
-| Eval | 更新并执行 PM 入口与防绕过 eval，刷新 durable `comparison.md`。 | Engineer / QA |
-| Release Preflight | 运行仓库契约、eval 契约和 artifact 检查。 | Maintainer |
+本轮在一个 PR 内完成 PRD/TRD、7 个 router、发现描述、必要用户文档、受影响 eval、
+deterministic tests 与 `skills-lock.json` 的同步。PR 创建后等待 CI、Codex Review 和维护者
+确认；不在本轮自动合并。
 
-## 9. 风险与缓解
+## 8. 风险与约束
 
-| 风险 | 影响 | 缓解 |
-| --- | --- | --- |
-| 平台机制无法物理隐藏非 PM skill，收口只是「弱化 + 行为拦截」。 | 直接触发仍可能发生。 | specialist 内 gate 作为纵深防御；eval 覆盖绕过场景；TRD 记录残余风险。 |
-| specialist description 弱化过度，导致携带 handoff 的合法调用也触发不到。 | 编排链路断裂，PM 无法调用下游。 | description 保留「PM/router handoff 后使用」的明确定位短语；eval 覆盖 handoff 放行场景。 |
-| PM 高召回描述过宽，抢走本应直达的非工作型请求。 | 简单状态查询被拖入重流程。 | FR-003 fast lane：delivery/status/hotfix 分类后立即放行。 |
-| 所有请求过 PM 增加流程成本，反向促使用户绕开流程。 | 与收口目标冲突。 | `change_tier` 分级放行（衔接 #55）；分类本身保持轻量。 |
-| description 大改与在途 PR（#57/#64-#68）冲突。 | 大面积 merge 冲突。 | 本次 docs-only；实现推迟到在途 PR 合并后分批进行。 |
+| 风险 | 约束 |
+| --- | --- |
+| 研发意图描述过窄导致漏触发 | eval 同时覆盖“无 docs 的研发请求”和“有 docs 的非研发请求” |
+| 显式调用被自动判断覆盖 | eval 固定验证显式点名优先 |
+| 删除输出文案时误删内部路由规则 | diff 审查与 deterministic tests 检查 gate、handoff 字段仍存在 |
+| 修改范围扩大为新协议 | 实施计划禁止新增输出抽象、配置项和 handoff schema 变更 |
 
-## 10. 假设与待确认问题
+## 9. 最终决策
 
-| 类型 | 内容 | Owner | Blocking |
-| --- | --- | --- | --- |
-| Decision | 入口策略采用「PM 收口 + specialist description 弱化 + specialist 内 gate 纵深防御」，不采用 #61 纯方案 A（双入口对等）。理由与影响见 TRD 决策记录。 | Maintainer | No |
-| Decision | 本 feature 使用 `repository-governance/pm-single-entry` 作为 feature_path，覆盖 issue #52 中建议的 `agent-collaboration/pm-only-public-entry` 路径口径。 | Maintainer | No |
-| Assumption | `change_tier` 分级契约（issue #55 / PR #68）先于或与本 feature 实现阶段同步合入；未合入时 PM 按 PRD 中同一定义判级。 | Maintainer | No |
-| Assumption | 实现阶段在在途 PR #57/#64/#65/#66/#67/#68 合并后进行，避免 SKILL.md / AGENTS.md 大面积冲突。 | Maintainer | No |
-| Open Question | marketplace.json 是否需要为非 PM plugin 增加显式 `internal` 类元数据字段（取决于 Claude Code marketplace schema 支持度），或仅通过 description 收口。 | Engineer | No |
+- 自动入口采用“显式调用优先，其余按研发意图判断”。
+- 项目上下文只作为进入 PM 后的处理证据。
+- #282 采用最小删除：移除 7 个 router 强制展示路由过程的要求。
+- 本轮实施门禁、归档门禁和计划门禁已由 Neplich 于 2026-08-14 批准。

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -4,7 +4,7 @@
     "pm-agent": {
       "source": "agents/product_manager/skills/pm-agent",
       "sourceType": "local",
-      "computedHash": "6ec163af2cf891a3e09f254a47b3086ccc748810eea03e217967dd95370c4362"
+      "computedHash": "6bcf9d6214e92c682ead4faf558367fd3dffd2e8f9543ea5d14cfd91536d8f3d"
     },
     "idea-to-spec": {
       "source": "agents/product_manager/skills/idea-to-spec",
@@ -49,7 +49,7 @@
     "engineer-agent": {
       "source": "agents/engineer/skills/engineer-agent",
       "sourceType": "local",
-      "computedHash": "cab952a89228b77dcf371aa94df9d3fcfe8ca3d84cfece0a287467837d3d662e"
+      "computedHash": "ccbfc8b995de722a69d5c74905c7225821bfe384a1a1371fbfdac66ff1c8735b"
     },
     "codebase-analyzer": {
       "source": "agents/engineer/skills/codebase-analyzer",
@@ -84,7 +84,7 @@
     "qa-agent": {
       "source": "agents/qa/skills/qa-agent",
       "sourceType": "local",
-      "computedHash": "f3dca1b724428519cfcadb5817f8a0c323bbb9dd4bc0d53ba998e4f058c90017"
+      "computedHash": "6f6df572fe8fe0566c66ab0d0f532d904ff9ec975e821b9e9abe134caf03114a"
     },
     "exploratory-tester": {
       "source": "agents/qa/skills/exploratory-tester",
@@ -109,7 +109,7 @@
     "devops-agent": {
       "source": "agents/devops/skills/devops-agent",
       "sourceType": "local",
-      "computedHash": "d0c489b44f5df18f61ab68af771963a0681c3fb7f5e2ebc0c62a3016f5f9c9f0"
+      "computedHash": "11a75f9ba54fcff602edc50a75177dbbf1aed191c22f0dd0bdaefc197cfab27f"
     },
     "deployment-planner": {
       "source": "agents/devops/skills/deployment-planner",
@@ -134,7 +134,7 @@
     "designer-agent": {
       "source": "agents/designer/skills/designer-agent",
       "sourceType": "local",
-      "computedHash": "a6bb4cc6bdfd01d2e4be8c05eca2da4b416481874f8f5079723170878be9cda9"
+      "computedHash": "66b222fec93d82619f5d1ff4d1a6603aa338bdb706ece6d26bc27be7638906ae"
     },
     "ui-ux-design": {
       "source": "agents/designer/skills/ui-ux-design",
@@ -149,7 +149,7 @@
     "security-agent": {
       "source": "agents/security/skills/security-agent",
       "sourceType": "local",
-      "computedHash": "d719807a4c0987bdefd57864821eac42a56c22a643211a28b8c148afe23894b5"
+      "computedHash": "3fe72e042f3947dff8467fef4ff6c488ebb566bf085b9077a7d8bf87588da87e"
     },
     "appsec-checklist": {
       "source": "agents/security/skills/appsec-checklist",
@@ -174,7 +174,7 @@
     "docs-agent": {
       "source": "agents/docs/skills/docs-agent",
       "sourceType": "local",
-      "computedHash": "efce0d88396ab7394452417ec04e816156f2251191aa41c1825daba951d3ad26"
+      "computedHash": "1fc2a896ea86a542c7989608aeb7107ce5ce32671b2768402384728674786e9b"
     },
     "docs-site-bootstrap": {
       "source": "agents/docs/skills/docs-site-bootstrap",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -4,7 +4,7 @@
     "pm-agent": {
       "source": "agents/product_manager/skills/pm-agent",
       "sourceType": "local",
-      "computedHash": "0f318440d00acccd34459c7c4bcabe5ec29e17cc9948190f40d9a6cf8ad961d1"
+      "computedHash": "e3a165bd95e108b86d4ed82992b26c424287ea22f43f0a04d7d8a354607cc5a6"
     },
     "idea-to-spec": {
       "source": "agents/product_manager/skills/idea-to-spec",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -4,7 +4,7 @@
     "pm-agent": {
       "source": "agents/product_manager/skills/pm-agent",
       "sourceType": "local",
-      "computedHash": "6bcf9d6214e92c682ead4faf558367fd3dffd2e8f9543ea5d14cfd91536d8f3d"
+      "computedHash": "0f318440d00acccd34459c7c4bcabe5ec29e17cc9948190f40d9a6cf8ad961d1"
     },
     "idea-to-spec": {
       "source": "agents/product_manager/skills/idea-to-spec",


### PR DESCRIPTION
## 变更内容

- 调整 PM 默认入口：显式点名能力时始终使用；未显式点名时按产品/工程研发意图进入 PM；项目文档、代码和 marker 仅作为进入后的上下文。
- 删除 PM、Designer、Engineer、QA、DevOps、Security、Docs 7 个 router 强制向用户展示 routing block、decision、owner 等过程信息的要求，保留 specialist gate、handoff schema 和职责边界。
- 同步发现描述、用户文档、PRD/TRD、实施计划、skill lock、确定性测试和受影响 eval。
- 新增显式点名下游 `engineer-agent:codebase-analyzer` 的真实行为 eval。

## 原因

修复 #281 中 PM 入口过度依赖项目标记的问题，并落实 #282：路由仍在 skill 流程中完成，但不再强制把内部过程块展示给用户。

## 验证

- `uv run scripts/check_repository_contract.py`
- `uv run scripts/check_eval_contract.py`
- `uv run scripts/check_eval_artifacts.py`
- `uv run scripts/check_doc_contract.py`
- 独立全仓 pytest：318 passed，6 subtests passed
- 42 个 router fresh paired comparison：29 PASS、10 PASS (partial coverage)、3 个变更前既有 Docs FAIL；本次新增 FAIL 为 0
- `git diff --check`
- 独立只读 diff/contract/eval 验收通过

## 影响与边界

- 不修改共享 PM handoff contract、specialist gate、eval runtime 或 release 流程。
- Docs eval-004、005、006 的既有 FAIL 保留为独立后续问题，不在本 PR 扩大修复范围。
- 本 PR 保持 draft，等待 CI、review 与维护者合并确认；不会自动合并。

Closes #281
Closes #282