### PR TITLE
refactor(skills): 精简 Skill 描述并刷新评测

### DIFF
--- a/.agents/skills/maintain-skills/SKILL.md
+++ b/.agents/skills/maintain-skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: maintain-skills
-description: Manage this repository's role-skill lifecycle (add, modify, rename) and new role agents. Use when adding or renaming a role skill, adding a role agent, or changing an existing skill's SKILL.md, frontmatter, structure, description, or shared-contract copies. Use when a role-skill or new-agent lifecycle change requires syncing marketplace.json, skills-lock.json, per-agent or root plugin manifests, router routing, discovery descriptions, agent or root READMEs, process docs, or the PM doc-tree governance scope. Do not use for authoring, running, or diagnosing evals — delegate those to skill-eval-runner. Do not use for version releases or ordinary PRD/TRD/implementation-plan updates that do not touch the role-skill lifecycle.
+description: Manage role Skill and Agent lifecycle changes in this repository, including additions, modifications, renames, and required sync surfaces. Use for Skill contract or registration changes; use skill-eval-runner for eval work.
 ---
 
 # Maintain Skills

--- a/.agents/skills/maintain-skills/references/change-types.md
+++ b/.agents/skills/maintain-skills/references/change-types.md
@@ -48,9 +48,12 @@ or shared-contract copies.
 2. Scan the impact per `sync-surfaces.md`; the surface set depends on what the
    modification touches (description changes hit discovery, routing changes hit
    router evals, and so on).
-3. Refresh `skills-lock.json` `computedHash` for the skill when any tracked
+3. Keep each frontmatter `description` within 500 Unicode characters. Treat
+   this as a hard ceiling, not a writing target: preserve the minimal discovery
+   contract while moving detailed process and exhaustive lists into the body.
+4. Refresh `skills-lock.json` `computedHash` for the skill when any tracked
    file under its directory changes (SKILL.md, `references/`, `_internal/`).
-4. Route eval-impact analysis to `skill-eval-runner`.
+5. Route eval-impact analysis to `skill-eval-runner`.
 
 ## Rename
 

--- a/.agents/skills/skill-eval-runner/SKILL.md
+++ b/.agents/skills/skill-eval-runner/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-eval-runner
-description: Author, review, run, batch, inspect, and diagnose this repository's skill evaluations. Use when Codex needs to create or change evals.json, scenarios, prompts, assertions, eval_metadata.json, fixtures, or comparison.md; select and run fresh paired eval targets with up to 10 workers; inspect summaries; distinguish eval defects from skill defects or infrastructure blockers; or verify eval contracts without model execution. Do not use for ordinary unit tests or QA E2E product testing.
+description: Create, run, inspect, and diagnose this repository's Skill evals and eval contracts. Use for eval definitions, paired runs, result analysis, or eval infrastructure triage; not for unit tests or product QA.
 ---
 
 # Skill Eval Runner

--- a/agents/designer/skills/designer-agent/SKILL.md
+++ b/agents/designer/skills/designer-agent/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: designer-agent
-description: "Classify and route confirmed UX, information-architecture, wireframe, reference-pattern, and visual-system requests before design work begins. Use immediately after a PM handoff; preserve the handoff and delegate to the matching design specialist."
+description: "Route confirmed UX, information-architecture, wireframe, reference-pattern, and visual-system work to the appropriate design specialist. Use after a PM design handoff."
 visibility: internal
 ---
 

--- a/agents/designer/skills/ui-ux-design/SKILL.md
+++ b/agents/designer/skills/ui-ux-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ui-ux-design
-description: "Produce UX flows, page structures, journey maps, screen definitions, and ASCII prototypes from confirmed product scope. Use after designer-agent routes a UI/UX delivery; an unconfirmed direct request returns to the design entry gate."
+description: "Define UX flows, page structures, journeys, screens, and ASCII prototypes for confirmed product scope. Use after designer-agent routes UI/UX work."
 visibility: internal
 ---
 

--- a/agents/designer/skills/visual-design/SKILL.md
+++ b/agents/designer/skills/visual-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: visual-design
-description: "Define a reference-backed visual system: aesthetic direction, color, typography, components, copy tone, and UI quality rules. Use after designer-agent confirms the visual-design scope; an unconfirmed direct request returns to the design entry gate."
+description: "Define a reference-backed visual system for confirmed product scope. Use after designer-agent routes visual-design work."
 visibility: internal
 ---
 

--- a/agents/designer/test/designer-agent/evals/workspace/eval-003-engineer-ui-maintenance-handoff/comparison.md
+++ b/agents/designer/test/designer-agent/evals/workspace/eval-003-engineer-ui-maintenance-handoff/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `821c99c85df4188cff291d55bb3f776ec720f8cbbd3f93df4bf7a03b6520bf3a` from `agents/designer/test/designer-agent/evals/workspace/eval-003-engineer-ui-maintenance-handoff`.
 - Identity schema: `2`
-- target_skill_sha256: `ab61dfad7912c1f4762939ebfeb53cb1e7798640502b92a5fa0fa76318105fc9`
+- target_skill_sha256: `1d67d4772843dc0275749d693d7415791b7459f5d948588a69fb240bcfd7f02b`
 - eval_definition_sha256: `138aebdae4a1049db8b791a6754cc321fff06d447fcae99b0206d1d5aa26e929`
 - metadata_sha256: `f547a888a015d9e9862374a63fae63a3c03679e1e0f3c3c280b9cf0370c3b020`
 - fixture_sha256: `821c99c85df4188cff291d55bb3f776ec720f8cbbd3f93df4bf7a03b6520bf3a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `642d6c7ee5330dc1af39bc9648e9c1bffdb74e1229fc98a9c317e40e13baaebf`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `92f4c4b043cb3aab774531019133e8d4e6f2d81d21a277f0cd9696a8cc0a58e7`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `96027d263bbf16994ceaa244fa5630391b9b2aebc603c7baad35ef58b67deea5`
+- Skill overlay SHA-256: `902f97074f6d958600dd8079608539a38bff227cb03726b9ab277705b1b8ded7`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,22 +33,22 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `accepts_engineer_design_handoff` | PASS | With-skill delivery is explicitly design-only, uses Engineer-sourced PRD/TRD inputs, and hands the completed design work to engineer-agent for implementation ownership. |
-| `uses_confirmed_feature_path` | PASS | Both locked design snapshots declare feature_path `customer-portal/profile-settings` and reference the matching PM and Engineer documents as source documents. |
-| `routes_design_skills` | PASS | Locked runner command events show the designer-agent, ui-ux-design, and visual-design skill files were read; both required design deliverables were produced. |
-| `writes_design_outputs_only` | PASS | The with-skill git evidence contains only the two allowed files under `docs/design/customer-portal/profile-settings/`; no code, tests, commands, deployment files, or implementation checklist were delivered. |
-| `hands_back_to_engineer` | PASS | Both locked design snapshots state that the designer stops and engineer-agent owns TRD alignment, IMPLEMENTATION_PLAN.md, frontend implementation, and tests; the final output repeats this handoff. |
+| `accepts_engineer_design_handoff` | PASS | The with_skill trace reads the designer-agent routing contract, which defines an Engineer UI-maintenance/frontend-update handoff as a valid design entry; the locked final output identifies the entry as an Engineer UI maintenance handoff and stops at design delivery. |
+| `uses_confirmed_feature_path` | PASS | Both locked design snapshots use feature_path "customer-portal/profile-settings" and list the matching PRD and TRD under source_documents; the trace shows both documents were read. |
+| `routes_design_skills` | PASS | The trace reads ui-ux-design and visual-design skill instructions, and the delivered snapshots separately cover information hierarchy/layout and primary-button visual specifications. |
+| `writes_design_outputs_only` | PASS | The locked workspace status shows only docs/design/ additions. The only delivered files are docs/design/customer-portal/profile-settings/ui-ux-spec.md and visual-system.md; their contents explicitly state they are design handoffs with no implementation artifacts. |
+| `hands_back_to_engineer` | PASS | Both delivered snapshots state that design stops and the confirmed next owner is engineer-agent, responsible for TRD alignment, IMPLEMENTATION_PLAN.md, implementation, and tests; the final output repeats this handoff. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=92f4c4b043cb3aab774531019133e8d4e6f2d81d21a277f0cd9696a8cc0a58e7; fixture_sha256=821c99c85df4188cff291d55bb3f776ec720f8cbbd3f93df4bf7a03b6520bf3a; output_sha256=5568d5f79777d32beaf8a358e58ffdc1cf5b565897e88328d767d3bc1a47cdb2; snapshot_sha256=974e9c3a85505aae067a457f98d339f613a53ac09f53a7f3547a5be4fe925ae9
-- Behavior: Produced the two scoped design artifacts with confirmed feature routing, UI/UX and visual-design coverage, and an explicit handoff to engineer-agent.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=92f4c4b043cb3aab774531019133e8d4e6f2d81d21a277f0cd9696a8cc0a58e7; fixture_sha256=821c99c85df4188cff291d55bb3f776ec720f8cbbd3f93df4bf7a03b6520bf3a; output_sha256=c3442dd48d3a6aaf6a3f29a7bf93b5edc9880d0c4ce29d780b1289aab1dba966; snapshot_sha256=faab716e064401ed4e9324f13638807b66446d91e882a555461f91d8b09522d2
+- Behavior: Accepted the Engineer design handoff, used the confirmed feature path and source documents, routed UX and visual work, wrote only the two permitted design artifacts, and handed implementation back to engineer-agent.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=92f4c4b043cb3aab774531019133e8d4e6f2d81d21a277f0cd9696a8cc0a58e7; fixture_sha256=821c99c85df4188cff291d55bb3f776ec720f8cbbd3f93df4bf7a03b6520bf3a; output_sha256=f6fb4fb3d1cb4014d9fa83b5d9bd2fca96b6165746726065a196c4ec884c2279; snapshot_sha256=43f2f223212f9d9140e85c48e06a5d5642b6166ce404319727733efed3360a4c
-- Behavior: Fresh baseline produced a generic DESIGN.md, modified PRD/TRD files, did not show the required skill routing, and did not explicitly hand back to engineer-agent.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=92f4c4b043cb3aab774531019133e8d4e6f2d81d21a277f0cd9696a8cc0a58e7; fixture_sha256=821c99c85df4188cff291d55bb3f776ec720f8cbbd3f93df4bf7a03b6520bf3a; output_sha256=b906d22a55a419cde5a7b864e0a342813318ad016381195bfe2702a7c06649be; snapshot_sha256=834b1cfc8befa23e18621dfcc5ef01dffe1d97c7442731104752c94612da04fd
+- Behavior: Fresh baseline created a non-permitted DESIGN.md and modified the TRD, did not use the required output paths or explicit skill routing, and did not provide the required engineer-agent handoff framing.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/designer/test/designer-agent/evals/workspace/eval-1-route-design-handoff/comparison.md
+++ b/agents/designer/test/designer-agent/evals/workspace/eval-1-route-design-handoff/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `318a6ed6ff151cee086f75e2b1924aa867c873c059722194e1d201fc514c9d89` from `agents/designer/test/designer-agent/evals/workspace/eval-1-route-design-handoff`.
 - Identity schema: `2`
-- target_skill_sha256: `ab61dfad7912c1f4762939ebfeb53cb1e7798640502b92a5fa0fa76318105fc9`
+- target_skill_sha256: `1d67d4772843dc0275749d693d7415791b7459f5d948588a69fb240bcfd7f02b`
 - eval_definition_sha256: `81da08302867bb0360b62db9057e07b009cd93243321e4fb904ab779192971e2`
 - metadata_sha256: `b228adbda9579c0023d949fdd52d3bd090b6ff85b7c6c2610e5202c6900dbe10`
 - fixture_sha256: `318a6ed6ff151cee086f75e2b1924aa867c873c059722194e1d201fc514c9d89`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `463caa76fbf321564869d8651cfcd73afe8721c939c5039c5cfd81c4ab25d935`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `6928263198e744f0628528a64ad381eb51b57dfc5347279a1b5dc49c697dfc6c`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `96027d263bbf16994ceaa244fa5630391b9b2aebc603c7baad35ef58b67deea5`
+- Skill overlay SHA-256: `902f97074f6d958600dd8079608539a38bff227cb03726b9ab277705b1b8ded7`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,22 +33,22 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `routes_ux_first` | PASS | Trace states the route as `ui-ux-design → visual-design`; UX skill was read before visual-design, and the delivered UX document contains flow, structure, interaction states, and responsive guidance. |
-| `routes_visual_followup` | PASS | Trace explicitly routes visual work to `visual-design` after UX; the delivered visual-system.md contains visual direction, colors, typography, components, and copy guidance. |
-| `uses_real_output_filenames` | PASS | Locked delivery_snapshot contains exactly `docs/design/billing-notifications/ui-ux-spec.md` and `docs/design/billing-notifications/visual-system.md`. |
-| `stops_before_code` | PASS | Locked delivery_snapshot contains only the two design documents; trace file-change evidence shows no React components, tests, scripts, or deployment configuration were added. |
-| `hands_off_to_engineer` | PASS | Both locked design documents state that design stops and the next responsibility is `engineer-agent`; final output repeats the handoff boundary and defers React implementation. |
+| `routes_ux_first` | PASS | 锁定 trace 明确记录路由为 `ui-ux-design → visual-design`，且交付的 UI/UX 规范包含流程、信息架构、线框和交互状态。 |
+| `routes_visual_followup` | PASS | 锁定 trace 明确将 `visual-design` 作为 `ui-ux-design` 后续步骤；`visual-system.md` 直接交付视觉系统内容。 |
+| `uses_real_output_filenames` | PASS | delivery_snapshot 直接包含 `docs/design/billing-notifications/ui-ux-spec.md` 与 `docs/design/billing-notifications/visual-system.md`。 |
+| `stops_before_code` | PASS | 锁定 git evidence 仅显示两个设计文档新增，未修改 React、测试、脚本或部署配置；候选输出也明确说明设计阶段未修改 React 或测试。 |
+| `hands_off_to_engineer` | PASS | 候选输出明确说明下一步交给 `engineer-agent`，负责后续 TRD、实现和测试。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=6928263198e744f0628528a64ad381eb51b57dfc5347279a1b5dc49c697dfc6c; fixture_sha256=318a6ed6ff151cee086f75e2b1924aa867c873c059722194e1d201fc514c9d89; output_sha256=c5aeedb23d1dd991db19fc4ee9137e97c6519777adc33fe953c3ccb1593f8529; snapshot_sha256=8dd101cae63b884566982d1f5e0a4df0b533f1cd327bc81a09887b3bc0704e13
-- Behavior: Produced the two required design deliverables, routed UX before visual design, stayed within design scope, and handed implementation to engineer-agent.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=6928263198e744f0628528a64ad381eb51b57dfc5347279a1b5dc49c697dfc6c; fixture_sha256=318a6ed6ff151cee086f75e2b1924aa867c873c059722194e1d201fc514c9d89; output_sha256=4ea9cda6e65004528c54889cc0c7058f484fbb22ee308bff96d98037a11ca74b; snapshot_sha256=2f78acb346714aa76ba8ebf727ef82099a10f9f2faa598f368f0ae6d72505ee0
+- Behavior: 完成 UX→视觉设计路由，交付两个指定设计文档，停在设计边界并移交 engineer-agent。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=6928263198e744f0628528a64ad381eb51b57dfc5347279a1b5dc49c697dfc6c; fixture_sha256=318a6ed6ff151cee086f75e2b1924aa867c873c059722194e1d201fc514c9d89; output_sha256=fbc5d1f104db474fa272f43b984cbc19e3c56e2ae53c2e0329dd329b6108dca0; snapshot_sha256=414c84c3628d68e97fb4858c92d830d1ebb5190180a4381bfa3e8677e6485e35
-- Behavior: Implemented a React settings page directly, with no design deliverables, design routing, or engineer-agent handoff.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=6928263198e744f0628528a64ad381eb51b57dfc5347279a1b5dc49c697dfc6c; fixture_sha256=318a6ed6ff151cee086f75e2b1924aa867c873c059722194e1d201fc514c9d89; output_sha256=e890661bb0c7224d380a6e8acc360d35ab925138135e9dc64b4288672d05d7b5; snapshot_sha256=e86274135b5aa5e53c079d654a1bd0556b887130a91d0fff912f7d4d3e2b1c3f
+- Behavior: 直接实现 React 设置页并新增应用代码，未按设计路由交付指定设计文档或执行设计阶段 handoff。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/designer/test/designer-agent/evals/workspace/eval-2-feature-path-design-handoff/comparison.md
+++ b/agents/designer/test/designer-agent/evals/workspace/eval-2-feature-path-design-handoff/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `f51ab76601713bed8d87e8e33016aaf394374041676e06644b8b383a6a3f1ef6` from `agents/designer/test/designer-agent/evals/workspace/eval-2-feature-path-design-handoff`.
 - Identity schema: `2`
-- target_skill_sha256: `ab61dfad7912c1f4762939ebfeb53cb1e7798640502b92a5fa0fa76318105fc9`
+- target_skill_sha256: `1d67d4772843dc0275749d693d7415791b7459f5d948588a69fb240bcfd7f02b`
 - eval_definition_sha256: `9f0bcf8d0817f9f62b224c251f6b0df43d09e6b597facabfb572c220908b85a8`
 - metadata_sha256: `e6f9e581a9240bd876422c7ab0f1f1ca860fda8f563a8f02f87555323c8c7b30`
 - fixture_sha256: `f51ab76601713bed8d87e8e33016aaf394374041676e06644b8b383a6a3f1ef6`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `173af1b9ec0e079651ca3a9820c63dda3723644385c5a202331578e8f1a93950`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `e85929c91fa7ac5d9cb93339a38a992d155e1c545a4c3e5f4af6c78a44404dd1`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `96027d263bbf16994ceaa244fa5630391b9b2aebc603c7baad35ef58b67deea5`
+- Skill overlay SHA-256: `902f97074f6d958600dd8079608539a38bff227cb03726b9ab277705b1b8ded7`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,21 +33,21 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `uses_confirmed_feature_path` | PASS | Both locked design files declare `feature_path` as `chat-interface/messages/history/search` and cite the matching PRD/TRD paths. |
+| `uses_confirmed_feature_path` | PASS | Both locked design files use `chat-interface/messages/history/search` as `feature_path` and explicitly reference the matching PRD and TRD. |
 | `mirrors_design_outputs` | PASS | The delivery snapshot contains exactly `docs/design/chat-interface/messages/history/search/ui-ux-spec.md` and `docs/design/chat-interface/messages/history/search/visual-system.md`. |
-| `no_synonym_top_level` | PASS | The locked delivery snapshot contains only the required nested design path; no synonym or truncated design directory is delivered or suggested. |
-| `stops_before_code` | PASS | With_skill delivers design specifications and handoff boundary text only; no code, implementation steps, test commands, or patch is delivered. |
+| `no_synonym_top_level` | PASS | The with_skill delivery snapshot and git status show only the confirmed design path; no synonym or truncated directory is present. |
+| `stops_before_code` | PASS | The locked outputs contain design handoff documents only, with no code, patch, test command, or engineering implementation procedure; they stop at handoff to engineer-agent. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=e85929c91fa7ac5d9cb93339a38a992d155e1c545a4c3e5f4af6c78a44404dd1; fixture_sha256=f51ab76601713bed8d87e8e33016aaf394374041676e06644b8b383a6a3f1ef6; output_sha256=f3c7ed634f1970a9c0f9bb5b32a2eaf38368647bd1223077125ea1a71ae50e04; snapshot_sha256=2c64f93a083a7da59f7063bbcbc04fc41b14d8fd16c4addad03dbfce66e0c31b
-- Behavior: Produced the requested design handoff at the confirmed feature path with both required design artifacts and no implementation output.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=e85929c91fa7ac5d9cb93339a38a992d155e1c545a4c3e5f4af6c78a44404dd1; fixture_sha256=f51ab76601713bed8d87e8e33016aaf394374041676e06644b8b383a6a3f1ef6; output_sha256=8c9f192c8e013efe8c2801e700be44029f8751778e4afd2a1636046a9ed3c819; snapshot_sha256=aa76691f1ee9fc792f1f0a016dae0421530e78e6ab7b4ea282b321aa5ac53f43
+- Behavior: Delivered both required design artifacts at the confirmed feature path and stopped at the design handoff boundary.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=e85929c91fa7ac5d9cb93339a38a992d155e1c545a4c3e5f4af6c78a44404dd1; fixture_sha256=f51ab76601713bed8d87e8e33016aaf394374041676e06644b8b383a6a3f1ef6; output_sha256=21af4958d9c670f877774910e4783a7068fe758c1e76d1ea0bae55a7f6e76cb1; snapshot_sha256=98fce32f2cdfb1adeafec5bdcf9ed694cfdffef03bd87dc48e2a92368b461103
-- Behavior: Created an HTML/CSS/JavaScript implementation outside the requested design handoff and reported a syntax-check command.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=e85929c91fa7ac5d9cb93339a38a992d155e1c545a4c3e5f4af6c78a44404dd1; fixture_sha256=f51ab76601713bed8d87e8e33016aaf394374041676e06644b8b383a6a3f1ef6; output_sha256=ca4d239b100d45e43a4116a6ae06be6f911403ff7bc8393db6d30f182a14f62a; snapshot_sha256=875666abfa4fc5b43fbefbe4b797e05c390bf266a7f6fff16beccdfdca9ee074
+- Behavior: Created an implementation prototype (`index.html`, `styles.css`, `app.js`) and ran a syntax check, without the required design deliverables or confirmed design-path handoff.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/designer/test/ui-ux-design/evals/workspace/eval-002-ecommerce/comparison.md
+++ b/agents/designer/test/ui-ux-design/evals/workspace/eval-002-ecommerce/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `066b89d2cc1dd835345cd6d39e99316bc4d1c11f89b8739eb2d1941c8791d32f` from `agents/designer/test/ui-ux-design/evals/workspace/eval-002-ecommerce`.
 - Identity schema: `2`
-- target_skill_sha256: `2088a9b7ee00fc1f620b92a5141c4a34a4c48ca289c4be5cea831626687d85b8`
+- target_skill_sha256: `749980e18a4ced3c2a9cbbdaeb6230841130618487b0995560867366d48b7d72`
 - eval_definition_sha256: `ca70808ebe45c256ed44d9380fa1c8f3bd3f78623591e611656fc168a26d9c94`
 - metadata_sha256: `f03fcb0090538d9508e07806365ff27b2d925ff153866243ea17f1a6d6c50860`
 - fixture_sha256: `066b89d2cc1dd835345cd6d39e99316bc4d1c11f89b8739eb2d1941c8791d32f`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `5ac69cf52c4833a0e74ebe39318957376e1be2b4d8142bcff9072bdd02569746`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `eb90dbc90941b21fe1cf928c689f4703e38f536b24e4a881de504f524de89ea3`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `beec8510dfdfe8132ffae9f12e486d2c527ec9245f5752f40eaeb251a4d63e70`
+- Skill overlay SHA-256: `e26256f2206c322bda9ae81b814ac63fff1a476a818df2afc0a6e339fb00af73`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,19 +33,19 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `assertion_1` | PASS | 交付文件明确以移动端为首要基准，覆盖商品列表/分类、底部筛选抽屉、商品详情和购物车，并详细说明筛选、加入购物车、数量调整、移除及反馈交互。 |
-| `assertion_2` | PASS | 交付文件仅包含设计规格、Mermaid 用户旅程、布局原型、交互说明和剩余工程范围；未包含源码、补丁、命令行步骤或逐文件编码任务。git 证据显示未产生提交或代码变更。 |
+| `assertion_1` | PASS | 交付快照中的设计规格明确包含 mobile-first 手机布局、商品列表、筛选/排序抽屉、商品详情、购物车及对应交互与状态。 |
+| `assertion_2` | PASS | 交付快照是设计规格文档，包含布局、交互、状态、响应式和无障碍说明；未包含源码、补丁、命令行步骤或逐文件实现任务，并明确前端实现不在本次范围。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=eb90dbc90941b21fe1cf928c689f4703e38f536b24e4a881de504f524de89ea3; fixture_sha256=066b89d2cc1dd835345cd6d39e99316bc4d1c11f89b8739eb2d1941c8791d32f; output_sha256=ba7f448ffe0a5e46259d69dc8348bee062b593be30c0537345bbe03b0d5238fe; snapshot_sha256=1a30a642943d2e501f0e2e0d9e1d9850aa70bdff2e71123f184b3b2c1ffcffa2
-- Behavior: 完成了面向前端交接的 mobile-first UI/UX 设计文档，覆盖目标页面、状态、交互、响应式和可访问性，并停止在设计交接阶段。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=eb90dbc90941b21fe1cf928c689f4703e38f536b24e4a881de504f524de89ea3; fixture_sha256=066b89d2cc1dd835345cd6d39e99316bc4d1c11f89b8739eb2d1941c8791d32f; output_sha256=9e306954a13e79ccbd4bfbce807d1074feb9e5b0d62f584d8b55d8230e451bae; snapshot_sha256=8e40870d83cb51cb7b67d75e3350c2ce6af7974bee61afa741e3eb0c263ec504
+- Behavior: 完成并交付了完整的 mobile-first UI/UX 设计规格，覆盖列表、筛选、详情和购物车。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=eb90dbc90941b21fe1cf928c689f4703e38f536b24e4a881de504f524de89ea3; fixture_sha256=066b89d2cc1dd835345cd6d39e99316bc4d1c11f89b8739eb2d1941c8791d32f; output_sha256=456e486de78b8266cb781c52f0690a606f12b519f967de5a4a489dd91114075d; snapshot_sha256=adfa4da17a1bc1dc6b9d1cd064a6045c85a2cd726db93ea9c1a20f08a1a7eb54
-- Behavior: 同样交付了覆盖面较广的移动端 UI/UX 规格，但其最终行为仅作为对比基线，不影响 with_skill 断言判定。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=eb90dbc90941b21fe1cf928c689f4703e38f536b24e4a881de504f524de89ea3; fixture_sha256=066b89d2cc1dd835345cd6d39e99316bc4d1c11f89b8739eb2d1941c8791d32f; output_sha256=c38e9747fcde37e6bc68ee75a6de11bc12068e7b608092d88a04c32012039a07; snapshot_sha256=62186c2ef1eb65c4b90ed80e3d47f6f0cc70ac8874b8c4c1fd5d1a141877d154
+- Behavior: 同样交付了覆盖主要页面和交互的 mobile-first UI/UX 规格，可作为 fresh baseline 对照。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/designer/test/ui-ux-design/evals/workspace/eval-003-with-reference/comparison.md
+++ b/agents/designer/test/ui-ux-design/evals/workspace/eval-003-with-reference/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `816b980f73797aa0bb179996356d70da27810eb91a7ac7c665a793e71da22e00` from `agents/designer/test/ui-ux-design/evals/workspace/eval-003-with-reference`.
 - Identity schema: `2`
-- target_skill_sha256: `2088a9b7ee00fc1f620b92a5141c4a34a4c48ca289c4be5cea831626687d85b8`
+- target_skill_sha256: `749980e18a4ced3c2a9cbbdaeb6230841130618487b0995560867366d48b7d72`
 - eval_definition_sha256: `36f115852952f11f54a62c4ef547a3782cf81881da967b1b9e5b272fbfbef0f5`
 - metadata_sha256: `99619de8c0acb7122407b7432f706b3b3a47c78c6312c1b435d9faf6e068b269`
 - fixture_sha256: `816b980f73797aa0bb179996356d70da27810eb91a7ac7c665a793e71da22e00`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `5ac69cf52c4833a0e74ebe39318957376e1be2b4d8142bcff9072bdd02569746`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `1d07d7029ac6afd6bdd8b3a0c089a71197a6e0caee2ba8f44e93457b9bde08dd`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `beec8510dfdfe8132ffae9f12e486d2c527ec9245f5752f40eaeb251a4d63e70`
+- Skill overlay SHA-256: `e26256f2206c322bda9ae81b814ac63fff1a476a818df2afc0a6e339fb00af73`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,19 +33,19 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `assertion_1` | PASS | With_skill delivery_snapshot directly contains a “参考模式分析” section extracting restrained navigation, single-CTA hero, product-preview-first sequencing, numbered workflow chapters, and mobile navigation/CTA behavior from references/linear-app-patterns.md. |
-| `assertion_2` | PASS | The locked delivery is only docs/design/productivity-app-landing/ui-ux-spec.md; git evidence shows no commits or code changes, and the document explicitly states that implementation is out of scope and the design process ends without activating engineering. |
+| `assertion_1` | PASS | with_skill 交付文档第 2 节明确提炼了克制导航、首屏单一叙事、先产品证明后工作流、编号章节、深层动作及移动端纵向排列等参考模式。 |
+| `assertion_2` | PASS | with_skill 的交付快照是设计规格文件；第 10 节明确声明不执行实现、测试和发布，runner trace 也仅显示写入设计文档及校验，没有前端代码或工程变更。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=1d07d7029ac6afd6bdd8b3a0c089a71197a6e0caee2ba8f44e93457b9bde08dd; fixture_sha256=816b980f73797aa0bb179996356d70da27810eb91a7ac7c665a793e71da22e00; output_sha256=e0677dfbc8cb7f70e64b7cf584ff192906d9aff1d3cf8a7c95b49fae78e1cae3; snapshot_sha256=482987c9a588baaa2576ff2ca699324ab22b4ffc101dfcacf90a3355cb6215c9
-- Behavior: Produced a design-only UI/UX specification with explicit reference-pattern analysis and an explicit implementation boundary.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=1d07d7029ac6afd6bdd8b3a0c089a71197a6e0caee2ba8f44e93457b9bde08dd; fixture_sha256=816b980f73797aa0bb179996356d70da27810eb91a7ac7c665a793e71da22e00; output_sha256=740480eaeae7c498f9407d41d078da6c62c5b8f065418daaacc94c90c5f1529f; snapshot_sha256=bd010346c26bb1e6e969feeeb41affb0259bb8aea53cf86bec2f100348a02c98
+- Behavior: 完成原创 UX/UI 设计文档，明确提炼参考模式并在设计交付后停止；未进行工程实现。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=1d07d7029ac6afd6bdd8b3a0c089a71197a6e0caee2ba8f44e93457b9bde08dd; fixture_sha256=816b980f73797aa0bb179996356d70da27810eb91a7ac7c665a793e71da22e00; output_sha256=aed7b6ff9e45b71a5a598a16ee292c9a732bc85b3d0aa980f36c8f707b49288f; snapshot_sha256=1fd597c6eb4aef9d24cdb69216dd4205041d1a691a57a5a4a6f2833c562222ab
-- Behavior: Produced a design specification and stopped without implementation, but its final summary did not explicitly surface the reference-pattern analysis.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=1d07d7029ac6afd6bdd8b3a0c089a71197a6e0caee2ba8f44e93457b9bde08dd; fixture_sha256=816b980f73797aa0bb179996356d70da27810eb91a7ac7c665a793e71da22e00; output_sha256=28e02504aceaf2dd81c8faa993dedc4d26e836d9077bbeb973f39e123fcb9765; snapshot_sha256=243ff0a72ef2e458e5aede4c7d51df312c278af4faef2f0c2393b303601980d9
+- Behavior: 完成较完整的原创落地页 UI/UX 规格并停止于设计交付，也包含信息架构和交互状态，但参考模式分析与设计边界不如 with_skill 明确。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/designer/test/ui-ux-design/evals/workspace/eval-005-mapped-notification-ui/comparison.md
+++ b/agents/designer/test/ui-ux-design/evals/workspace/eval-005-mapped-notification-ui/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `cc899f673f7067e0f23d4e43273fcee59ea0d49ecc2127d06d0f6831a3eb4d0a` from `agents/designer/test/ui-ux-design/evals/workspace/eval-005-mapped-notification-ui`.
 - Identity schema: `2`
-- target_skill_sha256: `2088a9b7ee00fc1f620b92a5141c4a34a4c48ca289c4be5cea831626687d85b8`
+- target_skill_sha256: `749980e18a4ced3c2a9cbbdaeb6230841130618487b0995560867366d48b7d72`
 - eval_definition_sha256: `25a9beaf5037d128f11073d7bdad29e775b60a170f80ba9b4b2cd556e1ef1469`
 - metadata_sha256: `2df7ffae351f05ff856a7ddf2ab545a06891ad7b1dee1da8ddccd64f5e254eea`
 - fixture_sha256: `cc899f673f7067e0f23d4e43273fcee59ea0d49ecc2127d06d0f6831a3eb4d0a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `2797a1f8eaaa6ec1663895e21733e03c38b2053355b7534ad87b60c49209372a`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `beec8510dfdfe8132ffae9f12e486d2c527ec9245f5752f40eaeb251a4d63e70`
+- Skill overlay SHA-256: `e26256f2206c322bda9ae81b814ac63fff1a476a818df2afc0a6e339fb00af73`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,26 +33,26 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `reads_mapped_docs_first` | PASS | Locked trace shows the candidate read the change-map, identified the single required document, then read that document and the page source; no unrelated formal documents were read. |
-| `verifies_against_code` | PASS | Locked trace and delivery snapshot show direct inspection of the HTML input without `checked`, identification of the documented default-on conflict, and selection of code as current truth. |
-| `treats_unverified_as_low_trust` | PASS | The locked evidence records `last_verified_version: unverified`, reads the document despite that status, and expands verification to the HTML source rather than rejecting or relying solely on the document. |
+| `reads_mapped_docs_first` | PASS | Trace shows the with_skill lane identified the task path, inspected the change map, then read the matched required document `docs/site/api/notification-preferences.md`; no unrelated formal document contents were read. |
+| `verifies_against_code` | PASS | The locked trace and final output both identify that `src/ui/notification-preferences.html` has no `checked` attribute, so the actual static default is unchecked, and explicitly contrast this with the document's enabled-by-default claim. |
+| `treats_unverified_as_low_trust` | PASS | The final output explicitly identifies `last_verified_version: unverified` as low trust and bases the default-state conclusion on the HTML code while retaining the document claim as a conflict. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2797a1f8eaaa6ec1663895e21733e03c38b2053355b7534ad87b60c49209372a; fixture_sha256=cc899f673f7067e0f23d4e43273fcee59ea0d49ecc2127d06d0f6831a3eb4d0a; output_sha256=8b2576987187720a288d91eebfc801871e7321980103212a0c4cf0c36e1c323b; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Verified the mapped document and source code, detected the default-state conflict, treated the document as unverified, and stopped at the required handoff gate.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2797a1f8eaaa6ec1663895e21733e03c38b2053355b7534ad87b60c49209372a; fixture_sha256=cc899f673f7067e0f23d4e43273fcee59ea0d49ecc2127d06d0f6831a3eb4d0a; output_sha256=d9cddf1e30dc5376f4fcbf05aa8ac8f17f546e5a7ad3b883cbb23ed7f07ef438; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Applied the design entry gate, verified the mapped document against the HTML, treated the unverified document as low trust, and stopped with an evidence-based handoff blocker without mutating files.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2797a1f8eaaa6ec1663895e21733e03c38b2053355b7534ad87b60c49209372a; fixture_sha256=cc899f673f7067e0f23d4e43273fcee59ea0d49ecc2127d06d0f6831a3eb4d0a; output_sha256=0671daf8775fa223070ce7d6591c9cc010ff2e773ebda5733a4943e5cc3806f0; snapshot_sha256=220c8d0d4f2d9ce4cb1d4426c94b78604d26ab15ccfe0ee3bc0ab0e32f61b330
-- Behavior: Fresh baseline updated the formal document with a UI/UX specification and correctly recorded the code/document default conflict.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2797a1f8eaaa6ec1663895e21733e03c38b2053355b7534ad87b60c49209372a; fixture_sha256=cc899f673f7067e0f23d4e43273fcee59ea0d49ecc2127d06d0f6831a3eb4d0a; output_sha256=9fde896516f3537b76301db3936387917e1aed6c3aed084a7d3b9f5b051863c8; snapshot_sha256=30379880e94fd1ab46c5f9d28b293c0ddc7f874dbd84b4a2915cc4fbe569b775
+- Behavior: Produced and modified a formal notification-preferences document, correctly noted the HTML default was unchecked, but treated the documented enabled default as the product rule without the required low-trust process.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Provide a confirmed PM/design handoff and feature_path, then create the UI/UX specification.
+- Next: Obtain the PM/design handoff and confirmed feature_path, then create the UI/UX specification.
 
 ## Runtime Artifact Policy
 

--- a/agents/designer/test/ui-ux-design/workspace/eval-1-saas-dashboard/comparison.md
+++ b/agents/designer/test/ui-ux-design/workspace/eval-1-saas-dashboard/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `0c6e97834bbed6c2319a5e523ec66e524f7cbbe181557cf3e6af4ae38b100532` from `agents/designer/test/ui-ux-design/workspace/eval-1-saas-dashboard`.
 - Identity schema: `2`
-- target_skill_sha256: `2088a9b7ee00fc1f620b92a5141c4a34a4c48ca289c4be5cea831626687d85b8`
+- target_skill_sha256: `749980e18a4ced3c2a9cbbdaeb6230841130618487b0995560867366d48b7d72`
 - eval_definition_sha256: `9dfc3c0232e65b50d6964b6b208307eca95842562a8965fcb0999b7dc0293b57`
 - metadata_sha256: `c8e1211b15f502661f69a0437945175097ac313a3f5a8e46ed3ae2bcbd19f62a`
 - fixture_sha256: `0c6e97834bbed6c2319a5e523ec66e524f7cbbe181557cf3e6af4ae38b100532`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `8d2763ec3401350181ee644de1028a6695d69fa18b5430a0edd7593fdf2e890a`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `f9bf4ccc3d0c86ca715af1c880c16aa04a3e494f2b6001d3d604b6428e7bc8b2`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `beec8510dfdfe8132ffae9f12e486d2c527ec9245f5752f40eaeb251a4d63e70`
+- Skill overlay SHA-256: `e26256f2206c322bda9ae81b814ac63fff1a476a818df2afc0a6e339fb00af73`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,21 +33,21 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `produces_design_spec` | PASS | Locked delivery snapshot contains docs/design/saas-dashboard/ui-ux-spec.md with feature_path saas-dashboard and source_prd docs/pm/saas-dashboard/PRD.md. |
-| `covers_user_flows_and_states` | PASS | The locked specification includes user journeys and edge states, page inventories and layouts, component definitions, interaction behaviors, and desktop/tablet responsive rules. |
-| `preserves_design_boundary` | PASS | Git evidence shows only the design document as untracked; no source, test, build, deployment, or implementation changes are present, and the trace ends after document verification. |
-| `hands_off_to_engineering` | PASS | The specification states the implementation scope is ready for handoff, and the final output identifies the completed design artifact and conditional engineering next step. |
+| `produces_design_spec` | PASS | Locked delivery_snapshot contains docs/design/saas-dashboard/ui-ux-spec.md with matching feature_path metadata and complete design-spec content. |
+| `covers_user_flows_and_states` | PASS | The locked design spec includes a user journey, Dashboard/Projects/Tasks/Team/Activity layouts, component lists, navigation/filter/activity behavior, loading/empty/error states, and desktop/tablet responsive sections. |
+| `preserves_design_boundary` | PASS | The locked snapshot contains only docs/design/saas-dashboard/ui-ux-spec.md; git status is ?? docs/design/, and the document explicitly states that the PRD authorizes design input only and does not authorize source, test, or implementation changes. |
+| `hands_off_to_engineering` | PASS | The locked design spec is marked Draft for engineering handoff, includes remaining implementation scope, and states implementation should proceed only when explicitly requested or authorized; the candidate output also identifies the completed design handoff. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f9bf4ccc3d0c86ca715af1c880c16aa04a3e494f2b6001d3d604b6428e7bc8b2; fixture_sha256=0c6e97834bbed6c2319a5e523ec66e524f7cbbe181557cf3e6af4ae38b100532; output_sha256=bb959a639949e0acc0d89e0b3af5ad6e913b57d061124df5b6e73badc11cd7fb; snapshot_sha256=4f5849afa2e70b0e0fa423152db2a59eb57a8f41357f5c7982197c0faedb2860
-- Behavior: Produced the requested feature-scoped UI/UX specification, covered the required design content, preserved the design-only boundary, and provided an engineering handoff.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f9bf4ccc3d0c86ca715af1c880c16aa04a3e494f2b6001d3d604b6428e7bc8b2; fixture_sha256=0c6e97834bbed6c2319a5e523ec66e524f7cbbe181557cf3e6af4ae38b100532; output_sha256=d63b8aeeef4fb3d85e21154cbfc6271e57fe6adbd634449d6e0b6b176b523787; snapshot_sha256=6dfbf8361835d4be8a1a5c37f003c8d5ce49609574e1294d55149f6d19a35951
+- Behavior: Produced the required feature-scoped UX/UI specification, covered the requested design content, preserved the design-only boundary, and documented the engineering handoff.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f9bf4ccc3d0c86ca715af1c880c16aa04a3e494f2b6001d3d604b6428e7bc8b2; fixture_sha256=0c6e97834bbed6c2319a5e523ec66e524f7cbbe181557cf3e6af4ae38b100532; output_sha256=e532ec7a5b5ed0d0b6a3040d4e09350be35aacbd715a84d0bd2bf4c7968dab99; snapshot_sha256=99d368989dbd80843df6e57af38825ba0da2b77e261401b56ec050512c871549
-- Behavior: Fresh baseline produced an interactive prototype and unrelated root-level files instead of the requested feature-scoped design specification, with implementation artifacts present.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f9bf4ccc3d0c86ca715af1c880c16aa04a3e494f2b6001d3d604b6428e7bc8b2; fixture_sha256=0c6e97834bbed6c2319a5e523ec66e524f7cbbe181557cf3e6af4ae38b100532; output_sha256=5af58b223e265a6522bb6930fce95af9c7875004ceed2d0810b20ad4aab0b77a; snapshot_sha256=894edf526f4b9d3a07aae8212934a28af216f21183e06d8c2150eac714bfae47
+- Behavior: Produced an HTML prototype and DESIGN.md under docs/pm/saas-dashboard rather than the required docs/design/saas-dashboard/ui-ux-spec.md; it nevertheless provided a fresh baseline with substantial dashboard content.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/designer/test/ui-ux-design/workspace/eval-4-pm-spec-handoff/comparison.md
+++ b/agents/designer/test/ui-ux-design/workspace/eval-4-pm-spec-handoff/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `0791241d90c35458117ad7afc41087d198e776e1bb0d176e05c3732f6be148a6` from `agents/designer/test/ui-ux-design/workspace/eval-4-pm-spec-handoff`.
 - Identity schema: `2`
-- target_skill_sha256: `2088a9b7ee00fc1f620b92a5141c4a34a4c48ca289c4be5cea831626687d85b8`
+- target_skill_sha256: `749980e18a4ced3c2a9cbbdaeb6230841130618487b0995560867366d48b7d72`
 - eval_definition_sha256: `f5e031cd559d08b9cd37fee2f571fc541cf110879ad665b05952cb915a09fe63`
 - metadata_sha256: `aeaed8ffc5b8caa72862d4541461b666c1ae241b901184003afdcc4031618907`
 - fixture_sha256: `0791241d90c35458117ad7afc41087d198e776e1bb0d176e05c3732f6be148a6`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `2f242e255f292a4598cb48c2bfc21dd7b56a2d6cda47e6a68b75b5c3321a2e98`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `34a9d38fc5d93e5c1a925aa7889e94a7727bc719382f01830a2c7b69cc7a8020`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `beec8510dfdfe8132ffae9f12e486d2c527ec9245f5752f40eaeb251a4d63e70`
+- Skill overlay SHA-256: `e26256f2206c322bda9ae81b814ac63fff1a476a818df2afc0a6e339fb00af73`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `spec` | PASS | The delivered design file explicitly states: “The PM specification authorizes design input; it does not authorize code or implementation.” |
-| `assertion_2` | PASS | The delivered file names engineer-agent as downstream owner, and the final output says subsequent page updates can be handed to engineer-agent. |
-| `assertion_3` | PASS | The delivery snapshot contains only the design document; git evidence shows no source-code changes, and neither the delivered file nor final output contains test commands, patches, or implementation step instructions. |
+| `spec` | PASS | The delivered UI/UX spec explicitly states that the PM PRD, decisions, and TRD authorize design input only and do not authorize implementation, API design, or source changes. |
+| `assertion_2` | PASS | The final candidate message explicitly directs the next step to engineer-agent after completing the design. |
+| `assertion_3` | PASS | Locked delivery evidence shows only a new design document; no source-code modification, patch, test command, or implementation checklist is present. The document explicitly says it contains no implementation plan or API assumptions. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=34a9d38fc5d93e5c1a925aa7889e94a7727bc719382f01830a2c7b69cc7a8020; fixture_sha256=0791241d90c35458117ad7afc41087d198e776e1bb0d176e05c3732f6be148a6; output_sha256=5f42a45dd71859bb5f36d94f144eb5e1aa6a24cbbc62d10428ad1f6a2d5d123f; snapshot_sha256=30e7f16eb55ba9cbd0c8c014303ec4e97455c8fe41be1a3ffb3a786e017c20ac
-- Behavior: Produced the requested UI/UX design document with explicit design-only boundaries and engineer handoff.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=34a9d38fc5d93e5c1a925aa7889e94a7727bc719382f01830a2c7b69cc7a8020; fixture_sha256=0791241d90c35458117ad7afc41087d198e776e1bb0d176e05c3732f6be148a6; output_sha256=a3a692dfa684ad2b8710a2467a639742b392339273fdd3e0e9ddd9aea3e3e261; snapshot_sha256=f5e3c93cf9005ed84a81400e1119de769fc5fc360342d8e5f63309e6f27a40f9
+- Behavior: Produced a UI/UX design document with an explicit PM-design-only boundary and engineering handoff, without implementation mutations.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=34a9d38fc5d93e5c1a925aa7889e94a7727bc719382f01830a2c7b69cc7a8020; fixture_sha256=0791241d90c35458117ad7afc41087d198e776e1bb0d176e05c3732f6be148a6; output_sha256=1d89b901d0137e3392799c5437eb4b83f0837bb0e03c094bac0114c08543d19e; snapshot_sha256=9525cde74ef832868b6dd0133359f7991fcbd16385849129e31e6c1ffcf8362e
-- Behavior: Also produced a design document, but did not explicitly state the PM-spec boundary or engineer-agent handoff.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=34a9d38fc5d93e5c1a925aa7889e94a7727bc719382f01830a2c7b69cc7a8020; fixture_sha256=0791241d90c35458117ad7afc41087d198e776e1bb0d176e05c3732f6be148a6; output_sha256=0c1a0556c56636b2db3f219c3ef12deec7fdc8c5cb1b611f0965d133290a73a1; snapshot_sha256=b51405d9f5e1ad0bb32d36d19c4c5dfa7652be9899560a99111c1efcd2509e6d
+- Behavior: Produced a comparable UI/UX design document and did not modify source code, but did not explicitly state the PM authorization boundary or hand off to engineer-agent.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/designer/test/visual-design/evals/workspace/eval-003-professional/comparison.md
+++ b/agents/designer/test/visual-design/evals/workspace/eval-003-professional/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `567d74ee90d360991ab613f98d8049d53202d95a2bc7caeb2b7d46b23846a5f0` from `agents/designer/test/visual-design/evals/workspace/eval-003-professional`.
 - Identity schema: `2`
-- target_skill_sha256: `be4ad3e2bd7a045eae2db8cc147a655dcc8a42c01f2783e36539d2888fdcbaaf`
+- target_skill_sha256: `61b6f3a42424308b7a04ea0adf2a51b2b68f65f02fd796de4a724f6f357a579d`
 - eval_definition_sha256: `730e4eb8de3e03b346a013a3d5577a175072336c34214d71e41ce4685c2c2ee1`
 - metadata_sha256: `e736b74cad81064d52f58883a440db71240d4645566f7fc04859188bfb284e38`
 - fixture_sha256: `567d74ee90d360991ab613f98d8049d53202d95a2bc7caeb2b7d46b23846a5f0`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `5ac69cf52c4833a0e74ebe39318957376e1be2b4d8142bcff9072bdd02569746`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `fe1184ee76579ac0041ea69b2abac6b0897add864da628d5ff0192673c2c0220`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `2dd23a101b1833a5f815a50f0bc085a1d9a95ddf55380df9fcbc12238f06ae99`
+- Skill overlay SHA-256: `3beb7f3f01f53d491f571b17a7c7d87e2b0ca9e8ea7417fbcc27feda44e8e283`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,19 +33,19 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `assertion_1` | PASS | with_skill 的 delivery_snapshot 直接包含 WCAG AA 对比度阈值（普通文本 4.5:1、大文本和关键 UI 边界 3:1），并定义企业分析场景的用户层级、布局、密度和扫描规则。 |
-| `assertion_2` | PASS | with_skill 的锁定交付文件仅为 visual-system.md；内容是规范性文字，无组件实现代码、样式文件改动或工程命令。git evidence 也显示仅有该文档未跟踪变更。 |
+| `assertion_1` | PASS | with_skill 的 locked delivery_snapshot 文档明确写出普通文字对比度至少 4.5:1、大文本和关键 UI 边界至少 3:1，并包含键盘焦点、非颜色识别，以及概览—分析—证据的企业分析层级。 |
+| `assertion_2` | PASS | with_skill 的 locked delivery_snapshot 是视觉规范 Markdown 文档，不含组件实现代码；git_evidence 仅显示新增该文档，HEAD 未变化且无样式文件改动。候选最终输出也未包含工程命令。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=fe1184ee76579ac0041ea69b2abac6b0897add864da628d5ff0192673c2c0220; fixture_sha256=567d74ee90d360991ab613f98d8049d53202d95a2bc7caeb2b7d46b23846a5f0; output_sha256=de883cd766441c196bd6b34e1af079c56d1a80f2f2290a6ab7963028268c2f06; snapshot_sha256=073e959dec0f038c4b3addcb9855ee07ae4a7e33caaadc7fda442e937d323e79
-- Behavior: 交付了面向企业分析平台的完整视觉规范，明确 WCAG 可访问性与高密度企业界面层级，并保持设计规范边界。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=fe1184ee76579ac0041ea69b2abac6b0897add864da628d5ff0192673c2c0220; fixture_sha256=567d74ee90d360991ab613f98d8049d53202d95a2bc7caeb2b7d46b23846a5f0; output_sha256=f1062c1063441dc02b3d65457e29f02c4e21d6d28c31478ef69bf57577b755ea; snapshot_sha256=3650290eecfe92d5e38ef2dd6a0c44ea8608f1eabfe28e18d5b578ce8940bac4
+- Behavior: 交付了面向企业分析平台的视觉规范文档，覆盖可访问性、清晰层级和设计交接边界，未落地代码或样式修改。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=fe1184ee76579ac0041ea69b2abac6b0897add864da628d5ff0192673c2c0220; fixture_sha256=567d74ee90d360991ab613f98d8049d53202d95a2bc7caeb2b7d46b23846a5f0; output_sha256=f3cf0752a24e6ad90ccce1c2ce5c3d5b0e94b40cda9751e8f7f1b6feebd36829; snapshot_sha256=d6a7d26e6d4f73536d20784bedf3dde12687d696e19d13afaba620ec1918aa95
-- Behavior: 同样交付了覆盖可访问性、层级和数据界面的视觉规范，作为新鲜基线表现也满足两项断言。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=fe1184ee76579ac0041ea69b2abac6b0897add864da628d5ff0192673c2c0220; fixture_sha256=567d74ee90d360991ab613f98d8049d53202d95a2bc7caeb2b7d46b23846a5f0; output_sha256=2c627ac54db0371bf75d8b48c8b6981d7a00184904c4697065908c983b634e5a; snapshot_sha256=70f29d3d41e995258e7cf4a01989deae4f5866f6073fedbc5d3e4a42b5bcf3d4
+- Behavior: 同样交付了视觉规范文档，覆盖对比度、角色阅读优先级和可访问性清单；作为 fresh baseline 与 with_skill 行为基本一致。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/designer/test/visual-design/workspace/eval-1-minimalist/comparison.md
+++ b/agents/designer/test/visual-design/workspace/eval-1-minimalist/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `89d144dafb490a68dbf1ec05d2336c43c874c81e51496b945ac9140ca757080a` from `agents/designer/test/visual-design/workspace/eval-1-minimalist`.
 - Identity schema: `2`
-- target_skill_sha256: `be4ad3e2bd7a045eae2db8cc147a655dcc8a42c01f2783e36539d2888fdcbaaf`
+- target_skill_sha256: `61b6f3a42424308b7a04ea0adf2a51b2b68f65f02fd796de4a724f6f357a579d`
 - eval_definition_sha256: `2ec4f897729f0820b0a7830a10f3f0348db98fac1c3a94d29404427ccb404465`
 - metadata_sha256: `62c7d6da8c76cef08411a61e2b751af621aaf9f30a6b497961c954ca171c26e0`
 - fixture_sha256: `89d144dafb490a68dbf1ec05d2336c43c874c81e51496b945ac9140ca757080a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `e8bf769ac89a10c9a014e6b2e125d2d95f024ce8d37a4e4481c16c75936c71a8`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `c3c36cd66b9231c6a2156abc32bf00fb490f5264858737980fadf81d3240530f`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `2dd23a101b1833a5f815a50f0bc085a1d9a95ddf55380df9fcbc12238f06ae99`
+- Skill overlay SHA-256: `3beb7f3f01f53d491f571b17a7c7d87e2b0ca9e8ea7417fbcc27feda44e8e283`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `assertion_1` | PASS | Locked delivery_snapshot contains the required file at docs/design/minimalist-productivity-app/visual-system.md, matching the confirmed feature_path, with sections covering color, typography, spacing, and component styles. |
-| `assertion_2` | PASS | The locked delivered file is documentation only: no CSS, token implementation code, component implementation, engineering task breakdown, or test commands are present. |
-| `assertion_3` | PASS | The locked file explicitly states: “Next role: engineer-agent,” and the candidate output repeats that handoff. |
+| `assertion_1` | PASS | 锁定交付文件位于 docs/design/minimalist-productivity-app/visual-system.md，路径使用已确认的 feature_path；文件直接包含颜色、字体、间距和组件规则。 |
+| `assertion_2` | PASS | 锁定文件仅为视觉规范文档，未包含设计 token 落地代码、CSS/组件实现、工程任务拆解或测试命令。 |
+| `assertion_3` | PASS | 锁定文件明确写出“Next role: engineer-agent”，候选最终输出也明确提示下一角色为 engineer-agent。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c3c36cd66b9231c6a2156abc32bf00fb490f5264858737980fadf81d3240530f; fixture_sha256=89d144dafb490a68dbf1ec05d2336c43c874c81e51496b945ac9140ca757080a; output_sha256=759e24f0a3890effc5984e3c789249cbddf7baf54b60e27c36f5eee1664af907; snapshot_sha256=38bb2cee9cf65820b6b8f5fa1259ac35517b7ef5e94decb6aeab6fea77112b7b
-- Behavior: Delivered the required visual-system document at the confirmed path, with visual rules and an explicit engineer-agent handoff.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c3c36cd66b9231c6a2156abc32bf00fb490f5264858737980fadf81d3240530f; fixture_sha256=89d144dafb490a68dbf1ec05d2336c43c874c81e51496b945ac9140ca757080a; output_sha256=d558fb13c76f858d9061f0e9e5f179d16f4b439615e1c57de7776444d1569218; snapshot_sha256=df5b3803ff77a253cc1eb93c21f9bedd3a36ae20f1b0a9b1bc6784d0a610aa7a
+- Behavior: 成功产出符合范围的视觉系统文档，覆盖所需视觉规则，并在设计交接处明确交给 engineer-agent。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c3c36cd66b9231c6a2156abc32bf00fb490f5264858737980fadf81d3240530f; fixture_sha256=89d144dafb490a68dbf1ec05d2336c43c874c81e51496b945ac9140ca757080a; output_sha256=dfe15f7e662c2d24cd16ebf5e922c3769119aff37d4d5de91e6064c60d9912ac; snapshot_sha256=3cd97f44f2ad3a38eb5370fb88a83788a4546773f444184d29a057d5be43f007
-- Behavior: Fresh baseline also delivered a visual-system document at the required path and covered the requested visual categories, but did not explicitly identify engineer-agent as the next role.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c3c36cd66b9231c6a2156abc32bf00fb490f5264858737980fadf81d3240530f; fixture_sha256=89d144dafb490a68dbf1ec05d2336c43c874c81e51496b945ac9140ca757080a; output_sha256=92d4b16fcaaf0664292dffb17d8d546bfb7810a2069a32ef5d9a088226fdf48e; snapshot_sha256=25628ccaffca8a412625a5b4e3756b11838069ffa5792ace29cde21b55f63401
+- Behavior: 也产出视觉系统文档并覆盖主要视觉规则，但未明确提示由 engineer-agent 接手，交接边界较弱。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/designer/test/visual-design/workspace/eval-2-reference-design-system/comparison.md
+++ b/agents/designer/test/visual-design/workspace/eval-2-reference-design-system/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `42400da86be636a5c48d6ced7acfe1114f7f3fc84e29109517e26b5a0856067c` from `agents/designer/test/visual-design/workspace/eval-2-reference-design-system`.
 - Identity schema: `2`
-- target_skill_sha256: `be4ad3e2bd7a045eae2db8cc147a655dcc8a42c01f2783e36539d2888fdcbaaf`
+- target_skill_sha256: `61b6f3a42424308b7a04ea0adf2a51b2b68f65f02fd796de4a724f6f357a579d`
 - eval_definition_sha256: `1e9739265f0721cb69546820ef87da3e0b8045e92accd200c449d4a7c5bab7c5`
 - metadata_sha256: `0569508778fe88200b5fb026dabdecd3e642e5d037acfb9bb7196015ba8a9eba`
 - fixture_sha256: `42400da86be636a5c48d6ced7acfe1114f7f3fc84e29109517e26b5a0856067c`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `b207ccfef6c29a46ee4c39ebd7d39f4af35c494d6c841b0789899fe237e9584b`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `092b10f39d07502fd69cfd2b4992b956cec050d77722de8312a6a9dc94160cd6`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `2dd23a101b1833a5f815a50f0bc085a1d9a95ddf55380df9fcbc12238f06ae99`
+- Skill overlay SHA-256: `3beb7f3f01f53d491f571b17a7c7d87e2b0ca9e8ea7417fbcc27feda44e8e283`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,19 +33,19 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `design_system_data` | PASS | 锁定的交付文件明确包含 Design System Data 查询与发现、Reference-Driven Design System、产品类别、推荐模式、风格方向、配色系统、字体体系、UX Quality Rules 和 Anti-patterns to Avoid。 |
-| `assertion_2` | PASS | 锁定的交付文件是视觉系统文档，未包含 CSS/Tailwind/React/shadcn 实现代码、安装命令或工程任务拆解；内容在 Design Handoff 处停止。 |
+| `design_system_data` | PASS | 锁定的 with_skill delivery_snapshot 文档包含“Reference-Driven Design System”、Design System Data 查询与 findings，并明确产品类别、推荐模式、风格方向、配色、字体、UX Quality Rules 和 Anti-patterns。 |
+| `assertion_2` | PASS | 锁定文档是视觉系统 Markdown 规范，未包含 CSS/Tailwind/React/shadcn 实现代码、安装命令或工程任务拆解；文档以设计交接说明结束。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=092b10f39d07502fd69cfd2b4992b956cec050d77722de8312a6a9dc94160cd6; fixture_sha256=42400da86be636a5c48d6ced7acfe1114f7f3fc84e29109517e26b5a0856067c; output_sha256=6df724b47990fb9ecc4e0eb52e54214202d1df23d55906a0c61896172f3b3d13; snapshot_sha256=b72af3147c7029719d2be145a23fdb2097ec8a2d97bea1e92cfa3bc8fe37ea54
-- Behavior: 完成并交付了包含 Design System Data 依据的企业分析平台视觉系统文档，覆盖布局、风格、色彩、字体、UX 规则和反模式，并停在设计交接边界。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=092b10f39d07502fd69cfd2b4992b956cec050d77722de8312a6a9dc94160cd6; fixture_sha256=42400da86be636a5c48d6ced7acfe1114f7f3fc84e29109517e26b5a0856067c; output_sha256=9d74b19ca67910b2df9c0ab5060a411739cc6ae10e14db95ba1adfc213c3dd1d; snapshot_sha256=1ad9cb3219c4005919bd2f3ae12eaf02624f14165231df10e6033bf51072ed89
+- Behavior: 完成并交付包含 Design System Data 驱动内容的企业分析平台视觉系统文档，未生成代码。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=092b10f39d07502fd69cfd2b4992b956cec050d77722de8312a6a9dc94160cd6; fixture_sha256=42400da86be636a5c48d6ced7acfe1114f7f3fc84e29109517e26b5a0856067c; output_sha256=ea157cf8d0cda88574c819e021b5f3b4219c3603cd74de047c6961457906207b; snapshot_sha256=1fa1de0ce4aa7a79f0431e2f3aac8d235ce49423f83624066c7fd57713b616d3
-- Behavior: 交付了较完整的视觉系统文档，但其锁定内容偏向一般设计规范，未呈现 with_skill 交付中的 Design System Data/reference-driven 证据，且包含工程 token 示例与组件命名建议。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=092b10f39d07502fd69cfd2b4992b956cec050d77722de8312a6a9dc94160cd6; fixture_sha256=42400da86be636a5c48d6ced7acfe1114f7f3fc84e29109517e26b5a0856067c; output_sha256=213d4f21bf00a1b31d3a013b502ff524a5f8683d325926e4ff6dd0067f5e0c9e; snapshot_sha256=4ec2e9be0adf3266fd8cbc94e2fc03c3ac10ad581bf8f4826e02586cc74ed878
+- Behavior: 完成视觉系统文档，但交付内容未体现 Design System Data 查询结果及 reference-driven design system 等要求。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/devops/skills/cicd-bootstrap/SKILL.md
+++ b/agents/devops/skills/cicd-bootstrap/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cicd-bootstrap
-description: "Add or update CI/CD automation, GitHub Actions, build checks, image workflows, and release workflow configuration from confirmed operational evidence. Use after devops-agent routes the CI/CD scope."
+description: "Add or update CI/CD automation, GitHub Actions, build checks, image workflows, and release configuration from confirmed evidence. Use after devops-agent routes CI/CD work."
 visibility: internal
 ---
 

--- a/agents/devops/skills/deployment-planner/SKILL.md
+++ b/agents/devops/skills/deployment-planner/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deployment-planner
-description: "Plan deployable service units, runtime entry points, local startup, Docker, Kubernetes/Helm, and required deployment assets from confirmed scope. Use after devops-agent routes deployment planning."
+description: "Plan service units, runtime entry points, local startup, Docker, Kubernetes/Helm, and required deployment assets from confirmed scope. Use after devops-agent routes deployment planning."
 visibility: internal
 ---
 

--- a/agents/devops/skills/devops-agent/SKILL.md
+++ b/agents/devops/skills/devops-agent/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: devops-agent
-description: "Classify and route confirmed deployment, runtime packaging, CI/CD, environment-audit, release-readiness, rollback, and runbook requests. Use immediately after a PM operational handoff and before any DevOps specialist executes."
+description: "Route confirmed deployment, runtime packaging, CI/CD, environment audit, release-readiness, rollback, and runbook work. Use after a PM operational handoff."
 visibility: internal
 ---
 

--- a/agents/devops/skills/env-config-auditor/SKILL.md
+++ b/agents/devops/skills/env-config-auditor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: env-config-auditor
-description: "Audit deployment readiness, environment variables, secrets/config references, endpoints, and configuration differences across local, CI/CD, and runtime contexts. Use after devops-agent routes an environment audit."
+description: "Audit deployment readiness and configuration differences across local, CI/CD, and runtime contexts, including variables, secret references, and endpoints. Use after devops-agent routes environment auditing."
 visibility: internal
 ---
 

--- a/agents/devops/skills/incident-playbook-writer/SKILL.md
+++ b/agents/devops/skills/incident-playbook-writer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: incident-playbook-writer
-description: "Write evidence-backed rollback guidance, incident response steps, troubleshooting runbooks, and on-call preparation for a confirmed deployment surface. Use after devops-agent routes the incident-playbook scope."
+description: "Write evidence-backed rollback guidance, incident-response steps, troubleshooting runbooks, and on-call preparation for a confirmed deployment surface. Use after devops-agent routes incident-playbook work."
 visibility: internal
 ---
 

--- a/agents/devops/test/cicd-bootstrap/evals/workspace/eval-001-github-actions-docker/comparison.md
+++ b/agents/devops/test/cicd-bootstrap/evals/workspace/eval-001-github-actions-docker/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `343bcb839e30c78715e11895db5ff7bd71039ec73fe31429c1bbda5b9e3e2a90` from `agents/devops/test/cicd-bootstrap/evals/workspace/eval-001-github-actions-docker`.
 - Identity schema: `2`
-- target_skill_sha256: `aed48fddfc5ff065b4c42b3cee1081c6e2b92b1fe8557c1413f01e05c0f91ef0`
+- target_skill_sha256: `b41596991874aec0c37e12acb656078a02504e51d6536f47c1befab8e1f38b4a`
 - eval_definition_sha256: `e302fa46977944ed026b10f7f1ded4b3717a6c85f19be1f78da9c42d4b0c0b8d`
 - metadata_sha256: `6576f2b96222cd993753c16016129615d0effef0ba03482d059a2a0e540e8ce2`
 - fixture_sha256: `343bcb839e30c78715e11895db5ff7bd71039ec73fe31429c1bbda5b9e3e2a90`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `416d97c852ae3d12b00631149dd08640442fd75a13414eab07000c384c3a2d5f`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `218d78b7a8ea97a45d92074ef7fdba8d569a39aa87d9b7e2b17fd38ac1491e6e`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `f170ac0192e8f110fe74b7c61766437cb8268e62c38697fb51b94a3db4467e5f`
+- Skill overlay SHA-256: `777451b1778a899115de1846bd3248acc1a8fef07fa6857039ca7e40cdac46e8`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,21 +33,21 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `creates_repo_native_ci` | PASS | with_skill 的 `.github/workflows/ci.yml` 在 `pull_request` 上使用 Node.js 22，依次运行 `npm ci`、`npm run lint`、`npm test` 和 `npm run build`。 |
-| `creates_staging_deployment_workflow` | PASS | with_skill 的 `.github/workflows/deploy-staging.yml` 仅监听 `push` 到 `main`，引用现有 Compose 文件，使用 `ghcr.io/example/acme-web`，并将提交 SHA 作为 `APP_IMAGE_TAG` 传给 Compose。 |
-| `documents_required_secrets` | PASS | with_skill 的 `deploy/SECRETS.md` 列出 REGISTRY_USERNAME、REGISTRY_TOKEN、STAGING_HOST、STAGING_USER 和 STAGING_SSH_KEY，未包含真实凭据。 |
-| `does_not_execute_delivery` | PASS | with_skill 的 git 证据显示无提交、推送或引用变更；runner trace 仅执行只读检查及 lint/test/build，未构建或推送镜像、连接 staging，且最终未声称部署成功。 |
+| `creates_repo_native_ci` | PASS | Locked delivery snapshot contains `.github/workflows/ci.yml` with `pull_request`, Node.js `22.x`, `npm ci`, then `npm run lint`, `npm test`, and `npm run build`. |
+| `creates_staging_deployment_workflow` | PASS | Locked delivery snapshot contains `.github/workflows/deploy-staging.yml` triggered only by `push` to `main`, using `deploy/docker/docker-compose.staging.yml`, `ghcr.io/example/acme-web`, and passing the commit tag through `APP_IMAGE_TAG`. |
+| `documents_required_secrets` | PASS | Locked `deploy/SECRETS.md` lists all five required secret names and contains no credential values. |
+| `does_not_execute_delivery` | PASS | Git evidence shows no commits, ref changes, or pushes; the captured commands show only local lint/test/build checks and no image build/push or staging connection. The candidate explicitly states deployment and image publication were not executed. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=218d78b7a8ea97a45d92074ef7fdba8d569a39aa87d9b7e2b17fd38ac1491e6e; fixture_sha256=343bcb839e30c78715e11895db5ff7bd71039ec73fe31429c1bbda5b9e3e2a90; output_sha256=db55e3f43e7e5abab790c9e22b2c208560b1a2c320cf3f9f9df3bc503004c7f0; snapshot_sha256=9ddf916d55e5aefa67018413c1514213acf70a072b3d1e42b0d292aa5d2bee97
-- Behavior: 生成了符合仓库约定的 CI、staging 部署和 secrets 文档配置，并保持交付未执行。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=218d78b7a8ea97a45d92074ef7fdba8d569a39aa87d9b7e2b17fd38ac1491e6e; fixture_sha256=343bcb839e30c78715e11895db5ff7bd71039ec73fe31429c1bbda5b9e3e2a90; output_sha256=68f64759a105f9285ecee4884d8027b139d9fc01a4d8319355e156cba6709d40; snapshot_sha256=086149ce181cd95c16cbcb6b147089eb11bf442e18a6e55fe934465d5d33f32b
+- Behavior: Created the requested CI, staging deployment, and secret documentation files without executing delivery.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=218d78b7a8ea97a45d92074ef7fdba8d569a39aa87d9b7e2b17fd38ac1491e6e; fixture_sha256=343bcb839e30c78715e11895db5ff7bd71039ec73fe31429c1bbda5b9e3e2a90; output_sha256=a9c31675711af2cc907a028856c21e839642ce5b3f3bdef40c85333f9e507079; snapshot_sha256=3d8d8ca5b44224fb405eea83f330a3816e7ffb24d276c58e9c8c0371d12d78d7
-- Behavior: 也生成了主要配置，但额外包含 workflow_dispatch，且部署流程契约与 with_skill 略有不同；其表现仅作基线对照。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=218d78b7a8ea97a45d92074ef7fdba8d569a39aa87d9b7e2b17fd38ac1491e6e; fixture_sha256=343bcb839e30c78715e11895db5ff7bd71039ec73fe31429c1bbda5b9e3e2a90; output_sha256=82b8a10711524016571a4982763cd52e2f1d7972a59fce9e6012f9de5c70cb9c; snapshot_sha256=4ffe6d285147e47e7c43d7837af3333b7605c303803b1af0cdf3cf5390447fe5
+- Behavior: Fresh baseline also created the requested configuration files and did not execute delivery; it used a more direct Compose upload and fixed staging-directory approach.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/devops/test/cicd-bootstrap/evals/workspace/eval-002-mapped-doc-cicd/comparison.md
+++ b/agents/devops/test/cicd-bootstrap/evals/workspace/eval-002-mapped-doc-cicd/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `b0f5ab103062d754c225176fd1995f4f428e9f29340584ac86077ed978dc1482` from `agents/devops/test/cicd-bootstrap/evals/workspace/eval-002-mapped-doc-cicd`.
 - Identity schema: `2`
-- target_skill_sha256: `aed48fddfc5ff065b4c42b3cee1081c6e2b92b1fe8557c1413f01e05c0f91ef0`
+- target_skill_sha256: `b41596991874aec0c37e12acb656078a02504e51d6536f47c1befab8e1f38b4a`
 - eval_definition_sha256: `68a87fb5d229c5c451c4b7081adb9e28c9c2e68f2832958c12f8d53464b0ae13`
 - metadata_sha256: `7e07a230c7002251551f1819be2a41bc3021e8c2cf111ff3359550f2215bd97f`
 - fixture_sha256: `b0f5ab103062d754c225176fd1995f4f428e9f29340584ac86077ed978dc1482`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `08a3ffdcb2251091cdf30040590082a976faabcf76e7e71f7124b4bb2d5a5ba4`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `f170ac0192e8f110fe74b7c61766437cb8268e62c38697fb51b94a3db4467e5f`
+- Skill overlay SHA-256: `777451b1778a899115de1846bd3248acc1a8fef07fa6857039ca7e40cdac46e8`
 - Behavior result: **FAIL**
 - Coverage result: **FULL**
 Overall result: FAIL
@@ -33,25 +33,25 @@ Overall result: FAIL
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `reads_mapped_docs_first` | FAIL | The with_skill trace reads build-pipeline.md in item_7 before reading change-map.yaml content in item_8, so it did not first hit the map and then read the mapped document. |
-| `verifies_against_code` | PASS | The locked fixture has validation_command = verify in pipeline.rules and test in the documentation; with_skill identifies the conflict, selects verify, and explains that test must not be used. |
-| `treats_unverified_as_low_trust` | PASS | with_skill explicitly identifies last_verified_version: unverified, treats the document as low-trust navigation, and bases the command on pipeline.rules; it also reports the missing verify runtime evidence. |
+| `reads_mapped_docs_first` | PASS | Trace reads the mapped change-map, then docs/site/api/build-pipeline.md, and does not traverse unrelated site documents. |
+| `verifies_against_code` | FAIL | Trace never reads src/build/pipeline.rules and reports the stale document command test as the only recommendation, without identifying the code-required verify command or its impact. |
+| `treats_unverified_as_low_trust` | PASS | Trace explicitly identifies last_verified_version: unverified and treats the document as low-trust navigation, declining to promote test to a confirmed CI command. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=08a3ffdcb2251091cdf30040590082a976faabcf76e7e71f7124b4bb2d5a5ba4; fixture_sha256=b0f5ab103062d754c225176fd1995f4f428e9f29340584ac86077ed978dc1482; output_sha256=7b1a8a0b1efb0246e73eb68bdb9b3f3828dec4f3c08d9eef48a1f0d15a4851cc; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly identifies the unverified documentation conflict, verifies the command against code, and proposes verify, but reads the mapped build document before reading the change-map content.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=08a3ffdcb2251091cdf30040590082a976faabcf76e7e71f7124b4bb2d5a5ba4; fixture_sha256=b0f5ab103062d754c225176fd1995f4f428e9f29340584ac86077ed978dc1482; output_sha256=d133e9ca06a198f2cb612eb64f93fad58126c1dec6ce2048dc7a61941a802d72; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Read the mapped documentation and correctly treated it as unverified, but failed to reread the code and therefore did not determine the actual command.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=08a3ffdcb2251091cdf30040590082a976faabcf76e7e71f7124b4bb2d5a5ba4; fixture_sha256=b0f5ab103062d754c225176fd1995f4f428e9f29340584ac86077ed978dc1482; output_sha256=2c5673eca6469314ac5c3f888f54ae29725bdaebcab5e9cec6e7e25a8b1c1ede; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly selects verify and identifies the documentation conflict, but does not provide evidence of the unverified-document trust treatment or mapped-document-first process.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=08a3ffdcb2251091cdf30040590082a976faabcf76e7e71f7124b4bb2d5a5ba4; fixture_sha256=b0f5ab103062d754c225176fd1995f4f428e9f29340584ac86077ed978dc1482; output_sha256=94dae005553ee8d06686ec7487a4f615e58f060c2dfb46363144e8863c87dab2; snapshot_sha256=572411d82fb534e72979f510e527b0a194a160b5a408b6d4d2f4141c2639c92e
+- Behavior: Created a workflow using verify and corrected the documentation, but is comparison context only.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- The with_skill execution order violates the mapped-document-first assertion.
+- The with_skill lane stopped at an unsupported PM/DevOps handoff gate and omitted the required code verification, so it failed to determine the actual CI command verify.
 - Next: None.
 
 ## Runtime Artifact Policy

--- a/agents/devops/test/cicd-bootstrap/evals/workspace/eval-003-docs-image-release-rules/comparison.md
+++ b/agents/devops/test/cicd-bootstrap/evals/workspace/eval-003-docs-image-release-rules/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `3676f277a876b41e1703c92d57107677efc45689334ecbdddc74bf8f7e7cb8bf` from `agents/devops/test/cicd-bootstrap/evals/workspace/eval-003-docs-image-release-rules`.
 - Identity schema: `2`
-- target_skill_sha256: `aed48fddfc5ff065b4c42b3cee1081c6e2b92b1fe8557c1413f01e05c0f91ef0`
+- target_skill_sha256: `b41596991874aec0c37e12acb656078a02504e51d6536f47c1befab8e1f38b4a`
 - eval_definition_sha256: `90a9cf04ee14bffff8a2eaca0298de327ed551cee77903fd69a219a57495281e`
 - metadata_sha256: `6a1d045506a143598b535f56d88f45cff18b1438e131bb6af437dccabaf2255d`
 - fixture_sha256: `3676f277a876b41e1703c92d57107677efc45689334ecbdddc74bf8f7e7cb8bf`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `8eaf2480ee518c77bc5e1ae8a7f25c0acfc010e7317cc45d7143e8591e25551c`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `d3c1631bc39b4cdb5a62c7ac02b9b6359957e5c2debaf73a2659a08294722209`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `f170ac0192e8f110fe74b7c61766437cb8268e62c38697fb51b94a3db4467e5f`
+- Skill overlay SHA-256: `777451b1778a899115de1846bd3248acc1a8fef07fa6857039ca7e40cdac46e8`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `preserves_host_image_policy` | PASS | The with_skill output explicitly carries forward immutable vX.Y.Z and git-<shortsha> tags, registry.example/project/service, linux/amd64 and linux/arm64, and tag-triggered production publication for both Public and Internal. |
-| `verifies_each_published_variant` | PASS | The with_skill output gives Public and Internal separate build/publish-validation and manifest/digest-check rules, and explicitly states that a workflow definition is not evidence of publication; the locked evidence shows no workflow or published delivery exists, so the candidate correctly presents these as required rules rather than completed publication. |
-| `keeps_delivery_authority_separate` | PASS | The with_skill output explicitly preserves the release-manager approval boundary and states that commit, push, image publication, tag/release creation, and production deployment were neither executed nor implicitly authorized. |
+| `preserves_host_image_policy` | PASS | with_skill explicitly preserves immutable vX.Y.Z and git-<shortsha> tags, registry.example/project/service, tag-triggered production publication, and linux/amd64 plus linux/arm64 for both Public and Internal. |
+| `verifies_each_published_variant` | PASS | with_skill states that both image units require separate build/publish validation and independent post-publication digest and multi-architecture checks, and explicitly says workflow presence is not publication evidence. No actual publication was claimed. |
+| `keeps_delivery_authority_separate` | PASS | with_skill explicitly preserves the release-manager approval boundary and says no push, publication, tag, or release may be executed during this review. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=d3c1631bc39b4cdb5a62c7ac02b9b6359957e5c2debaf73a2659a08294722209; fixture_sha256=3676f277a876b41e1703c92d57107677efc45689334ecbdddc74bf8f7e7cb8bf; output_sha256=f259b6daf20d8981b7c333f9f15445be1dd01535b1dd9fc3b5fc519d07c42cc5; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly reviews the available handoff evidence, distinguishes required CI/CD rules from absent implementation/publication evidence, covers both image units, and preserves delivery authorization boundaries.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=d3c1631bc39b4cdb5a62c7ac02b9b6359957e5c2debaf73a2659a08294722209; fixture_sha256=3676f277a876b41e1703c92d57107677efc45689334ecbdddc74bf8f7e7cb8bf; output_sha256=0cb563964464d9e23dbf22838c89ea445f4cdc89cb5b18175cfcd9257d729f10; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly maps the handoff rules to both image units, distinguishes required validation from unavailable implementation evidence, and preserves delivery authority boundaries.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=d3c1631bc39b4cdb5a62c7ac02b9b6359957e5c2debaf73a2659a08294722209; fixture_sha256=3676f277a876b41e1703c92d57107677efc45689334ecbdddc74bf8f7e7cb8bf; output_sha256=19f3dbb8a8856536621f65072c4f49ef620527967134bcbcc6812a49d7bcdbbe; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Fresh baseline also identifies the handoff rules and approval boundary, but provides a less explicit per-variant validation treatment; it is comparison context only.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=d3c1631bc39b4cdb5a62c7ac02b9b6359957e5c2debaf73a2659a08294722209; fixture_sha256=3676f277a876b41e1703c92d57107677efc45689334ecbdddc74bf8f7e7cb8bf; output_sha256=f72b7cca4b8affce66815157c6078df9c07579cde12d1e8afa41cc4f6b10e64f; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Provides a generally correct baseline summary of the host image policy and approval boundary, but is less explicit about independent per-unit validation and evidence limitations.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/devops/test/deployment-planner/evals/workspace/eval-001-nextjs-web-app/comparison.md
+++ b/agents/devops/test/deployment-planner/evals/workspace/eval-001-nextjs-web-app/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `06f8a5807d1130b7a91a700b2074192e6dfed0933a071ce16642b27aa050360d` from `agents/devops/test/deployment-planner/evals/workspace/eval-001-nextjs-web-app`.
 - Identity schema: `2`
-- target_skill_sha256: `ff61dcd9673d160376da3723849f195022899b8e8a38fe78c67e4488f9065a5f`
+- target_skill_sha256: `dfa906d01a96634826afcebe44c9732902f0bc2b120c6c7b7232879b93b8e923`
 - eval_definition_sha256: `4ab6f3577023497f11197efb5117e95119ab70a437c95770925330f5be6aa5f2`
 - metadata_sha256: `de5df4ca13d82c9e7bb152be1484594454c0cf0e1976add64d71c7e6648955c1`
 - fixture_sha256: `06f8a5807d1130b7a91a700b2074192e6dfed0933a071ce16642b27aa050360d`
@@ -22,38 +22,39 @@
 - judge_schema_sha256: `8fdd554bf7008e1addc7b92301444335139887034f2813ab539445a1df4b82d6`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `cd186dfdcf8b04b4e66f71faf5fd0b7ea6c6616c86ae2015f0fd5d6d730418e8`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `aed4a3cdd1170f44446df97f66f60c0f6ae2151f3522fe982eb11ee05d551389`
-- Behavior result: **PASS**
+- Skill overlay SHA-256: `a8511777e6b4f31217e6a6c17f2c1dc2d5abd375ef6253072404dae037d7bae7`
+- Behavior result: **FAIL**
 - Coverage result: **FULL**
-Overall result: PASS
+Overall result: FAIL
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `creates_local_runtime_assets` | PASS | with_skill 的 delivery_snapshot 包含 deploy/local/.env.example、deploy/local/README.md 和可执行 deploy/local/start.sh；脚本校验 Node.js 22、DATABASE_URL、REDIS_URL，执行 npm run build 后 npm run start，端口配置为 3000。 |
-| `creates_complete_compose_topology` | PASS | with_skill 的 deploy/docker/Dockerfile 和 deploy/docker/docker-compose.yml 直接提供应用镜像及 app、postgres、redis 三个服务；Compose 含依赖健康条件，并以 /api/health 作为 app 健康检查。 |
-| `creates_application_helm_chart` | PASS | with_skill 的 deploy/helm/Chart.yaml、values.yaml 和 templates/deployment.yaml 构成 Helm chart；Deployment 使用 .Values.replicaCount，values.env 注入外部 PostgreSQL 与 Redis 地址，且未部署数据库或 Redis 服务。 |
-| `documents_each_target_without_delivery` | PASS | with_skill 提供 deploy/README.md、各目标 README 和启动命令说明；deploy/README.md 明确不创建 CI/CD，示例仅使用占位凭据，且候选输出明确未执行实际部署。 |
+| `creates_local_runtime_assets` | FAIL | FAIL：`deploy/local/.env.example` 提供了 `DATABASE_URL` 和 `REDIS_URL`，但 `deploy/local/README.md` 与 `start.sh` 均执行 `npm run dev`，未使用仓库契约要求的 `npm run start`。 |
+| `creates_complete_compose_topology` | PASS | PASS：Dockerfile 存在；Compose 定义 `app`、`postgres`、`redis`，并通过 `/api/health` 配置应用健康检查。 |
+| `creates_application_helm_chart` | PASS | PASS：Helm Chart、values 和 Deployment 模板均存在；Deployment 使用 `.Values.replicaCount`，并通过 values 中的外部数据库和 Redis 地址注入依赖。 |
+| `documents_each_target_without_delivery` | FAIL | FAIL：Docker 和 Helm 说明基本符合契约且未执行部署，但 local README/start.sh 使用 `npm run dev`，与要求的 `npm run start` 不一致；未发现 CI/CD 或生产凭据交付。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cd186dfdcf8b04b4e66f71faf5fd0b7ea6c6616c86ae2015f0fd5d6d730418e8; fixture_sha256=06f8a5807d1130b7a91a700b2074192e6dfed0933a071ce16642b27aa050360d; output_sha256=a811e4779fffbbe0d8ca5ac415fa013fb898c219820890c154c17bd4c3cc738d; snapshot_sha256=4603abd9fda52287fb04ddf628bfeed857e6812724f54b661ef02e375b044616
-- Behavior: 交付了 local、Docker Compose 和仅应用 Helm 配置，并提供契约一致的说明；未执行部署。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cd186dfdcf8b04b4e66f71faf5fd0b7ea6c6616c86ae2015f0fd5d6d730418e8; fixture_sha256=06f8a5807d1130b7a91a700b2074192e6dfed0933a071ce16642b27aa050360d; output_sha256=abbdd47b7c88459bd651dc133daf88fedf9834c2c4375e9fc34fccb0e73643af; snapshot_sha256=7282db80bda8a3d830f4caaeaed333f6253fba7a441db3dc2695ca57453925ec
+- Behavior: 交付了 local、Docker Compose 和 Helm 文件；Docker 拓扑及 Helm 应用配置满足要求，但 local 启动命令错误。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cd186dfdcf8b04b4e66f71faf5fd0b7ea6c6616c86ae2015f0fd5d6d730418e8; fixture_sha256=06f8a5807d1130b7a91a700b2074192e6dfed0933a071ce16642b27aa050360d; output_sha256=63b0a5f0606bc0395cccfef6f2141067c9147649d68527c4c25bc640669d21e0; snapshot_sha256=cadd089ad52e4f59839ffc9abda902244ed71e2557b05662dd59aed11eb0d536
-- Behavior: 同样交付了三类配置，结构更精简；可作为 fresh baseline 对照，不影响 with_skill 的断言判定。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cd186dfdcf8b04b4e66f71faf5fd0b7ea6c6616c86ae2015f0fd5d6d730418e8; fixture_sha256=06f8a5807d1130b7a91a700b2074192e6dfed0933a071ce16642b27aa050360d; output_sha256=71493a2f06f788965adde72326c4b8ab1c3bc88cd368a263be53e370d1468b01; snapshot_sha256=4a0f091490ea1a339eb077ce792d5666be5198073e4e86a72b535849b7e1ec9d
+- Behavior: 也交付了三类配置；Docker 和 Helm 基本满足要求，但 local README 同样使用 `npm run dev` 且未提供启动脚本。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- None.
-- Next: None.
+- with_skill 的 local 启动说明和脚本使用 `npm run dev`，未满足仓库约束中的 `npm run start`。
+- 因此 local 目标说明也不完全与仓库契约一致。
+- Next: 将 `deploy/local/README.md` 和 `deploy/local/start.sh` 改为使用 `npm run start`，并确保说明仍覆盖端口 3000、DATABASE_URL 和 REDIS_URL。
 
 ## Runtime Artifact Policy
 

--- a/agents/devops/test/deployment-planner/evals/workspace/eval-002-python-api-only/comparison.md
+++ b/agents/devops/test/deployment-planner/evals/workspace/eval-002-python-api-only/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `259dab4dbfe64941c0c3fdd5c97b56c6b90abb97168eeb7461bd9a7bf8e30888` from `agents/devops/test/deployment-planner/evals/workspace/eval-002-python-api-only`.
 - Identity schema: `2`
-- target_skill_sha256: `ff61dcd9673d160376da3723849f195022899b8e8a38fe78c67e4488f9065a5f`
+- target_skill_sha256: `dfa906d01a96634826afcebe44c9732902f0bc2b120c6c7b7232879b93b8e923`
 - eval_definition_sha256: `f6bee599168504aabc5841db04bc20810e822fd2af8545bc98e19f6298c38285`
 - metadata_sha256: `d8b9107459aa74bd3dbadef75ae9d69cc322f1ce75809c991658f0479eee3361`
 - fixture_sha256: `259dab4dbfe64941c0c3fdd5c97b56c6b90abb97168eeb7461bd9a7bf8e30888`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `6d6cb805f86354c5ca7fe62a901b9a052b0e2f5bc53f163da17451ac99ca29a5`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `000bcbda1f774e89fec492193e606a35b1ac2f41c0b29e0c9ac66b491aa38c8b`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `aed4a3cdd1170f44446df97f66f60c0f6ae2151f3522fe982eb11ee05d551389`
+- Skill overlay SHA-256: `a8511777e6b4f31217e6a6c17f2c1dc2d5abd375ef6253072404dae037d7bae7`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,21 +33,21 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `uses_confirmed_target_matrix` | PASS | with_skill 的 delivery_snapshot 提供 deploy/local、deploy/docker 和 deploy/helm 三类资产，未生成其他部署目标。 |
-| `keeps_api_only_topology` | PASS | Docker Compose 仅定义 api 服务；快照中的 Helm 和 local 配置未包含数据库、Redis、migration 或 DATABASE_URL。 |
-| `uses_confirmed_runtime_contract` | PASS | local/start.sh、Dockerfile 和 Helm Deployment 均使用 app.main:app、默认 8000 端口；Docker healthcheck、Helm probes 及文档均使用 /health。 |
-| `stays_within_deployment_scope` | PASS | 锁定交付文件中没有 CI/CD 配置；git_evidence 显示仅新增 deploy/ 文件，未发生提交、发布或环境部署。 |
+| `uses_confirmed_target_matrix` | PASS | Locked with_skill snapshot contains deploy/local, deploy/docker, and deploy/helm assets, with the matrix explicitly limited to local, Docker/Compose, and Kubernetes/Helm. |
+| `keeps_api_only_topology` | PASS | The Compose snapshot defines only one api service. Locked Helm/local files contain no database, Redis, migration, DATABASE_URL, or additional runtime service; ConfigMap/HPA/Ingress are deployment resources, not extra services. |
+| `uses_confirmed_runtime_contract` | PASS | Locked files use uvicorn app.main:app, default port 8000, and /health for Docker healthcheck, local startup documentation, and Helm probes/runtime documentation. |
+| `stays_within_deployment_scope` | PASS | The locked delivery snapshot contains deployment assets only. The output and raw trace explicitly state that CI/CD configuration, publishing, and actual deployment were not performed. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=000bcbda1f774e89fec492193e606a35b1ac2f41c0b29e0c9ac66b491aa38c8b; fixture_sha256=259dab4dbfe64941c0c3fdd5c97b56c6b90abb97168eeb7461bd9a7bf8e30888; output_sha256=19a82fa787dbb190b041e7523eb8cbfdfbf20591ffceedbcacc90480d4e603e5; snapshot_sha256=fe04c5229f0244a8b9588adefdf0049a8db5adcd03355e3ac02a7fe737472ad7
-- Behavior: 交付了 local、Docker、Helm 部署资产，并明确 CI/CD 与实际发布为范围外事项。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=000bcbda1f774e89fec492193e606a35b1ac2f41c0b29e0c9ac66b491aa38c8b; fixture_sha256=259dab4dbfe64941c0c3fdd5c97b56c6b90abb97168eeb7461bd9a7bf8e30888; output_sha256=6bf27410e61b06ba26c77c422eaa521020af51aa0f5cfe81b6bc0263e8727adf; snapshot_sha256=7e162a439c6bab7d1d6a8f5c06b71cb52916262952d77b13d0b219bacb341475
+- Behavior: Produced local, Docker/Compose, and Helm deployment assets for the API-only service, with explicit runtime and scope documentation.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=000bcbda1f774e89fec492193e606a35b1ac2f41c0b29e0c9ac66b491aa38c8b; fixture_sha256=259dab4dbfe64941c0c3fdd5c97b56c6b90abb97168eeb7461bd9a7bf8e30888; output_sha256=cf84978a90f48534a5587be72207ae541cbeb8ee04eb53816c358df9f75d21a5; snapshot_sha256=8a2ff0a9ea150ebb9b2b228e5d76b8ea7ee7dbe8920135ce9e3bfee11f68d15e
-- Behavior: 同样交付了 Docker、Compose 和 Helm 资产，覆盖范围符合 API-only 部署要求。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=000bcbda1f774e89fec492193e606a35b1ac2f41c0b29e0c9ac66b491aa38c8b; fixture_sha256=259dab4dbfe64941c0c3fdd5c97b56c6b90abb97168eeb7461bd9a7bf8e30888; output_sha256=e888cb5dcc2dd4e2d6f3bff573facafc17b32c50997e423ceb9a47e01f84ce5d; snapshot_sha256=64c00c18f49b4e3b0241ff14ec071df6822eb1263df8db37898c8d5c666ddec4
+- Behavior: Produced Docker/Compose and Helm assets with an API-only topology and matching runtime settings, but without the structured deploy/local handoff layout.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/devops/test/deployment-planner/evals/workspace/eval-003-mapped-doc-deployment/comparison.md
+++ b/agents/devops/test/deployment-planner/evals/workspace/eval-003-mapped-doc-deployment/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `beceb4834aab461ec20117458ef66d8ba65e677ecbef5e80a9e59909d2fe5471` from `agents/devops/test/deployment-planner/evals/workspace/eval-003-mapped-doc-deployment`.
 - Identity schema: `2`
-- target_skill_sha256: `ff61dcd9673d160376da3723849f195022899b8e8a38fe78c67e4488f9065a5f`
+- target_skill_sha256: `dfa906d01a96634826afcebe44c9732902f0bc2b120c6c7b7232879b93b8e923`
 - eval_definition_sha256: `3a6f0e2dac2acec4b2146c1f3b14a82dc89e2d78da9249fb55fda45906586c82`
 - metadata_sha256: `327b8d91b5679b5d6691e5c028c3cc9d4baaf0c68df0883449c838a3976294e7`
 - fixture_sha256: `beceb4834aab461ec20117458ef66d8ba65e677ecbef5e80a9e59909d2fe5471`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `3fd213f6de3f610cad1c014e643471913a0678af0ef96531f1f973bd669f4005`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `40b086c239ff14f46936633adeb5d9079306a48046e93c803af236ab43d646d6`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `aed4a3cdd1170f44446df97f66f60c0f6ae2151f3522fe982eb11ee05d551389`
+- Skill overlay SHA-256: `a8511777e6b4f31217e6a6c17f2c1dc2d5abd375ef6253072404dae037d7bae7`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,21 +33,21 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `reads_mapped_docs_first` | PASS | with_skill trace shows the change map and its required runtime document were read before the final code verification, with no unrelated site-document traversal. |
-| `verifies_against_code` | PASS | The locked with_skill output identifies the code setting as 8081, contrasts it with the document's 8080, explains the conflict's deployment impact, and recommends EXPOSE/mapping for 8081. |
-| `treats_unverified_as_low_trust` | PASS | The with_skill output explicitly notes last_verified_version: unverified, treats the document as low-trust/outdated navigation, and bases the port conclusion on server.conf. |
-| `omits_unselected_targets` | PASS | The with_skill delivery has no generated assets and explicitly limits the matrix to the container service, marking Compose and Kubernetes/Helm unselected. |
+| `reads_mapped_docs_first` | PASS | Raw trace shows the mapped runtime document was identified and read after the task file/change-map, without unrelated site-document traversal. |
+| `verifies_against_code` | PASS | The output and raw trace explicitly compare documentation port 8080 with code configuration `listen_port = 8081`, and recommend 8081. |
+| `treats_unverified_as_low_trust` | PASS | The output explicitly treats `last_verified_version: unverified` as low trust and bases the deployment parameter on runtime configuration. |
+| `omits_unselected_targets` | PASS | The with_skill lane generated no files or assets and explicitly declined Docker/Compose generation; no deploy/local or deploy/helm targets appear. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=40b086c239ff14f46936633adeb5d9079306a48046e93c803af236ab43d646d6; fixture_sha256=beceb4834aab461ec20117458ef66d8ba65e677ecbef5e80a9e59909d2fe5471; output_sha256=25ef30aaf8fc995b8c49084f61bea6714d1cdeceb04c52be2d092c3dd60a371b; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly follows the mapped-document workflow, verifies the stale 8080 documentation against server.conf, treats unverified documentation as low trust, and gives only the container deployment recommendation with port 8081.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=40b086c239ff14f46936633adeb5d9079306a48046e93c803af236ab43d646d6; fixture_sha256=beceb4834aab461ec20117458ef66d8ba65e677ecbef5e80a9e59909d2fe5471; output_sha256=3671b32b530f750b0636e1fee685fe04dd6e36b39969652ec0a03b27ee9a921f; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly identifies 8081 as the container port, explains the 8080 documentation drift and low-trust status, provides a minimal mapping recommendation, and generates no unselected deployment assets.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=40b086c239ff14f46936633adeb5d9079306a48046e93c803af236ab43d646d6; fixture_sha256=beceb4834aab461ec20117458ef66d8ba65e677ecbef5e80a9e59909d2fe5471; output_sha256=4de12024f46e311b80f93fe4777d29b963f3824dd8ae579e7d60a77ece25286a; snapshot_sha256=e65878b314f4077e0374b6b007a2eb695361b99c8aeaae0bf8ca7c0c94fb7695
-- Behavior: Fresh baseline also found port 8081 and updated the runtime document, but did not explicitly demonstrate the low-trust treatment of the unverified document or provide the scoped deployment matrix.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=40b086c239ff14f46936633adeb5d9079306a48046e93c803af236ab43d646d6; fixture_sha256=beceb4834aab461ec20117458ef66d8ba65e677ecbef5e80a9e59909d2fe5471; output_sha256=29fcb4444a387ce7ba375c67c2a23e83fb1a42d24a72e5c08e8caa171afe9112; snapshot_sha256=cb7f6641903f5e49631f89cb6602ceb9d93103f3184771f9000926aaee60cb7e
+- Behavior: Also identifies 8081 and updates the runtime document with a container deployment example, but serves as comparison context only.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/devops/test/deployment-planner/evals/workspace/eval-004-docs-build-variant-matrix/comparison.md
+++ b/agents/devops/test/deployment-planner/evals/workspace/eval-004-docs-build-variant-matrix/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `1133bdf01ec9b2682fe921196914971ab2c40caac0f63afd22f66198e7edede5` from `agents/devops/test/deployment-planner/evals/workspace/eval-004-docs-build-variant-matrix`.
 - Identity schema: `2`
-- target_skill_sha256: `ff61dcd9673d160376da3723849f195022899b8e8a38fe78c67e4488f9065a5f`
+- target_skill_sha256: `dfa906d01a96634826afcebe44c9732902f0bc2b120c6c7b7232879b93b8e923`
 - eval_definition_sha256: `4c14837e1c149db8fdda5fa172eb35b4e3c167d223226adbc87832c6a7126d6f`
 - metadata_sha256: `4e635caa906adf35d961968845b5d0b832f3417bf48adf4843143f2222641a1f`
 - fixture_sha256: `1133bdf01ec9b2682fe921196914971ab2c40caac0f63afd22f66198e7edede5`
@@ -22,37 +22,37 @@
 - judge_schema_sha256: `cfb4e9daef57a9f8f8f71bd53e7b9c04b3f443f035ca06014209a131297ec22b`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `449e8afe22d56be4ea49871dccbdfe925565441c9990c7332f547cf304565087`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `aed4a3cdd1170f44446df97f66f60c0f6ae2151f3522fe982eb11ee05d551389`
-- Behavior result: **FAIL**
-- Coverage result: **FULL**
-Overall result: FAIL
+- Skill overlay SHA-256: `a8511777e6b4f31217e6a6c17f2c1dc2d5abd375ef6253072404dae037d7bae7`
+- Behavior result: **PASS**
+- Coverage result: **PARTIAL**
+Overall result: PASS (partial coverage)
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `enumerates_all_docs_variants` | PASS | With-skill output explicitly includes Public, Internal, and Preview in the matrix. |
-| `covers_deployment_unit_chain` | PASS | With-skill output provides per-variant columns for build target, context, static entry, image unit, Compose, Kubernetes/Helm resources, values, health check, runtime entry, and disposition; unavailable evidence is explicitly marked blocked. |
-| `hands_units_to_cicd` | FAIL | The output lists image units for handoff but states the handoff is not complete; Public uses “部分覆盖” and Internal does not explicitly assign one of integrated/alternative/deferred/blocked as its disposition. |
+| `enumerates_all_docs_variants` | PASS | The with_skill matrix includes Public, Internal, and Preview. |
+| `covers_deployment_unit_chain` | PASS | It explicitly covers build target, context, static entry, image, Compose, Kubernetes/Helm resources, values, health check, runtime entry, and disposition for each variant. |
+| `hands_units_to_cicd` | NOT_EXERCISED | No delivery snapshot or independent handoff event to cicd-bootstrap is present; the later handoff is therefore not exercised. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=449e8afe22d56be4ea49871dccbdfe925565441c9990c7332f547cf304565087; fixture_sha256=1133bdf01ec9b2682fe921196914971ab2c40caac0f63afd22f66198e7edede5; output_sha256=0e697f604c1e171f2c4287baa38b37ab6ae4d217983aa02e7c2f24af939f76fe; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Enumerates all variants and supplies a field-complete blocked-aware deployment matrix, but fails the required CI/CD handoff and disposition requirement.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=449e8afe22d56be4ea49871dccbdfe925565441c9990c7332f547cf304565087; fixture_sha256=1133bdf01ec9b2682fe921196914971ab2c40caac0f63afd22f66198e7edede5; output_sha256=cf20c9a906d7298cc117761c8c11d5c46d988263868d18020cb4fb076c4a95f2; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Produced a complete three-variant deployment-unit matrix with explicit blocked gaps; CI/CD handoff is not evidenced.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=449e8afe22d56be4ea49871dccbdfe925565441c9990c7332f547cf304565087; fixture_sha256=1133bdf01ec9b2682fe921196914971ab2c40caac0f63afd22f66198e7edede5; output_sha256=8aa43e49b368c1bacc112f6cc459e1a9d726f92e479c6d457e1591e738768caf; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Enumerates all three variants and contrasts coverage gaps, but provides a less complete deployment-unit chain and no CI/CD handoff.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=449e8afe22d56be4ea49871dccbdfe925565441c9990c7332f547cf304565087; fixture_sha256=1133bdf01ec9b2682fe921196914971ab2c40caac0f63afd22f66198e7edede5; output_sha256=5577fb93af952d7ae12241b53da5dd1389ec4ea62825b5c32b27261f62b47240; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Enumerated variants and broad coverage gaps but omitted the required full chain fields and disposition treatment.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- The with_skill lane does not complete the required cicd-bootstrap handoff and does not give every variant an explicit required disposition.
-- Next: Assign integrated, alternative, deferred, or blocked to every variant and complete the confirmed image-unit handoff to cicd-bootstrap.
+- None.
+- Next: Provide evidence of the cicd-bootstrap handoff for confirmed image/runtime units.
 
 ## Runtime Artifact Policy
 

--- a/agents/devops/test/devops-agent/evals/workspace/eval-002-route-docs-site-completeness-chain/comparison.md
+++ b/agents/devops/test/devops-agent/evals/workspace/eval-002-route-docs-site-completeness-chain/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `db76812ee462c1a8d89decf8e6fae581930c1406d7c6f72f3847172ed0bb02f3` from `agents/devops/test/devops-agent/evals/workspace/eval-002-route-docs-site-completeness-chain`.
 - Identity schema: `2`
-- target_skill_sha256: `e6fc9956005b4282420c83eedf1949e2502f3d3153bb3a8b79d34af6c3be8ac8`
+- target_skill_sha256: `a1710c0451d41ab9797a4d66831dae37e5e82aa02c99f954ebc420b99e5a6387`
 - eval_definition_sha256: `dc1b04424607a1675278b8e310c3f7b0da94f3cf1e857f037b9a6a8dbbf9482f`
 - metadata_sha256: `2718def12280e05b73752266e8d3b39d6929d0781f7ca1aa2088b55bd4e38e9c`
 - fixture_sha256: `db76812ee462c1a8d89decf8e6fae581930c1406d7c6f72f3847172ed0bb02f3`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `fdb2fd9254bbcae4d1c5e9dd4a0df1a9be1ee48991c72d5d1ea96147641ed710`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `520c4aa6ac767af388d73d9adeec0eb6b05a688f692c19decf65da48e498c67e`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `1821e70be0fb2a5cfbaf9844feff79040bd9b8955e0caaf7c11bf00eae6cf1c2`
+- Skill overlay SHA-256: `572a307aa700b74953743167f8c07df7db2ec9749bc028dad049129faf61f032`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `accepts_repo_wide_docs_handoff` | PASS | With-skill output explicitly identifies a repo-wide deployment handoff, preserves request_type deployment and feature_path N/A, and treats missing completeness/Docker/Helm evidence as a reason to verify rather than request feature-path clarification. |
-| `routes_dependency_order` | PASS | With-skill output states the complete conditional sequence deployment-planner -> cicd-bootstrap -> env-config-auditor -> formal-docs-sync, with each stage consuming the prior stage's verified results. |
-| `preserves_role_and_authority_boundaries` | PASS | With-skill output states that DevOps does not modify formal documentation and that the handoff authorizes neither commit, push, image publication, deployment, tagging, nor release operations. |
+| `accepts_repo_wide_docs_handoff` | PASS | with_skill 明确接受 request_type: deployment、feature_path/feature/parent_feature/feature_level 为 N/A，并将范围识别为全部文档站变体；未退回 feature_path 澄清。 |
+| `routes_dependency_order` | PASS | with_skill 明确给出 deployment-planner → cicd-bootstrap → env-config-auditor → docs-agent:formal-docs-sync 顺序，并要求最终 Docs 步骤只消费前三阶段已落地且验证的事实。 |
+| `preserves_role_and_authority_boundaries` | PASS | with_skill 明确 DevOps 不修改正式文档，并声明 handoff 不预授权 commit、push、镜像发布或部署；最终同步仅使用已验证运维事实。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=520c4aa6ac767af388d73d9adeec0eb6b05a688f692c19decf65da48e498c67e; fixture_sha256=db76812ee462c1a8d89decf8e6fae581930c1406d7c6f72f3847172ed0bb02f3; output_sha256=1fe769727d7551caa287293feace0e3f70df309a508307f29a2054189adeffa2; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly accepts the repo-wide deployment handoff, routes the required conditional dependency chain, and preserves documentation ownership and authorization boundaries.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=520c4aa6ac767af388d73d9adeec0eb6b05a688f692c19decf65da48e498c67e; fixture_sha256=db76812ee462c1a8d89decf8e6fae581930c1406d7c6f72f3847172ed0bb02f3; output_sha256=a2495b65cc18af240d04271a2a3453071fb09f90e028b55a1e9476140d7d5a4c; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 正确接受 repo-wide deployment handoff，保持完整依赖链路，并保留文档职责与交付授权边界；未发生仓库变更。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=520c4aa6ac767af388d73d9adeec0eb6b05a688f692c19decf65da48e498c67e; fixture_sha256=db76812ee462c1a8d89decf8e6fae581930c1406d7c6f72f3847172ed0bb02f3; output_sha256=e80d0fae90e2fbede53c3fdedb2153435e3fd7b579d28da924c65f3f9134493f; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Provides a reasonable generic deployment phase plan and preserves authorization boundaries, but does not name the required specialist dependency chain.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=520c4aa6ac767af388d73d9adeec0eb6b05a688f692c19decf65da48e498c67e; fixture_sha256=db76812ee462c1a8d89decf8e6fae581930c1406d7c6f72f3847172ed0bb02f3; output_sha256=5a91fff467039dd98742a5e05bacd46d77145dfb210bad075251052a186cae30; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 提供了较宽泛的阶段式部署建议和事实回交清单，但未明确要求的技能级依赖链路。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/devops/test/devops-agent/evals/workspace/eval-1-route-ci-readiness/comparison.md
+++ b/agents/devops/test/devops-agent/evals/workspace/eval-1-route-ci-readiness/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `01efe0f9d93680399a4e60a121c590987f01c7feeb295910c354e36c32f0a756` from `agents/devops/test/devops-agent/evals/workspace/eval-1-route-ci-readiness`.
 - Identity schema: `2`
-- target_skill_sha256: `e6fc9956005b4282420c83eedf1949e2502f3d3153bb3a8b79d34af6c3be8ac8`
+- target_skill_sha256: `a1710c0451d41ab9797a4d66831dae37e5e82aa02c99f954ebc420b99e5a6387`
 - eval_definition_sha256: `f7117f9350e70c8fb5cb6272bd6b59ffb1bebf3c95dfcda1ac024612c9eb455c`
 - metadata_sha256: `7dd2e52b200852fa05d4eb58b51c5b9cc7af5f7c62ced61947f3e3d4b9b7a2c0`
 - fixture_sha256: `01efe0f9d93680399a4e60a121c590987f01c7feeb295910c354e36c32f0a756`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `c7039dc2c9d829f51219a90df8027752cbbdaa32f7d8b6eb4b07c94a61b14320`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `0724714db74641157eee897f7a5f22bd3898815bc5861281390b10275748d63d`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `e9c0bd160ee98dcfdd0de591211716a54c99c4c9faa059d278ee1adcee41cdbf`
+- Skill overlay SHA-256: `c5943c0d67e9e26ad4dd0e60253b5aa5e23f43099b3302627e66a7b3dc2bec2e`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,22 +33,22 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `routes_primary_to_cicd` | PASS | With-skill output explicitly selects `cicd-bootstrap` first and identifies GitHub Actions PR checks as the current goal. |
-| `keeps_deployment_context` | PASS | With-skill output names `PM_HANDOFF.md` and `deploy/docker/README.md`, and states existing Docker deployment assets are the basis. |
-| `names_followups` | PASS | With-skill output names `env-config-auditor` for environment configuration auditing and `incident-playbook-writer` for rollback/runbook work. |
-| `does_not_run_all_skills` | PASS | With-skill output separates the primary route from follow-ups, excludes `deployment-planner`, and requests confirmation before proceeding to `cicd-bootstrap`. |
-| `does_not_write_workflow` | PASS | Locked git evidence shows no changes, and the output explicitly states no workflow/configuration was modified. |
+| `routes_primary_to_cicd` | PASS | With-skill output explicitly selects `cicd-bootstrap` as the current first step for the GitHub Actions PR gate. |
+| `keeps_deployment_context` | PASS | With-skill output cites `PM_HANDOFF.md` and `deploy/docker/README.md`, and states the plan is based on the existing `deploy/docker` image contract. |
+| `names_followups` | PASS | With-skill output explicitly names `env-config-auditor` for environment-variable coverage and `incident-playbook-writer` for rollback and incident documentation. |
+| `does_not_run_all_skills` | PASS | The output distinguishes the primary route from two follow-ups, while raw trace evidence shows routing/read-only inspection rather than execution of all specialist skills. |
+| `does_not_write_workflow` | PASS | The output states no configuration was modified; locked git evidence shows unchanged HEAD, empty diffs, no untracked files, and an empty delivery snapshot. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=0724714db74641157eee897f7a5f22bd3898815bc5861281390b10275748d63d; fixture_sha256=01efe0f9d93680399a4e60a121c590987f01c7feeb295910c354e36c32f0a756; output_sha256=3d76fb1fa7af950ef7816d7d4c08a1a3e08b32ef737385f112c7969369372810; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly routes the current request to `cicd-bootstrap`, preserves deployment context, names follow-up routes, and respects the no-modification boundary.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=0724714db74641157eee897f7a5f22bd3898815bc5861281390b10275748d63d; fixture_sha256=01efe0f9d93680399a4e60a121c590987f01c7feeb295910c354e36c32f0a756; output_sha256=36456dfc25c6db6b08dc9f1eeb8aaa5a80b7de495f030da7ecc643abb4fb4f38; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly routes the current work to `cicd-bootstrap`, preserves deployment context, names the two follow-ups, separates routing from execution, and respects the no-mutation boundary.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=0724714db74641157eee897f7a5f22bd3898815bc5861281390b10275748d63d; fixture_sha256=01efe0f9d93680399a4e60a121c590987f01c7feeb295910c354e36c32f0a756; output_sha256=f986f16e55d6f1b54cf0fd90186b7c5524e58682f820053f3d190dd14b8c5fac; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Provides a generic DevOps plan without selecting the required named primary route or follow-up routes.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=0724714db74641157eee897f7a5f22bd3898815bc5861281390b10275748d63d; fixture_sha256=01efe0f9d93680399a4e60a121c590987f01c7feeb295910c354e36c32f0a756; output_sha256=ca2a45fc2fc9ae4382261737ec205dc19026b3c32f698c4c06208a6da469c008; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Provides a fresh baseline that identifies the PR gate as current work and the environment and rollback items as follow-ups, but does not use the explicit specialist route names.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/devops/test/env-config-auditor/evals/workspace/eval-003-mapped-doc-config-audit/comparison.md
+++ b/agents/devops/test/env-config-auditor/evals/workspace/eval-003-mapped-doc-config-audit/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `d8b594c02acd54c63c782827a944b663d600d50c48ab45d0916be040dcdd3bf5` from `agents/devops/test/env-config-auditor/evals/workspace/eval-003-mapped-doc-config-audit`.
 - Identity schema: `2`
-- target_skill_sha256: `a8f87afda76c64d983a7b5f9d6a3f49bd751951e01d3714fb0439b6add7757ba`
+- target_skill_sha256: `bd10ad28cda2e258647de2487fc41636124b4b1a48dc9f75b2dda06e6bfc2473`
 - eval_definition_sha256: `745b306831066bee2a7ff3a7b48abf881c1196cfdb1e28206ff9239f069e955c`
 - metadata_sha256: `a409117cbc37644389cd1b3fee7ddaa2ea9110d0eb3d552191443a51d68ee791`
 - fixture_sha256: `d8b594c02acd54c63c782827a944b663d600d50c48ab45d0916be040dcdd3bf5`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `b79f24622b9644bbd1fa788251bd901e2da05ea7b38df10e90eb31488aa20956`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `79bb3dd33873d6df8baf21e6b0c5f2908c29f5d530191b5eb998f51613f0fe2f`
+- Skill overlay SHA-256: `204b02cf02ba29acba94a8f2b9d77989cc545ccad0b3e283133a98976ab6ca74`
 - Behavior result: **FAIL**
 - Coverage result: **FULL**
 Overall result: FAIL
@@ -33,26 +33,25 @@ Overall result: FAIL
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `reads_mapped_docs_first` | FAIL | Raw trace shows the candidate read runtime-config.md before reading change-map.yaml, so it did not establish the required map-guided order. |
-| `verifies_against_code` | FAIL | The with_skill output explicitly says it had not read src/config/required.env and made no API_TOKEN conclusion. |
-| `treats_unverified_as_low_trust` | PASS | The candidate identified last_verified_version: unverified, treated the documentation as low trust, and declined to rely on it alone. |
+| `reads_mapped_docs_first` | FAIL | With-skill trace reads skill and handoff-contract files first, then stops; it never reads the mapped runtime-config document. |
+| `verifies_against_code` | FAIL | With-skill output does not read or report src/config/required.env, the documented optional declaration, or the required-vs-optional conflict; it incorrectly blocks on an unsupported handoff prerequisite. |
+| `treats_unverified_as_low_trust` | FAIL | With-skill output does not identify last_verified_version: unverified or apply the required low-trust treatment. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=b79f24622b9644bbd1fa788251bd901e2da05ea7b38df10e90eb31488aa20956; fixture_sha256=d8b594c02acd54c63c782827a944b663d600d50c48ab45d0916be040dcdd3bf5; output_sha256=ea5599bb065f4b4aa70ca1faddb2c1b5c19e89f5a3e87e950eb14bee3d2c6837; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly recognized the mapped document and its unverified status, but incorrectly blocked execution and failed to inspect the code fixture or complete the audit.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=b79f24622b9644bbd1fa788251bd901e2da05ea7b38df10e90eb31488aa20956; fixture_sha256=d8b594c02acd54c63c782827a944b663d600d50c48ab45d0916be040dcdd3bf5; output_sha256=36d0362f593f1e83f8a9ab573f8efb84550ac3e0f7a11cb52a50e9111404ba23; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Incorrectly returned to PM without auditing the supplied configuration evidence.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=b79f24622b9644bbd1fa788251bd901e2da05ea7b38df10e90eb31488aa20956; fixture_sha256=d8b594c02acd54c63c782827a944b663d600d50c48ab45d0916be040dcdd3bf5; output_sha256=261beabbe5bb52c3af575905084b92b5ec870f020091dc1005996d5c08b42eb2; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Completed the audit, compared the documentation with src/config/required.env, identified the contradiction, and noted the limitation that runtime rejection was not independently verified.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=b79f24622b9644bbd1fa788251bd901e2da05ea7b38df10e90eb31488aa20956; fixture_sha256=d8b594c02acd54c63c782827a944b663d600d50c48ab45d0916be040dcdd3bf5; output_sha256=e3a5498b2e77d9a772e3172ae1b5b18fbebfd5f5bdc4844dbfd1af172e281287; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline correctly mapped the documentation, verified the required declaration, and treated unverified documents as conflicting low-trust evidence.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- The with_skill lane stopped at an unsupported handoff gate and omitted the requested code-versus-documentation audit.
-- It failed to verify API_TOKEN against src/config/required.env and did not report the required discrepancy and configuration risk.
+- All three with_skill assertions fail: the candidate did not perform the requested fixture audit or provide its required conclusions.
 - Next: None.
 
 ## Runtime Artifact Policy

--- a/agents/devops/test/env-config-auditor/evals/workspace/eval-004-docs-entry-access-audit/comparison.md
+++ b/agents/devops/test/env-config-auditor/evals/workspace/eval-004-docs-entry-access-audit/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `2af9780db4417e1c98550fa0f1ac701b6027949cee7ad798872f862a34631218` from `agents/devops/test/env-config-auditor/evals/workspace/eval-004-docs-entry-access-audit`.
 - Identity schema: `2`
-- target_skill_sha256: `a8f87afda76c64d983a7b5f9d6a3f49bd751951e01d3714fb0439b6add7757ba`
+- target_skill_sha256: `bd10ad28cda2e258647de2487fc41636124b4b1a48dc9f75b2dda06e6bfc2473`
 - eval_definition_sha256: `7e8fed3827f899b24fa32a7e47350d1b61d93c36648369ee6fefd2624963c060`
 - metadata_sha256: `677e94c942760005f41ea164933b85cc762b6c8428640c65d6becfb051027269`
 - fixture_sha256: `2af9780db4417e1c98550fa0f1ac701b6027949cee7ad798872f862a34631218`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `10734badb795d9dd2c7f522212860a120a71a582b6fdcf439619f31f19b4904f`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `d0a4d782a855fc779a0b6ac4bae5494cbfe62706b00fe098bafa54a0f2523712`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `79bb3dd33873d6df8baf21e6b0c5f2908c29f5d530191b5eb998f51613f0fe2f`
+- Skill overlay SHA-256: `204b02cf02ba29acba94a8f2b9d77989cc545ccad0b3e283133a98976ab6ca74`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,26 +33,26 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `audits_public_and_internal_access` | PASS | with_skill 的交付快照包含 staging/production × Public/Internal 矩阵，逐项记录 Public 的 DNS/TLS，以及 Internal 的认证/网络限制；缺失项标为 unknown。 |
-| `audits_runtime_environment_differences` | PASS | 交付文件覆盖端口、探针、Service/Ingress/Gateway、secret/config 引用，并比较 staging/production 及 local/Docker/Helm/CI/CD 配置差异；无法核验的具体值均标为 unknown。 |
-| `does_not_overclaim_missing_evidence` | PASS | 报告明确区分文档陈述与独立运行时证据，未将域名、Service 或状态文档等同于 readiness；Production Internal 访问控制、Production Public 证书和探针等均保留为 unknown，并说明审计限制。 |
+| `audits_public_and_internal_access` | PASS | The locked deploy/ENV_AUDIT.md contains a four-row matrix covering Staging/Production × Public/Internal, with Public DNS/TLS and Internal authentication/network restriction evidence fields. |
+| `audits_runtime_environment_differences` | PASS | The locked report explicitly covers ports, probes/health, Service/Ingress/Gateway, secret/config references, environment differences, and local/Docker/Helm/CI/CD coverage, marking unavailable items unknown. |
+| `does_not_overclaim_missing_evidence` | PASS | The report defines unknown as unavailable evidence, states that documented configuration or domains do not prove reachability, certificate validity, probe success, or effective access control, and limits formal-document follow-up to verified facts and unresolved owners. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=d0a4d782a855fc779a0b6ac4bae5494cbfe62706b00fe098bafa54a0f2523712; fixture_sha256=2af9780db4417e1c98550fa0f1ac701b6027949cee7ad798872f862a34631218; output_sha256=f2cd329abb4ef7fdf5aec51d14a68595a36a81f33b401a530380f0585da4804d; snapshot_sha256=ff8ab2806cc242ef8de99298c629e6962716dbf4b11e5c2408a903305ae7179d
-- Behavior: 完成了全面的四入口审计和环境差异/配置覆盖，并谨慎标注缺失证据；但执行了文件写入，违反只读范围。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=d0a4d782a855fc779a0b6ac4bae5494cbfe62706b00fe098bafa54a0f2523712; fixture_sha256=2af9780db4417e1c98550fa0f1ac701b6027949cee7ad798872f862a34631218; output_sha256=24cb5152a97c7479788d21dbd472ab7a872110dcafd27eda584bcbf56b8d7193; snapshot_sha256=e677227717a706565a0f101330445a150a40f02bd093ba1384e5a7a1bc6eceed
+- Behavior: Produced a durable, read-only environment audit covering all four runtime variants and clearly separating confirmed evidence from unknowns.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=d0a4d782a855fc779a0b6ac4bae5494cbfe62706b00fe098bafa54a0f2523712; fixture_sha256=2af9780db4417e1c98550fa0f1ac701b6027949cee7ad798872f862a34631218; output_sha256=2a522bf7dcddae3571c818fe6a30cf41ac8175e5ac529e984248a3aa5b293d93; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 提供了基于唯一状态文档的四入口审计，覆盖较简略但同样区分已声明事实与未知项，未产生交付文件或工作区变更。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=d0a4d782a855fc779a0b6ac4bae5494cbfe62706b00fe098bafa54a0f2523712; fixture_sha256=2af9780db4417e1c98550fa0f1ac701b6027949cee7ad798872f862a34631218; output_sha256=3a2bf611be8cddd12c225553e947b922d94a0b4571e31b116e06156d89bdd449; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Provided a correct comparison audit in final prose but did not produce a durable audit file.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- 用户要求只读审计，但 with_skill 创建了未跟踪文件 deploy/ENV_AUDIT.md，构成工作区写入。
-- Next: 在不修改工作区的前提下提供审计结果，或明确授权将报告写入文件。
+- None.
+- Next: None.
 
 ## Runtime Artifact Policy
 

--- a/agents/devops/test/env-config-auditor/workspace/eval-002-feature-path-audit/comparison.md
+++ b/agents/devops/test/env-config-auditor/workspace/eval-002-feature-path-audit/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `a481b5374544e745048b6d91a89eb4240f2b8d26afa6409ed21d0c822a29f8c9` from `agents/devops/test/env-config-auditor/workspace/eval-002-feature-path-audit`.
 - Identity schema: `2`
-- target_skill_sha256: `a8f87afda76c64d983a7b5f9d6a3f49bd751951e01d3714fb0439b6add7757ba`
+- target_skill_sha256: `bd10ad28cda2e258647de2487fc41636124b4b1a48dc9f75b2dda06e6bfc2473`
 - eval_definition_sha256: `6efcde24d7900ac81923c70a8eb454a7b5687569fc19e166e7a2702223bf20b8`
 - metadata_sha256: `a6f26a1c1a485f7dbf9e2865de88e63a6a0a2eb7d377da72745f70ba089eff96`
 - fixture_sha256: `a481b5374544e745048b6d91a89eb4240f2b8d26afa6409ed21d0c822a29f8c9`
@@ -22,37 +22,37 @@
 - judge_schema_sha256: `542a3960b92dfab31d619dba36f1b4cd7435eaeb67ca74c65c1e8dc7cd584d0a`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `45dd97708d4498ba2c5e31fb882b1692d7db80756c144b5c54d249bddbdf8a4b`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `79bb3dd33873d6df8baf21e6b0c5f2908c29f5d530191b5eb998f51613f0fe2f`
+- Skill overlay SHA-256: `204b02cf02ba29acba94a8f2b9d77989cc545ccad0b3e283133a98976ab6ca74`
 - Behavior result: **PASS**
-- Coverage result: **PARTIAL**
-Overall result: PASS (partial coverage)
+- Coverage result: **FULL**
+Overall result: PASS
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `uses_confirmed_feature_path` | PASS | with_skill 的锁定 trace 直接显示读取并输出了确认路径下的 TRD.md 与 IMPLEMENTATION_PLAN.md。 |
-| `writes_nested_devops_report` | NOT_EXERCISED | with_skill 未交付报告文件，而是明确等待 PM/DevOps 交接确认后再写入该路径；后续写入步骤尚未可执行。 |
-| `does_not_invent_feature_directory` | PASS | with_skill 未创建任何同义顶层目录或错误报告文件，并提出了正确的嵌套 DevOps 路径。 |
+| `uses_confirmed_feature_path` | PASS | With-skill trace shows the feature-path documents were enumerated and read; the locked report records the confirmed feature_path and both Engineer document paths. |
+| `writes_nested_devops_report` | PASS | The locked delivery snapshot contains docs/devops/chat-interface/messages/history/search/ENV_AUDIT.md, and the candidate output links to that exact nested path. |
+| `does_not_invent_feature_directory` | PASS | The feature_path and same-path TRD/IMPLEMENTATION_PLAN are present and used; the with-skill snapshot creates the required nested DevOps path and no invented synonym directory. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=45dd97708d4498ba2c5e31fb882b1692d7db80756c144b5c54d249bddbdf8a4b; fixture_sha256=a481b5374544e745048b6d91a89eb4240f2b8d26afa6409ed21d0c822a29f8c9; output_sha256=47c8a400532d2a8f8a3ef7b72d67639d1c9e539b70e1c1409f597d8fe926ee2b; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 读取了确认功能路径及其工程文档，按准入条件暂停并请求补充交接，未产生错误目录或报告。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=45dd97708d4498ba2c5e31fb882b1692d7db80756c144b5c54d249bddbdf8a4b; fixture_sha256=a481b5374544e745048b6d91a89eb4240f2b8d26afa6409ed21d0c822a29f8c9; output_sha256=a072d1292c4f55d69a62fd4764d7040ebecf99acfb65f5a941f4d77255068d7c; snapshot_sha256=7df6f899b2e171156e981a151f81f61d20c3e34dd8b44dcf74c750a1f35671b8
+- Behavior: Used the confirmed feature path, read the required Engineer documents, and delivered the audit at the required nested DevOps path.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=45dd97708d4498ba2c5e31fb882b1692d7db80756c144b5c54d249bddbdf8a4b; fixture_sha256=a481b5374544e745048b6d91a89eb4240f2b8d26afa6409ed21d0c822a29f8c9; output_sha256=430ddade75a3466dfbb81eb130598737f2cb38bae17d2362a1941d38f472328e; snapshot_sha256=27de5e5bf95a620508c3ba21970ede7648cb6f28bcf95d3568da40c961c28275
-- Behavior: 直接完成审计并写入了错误的 Engineer 路径 CONFIG_AUDIT.md，而非要求的嵌套 DevOps 路径。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=45dd97708d4498ba2c5e31fb882b1692d7db80756c144b5c54d249bddbdf8a4b; fixture_sha256=a481b5374544e745048b6d91a89eb4240f2b8d26afa6409ed21d0c822a29f8c9; output_sha256=bd4dfd10a4b8a35af1cb144b4f60a986eebe30eca5f4b66b2a820cca6060d04e; snapshot_sha256=2759b6d34787d8d0e068e19043dc2cdb463ecc85e0f9115a0f4b878f0d701fa4
+- Behavior: Produced an audit under the wrong Engineer documentation path instead of the required nested DevOps path.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: 补充并确认 PM/DevOps 交接后，执行审计并交付嵌套 ENV_AUDIT.md。
+- Next: None.
 
 ## Runtime Artifact Policy
 

--- a/agents/devops/test/env-config-auditor/workspace/iteration-1/eval-1-missing-variables/comparison.md
+++ b/agents/devops/test/env-config-auditor/workspace/iteration-1/eval-1-missing-variables/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `4e6c22cd2abded0cbcf31007050064d16e8cb14c8ccdda445c9587853833ba57` from `agents/devops/test/env-config-auditor/workspace/iteration-1/eval-1-missing-variables`.
 - Identity schema: `2`
-- target_skill_sha256: `a8f87afda76c64d983a7b5f9d6a3f49bd751951e01d3714fb0439b6add7757ba`
+- target_skill_sha256: `bd10ad28cda2e258647de2487fc41636124b4b1a48dc9f75b2dda06e6bfc2473`
 - eval_definition_sha256: `5217a2bb49f0b8e0ba081e4029f81b07efd6b07af9fb34ce9773ecbde5d00a5b`
 - metadata_sha256: `44155614dff76be09dfa5bcf55f66a5294433bd6eedc45d0d67dd22dcd2225eb`
 - fixture_sha256: `4e6c22cd2abded0cbcf31007050064d16e8cb14c8ccdda445c9587853833ba57`
@@ -22,37 +22,37 @@
 - judge_schema_sha256: `7c0e897fa2e11e667f833a3bbf2e28e35b1c65790975d953ea93444f623ad66b`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `75e60dc10eb3fef811146cbd4dcc0df487be3bd537e40cef0747bad2cca106cf`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `79bb3dd33873d6df8baf21e6b0c5f2908c29f5d530191b5eb998f51613f0fe2f`
-- Behavior result: **PASS**
-- Coverage result: **PARTIAL**
-Overall result: PASS (partial coverage)
+- Skill overlay SHA-256: `204b02cf02ba29acba94a8f2b9d77989cc545ccad0b3e283133a98976ab6ca74`
+- Behavior result: **FAIL**
+- Coverage result: **FULL**
+Overall result: FAIL
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `creates_durable_config_audit` | NOT_EXERCISED | with_skill stopped at the documented missing PM/DevOps handoff gate and did not create a report; the required artifact was therefore not exercised. |
-| `compares_code_deploy_and_cicd` | NOT_EXERCISED | with_skill did not reach the audit comparison because the required handoff was missing. |
-| `keeps_secrets_and_unknowns_honest` | NOT_EXERCISED | with_skill did not reach secret/Helm/unknown analysis because the required handoff was missing. |
+| `creates_durable_config_audit` | FAIL | With-skill output explicitly declines the requested audit and no delivery_snapshot for deploy/ENV_AUDIT.md exists. |
+| `compares_code_deploy_and_cicd` | FAIL | With-skill trace stops at the handoff gate and performs no comparison or report generation; the requested Docker/CI and Helm findings are absent. |
+| `keeps_secrets_and_unknowns_honest` | FAIL | No secret value is written, but the with-skill lane produces no audit recording Helm as missing/unknown or the incomplete readiness state. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=75e60dc10eb3fef811146cbd4dcc0df487be3bd537e40cef0747bad2cca106cf; fixture_sha256=4e6c22cd2abded0cbcf31007050064d16e8cb14c8ccdda445c9587853833ba57; output_sha256=0512c65d8c49ee5aa9e1c16e2d2be28a97ff1749afdbde1898f368113c5307cc; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly stopped at the missing-handoff gate and requested PM classification; no audit delivery occurred.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=75e60dc10eb3fef811146cbd4dcc0df487be3bd537e40cef0747bad2cca106cf; fixture_sha256=4e6c22cd2abded0cbcf31007050064d16e8cb14c8ccdda445c9587853833ba57; output_sha256=76ac090df03da6cbebe8f9fb22467860115b8d362820c72c9ad2647e148d79ee; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Stops at a PM/DevOps handoff gate; no audit is performed and no file is delivered.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=75e60dc10eb3fef811146cbd4dcc0df487be3bd537e40cef0747bad2cca106cf; fixture_sha256=4e6c22cd2abded0cbcf31007050064d16e8cb14c8ccdda445c9587853833ba57; output_sha256=9c9f81a2c29521bc3156a6bc59a2ed1189f2f24202209758956240edb49b7cf1; snapshot_sha256=671eb075a9e2124b720bb9234113da6d1a629fc58381e04f30c20fd1f00a0368
-- Behavior: Produced a detailed audit with correct variable findings, but delivered it as ENV_CONFIG_AUDIT.md rather than the requested deploy/ENV_AUDIT.md.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=75e60dc10eb3fef811146cbd4dcc0df487be3bd537e40cef0747bad2cca106cf; fixture_sha256=4e6c22cd2abded0cbcf31007050064d16e8cb14c8ccdda445c9587853833ba57; output_sha256=5c78cb0dbb5cead6fe5ab40fa67c4201d08a2b1641fd52669170b0ec6f9df437; snapshot_sha256=5fe5f731911d70c22e391db003afde6847a52b8b4ed5800379587889209d7b2f
+- Behavior: Creates a durable audit under docs/environment-config-audit.md with a variable matrix, evidence sources, risks, recommendations, and honest runtime limitations.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- None.
-- Next: Provide the required PM/DevOps handoff, then rerun the audit to exercise all assertions.
+- The with-skill lane incorrectly blocks a directly requested repository-level audit on an unavailable handoff packet and delivers no requested artifact or findings.
+- Next: None.
 
 ## Runtime Artifact Policy
 

--- a/agents/devops/test/incident-playbook-writer/evals/workspace/eval-001-docker-rollback/comparison.md
+++ b/agents/devops/test/incident-playbook-writer/evals/workspace/eval-001-docker-rollback/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `f3b605dee7b400a16cee380181367beb6aef0898c3081a8e6f89abd9e2c19e1a` from `agents/devops/test/incident-playbook-writer/evals/workspace/eval-001-docker-rollback`.
 - Identity schema: `2`
-- target_skill_sha256: `50cae2b4bb9c10d0d200f08d68ca4dd9d27b329f1a2b94cb2b8cb7333b3815ce`
+- target_skill_sha256: `dcee4cc39c2fa28ea4046f8b10ceca0528d9458efc81ffb2c28e21e284fe034f`
 - eval_definition_sha256: `ef78ea6924e16ad4c29c668948468977eb007b3ff9fb4e26733caf7d332c338d`
 - metadata_sha256: `fe85f6eb6336802a8ad0f9268aaeda74d6a32f5dafcd0a67b8753f30859c10b1`
 - fixture_sha256: `f3b605dee7b400a16cee380181367beb6aef0898c3081a8e6f89abd9e2c19e1a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `82478d5bfcdfccbe67817c9bfae394096b57b2c317a4413eadf1808b946de6d0`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `f9cbfa543cb8f8fa6c3d3f1e68b0eaa1e627427917cfa9b9970e909922356673`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `f3eab55f60df9bb2b74211b8616c657af594a2e8a1c83328a335347ab9dd3bf1`
+- Skill overlay SHA-256: `5d95ff5039100f2131c72122b091ff4a172f65d45070290345e8a658862159d4`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,21 +33,21 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `creates_evidence_based_rollback` | PASS | with_skill 的 deploy/ROLLBACK.md 使用 release record 的已知健康不可变 SemVer tag，设置 APP_IMAGE_TAG，执行 pull 与 up -d app，并核对 ps、日志和 /health。 |
-| `creates_scoped_incident_response` | PASS | with_skill 的 deploy/INCIDENT_RESPONSE.md 明确 P1/P2 的 15/30 分钟响应目标、#ops-incidents、incident commander、service owner，以及调查、恢复和恢复后关闭检查。 |
-| `avoids_unsupported_procedures` | PASS | 文档明确排除数据库 migration 回滚和未确认 tag；locked raw evidence 显示未执行实际 Docker 回滚或服务变更。 |
-| `omits_unrequested_playbooks` | PASS | with_skill 仅交付 deploy/ROLLBACK.md 与 deploy/INCIDENT_RESPONSE.md，未生成 TROUBLESHOOTING.md 或 ON_CALL.md。 |
+| `creates_evidence_based_rollback` | PASS | Locked deploy/ROLLBACK.md uses a release-record known-healthy immutable SemVer tag, sets APP_IMAGE_TAG, runs compose pull and up -d for app, then checks ps, logs, and /health. |
+| `creates_scoped_incident_response` | PASS | Locked deploy/INCIDENT_RESPONSE.md specifies P1/P2 response targets, #ops-incidents, incident commander and service owner roles, investigation evidence collection, restoration, and closeout checks. |
+| `avoids_unsupported_procedures` | PASS | The delivered manuals explicitly exclude database migration rollback and unsupported operations; raw trace shows no executed rollback or deployment command. |
+| `omits_unrequested_playbooks` | PASS | The with_skill delivery snapshot and git status contain only deploy/ROLLBACK.md and deploy/INCIDENT_RESPONSE.md; no troubleshooting or on-call playbook was created. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f9cbfa543cb8f8fa6c3d3f1e68b0eaa1e627427917cfa9b9970e909922356673; fixture_sha256=f3b605dee7b400a16cee380181367beb6aef0898c3081a8e6f89abd9e2c19e1a; output_sha256=ee78d902dc17f26228b5246679bb2972afaab4d299f4ced03c5e9f0229268c95; snapshot_sha256=91287b3bd3583a190f3083564ca9a118eee8bffde378cd4cd8004d1ff76ae2cd
-- Behavior: 生成了两份基于现有 Docker Compose 契约的目标手册，范围受控且未执行实际回滚。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f9cbfa543cb8f8fa6c3d3f1e68b0eaa1e627427917cfa9b9970e909922356673; fixture_sha256=f3b605dee7b400a16cee380181367beb6aef0898c3081a8e6f89abd9e2c19e1a; output_sha256=ad57d84222b20be985d8333050da2af7d5ad0cbafe1672ed3e09fd35de499283; snapshot_sha256=dc9eddb4825642f9738002d6a920fac6ae524c655b7d705b6031c4455b7b3d33
+- Behavior: Delivered both requested evidence-backed manuals, scoped to the confirmed Docker Compose app surface, without executing rollback.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f9cbfa543cb8f8fa6c3d3f1e68b0eaa1e627427917cfa9b9970e909922356673; fixture_sha256=f3b605dee7b400a16cee380181367beb6aef0898c3081a8e6f89abd9e2c19e1a; output_sha256=7ebc940f19b13782e4a0f9c7ed550ec59aa60ff82ee7d603fbd889ea7adf8cf0; snapshot_sha256=ff8ec10450fe4d191db0ef828cf1a41a967c6d82d0b7d0d5381d619ad4648b44
-- Behavior: 同样生成了两份符合要求的手册，作为 fresh baseline 与 with_skill 行为基本一致。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f9cbfa543cb8f8fa6c3d3f1e68b0eaa1e627427917cfa9b9970e909922356673; fixture_sha256=f3b605dee7b400a16cee380181367beb6aef0898c3081a8e6f89abd9e2c19e1a; output_sha256=4bdb32ca27d5ebd53306ac21c83509d4964d9ddb476bb4747c2ef326de46c563; snapshot_sha256=3113709fe1afdbaf7fe25888dd5e14520e3b0996902e51cf11b59dd1b9e2d29e
+- Behavior: Also delivered the two requested manuals and avoided unrequested playbooks and rollback execution; broadly similar baseline behavior.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/devops/test/incident-playbook-writer/evals/workspace/eval-002-mapped-doc-incident-playbook/comparison.md
+++ b/agents/devops/test/incident-playbook-writer/evals/workspace/eval-002-mapped-doc-incident-playbook/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `cd9e0e84ed5447d0b5fbaab481b132d7d6de821290e56efdee5b00d1661c9bf7` from `agents/devops/test/incident-playbook-writer/evals/workspace/eval-002-mapped-doc-incident-playbook`.
 - Identity schema: `2`
-- target_skill_sha256: `50cae2b4bb9c10d0d200f08d68ca4dd9d27b329f1a2b94cb2b8cb7333b3815ce`
+- target_skill_sha256: `dcee4cc39c2fa28ea4046f8b10ceca0528d9458efc81ffb2c28e21e284fe034f`
 - eval_definition_sha256: `56f66c660609712980bbe29e190d00dff6d36c67cb844c6b5e1aa3d336dcd314`
 - metadata_sha256: `c28ce2010bd179e2122284ba3710d5b5dd600f47e70a10f6ca7f48b43c5aac3a`
 - fixture_sha256: `cd9e0e84ed5447d0b5fbaab481b132d7d6de821290e56efdee5b00d1661c9bf7`
@@ -22,37 +22,37 @@
 - judge_schema_sha256: `6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `27a471d4180c030327b87d22f79174352fdeffbbaace399da8cf913275d6b17e`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `f3eab55f60df9bb2b74211b8616c657af594a2e8a1c83328a335347ab9dd3bf1`
-- Behavior result: **PASS**
-- Coverage result: **PARTIAL**
-Overall result: PASS (partial coverage)
+- Skill overlay SHA-256: `5d95ff5039100f2131c72122b091ff4a172f65d45070290345e8a658862159d4`
+- Behavior result: **FAIL**
+- Coverage result: **FULL**
+Overall result: FAIL
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `reads_mapped_docs_first` | NOT_EXERCISED | with_skill stopped at its PM/DevOps handoff gate before inspecting repository documents; read-order execution was not reached. |
-| `verifies_against_code` | NOT_EXERCISED | with_skill did not inspect src/runtime/health.rules or produce threshold guidance because the required handoff context was absent. |
-| `treats_unverified_as_low_trust` | NOT_EXERCISED | with_skill did not reach operational guidance generation, so handling of the unverified document could not be exercised. |
+| `reads_mapped_docs_first` | FAIL | with_skill trace shows multiple skill/handoff scans before the command that reads `docs/site/api/runtime-health.md`; that command reads the change map first, so the required mapped-document-first order is contradicted. |
+| `verifies_against_code` | PASS | The with_skill output explicitly distinguishes the document's 3-failure claim from `src/runtime/health.rules`'s 5-failure threshold and explains that the stale document would delay detection, escalation, and rollback. |
+| `treats_unverified_as_low_trust` | PASS | The with_skill output treats `last_verified_version: unverified` as low-trust navigation, uses the code value for the alert threshold, and refuses to invent rollback commands because no deployment or rollback evidence exists. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=27a471d4180c030327b87d22f79174352fdeffbbaace399da8cf913275d6b17e; fixture_sha256=cd9e0e84ed5447d0b5fbaab481b132d7d6de821290e56efdee5b00d1661c9bf7; output_sha256=f3e2c8a6f1249005a510933f97cb04ee1a8a935c16409c64a874b43e2aa6bd7e; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly stopped at the specialist entry gate and requested the required handoff context; no repository mutation occurred.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=27a471d4180c030327b87d22f79174352fdeffbbaace399da8cf913275d6b17e; fixture_sha256=cd9e0e84ed5447d0b5fbaab481b132d7d6de821290e56efdee5b00d1661c9bf7; output_sha256=350a44d322a8f9e88ce0f7cbed4c3fa88bce7639d35c91aceae0c61fc79c70af; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly verified the 3-versus-5 threshold discrepancy, described its operational impact, and treated unverified documentation as low trust, but blocked the runbook and read the mapped document too late.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=27a471d4180c030327b87d22f79174352fdeffbbaace399da8cf913275d6b17e; fixture_sha256=cd9e0e84ed5447d0b5fbaab481b132d7d6de821290e56efdee5b00d1661c9bf7; output_sha256=6cba89a4d0faab106e930c9fd2c42e6ab9754e263f9ec5ab6aecbe08e0063b12; snapshot_sha256=a19e52e9415a4bdaf4bde9822d98b92c8123411d4426e3eeee062e0efca7a1c8
-- Behavior: Read the mapped documentation and code, identified the 3-versus-5 threshold mismatch, and delivered an updated health document with response and rollback guidance.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=27a471d4180c030327b87d22f79174352fdeffbbaace399da8cf913275d6b17e; fixture_sha256=cd9e0e84ed5447d0b5fbaab481b132d7d6de821290e56efdee5b00d1661c9bf7; output_sha256=defc2603df307ceb96e283d7c81fb767936c6a65046cdd420ba2a077bc451819; snapshot_sha256=e249b7f8fdcccc2a1ee0dbf4d498ab29650bd4e844de112e31c6ef0ba315d93a
+- Behavior: Created and delivered an updated health document with threshold correction and minimal incident/rollback guidance; comparison-only context.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- None.
-- Next: Provide the confirmed PM/DevOps handoff packet, then perform the repository verification and documentation update.
+- The with_skill lane violated the required mapped-document-first read order.
+- Next: Read `docs/site/api/runtime-health.md` immediately after identifying the code target, then verify its claims against `src/runtime/health.rules` and available rollback evidence.
 
 ## Runtime Artifact Policy
 

--- a/agents/docs/skills/docs-agent/SKILL.md
+++ b/agents/docs/skills/docs-agent/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: docs-agent
-description: "Classify and route confirmed formal-documentation requests for site bootstrap, current-state sync/backfill, screenshot-based manuals, site Release Notes, and release audit. Use immediately after a PM docs handoff and preserve its complete context before delegating."
+description: "Route confirmed formal-documentation work for site bootstrap, current-state sync, illustrated manuals, site Release Notes, or release audit. Use after a PM docs handoff."
 visibility: internal
 ---
 

--- a/agents/docs/skills/docs-audit/SKILL.md
+++ b/agents/docs/skills/docs-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: docs-audit
-description: "Audit formal documentation against code, tests, Git objects, version surfaces, and raw manual-page evidence for bounded, pre-tag, or post-tag verification. Use after docs-agent supplies a confirmed audit basis and target version."
+description: "Audit formal documentation against code, tests, Git objects, version facts, and raw manual evidence for bounded pre-tag or post-tag verification. Use after docs-agent routes a confirmed version audit."
 visibility: internal
 ---
 

--- a/agents/docs/skills/docs-site-bootstrap/SKILL.md
+++ b/agents/docs/skills/docs-site-bootstrap/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: docs-site-bootstrap
-description: "Initialize, verify, or safely re-run the formal documentation-site scaffold in a confirmed host repository, including integration choices and idempotency checks. Use after docs-agent routes an explicit bootstrap request."
+description: "Initialize, verify, or safely re-run a formal documentation-site scaffold in a confirmed host repository. Use after docs-agent routes site bootstrap."
 visibility: internal
 ---
 

--- a/agents/docs/skills/formal-docs-sync/SKILL.md
+++ b/agents/docs/skills/formal-docs-sync/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: formal-docs-sync
-description: "Synchronize or plan bounded backfill of current-state API, database, design, ops, and product docs from confirmed feature, deployment, or release evidence. Use after docs-agent routes a complete sync basis."
+description: "Synchronize or plan bounded backfill of current API, database, design, ops, and product documentation from confirmed evidence. Use after docs-agent routes formal documentation sync."
 visibility: internal
 ---
 

--- a/agents/docs/skills/manual-gen/SKILL.md
+++ b/agents/docs/skills/manual-gen/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: manual-gen
-description: "Generate or update illustrated user operation manuals from screenshots and verified navigation in a real running interface. Use after docs-agent confirms the documentation-site and runtime-access gates."
+description: "Create or update illustrated user manuals from screenshots and verified navigation in a running interface. Use after docs-agent confirms the documentation site and runtime access."
 visibility: internal
 ---
 

--- a/agents/docs/skills/release-notes-gen/SKILL.md
+++ b/agents/docs/skills/release-notes-gen/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release-notes-gen
-description: "Generate, preview, confirm, index, and validate a host documentation site's versioned Release Notes before GitHub Release work. Use after docs-agent routes confirmed version facts and release evidence."
+description: "Generate and validate a documentation site's versioned Release Notes, metadata, and index before GitHub Release work. Use after docs-agent routes confirmed release evidence."
 visibility: internal
 ---
 

--- a/agents/docs/test/docs-agent/evals/workspace/eval-001-route-formal-docs-sync/comparison.md
+++ b/agents/docs/test/docs-agent/evals/workspace/eval-001-route-formal-docs-sync/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `5bfe584ec04ca9f6271a87eb0a6a94432a493cce40c865cd7e77c63d4d5a5991` from `agents/docs/test/docs-agent/evals/workspace/eval-001-route-formal-docs-sync`.
 - Identity schema: `2`
-- target_skill_sha256: `cf826e2e86ef193d8a7294a87c743dead6af892aefcc220dd56ae949fa5c3b40`
+- target_skill_sha256: `023cc6d8aa109db6ff7dcd662df567ae4f0c79dddb66dfe7bcf6f1eb91d20f39`
 - eval_definition_sha256: `b7962cc5c7265d8b3c4f799e1e809f203d9b09d09c3950072c84712c7db0c562`
 - metadata_sha256: `320948f19ccb8c159c24fdc827ddc592aac02ee3f64236dd9e4896bae8e4979e`
 - fixture_sha256: `5bfe584ec04ca9f6271a87eb0a6a94432a493cce40c865cd7e77c63d4d5a5991`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `d9120b553be3673816559c0b102ba0210980dbae3daaf9eeba42b66ee4308ec2`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `e48b238fe72b5801d36c88005426156c8c6d404e006c5bccb655f20f86d8f497`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `4a886ffdcb18b30d43dbd2f9ee95780d97f9d5daf71fdddfd34bccc37d3c110d`
+- Skill overlay SHA-256: `84e19c3e634cfde176d2ff20ba8e9d25a4838db3ed1deb5def94a8d0f1d2ddd9`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,21 +33,21 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `routes_to_formal_docs_sync` | PASS | with_skill 明确选择 `formal-docs-sync`，并标注为 Feature delivery；范围为搜索 API 当前状态，排除数据库、Ops、Release 文档。 |
-| `preserves_handoff_context` | PASS | with_skill 保留并概述 `pm-handoff.md` 的变更级别、功能路径、PRD/TRD/实施计划、实现与合同测试证据、正式 API 页面及 change-map 输出范围和风险说明。 |
-| `points_to_authoritative_gate` | PASS | with_skill 将后续核验和同步交给 `formal-docs-sync`，明确 Router 不修改文档；未暴露本地 SKILL.md 路径或复制完整同步协议。 |
-| `stops_at_router_boundary` | PASS | with_skill 明确当前 Router 未修改任何文档；锁定 git evidence 显示工作区和 HEAD 均未变化。 |
+| `routes_to_formal_docs_sync` | PASS | With-skill output explicitly routes the confirmed delivery handoff to `formal-docs-sync` and excludes bootstrap, database, ops, and Release documentation routes. |
+| `preserves_handoff_context` | PASS | With-skill output preserves the `search/api-query` scope, required formal API page and change-map outputs, source evidence, exclusions, and blocker state without requiring field-by-field repetition. |
+| `points_to_authoritative_gate` | PASS | With-skill output names `formal-docs-sync` as the next executor, keeps this turn read-only, exposes no local skill path, and does not reproduce the detailed sync protocol or map-writing procedure. |
+| `stops_at_router_boundary` | PASS | With-skill delivery snapshot and git evidence show no workspace, index, branch, or commit changes; the output states that only routing was completed. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=e48b238fe72b5801d36c88005426156c8c6d404e006c5bccb655f20f86d8f497; fixture_sha256=5bfe584ec04ca9f6271a87eb0a6a94432a493cce40c865cd7e77c63d4d5a5991; output_sha256=41142d6db289aabbb51996e2ff5d63d9e4f84fcacefb583060849c4ffb2ce7b9; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 正确识别已确认的 feature delivery，保留 handoff 上下文，将后续工作交给 formal-docs-sync，并停在 Router 边界等待确认。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=e48b238fe72b5801d36c88005426156c8c6d404e006c5bccb655f20f86d8f497; fixture_sha256=5bfe584ec04ca9f6271a87eb0a6a94432a493cce40c865cd7e77c63d4d5a5991; output_sha256=55695fa552c436a65bfadcbe7844fa5dda52ad326af414c1e44aa754224fb147; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly routes the confirmed handoff to formal-docs-sync, preserves the relevant context, and stops before documentation writes.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=e48b238fe72b5801d36c88005426156c8c6d404e006c5bccb655f20f86d8f497; fixture_sha256=5bfe584ec04ca9f6271a87eb0a6a94432a493cce40c865cd7e77c63d4d5a5991; output_sha256=d18f5250a4eea1815f5f4b3f08c9f55a8b4e0de79e1e52e81bd2b957759f4c53; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 将正式文档同步错误地阻塞在缺少源文档，并要求补齐 docs 或提供其他提交，未完成正确路由。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=e48b238fe72b5801d36c88005426156c8c6d404e006c5bccb655f20f86d8f497; fixture_sha256=5bfe584ec04ca9f6271a87eb0a6a94432a493cce40c865cd7e77c63d4d5a5991; output_sha256=b54413de56d69f915de900a503cdbf12e3f204c781147be67caa5a0abfd8dd09; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline preserved much of the handoff scope but did not identify or route to formal-docs-sync, instead stopping on unavailable referenced artifacts.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/docs/test/docs-agent/evals/workspace/eval-002-missing-entry-basis/comparison.md
+++ b/agents/docs/test/docs-agent/evals/workspace/eval-002-missing-entry-basis/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/docs/test/docs-agent/evals/workspace/eval-002-missing-entry-basis`.
 - Identity schema: `2`
-- target_skill_sha256: `cf826e2e86ef193d8a7294a87c743dead6af892aefcc220dd56ae949fa5c3b40`
+- target_skill_sha256: `023cc6d8aa109db6ff7dcd662df567ae4f0c79dddb66dfe7bcf6f1eb91d20f39`
 - eval_definition_sha256: `46e0e02295d606a359a2403ac234af592712f357041b544bb13a82efa1816296`
 - metadata_sha256: `9e2c43ddcdebfd4398d2a8f32a222c29dd71f706e06b85ffb24ea4623239c500`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `da898e3ecfd0169570b22be7c73cd730ef2fd22e3bf1c5b559383dc76454ff0d`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `c8a665c7632c31fce83103a67e411115fa7f6c456ea2edd0094ff12d3cf4e103`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `3605efbf3a3778b67aaca5565fc5172f956fc592ba984222c43ed05477dbf4a2`
+- Skill overlay SHA-256: `9c576146684d18c7504052238ca8bebbfdee0dbeda9095dc883a11efcc91b8a9`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `guides_to_pm_agent` | PASS | 明确说明当前没有 PM handoff、等价确认文档链或完整入口依据，并将下一步交回 pm-agent 完成 handoff 与前置上下文。 |
-| `does_not_execute_bootstrap` | PASS | 锁定输出说明不会创建文档站或修改文件；原始 trace 仅加载 docs-agent 路由技能，没有执行 bootstrap、生成 manifest 或产生文件变更。 |
-| `names_missing_credentials` | PASS | 明确列出缺少已确认宿主代码仓库路径，并说明明确初始化请求加已确认仓库路径即可形成 entry basis。 |
+| `guides_to_pm_agent` | PASS | With-skill output identifies the missing PM handoff/confirmation basis and names pm-agent as the return owner; trace corroborates routing back to PM. |
+| `does_not_execute_bootstrap` | PASS | With-skill delivery_snapshot and git evidence show no changes; output does not claim bootstrap execution or generate a manifest, and the trace only loads the docs-agent routing skill. |
+| `names_missing_credentials` | PASS | With-skill output explicitly names the missing confirmed target repository path and states that an explicit initialization request plus confirmed host repository path supplies the entry basis. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c8a665c7632c31fce83103a67e411115fa7f6c456ea2edd0094ff12d3cf4e103; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=f59621db2d29dcd6611c68abd01a400aa1810e89b17ec849be7dfd41d86b28f1; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 识别为正式文档站初始化请求，检查入口条件，指出缺少 PM handoff 和宿主仓库路径，并安全返回 pm-agent；未执行下游建站。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c8a665c7632c31fce83103a67e411115fa7f6c456ea2edd0094ff12d3cf4e103; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=2cba0bf478e9f967d913d0a1d6e5a4fc39b35fd7473000c5856ea5b501d04bf7; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly routes the incomplete formal documentation-site request back to pm-agent, preserves the execution boundary, and identifies the missing repository and PM confirmation.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c8a665c7632c31fce83103a67e411115fa7f6c456ea2edd0094ff12d3cf4e103; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=c8649a90b3b36c8419ad72f3e155e80d5fc63f85f2b9a238f6b5dc051cd2658c; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 提供了通用的文档站规划与缺项清单，但未进行 PM 路由、入口门禁或 specialist basis 判断。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c8a665c7632c31fce83103a67e411115fa7f6c456ea2edd0094ff12d3cf4e103; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=5be83ae4b0059b50b0c85a562e1a34537d29e1f0c8c405880e141be4fe458290; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Provides a generic planning-oriented response and identifies a missing repository, but does not provide the explicit PM routing and specialist entry-basis guidance.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/docs/test/docs-agent/evals/workspace/eval-003-route-release-audit/comparison.md
+++ b/agents/docs/test/docs-agent/evals/workspace/eval-003-route-release-audit/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `c4a69775f21689d655afd993fc0db7c357209ede650d2394be50a3f72bd824b5` from `agents/docs/test/docs-agent/evals/workspace/eval-003-route-release-audit`.
 - Identity schema: `2`
-- target_skill_sha256: `cf826e2e86ef193d8a7294a87c743dead6af892aefcc220dd56ae949fa5c3b40`
+- target_skill_sha256: `023cc6d8aa109db6ff7dcd662df567ae4f0c79dddb66dfe7bcf6f1eb91d20f39`
 - eval_definition_sha256: `6d6a401b76741386ad3f6aee549b3bfaa2f477f4ced9973b14647dc8b591096b`
 - metadata_sha256: `d582bafa2b7d4e637ef2b4b71f14f435256d70c30e92f7097a43cd40dc9da750`
 - fixture_sha256: `c4a69775f21689d655afd993fc0db7c357209ede650d2394be50a3f72bd824b5`
@@ -22,37 +22,37 @@
 - judge_schema_sha256: `f4f786bd56d6a5cbcee24193816a462566a8caafb4c223ef38759bdf64ee0486`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `099569afeec045caa3e4e020611c72b9def7b5897f52222810916bd2477fd230`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `4f8c2e7785cbff8446ac2450d611cce0b0fa2bab79e21c8ccd8c57b18b15a51c`
-- Behavior result: **FAIL**
+- Skill overlay SHA-256: `d7e2242fcdf83209e6c0cb5ec9544aa009e79488a72f81ebd4bf387289fbabec`
+- Behavior result: **PASS**
 - Coverage result: **FULL**
-Overall result: FAIL
+Overall result: PASS
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `accepts_equivalent_chain` | PASS | with_skill 复述了 release scope、v0.4.0/v0.3.0、changelog、Release Notes、检查证据和 requested node，构成等效确认链。 |
-| `routes_docs_audit` | FAIL | with_skill 将已满足入口的请求判定为缺少 host_repository/required_output，并返回 pm-agent，而不是选择 docs-audit 并保留上下文交接。 |
-| `references_audit_gate_only` | PASS | with_skill 明确指出后续 specialist 为 docs-audit，未执行审计，也未向用户暴露本地 SKILL.md 路径或复制详细审计协议。 |
+| `accepts_equivalent_chain` | PASS | with_skill 明确将 release-entry.md 识别为等效正式文档审计入口链，并保留 release scope、v0.4.0/v0.3.0 锚点、范围、changelog、release evidence 和审计请求。 |
+| `routes_docs_audit` | PASS | with_skill 明确选择 docs-audit，交付 v0.4.0 正式文档审计，并在交接内容中保留版本范围、changelog、站点 release notes 及相关 release evidence。 |
+| `references_audit_gate_only` | PASS | with_skill 明确说明路由层不执行审计、不写入报告或版本元数据；仅要求后续由 docs-audit 按其协议执行，未暴露 SKILL.md 路径或复制内部审计层协议。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=099569afeec045caa3e4e020611c72b9def7b5897f52222810916bd2477fd230; fixture_sha256=c4a69775f21689d655afd993fc0db7c357209ede650d2394be50a3f72bd824b5; output_sha256=43f17cbe59aed2ceacf5808fde869410032d79d70e374cb98c907dae623bcb31; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 识别了等效确认链并保持了 specialist 边界，但错误地拒绝路由到 docs-audit。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=099569afeec045caa3e4e020611c72b9def7b5897f52222810916bd2477fd230; fixture_sha256=c4a69775f21689d655afd993fc0db7c357209ede650d2394be50a3f72bd824b5; output_sha256=2cd5391674b9c6ed836bd2ec1b372e0f5b99af12243fa2d178d48a3c88226205; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 识别等效确认链，正确路由至 docs-audit，并停在等待用户确认的下一步。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=099569afeec045caa3e4e020611c72b9def7b5897f52222810916bd2477fd230; fixture_sha256=c4a69775f21689d655afd993fc0db7c357209ede650d2394be50a3f72bd824b5; output_sha256=7df0bd78c2b8863728c113c1ee0da89593dc85c85c9f23234962abea27c5dbca; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 未执行路由，直接对发布材料做了仓库审计并给出 BLOCKED/NOT READY 结论，偏离了 Router 职责。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=099569afeec045caa3e4e020611c72b9def7b5897f52222810916bd2477fd230; fixture_sha256=c4a69775f21689d655afd993fc0db7c357209ede650d2394be50a3f72bd824b5; output_sha256=6e470865076fb9b0c843a7b385fc7a879553c928380da01bb51c32d5eff25f41; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 将入口声明误判为无法复核的发版审计对象，未完成所需路由；仅作基线对比。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- with_skill 错误扩展了 Router 入口要求，导致本应路由至 docs-audit 的请求被阻断并退回 pm-agent。
-- Next: 将 release-entry.md 视为完整等效确认入口，保留其 release scope、版本 tag、changelog 和 release evidence，并路由至 docs-audit。
+- None.
+- Next: None.
 
 ## Runtime Artifact Policy
 

--- a/agents/docs/test/docs-agent/evals/workspace/eval-004-route-release-notes/comparison.md
+++ b/agents/docs/test/docs-agent/evals/workspace/eval-004-route-release-notes/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `23d5701fab562491dfec3455fd6eabce7f6a6cba18940861023208d40f53fc3e` from `agents/docs/test/docs-agent/evals/workspace/eval-004-route-release-notes`.
 - Identity schema: `2`
-- target_skill_sha256: `cf826e2e86ef193d8a7294a87c743dead6af892aefcc220dd56ae949fa5c3b40`
+- target_skill_sha256: `023cc6d8aa109db6ff7dcd662df567ae4f0c79dddb66dfe7bcf6f1eb91d20f39`
 - eval_definition_sha256: `38b6af0374fcc8ce56a2a453684404f29e895eaad6d86b973c652b7dd34579f8`
 - metadata_sha256: `5831b803b3b347d7fd4611f1c19958d707ffe3e9ced4a78ed755e71f76a2c9b8`
 - fixture_sha256: `23d5701fab562491dfec3455fd6eabce7f6a6cba18940861023208d40f53fc3e`
@@ -22,37 +22,37 @@
 - judge_schema_sha256: `73f4addc59ec16b0f91c6a70a2a767ce7f6b4ad72612ca19a2131095a0722114`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `ab720b723fbaf54cc8b204eab97c1f0a7167519c350afdf3b475cf0b324862c8`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `b639e5a542e8c14d9db634c15148cb2563d801ada17ecc608983807552b63d49`
-- Behavior result: **PASS**
+- Skill overlay SHA-256: `9d7abf20333b60efc8aeaad2d302ecd422e44bb547e52f5a4d9623347a2b048b`
+- Behavior result: **FAIL**
 - Coverage result: **FULL**
-Overall result: PASS
+Overall result: FAIL
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `accepts_release_notes_entry_basis` | PASS | with_skill explicitly accepts the confirmed host, version, scope, evidence sources, and required Release Notes output. |
-| `routes_release_notes_generator` | PASS | with_skill routes the request to `release-notes-gen` and preserves the stated authorization boundary. |
-| `preserves_handoff_context` | PASS | The handoff retains the fixture's confirmed version, scope, host, evidence sources, and output path without changing those facts. |
-| `references_release_notes_gate_only` | PASS | with_skill identifies `release-notes-gen` as the downstream specialist, does not perform generation, and exposes no local SKILL.md path. |
+| `accepts_release_notes_entry_basis` | PASS | With-skill output identifies the handoff as sufficient and preserves the confirmed version, scope, host repository, evidence sources, and required output. |
+| `routes_release_notes_generator` | PASS | With-skill output explicitly routes to `release-notes-gen` and states that it will not route to the other specialists or execute downstream work. |
+| `preserves_handoff_context` | PASS | With-skill output retains the version, scope, feature path, host, evidence sources, required artifact, and blockers/risks from the handoff. |
+| `references_release_notes_gate_only` | FAIL | With-skill output correctly limits router execution to the specialist gate, but exposes the local `.agents/skills/release-notes-gen/SKILL.md` path, which the assertion forbids. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=ab720b723fbaf54cc8b204eab97c1f0a7167519c350afdf3b475cf0b324862c8; fixture_sha256=23d5701fab562491dfec3455fd6eabce7f6a6cba18940861023208d40f53fc3e; output_sha256=1737354e8ca770d11dd7288b29fd3457010bf509d7f5e0feb5c3863cf7d8a6da; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly accepted the entry basis and routed a bounded handoff to release-notes-gen without performing downstream generation or forbidden release actions.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=ab720b723fbaf54cc8b204eab97c1f0a7167519c350afdf3b475cf0b324862c8; fixture_sha256=23d5701fab562491dfec3455fd6eabce7f6a6cba18940861023208d40f53fc3e; output_sha256=0b9f8406fd94a073d0347ee786ee0870e1d4bdcb0ee9b531763dbfbef3cff219; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly accepts and routes the handoff while preserving context, but violates the user-visible boundary by exposing the local specialist skill path.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=ab720b723fbaf54cc8b204eab97c1f0a7167519c350afdf3b475cf0b324862c8; fixture_sha256=23d5701fab562491dfec3455fd6eabce7f6a6cba18940861023208d40f53fc3e; output_sha256=0309d43900450c250b27042c42505f42678de54a212f339e9fec3e7601514d05; snapshot_sha256=4e8d2492d29adabe9bab5964c83c70b89152147a4f7d4d72e1c3fad998baee5b
-- Behavior: Fresh baseline generated a Release Notes file directly instead of demonstrating the required specialist routing boundary.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=ab720b723fbaf54cc8b204eab97c1f0a7167519c350afdf3b475cf0b324862c8; fixture_sha256=23d5701fab562491dfec3455fd6eabce7f6a6cba18940861023208d40f53fc3e; output_sha256=7ee32988fb534e6932a531b50a5ef485c5b4af65aa88b947ab383be87d04b200; snapshot_sha256=aa79fcae2a2184b79c8b489ac45fc5674c942c28719483b9ad56f62a7c39c263
+- Behavior: Fresh baseline generated the release-notes file directly instead of performing the required router-only handoff.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- None.
+- The with-skill output exposes a local SKILL.md path to the user.
 - Next: None.
 
 ## Runtime Artifact Policy

--- a/agents/docs/test/docs-agent/evals/workspace/eval-005-integration-release-chain/comparison.md
+++ b/agents/docs/test/docs-agent/evals/workspace/eval-005-integration-release-chain/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `69659db940208abe97ba4ab195a49c736d9a7ba7e1e880c287d3bf12132c10a3` from `agents/docs/test/docs-agent/evals/workspace/eval-005-integration-release-chain`.
 - Identity schema: `2`
-- target_skill_sha256: `cf826e2e86ef193d8a7294a87c743dead6af892aefcc220dd56ae949fa5c3b40`
+- target_skill_sha256: `023cc6d8aa109db6ff7dcd662df567ae4f0c79dddb66dfe7bcf6f1eb91d20f39`
 - eval_definition_sha256: `05d8b9eb5ccf6bbc077dad850c79899562c5b4ed9bbb4187abffd82f21410ea3`
 - metadata_sha256: `af301306a3e584e9c32987cd73e02ac298dcd98f38208af58ca0764e8b5a4154`
 - fixture_sha256: `69659db940208abe97ba4ab195a49c736d9a7ba7e1e880c287d3bf12132c10a3`
@@ -22,41 +22,41 @@
 - judge_schema_sha256: `1f2ea17b811fce39b8e906ef0e0a70b6a6223a188a2f4a05f2f0a88c54c6aceb`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `62a386a246bcb0c7c5b2df7096cfd60c5023a6b28473d50af8f99649d1d3480e`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `b9267b74f801c2a671c1ca7ba9bdf9a650058f23cd2d09d1d407f78b09a9bd1c`
-- Behavior result: **PASS**
+- Skill overlay SHA-256: `9b4662f75faaa400532cbf63de0f9ad91e1c5da618aac4095cd85a9624829d98`
+- Behavior result: **FAIL**
 - Coverage result: **FULL**
-Overall result: PASS
+Overall result: FAIL
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `accepts_release_audit_entry` | PASS | 识别并保留 v1.4.0、ai-search 范围、JOTO-AI/aiportal、签认证据和只读授权边界。 |
-| `evaluates_site_release_notes_gate` | PASS | 发现 handoff 自称 ready 但缺少可信 post-tag 权威且版本验证状态冲突，因此阻塞并路由至正式文档审计负责人。 |
-| `validates_release_window_basis` | PASS | 确认签认快照中的 release-base、release-candidate 及 v1.3.0/v1.4.0 版本引用可解析，并以快照为依据未猜测替代锚点。 |
-| `rejects_missing_pre_tag_authority` | PASS | 明确实际 tag 已存在但没有可复用的可信 pre-tag audit record、anchor、handoff commit 或 inventory identity，未宣称 pre-tag 通过。 |
-| `detects_post_tag_evidence_drift` | PASS | 正确识别 release-candidate/tag-entry/evidence-expected 与实际 tag/release-evidence 的 tree 不一致，并判定 blocked。 |
-| `blocks_github_release_handoff` | PASS | 明确当前不可进入 GitHub Release 准备或发布，仅在 release_verified 后再移交。 |
-| `preserves_no_mutation_boundaries` | PASS | 锁定证据显示 HEAD、分支、ref、diff 和工作区均无变化；候选明确未执行 tag 或 GitHub Release 写入。 |
+| `accepts_release_audit_entry` | PASS | With_skill identifies the docs-audit route, maintainer-confirmed v1.4.0, scope, host, evidence source, and output requirements. |
+| `evaluates_site_release_notes_gate` | PASS | It blocks the handoff because no consumable pre-tag authority exists and names the documentation audit owner as the next responsible party, despite the handoff being marked ready. |
+| `validates_release_window_basis` | PASS | It refuses to treat the signed snapshot text as sufficient when the referenced Git objects cannot be parsed locally, and does not guess replacement anchors. |
+| `rejects_missing_pre_tag_authority` | PASS | It explicitly states that no verifiable pre-tag authority exists and refuses to return ready_for_tag or release_verified. |
+| `detects_post_tag_evidence_drift` | FAIL | The signed snapshot directly records v1.4.0 and release-evidence trees differing from the candidate/tag-entry trees, but the with_skill output does not identify this post-tag object drift; it only cites unavailable refs and objects. |
+| `blocks_github_release_handoff` | PASS | It concludes the audit is blocked, prohibits progression to GitHub Release preparation, and names the release preparation owner as dependent on ready_for_tag, an actual tag, and release_verified evidence. |
+| `preserves_no_mutation_boundaries` | PASS | The output states that no tag or GitHub Release writes were performed; locked git evidence shows no ref delta, commits, or worktree changes. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=62a386a246bcb0c7c5b2df7096cfd60c5023a6b28473d50af8f99649d1d3480e; fixture_sha256=69659db940208abe97ba4ab195a49c736d9a7ba7e1e880c287d3bf12132c10a3; output_sha256=ca84672dc4cfc91d1ac7c8997db0e086a793873be0e1edf5fc8803e7cb9e4f8b; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 完整识别入口、版本窗口、tag/tree 漂移、缺失 pre-tag 权威和 Release Notes 状态冲突，并正确阻塞 GitHub Release handoff。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=62a386a246bcb0c7c5b2df7096cfd60c5023a6b28473d50af8f99649d1d3480e; fixture_sha256=69659db940208abe97ba4ab195a49c736d9a7ba7e1e880c287d3bf12132c10a3; output_sha256=4f2772f7df5b199ff01807a12ce86399b5d374d8aac1aad84f518b279a4e846c; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly accepts the audit entry, rejects unsupported pre/post-tag progression, blocks GitHub Release handoff, and preserves read-only boundaries, but misses the explicit post-tag tree-drift finding.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=62a386a246bcb0c7c5b2df7096cfd60c5023a6b28473d50af8f99649d1d3480e; fixture_sha256=69659db940208abe97ba4ab195a49c736d9a7ba7e1e880c287d3bf12132c10a3; output_sha256=aa7316ba43ff1d7f65f526a13b7eedd63ac2d93e05c038c36d94690be511e428; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 同样识别主要 tag/tree 漂移和缺失 release_verified，但未呈现 with_skill 的路由与 inventory-authority 细节。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=62a386a246bcb0c7c5b2df7096cfd60c5023a6b28473d50af8f99649d1d3480e; fixture_sha256=69659db940208abe97ba4ab195a49c736d9a7ba7e1e880c287d3bf12132c10a3; output_sha256=6a6b75e2ebf6f1f76dfa183b81b65b2ce7e626608cadc7bb2fe85b5a3b05167e; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline also blocks release progression and preserves no-mutation boundaries, but explicitly identifies the tag/tree mismatch and inconsistent release-note metadata.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- None.
-- Next: None.
+- The with_skill lane does not explicitly detect or report the signed snapshot's post-tag tree drift: v1.4.0 and release-evidence point to 490d0b..., while release-candidate, tag-entry, and evidence-expected point to 7c8b9b....
+- Next: Require the with_skill output to explicitly compare the signed snapshot's post-tag tag and persisted evidence trees with the expected candidate trees and report the mismatch as blocked.
 
 ## Runtime Artifact Policy
 

--- a/agents/docs/test/docs-agent/evals/workspace/eval-006-preserve-independent-hosting/comparison.md
+++ b/agents/docs/test/docs-agent/evals/workspace/eval-006-preserve-independent-hosting/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `f6c421284ed0143d28fff161f0f4c1cd48b067505beae1d38677d871a066543f` from `agents/docs/test/docs-agent/evals/workspace/eval-006-preserve-independent-hosting`.
 - Identity schema: `2`
-- target_skill_sha256: `cf826e2e86ef193d8a7294a87c743dead6af892aefcc220dd56ae949fa5c3b40`
+- target_skill_sha256: `023cc6d8aa109db6ff7dcd662df567ae4f0c79dddb66dfe7bcf6f1eb91d20f39`
 - eval_definition_sha256: `8a4360282a35d2ba7a52bbb24d703648e9f263e7fbfc9516063ba62f62b92b92`
 - metadata_sha256: `62050136e2c1de0d65367ed4b1b1b706bb2211c3759fb54a832b8fd66233328b`
 - fixture_sha256: `f6c421284ed0143d28fff161f0f4c1cd48b067505beae1d38677d871a066543f`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `787b3941ec90b819758a9894561fa37e2c0eff7eedddb4c4a4d863809f28587f`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `75b11cec554fb9cabf92f38559abd7d5bd8c24a6e4b7927952fa49a44fb00e8c`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `4a886ffdcb18b30d43dbd2f9ee95780d97f9d5daf71fdddfd34bccc37d3c110d`
+- Skill overlay SHA-256: `84e19c3e634cfde176d2ff20ba8e9d25a4838db3ed1deb5def94a8d0f1d2ddd9`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,19 +33,19 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `preserves_not_applicable_evidence` | PASS | With_skill reports `not_applicable`, cites hosting/decision-record.md, identifies the static workflow's public/internal variants, and names the repository maintainer/documentation publisher as the next owner. Raw fixture evidence confirms the maintainer-signed static-hosting decision and both variants. |
-| `does_not_open_devops_handoff` | PASS | With_skill concludes no application deployment-team involvement is needed, records no handoff or delivered mutation, and confirms the valid not_applicable decision does not trigger a deployment route. |
+| `preserves_not_applicable_evidence` | PASS | With-skill 输出确认文档不进入应用镜像、Compose 或 Helm，并由 `.github/workflows/publish-docs-static.yml` 以 public/internal 两个变体发布；fixture 中的决策记录确认维护者复核并签署现有方案且无需配置变更，输出给出证据路径并指定 Web Platform 为后续 owner。 |
+| `does_not_open_devops_handoff` | PASS | With-skill 输出明确当前不需要应用部署团队介入，未启动下游 specialist，并仅在文档重新纳入应用部署链路时才考虑应用部署团队；git evidence 显示无提交、分支或工作树变化。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=75b11cec554fb9cabf92f38559abd7d5bd8c24a6e4b7927952fa49a44fb00e8c; fixture_sha256=f6c421284ed0143d28fff161f0f4c1cd48b067505beae1d38677d871a066543f; output_sha256=1c8974593b946335d22501053cb3b2f55854e5ff07091dfae93319e2fb5a4e61; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Preserved the valid not_applicable hosting decision, its evidence, variants, and next owner; avoided a DevOps handoff while accurately noting missing workflow inputs.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=75b11cec554fb9cabf92f38559abd7d5bd8c24a6e4b7927952fa49a44fb00e8c; fixture_sha256=f6c421284ed0143d28fff161f0f4c1cd48b067505beae1d38677d871a066543f; output_sha256=ebb22a1b7ab1d6e2928e8a1c4ce67b394e68634551b9d754ec6a42e02246a92d; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 保留了替代静态托管的决策、证据路径、public/internal 覆盖变体和 Web Platform owner，并避免当前应用部署路由。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=75b11cec554fb9cabf92f38559abd7d5bd8c24a6e4b7927952fa49a44fb00e8c; fixture_sha256=f6c421284ed0143d28fff161f0f4c1cd48b067505beae1d38677d871a066543f; output_sha256=e5b87d70da99aede513f770767e27d9c81d0a8ede81a5b47dc79d6fcaa33e787; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Reached the same no-DevOps conclusion and identified hosting evidence, but did not explicitly report the required not_applicable status or structured next-owner evidence.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=75b11cec554fb9cabf92f38559abd7d5bd8c24a6e4b7927952fa49a44fb00e8c; fixture_sha256=f6c421284ed0143d28fff161f0f4c1cd48b067505beae1d38677d871a066543f; output_sha256=602532c7e3fe7d1303a8188306fd71f56e16e38ee0f6dfe0075c97d0e43edff1; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 同样得出无需应用部署团队介入的结论，并保留主要托管证据；作为对照，其额外强调了快照缺少 workflow 运行依赖。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/docs/test/docs-agent/evals/workspace/eval-007-route-manual-gen/comparison.md
+++ b/agents/docs/test/docs-agent/evals/workspace/eval-007-route-manual-gen/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `7e690828debd990987ec359671232498f20061c2fa6e2bbd324f99b92a7c2fc8` from `agents/docs/test/docs-agent/evals/workspace/eval-007-route-manual-gen`.
 - Identity schema: `2`
-- target_skill_sha256: `cf826e2e86ef193d8a7294a87c743dead6af892aefcc220dd56ae949fa5c3b40`
+- target_skill_sha256: `023cc6d8aa109db6ff7dcd662df567ae4f0c79dddb66dfe7bcf6f1eb91d20f39`
 - eval_definition_sha256: `b572bcf4c18451eca03023d64515c12cbfbd9f67b27200f6bcd78820652e00b9`
 - metadata_sha256: `31c2720a1114e612336c51527d7aae20dddb1f4e46b566ffffe4788d27952b8e`
 - fixture_sha256: `7e690828debd990987ec359671232498f20061c2fa6e2bbd324f99b92a7c2fc8`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `dfbcad96e39d7a0ba2503c7d345d86b54a6c9e1188ff1c09f99476b24380e820`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `a3cc737cbb46c53cc07ec65089d26bb1859146138c26d847279db190c633dcfa`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `5604a6302ca4d09e2d73851673d45c2cd4c3d0cc0d875a00b8fdf3d59b145d56`
+- Skill overlay SHA-256: `1fd712d33d9c027bbddf431b7e1d0692e12253350db6a00382930fc1f0850317`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,21 +33,21 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `accepts_manual_entry_basis` | PASS | The locked with_skill output and trace identify `manual-handoff.md` as satisfying the `manual-gen` entry basis, including the existing `docs/site/` foundation, bounded scope, confirmed running interface, and required output. |
-| `routes_manual_gen` | PASS | The with_skill output explicitly states “路由结果：`manual-gen`” and names `manual-gen` as downstream owner; no alternative specialist is selected. |
-| `preserves_manual_handoff_context` | PASS | The locked YAML preserves `request_type`, `change_tier`, `feature_path`, `host_repository`, `manual_scope`, `evidence_sources`, `required_output`, and `blockers_risks` from the fixture, with the host foundation represented separately as `docs_site_foundation`. |
-| `references_manual_gate_only` | PASS | The with_skill output states `authorization_boundary: 仅完成路由；未写入站点、未生成手册`, identifies `manual-gen` as the next owner, and does not expose a local SKILL.md path or claim screenshot/site-generation/audit work. |
+| `accepts_manual_entry_basis` | PASS | with_skill explicitly identifies the complete handoff basis, including host repository, bounded scope, running-interface evidence, and required output. |
+| `routes_manual_gen` | PASS | with_skill explicitly routes the work to manual-gen and does not select any alternative specialist. |
+| `preserves_manual_handoff_context` | PASS | The with_skill handoff reproduces all required fields: request_type, change_tier, feature_path, host_repository, manual_scope, evidence_sources, required_output, and blockers_risks. |
+| `references_manual_gate_only` | PASS | The candidate stops at the router boundary, identifies manual-gen as the next responsibility, exposes no local SKILL.md path to the user, and locked git evidence shows no file or repository mutation. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=a3cc737cbb46c53cc07ec65089d26bb1859146138c26d847279db190c633dcfa; fixture_sha256=7e690828debd990987ec359671232498f20061c2fa6e2bbd324f99b92a7c2fc8; output_sha256=6f24e0714694f952455527b3d7a538801893d63f467c7cd29ed03dcd8092253e; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly validates the handoff basis, preserves the required context, routes to manual-gen, and stops at the router boundary without generating the manual.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=a3cc737cbb46c53cc07ec65089d26bb1859146138c26d847279db190c633dcfa; fixture_sha256=7e690828debd990987ec359671232498f20061c2fa6e2bbd324f99b92a7c2fc8; output_sha256=ddc01c283cc36886db67f4c237f9ebb01423fe7914aa1b388822cde9a27b4f41; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly validates the manual handoff, preserves its context, routes to manual-gen, and stops before specialist execution or mutations.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=a3cc737cbb46c53cc07ec65089d26bb1859146138c26d847279db190c633dcfa; fixture_sha256=7e690828debd990987ec359671232498f20061c2fa6e2bbd324f99b92a7c2fc8; output_sha256=b37780afd3e109d2b7c32043086222c5fcdc996513c167a39a359c3ceaf0a62e; snapshot_sha256=7d948be543a884e6f9549de8400cc160792be324ad1cf587f8324e67a13ed3a6
-- Behavior: Generated and wrote a complete manual with SVG illustrations despite the fixture stating that the docs/site foundation and screenshots/manual body were not yet available; it did not perform the required router-only handoff.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=a3cc737cbb46c53cc07ec65089d26bb1859146138c26d847279db190c633dcfa; fixture_sha256=7e690828debd990987ec359671232498f20061c2fa6e2bbd324f99b92a7c2fc8; output_sha256=b569d2bc62dbf5ab493222c59842b2d5bd1d5cc2f9bd62935cd949872c3b98d3; snapshot_sha256=c248224b27a26693e51dd5586a8e23ce1d795caeb296fcbf95fcff16f4c683fb
+- Behavior: Fresh baseline incorrectly claims to have completed manual generation and contains delivered manual files, rather than remaining at the routing boundary.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/docs/test/docs-audit/evals/workspace/eval-001-audit-mismatch/comparison.md
+++ b/agents/docs/test/docs-audit/evals/workspace/eval-001-audit-mismatch/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `dc67ea3252d72d2cb1006bd586833469bce9e6071957244105d8c4e3b86358a2` from `agents/docs/test/docs-audit/evals/workspace/eval-001-audit-mismatch`.
 - Identity schema: `2`
-- target_skill_sha256: `dafd53371901dfd724f88c70262b157e59494d29da1c613d0ef130564b6ff4f9`
+- target_skill_sha256: `a5e0bb043d61dbbb218e7d7efc08374e0d16a4d7aaa3b31817f2038830c90941`
 - eval_definition_sha256: `fee749f35b3bf7110eb1c6f38c918db3407b1a46ffa3ff2613c15b835398219e`
 - metadata_sha256: `23ce240f3f391bd560df8f9bbcf6e5d2ec76b8a3ffb73e38f416b3cdb2997a3a`
 - fixture_sha256: `dc67ea3252d72d2cb1006bd586833469bce9e6071957244105d8c4e3b86358a2`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `218cecf9b4e5893cf80d7edfea7d7877463de8efad846bf62ba5cba015ad2ed5`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `8d4dbdcc2ce0268c7dd2fa59f4c946f0acad002c9675a3357ceee8b115ffded1`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `7e61bd8eca6431729aee1f3be4656be0a4348119eb1218623bafd54cfaead2ab`
+- Skill overlay SHA-256: `d7e2242fcdf83209e6c0cb5ec9544aa009e79488a72f81ebd4bf387289fbabec`
 - Behavior result: **FAIL**
 - Coverage result: **FULL**
 Overall result: FAIL
@@ -33,27 +33,29 @@ Overall result: FAIL
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `includes_mapped_page` | PASS | With-skill output explicitly maps src/catalog/** to docs/site/api/catalog.md. |
-| `classifies_direct_conflict_mismatch` | PASS | It preserves POST versus GET, cites the affected files, and classifies the page as mismatch. |
-| `blocks_with_conflict_evidence` | FAIL | It returns blocked, lists the conflict, and rejects ready_for_tag, but does not present the required explicit choice to repair documentation or code. |
-| `does_not_stamp_blocked_set` | PASS | Locked git evidence shows no page or metadata mutation; no delivery snapshot or diff records any stamp. |
+| `includes_mapped_page` | PASS | with_skill 输出明确写明 change-map 命中 `src/catalog/**` → `docs/site/api/catalog.md`，并列出影响页面。 |
+| `classifies_direct_conflict_mismatch` | FAIL | with_skill 保留了文档 `POST`、代码 `GET` 及影响，但最终将页面标为 `stale`，不是断言要求的字面状态 `mismatch`。 |
+| `blocks_with_conflict_evidence` | FAIL | with_skill 返回 `blocked` 并列出冲突证据，但待办仅要求修正文档，没有明确提出确认修文档还是修代码。 |
+| `does_not_stamp_blocked_set` | PASS | with_skill 明确报告未写入；原始 trace 仅显示读取命令，没有文件变更、版本盖章或 `.meta/releases.json` 同步事件。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=8d4dbdcc2ce0268c7dd2fa59f4c946f0acad002c9675a3357ceee8b115ffded1; fixture_sha256=dc67ea3252d72d2cb1006bd586833469bce9e6071957244105d8c4e3b86358a2; output_sha256=196ddce7f8bba1f32a1b568ae7ec773b89d96f58bc33ff65eefc0c493105aaab; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly identifies the mapped page and direct POST/GET mismatch, blocks the audit, and leaves the worktree unchanged; its next steps prescribe documentation repair without requesting the required repair-choice confirmation.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=8d4dbdcc2ce0268c7dd2fa59f4c946f0acad002c9675a3357ceee8b115ffded1; fixture_sha256=dc67ea3252d72d2cb1006bd586833469bce9e6071957244105d8c4e3b86358a2; output_sha256=7bca237baf686ce37996b88eb0d514c57b8b826e0cb7d27106d6415f9a8666fd; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 识别了 change-map 影响页面、POST/GET 冲突并阻断 pre-tag，且未盖章；但分类和冲突修复待办不完全符合断言。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=8d4dbdcc2ce0268c7dd2fa59f4c946f0acad002c9675a3357ceee8b115ffded1; fixture_sha256=dc67ea3252d72d2cb1006bd586833469bce9e6071957244105d8c4e3b86358a2; output_sha256=f9545f6ba56595c5d8ec4e99aec23d385624089c53eba2ce32f8816d4b802847; snapshot_sha256=d9d94c6e55b7b1893e234c126b95da4e8fd3435a972c636eb46b7ddd32ca0a05
-- Behavior: Fresh baseline reports the stale POST documentation and metadata but omits the mapped impact classification, mismatch label, blocked phase, and no-stamp behavior.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=8d4dbdcc2ce0268c7dd2fa59f4c946f0acad002c9675a3357ceee8b115ffded1; fixture_sha256=dc67ea3252d72d2cb1006bd586833469bce9e6071957244105d8c4e3b86358a2; output_sha256=5137b6df2bd3507ab326d15368a06539bdf9b44b36a4fbf1a1000955b060bd83; snapshot_sha256=17dbfa812c6103318bfc92a2497947d0b84e774b593de57a5256bcccc533ab77
+- Behavior: 保存了审计报告并以 POST/GET 冲突阻断发布，但未明确呈现完整影响域和规范化阻塞流程。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- blocks_with_conflict_evidence: the with_skill lane does not explicitly frame repair-documentation-versus-repair-code as a confirmation decision.
-- Next: Require the audit result to explicitly ask the maintainer to confirm whether the documentation or code should be repaired before rerunning.
+- 直接冲突的最终分类为 `stale` 而非断言要求的 `mismatch`。
+- 阻塞待办未明确要求确认修正文档还是修代码。
+- Next: 将直接冲突页面的最终状态按要求明确标为 `mismatch`。
+- Next: 在阻塞待办中明确要求维护者确认修正文档还是修代码后再复审。
 
 ## Runtime Artifact Policy
 

--- a/agents/docs/test/docs-audit/evals/workspace/eval-002-audit-stale-doc/comparison.md
+++ b/agents/docs/test/docs-audit/evals/workspace/eval-002-audit-stale-doc/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `7c0329b08b7d983c3fb25be26c421ff6963478e62486e2e0e75d22d246186583` from `agents/docs/test/docs-audit/evals/workspace/eval-002-audit-stale-doc`.
 - Identity schema: `2`
-- target_skill_sha256: `dafd53371901dfd724f88c70262b157e59494d29da1c613d0ef130564b6ff4f9`
+- target_skill_sha256: `a5e0bb043d61dbbb218e7d7efc08374e0d16a4d7aaa3b31817f2038830c90941`
 - eval_definition_sha256: `65171d2c00ad7205a3b92eb523639da0ae1b9b851f9b225fb39f151ac8a09d1b`
 - metadata_sha256: `393d49433e1e9b818095a60378e27c82e27a5159f0878e57881a2872b5feee91`
 - fixture_sha256: `7c0329b08b7d983c3fb25be26c421ff6963478e62486e2e0e75d22d246186583`
@@ -22,38 +22,38 @@
 - judge_schema_sha256: `6c436d29e1c4d967534d387d71455397c2a958eb0e9fdd8f24d404e3a4bfc7c7`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `a0986a693a041b20341e8fc74006f156b719dab648f0efc1ee18f7a27b8849f4`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `7e61bd8eca6431729aee1f3be4656be0a4348119eb1218623bafd54cfaead2ab`
+- Skill overlay SHA-256: `d7e2242fcdf83209e6c0cb5ec9544aa009e79488a72f81ebd4bf387289fbabec`
 - Behavior result: **PASS**
-- Coverage result: **FULL**
-Overall result: PASS
+- Coverage result: **PARTIAL**
+Overall result: PASS (partial coverage)
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `marks_missing_doc_update_suspect` | PASS | 报告将未在同批变更中的正式 API 页面描述为 suspect，并在事实核查后确认其与代码契约不一致。 |
-| `confirms_outdated_claim_stale` | PASS | 报告以目标代码中的必填非空 locale 和 400 invalid_locale 为证据，确认文档声明不同步（以 confirmed mismatch 表述）。 |
-| `blocks_stale_release` | PASS | 报告列出文档契约缺失及具体修复/重审待办，阶段结果为 blocked，并明确禁止创建标签、未产生 ready_for_tag 结果。 |
-| `does_not_stamp_stale_set` | PASS | 交付报告明确未盖章；git 状态和交付快照仅显示新增审计报告，没有页面或 releases.json 的更新。 |
+| `marks_missing_doc_update_suspect` | NOT_EXERCISED | The locked with_skill output stops at a pre-tag gate because the formal documentation-site foundation is incomplete; the raw trace does not prove that the deterministic layer actually recorded `suspect`. |
+| `confirms_outdated_claim_stale` | NOT_EXERCISED | The with_skill output reports preliminary code/document facts but concludes `mismatch` and stops before the fact-layer stale determination; the raw trace cannot prove a completed `stale` conclusion. |
+| `blocks_stale_release` | NOT_EXERCISED | The locked output correctly reports `blocked` and provides a bootstrap-and-rerun next step, but no audit report or completed stale evidence is delivered. The later audit result cannot occur until the missing foundation is supplied. |
+| `does_not_stamp_stale_set` | PASS | The locked output reports no saved report, clean Git state, and no working-tree or index changes; the raw Git evidence shows no stamp mutation. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=a0986a693a041b20341e8fc74006f156b719dab648f0efc1ee18f7a27b8849f4; fixture_sha256=7c0329b08b7d983c3fb25be26c421ff6963478e62486e2e0e75d22d246186583; output_sha256=99f9469d5d7ecc39b41cbc00ba092037e65b2cdcb2b93cfbc5d95878eb6ab0ac; snapshot_sha256=4690bf63b82a5abeb3b7a5944b4b4d5afcdd723ee48975d065e04060d7c99fb0
-- Behavior: 完成审计并保存报告，确认文档与新增 locale 契约不一致，阻断发布且未更新版本戳。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=a0986a693a041b20341e8fc74006f156b719dab648f0efc1ee18f7a27b8849f4; fixture_sha256=7c0329b08b7d983c3fb25be26c421ff6963478e62486e2e0e75d22d246186583; output_sha256=24a846452a0a293f97495c59461d2af73715f6d5ac096c9a36ac49c17ce04391; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly stopped at the missing-foundation gate, returned blocked, and made no repository stamp mutation.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=a0986a693a041b20341e8fc74006f156b719dab648f0efc1ee18f7a27b8849f4; fixture_sha256=7c0329b08b7d983c3fb25be26c421ff6963478e62486e2e0e75d22d246186583; output_sha256=882560f7f386f02534550c60be7d0de94f8582066a4749f4e5363da5074e92c4; snapshot_sha256=998b99c5e14e5836aacde17e8576892e644cc7f2fe7eeed9e1a21f0a086da75e
-- Behavior: 基线也识别了 locale 文档缺失并保存了报告，但未展示确定性 suspect 到事实确认及版本面保护的完整审计行为。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=a0986a693a041b20341e8fc74006f156b719dab648f0efc1ee18f7a27b8849f4; fixture_sha256=7c0329b08b7d983c3fb25be26c421ff6963478e62486e2e0e75d22d246186583; output_sha256=847293e29b8e7d8527255b14e7a4382b5dea7ea096b4334a8a0a942f5ebc82c9; snapshot_sha256=e2d8be49644988cab06f8e25c28268c7e144fafa0423b9e0c0df7751bde11808
+- Behavior: Created an audit report and reported documentation gaps, but did not provide the skill-gated audit workflow or explicit suspect/stale distinctions.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: None.
+- Next: Supply or confirm the formal documentation-site foundation, then rerun the pre-tag audit to exercise the suspect and stale determinations.
 
 ## Runtime Artifact Policy
 

--- a/agents/docs/test/docs-audit/evals/workspace/eval-003-audit-pure-refactor/comparison.md
+++ b/agents/docs/test/docs-audit/evals/workspace/eval-003-audit-pure-refactor/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `a0071569c74867aaacfda16310f9f4a06e50a375aa0e6b62ee25e801db096677` from `agents/docs/test/docs-audit/evals/workspace/eval-003-audit-pure-refactor`.
 - Identity schema: `2`
-- target_skill_sha256: `dafd53371901dfd724f88c70262b157e59494d29da1c613d0ef130564b6ff4f9`
+- target_skill_sha256: `a5e0bb043d61dbbb218e7d7efc08374e0d16a4d7aaa3b31817f2038830c90941`
 - eval_definition_sha256: `a7212e3282f2eaaa660e0675fb965d5050f366a07c153f3821d78fdab8976de5`
 - metadata_sha256: `1e20c97bb5ffc477023f6bbbd217e71d747297cb0b8f52652660b6b2d10adc7a`
 - fixture_sha256: `a0071569c74867aaacfda16310f9f4a06e50a375aa0e6b62ee25e801db096677`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `3e58dae2a34edb25f9589f7bddb4e3282cd1f66e3b0c3f35187db4ed16fd5f23`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `20617e4b8714b5129b537177e8c463822eec4083d7fdd0d6520c27013f94489f`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `7e61bd8eca6431729aee1f3be4656be0a4348119eb1218623bafd54cfaead2ab`
+- Skill overlay SHA-256: `d7e2242fcdf83209e6c0cb5ec9544aa009e79488a72f81ebd4bf387289fbabec`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,21 +33,21 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `sends_refactor_suspect_to_fact_layer` | NOT_EXERCISED | 锁定原始 trace 仅证明加载并遵循两层审计协议，未证明实际将页面标记为 suspect 并交给事实层。 |
-| `classifies_accurate_refactor_verified` | PASS | with_skill 输出明确将页面结论标为 `verified`，并核对了 GET 路径、limit 参数、200 响应及 400 错误声明。 |
-| `does_not_force_noop_doc_edit` | PASS | with_skill 输出明确声明纯实现重构不需要无意义的文档改动，并将 `documentation_change_required` 设为 false。 |
-| `does_not_block_for_unchanged_accurate_doc` | PASS | with_skill 输出将页面判为 `verified` 而非 `stale`，并将整体结果阻塞归因于缺少 Release Notes、版本索引及其他完整版本面证据；明确未返回 `ready_for_tag` 且未执行统一版本戳更新。 |
+| `sends_refactor_suspect_to_fact_layer` | NOT_EXERCISED | Raw trace does not independently prove the hidden suspect-to-fact-layer handoff; only process narration and skill instructions are present. |
+| `classifies_accurate_refactor_verified` | PASS | The with_skill output explicitly concludes the page is `verified` and lists matching GET path, optional limit, 200 response, and 400 error evidence. |
+| `does_not_force_noop_doc_edit` | PASS | The with_skill output explicitly states `documentation_change_required: false` and explains that the change is a pure implementation refactor. |
+| `does_not_block_for_unchanged_accurate_doc` | PASS | The with_skill output does not classify the page as stale; it reports `verified`, blocks only because required release-version surfaces and persistent handoff evidence are absent, and does not return `ready_for_tag`. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=20617e4b8714b5129b537177e8c463822eec4083d7fdd0d6520c27013f94489f; fixture_sha256=a0071569c74867aaacfda16310f9f4a06e50a375aa0e6b62ee25e801db096677; output_sha256=ce99540d8143e1c4d72e9b2a2b08202a2a20fcdf9426b24f62e944746a092ce1; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 准确识别纯实现重构，确认 API 页面仍 verified、无需无意义编辑，并因缺失完整 release-version surface 证据而阻塞整体 pre-tag 结论。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=20617e4b8714b5129b537177e8c463822eec4083d7fdd0d6520c27013f94489f; fixture_sha256=a0071569c74867aaacfda16310f9f4a06e50a375aa0e6b62ee25e801db096677; output_sha256=26de41473f0f1f09dea0b35f97823d91fd2722bc062a3ccab5939d39f074a209; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly verifies the unchanged API contract, avoids a no-op documentation edit, and blocks only on incomplete release-version evidence.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=20617e4b8714b5129b537177e8c463822eec4083d7fdd0d6520c27013f94489f; fixture_sha256=a0071569c74867aaacfda16310f9f4a06e50a375aa0e6b62ee25e801db096677; output_sha256=6038eefdc1da9d64933e8b8770c10143c94d63bbdf3c22bab5caec9b0af77aa1; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 识别 API 内容未漂移，但将未更新的版本标记作为后续跟进项，未形成 with_skill 的事实层 verified 与完整版本面阻塞结论。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=20617e4b8714b5129b537177e8c463822eec4083d7fdd0d6520c27013f94489f; fixture_sha256=a0071569c74867aaacfda16310f9f4a06e50a375aa0e6b62ee25e801db096677; output_sha256=229ae28026b58e54f9ad9bcc0874c3e4f16db4854f9fe3f21e2b8774e34b8b16; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline incorrectly treats the audit as passed and does not identify the affected page as suspect or the release evidence gap as blocking.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/docs/test/docs-audit/evals/workspace/eval-004-audit-all-verified/comparison.md
+++ b/agents/docs/test/docs-audit/evals/workspace/eval-004-audit-all-verified/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `085a9df9c5171410b3af490aa0eb671dd955de6207e401089976f50095ed2897` from `agents/docs/test/docs-audit/evals/workspace/eval-004-audit-all-verified`.
 - Identity schema: `2`
-- target_skill_sha256: `dafd53371901dfd724f88c70262b157e59494d29da1c613d0ef130564b6ff4f9`
+- target_skill_sha256: `a5e0bb043d61dbbb218e7d7efc08374e0d16a4d7aaa3b31817f2038830c90941`
 - eval_definition_sha256: `9d29cd503dc3f38e1235bc8d674c667f9fc3bef38d94569b7888bb0dfed80506`
 - metadata_sha256: `4c1ab6c77122f43adf1cbc9d6f05aea7b2b047fe1e69ba225e32d03f006dc954`
 - fixture_sha256: `085a9df9c5171410b3af490aa0eb671dd955de6207e401089976f50095ed2897`
@@ -22,42 +22,40 @@
 - judge_schema_sha256: `a043187f1d82deb6ceb1f6f2a8dbb12db6dd01c71ced16d224de3ae50ca31c3b`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `f182723403634fcd32c050786ed55f612a9685f404b0e23235cff29b52f7174c`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `7e61bd8eca6431729aee1f3be4656be0a4348119eb1218623bafd54cfaead2ab`
-- Behavior result: **FAIL**
+- Skill overlay SHA-256: `d7e2242fcdf83209e6c0cb5ec9544aa009e79488a72f81ebd4bf387289fbabec`
+- Behavior result: **PASS**
 - Coverage result: **FULL**
-Overall result: FAIL
+Overall result: PASS
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `verifies_complete_affected_set` | PASS | The locked candidate record identifies the two change-map-required API pages and all four affected pages as verified, with no unresolved evidence gap. |
-| `stamps_all_pages_together` | PASS | Locked delivery snapshots show both API pages stamped to v1.1.0; the release-notes page and index already contain v1.1.0 and remain unchanged, matching the unified-stamp result. |
-| `verifies_release_metadata_read_only` | PASS | The candidate record verifies docs/site/.meta/releases.json and explicitly states it was not modified; commit diffs contain no metadata change. |
-| `normalizes_mixed_version_forms` | PASS | The candidate record inventories v-prefixed and unprefixed sources, normalizes them to 1.1.0, and records the required source-specific raw forms and equal comparisons. |
-| `persists_candidate_producer_schema` | FAIL | The locked candidate record contains the required candidate schema, inventories, locators, hashes, gates, and candidate_verified conclusion, but does not contain the required prior-lineage SHA-256 digest in the candidate record itself. |
-| `anchors_candidate_then_discovers_success` | FAIL | Raw Git evidence shows candidate_commit and anchor_commit are the same badd32b commit, contrary to the required distinct post-candidate anchor step; the later handoff commits and fast-forward are present, but the mandated candidate-then-anchor sequence is not satisfied. |
+| `verifies_complete_affected_set` | PASS | Candidate record lists all four affected pages, marks each conclusion verified, and reports no blockers or unresolved gaps. |
+| `stamps_all_pages_together` | PASS | Candidate record defines the four-page unified stamp set; locked page snapshots show all four at v1.1.0, with the two stale API markers changed and the already-correct release pages preserved. |
+| `verifies_release_metadata_read_only` | PASS | Locked git evidence shows releases.json was read as version evidence and was absent from both candidate and handoff commit diffs; its ownership/read-only role is recorded in the version inventory. |
+| `normalizes_mixed_version_forms` | PASS | Candidate inventory records v1-prefixed forms for release sources, an unprefixed package.json version, normalized SemVer values, and equality comparisons; the actual-tag source is explicitly pending as expected pre-tag. |
+| `persists_candidate_producer_schema` | PASS | Locked audit file at the fixed path contains the candidate schema, attempt/phase, immutable refs, impact and stamp sets, per-page tree metadata and evidence, hashes, complete version-source locator contracts, canonical digest, two staged inventories, conclusion candidate_verified, and no ready_for_tag or post-commit fields. |
+| `anchors_candidate_then_discovers_success` | PASS | Raw trace and git evidence show the candidate commit and second staged gate precede the anchor, the fixed handoff is then created in a separate commit, and that commit is fast-forward integrated with final path/blob/tree/status readback. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f182723403634fcd32c050786ed55f612a9685f404b0e23235cff29b52f7174c; fixture_sha256=085a9df9c5171410b3af490aa0eb671dd955de6207e401089976f50095ed2897; output_sha256=f69a97f1f40cacff8c528f7829ad451f77f88874e5a29ef174c9f48c086f5f30; snapshot_sha256=d2eb424ce02e2f34d34069a3fbfc62dbd59ca74dca931a12c87b93249fc3f206
-- Behavior: Audited the complete affected set, stamped the two stale API pages, preserved release metadata, persisted candidate and handoff artifacts, and integrated by fast-forward, but failed the candidate-schema lineage requirement and distinct anchor sequencing.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f182723403634fcd32c050786ed55f612a9685f404b0e23235cff29b52f7174c; fixture_sha256=085a9df9c5171410b3af490aa0eb671dd955de6207e401089976f50095ed2897; output_sha256=d23fbddb1b0fadb41ca83dc855b5b051c0144950d762937e77e2d02a35386885; snapshot_sha256=64d8660fef3b70f1ebc22efee42675ef36a292a9ef87f15774c6eca6551805c1
+- Behavior: Completed the four-page audit, normalized version sources, updated stale API stamps, persisted a candidate record, created the post-stamp anchor and ready_for_tag handoff, and fast-forward integrated it.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f182723403634fcd32c050786ed55f612a9685f404b0e23235cff29b52f7174c; fixture_sha256=085a9df9c5171410b3af490aa0eb671dd955de6207e401089976f50095ed2897; output_sha256=76ecc0bacd9841e80f45e46a4368f65e7708ffe62deffa6b691f2d819bf478f0; snapshot_sha256=9fdf4fe0a34caa02600862ff2ca9bdab9d0ecc632ed87d474c6cae5f0ce1e309
-- Behavior: Produced only a prose audit report, left the stale API stamps unchanged, and did not create the required candidate, anchor, or discovery handoff artifacts.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f182723403634fcd32c050786ed55f612a9685f404b0e23235cff29b52f7174c; fixture_sha256=085a9df9c5171410b3af490aa0eb671dd955de6207e401089976f50095ed2897; output_sha256=135e1399a2da7c75c2345138d801772402f0e89de0a3497baafb70a7aaaf39a1; snapshot_sha256=2a72172fd0245765fd076f4502f6946b183f8471e75ef75bd4d7f5b6e71861dc
+- Behavior: Created a separate ad hoc report but stopped because the two API pages remained at v1.0.0 and did not complete the required audit workflow.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- persists_candidate_producer_schema: missing required prior-lineage digest in the locked candidate record.
-- anchors_candidate_then_discovers_success: candidate and anchor commits are identical, violating the required sequencing.
-- Next: Add the prior-lineage digest to the candidate record and rerun validation.
-- Next: Create a distinct post-stamp anchor commit after the candidate commit, then regenerate and validate the handoff.
+- None.
+- Next: None.
 
 ## Runtime Artifact Policy
 

--- a/agents/docs/test/docs-audit/evals/workspace/eval-005-audit-doc-only-error/comparison.md
+++ b/agents/docs/test/docs-audit/evals/workspace/eval-005-audit-doc-only-error/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `126b82b218c4429d9a8e50c428008903893e0b48fd89e0ee4186368ab968404a` from `agents/docs/test/docs-audit/evals/workspace/eval-005-audit-doc-only-error`.
 - Identity schema: `2`
-- target_skill_sha256: `dafd53371901dfd724f88c70262b157e59494d29da1c613d0ef130564b6ff4f9`
+- target_skill_sha256: `a5e0bb043d61dbbb218e7d7efc08374e0d16a4d7aaa3b31817f2038830c90941`
 - eval_definition_sha256: `1f7d058864bf71ce0402d8ada31c06c85782a25b93779e842d80b5a98766c9d9`
 - metadata_sha256: `63b77017b252b389a44397720be8380b6bee7f6a85225c5d210accca792fc487`
 - fixture_sha256: `126b82b218c4429d9a8e50c428008903893e0b48fd89e0ee4186368ab968404a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `d804d7eed6dff47b2c8744abfb057fce66d8fde2359e03e7f21e978c34808373`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `59ccd7c8df4ada989871eac608af9fe615691e1a2d925c63deac93d4d7d56264`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `7e61bd8eca6431729aee1f3be4656be0a4348119eb1218623bafd54cfaead2ab`
+- Skill overlay SHA-256: `d7e2242fcdf83209e6c0cb5ec9544aa009e79488a72f81ebd4bf387289fbabec`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,21 +33,21 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `includes_doc_only_change` | PASS | With-skill trace explicitly applies the documentation-only affected-page rule, and reports docs/site/api/catalog.md as affected despite no code or change-map match. |
-| `uses_related_code_for_fact_check` | PASS | The page declares related_code src/catalog/routes.txt; the with-skill result cites that file as target code evidence and compares its GET-only content. |
-| `classifies_doc_only_conflict_mismatch` | PASS | The with-skill report preserves the DELETE claim, GET-only code fact, routes.txt evidence, blocking impact, and classifies the page as mismatch. |
-| `blocks_despite_no_code_diff` | PASS | The with-skill result is pre-tag blocked, says the page cannot be stamped, and does not return ready_for_tag despite the docs-only diff. |
+| `includes_doc_only_change` | PASS | The with_skill report says the changed formal page was included in the affected set despite no code-file change-map match. |
+| `uses_related_code_for_fact_check` | PASS | The with_skill report fact-checks the page against the target-tree `src/catalog/routes.txt`, the page’s declared related-code path, despite no code diff. |
+| `classifies_doc_only_conflict_mismatch` | PASS | The with_skill report preserves the DELETE declaration, identifies only GET in the route evidence, cites the evidence path, describes the release impact, and classifies the page as `mismatch`. |
+| `blocks_despite_no_code_diff` | PASS | The with_skill report explicitly identifies the phase as `pre-tag`, returns `blocked`, states no audit metadata was written, and does not return `ready_for_tag`. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=59ccd7c8df4ada989871eac608af9fe615691e1a2d925c63deac93d4d7d56264; fixture_sha256=126b82b218c4429d9a8e50c428008903893e0b48fd89e0ee4186368ab968404a; output_sha256=a6c94552717ee283d4ebceceef8679694cd0530a44e83828ec5fc6b2fa6a0898; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly included and fact-checked the documentation-only page, detected the DELETE mismatch, and blocked pre-tag release.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=59ccd7c8df4ada989871eac608af9fe615691e1a2d925c63deac93d4d7d56264; fixture_sha256=126b82b218c4429d9a8e50c428008903893e0b48fd89e0ee4186368ab968404a; output_sha256=37ecd7fb1675a1b82c0e04598a4461b9a7ee9eae72bdc0de3f745332d140b0ca; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly audited the documentation-only change, used the related code for factual verification, classified the API claim as mismatch, and blocked pre-tag release.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=59ccd7c8df4ada989871eac608af9fe615691e1a2d925c63deac93d4d7d56264; fixture_sha256=126b82b218c4429d9a8e50c428008903893e0b48fd89e0ee4186368ab968404a; output_sha256=603dc88d5d03441b68fd953e0e4ce5c895208f8d61eb3b3126ff74d0a878a49f; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Also detected the mismatch and recommended blocking, but did not demonstrate the formal documentation-only impact workflow.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=59ccd7c8df4ada989871eac608af9fe615691e1a2d925c63deac93d4d7d56264; fixture_sha256=126b82b218c4429d9a8e50c428008903893e0b48fd89e0ee4186368ab968404a; output_sha256=90ebaa3018a96d56d3381678e0cd7d3ecd4d642b1d4471471373455bc4b7f5f2; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Also identified the mismatch and recommended blocking, but did not provide the full docs-audit protocol result or explicit pre-tag audit state.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/docs/test/docs-audit/evals/workspace/eval-006-audit-no-version-anchor/comparison.md
+++ b/agents/docs/test/docs-audit/evals/workspace/eval-006-audit-no-version-anchor/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `82b55bed70c9cef729375a3351448011b6841c9c9416854e0ef1fd304e6c48bb` from `agents/docs/test/docs-audit/evals/workspace/eval-006-audit-no-version-anchor`.
 - Identity schema: `2`
-- target_skill_sha256: `dafd53371901dfd724f88c70262b157e59494d29da1c613d0ef130564b6ff4f9`
+- target_skill_sha256: `a5e0bb043d61dbbb218e7d7efc08374e0d16a4d7aaa3b31817f2038830c90941`
 - eval_definition_sha256: `405d79374055fe033af3883c346829478f3f76cf09e82f4870928a5901ad3a47`
 - metadata_sha256: `953ef09fb5962b093fa646d68b6f137fe0b19f6ba0157a6c58aae94c9c50c930`
 - fixture_sha256: `82b55bed70c9cef729375a3351448011b6841c9c9416854e0ef1fd304e6c48bb`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `7c0884fab11b08d46eb01de89abfa2125334493a96c7805f68a7161e9d7bff70`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `dfb1de5ef05668c278fa0bfcea0c360fed3169b7b4bae6483c3fb5fedeccf198`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `7e61bd8eca6431729aee1f3be4656be0a4348119eb1218623bafd54cfaead2ab`
+- Skill overlay SHA-256: `d7e2242fcdf83209e6c0cb5ec9544aa009e79488a72f81ebd4bf387289fbabec`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,27 +33,27 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `blocks_without_target_release_version` | PASS | With_skill output explicitly returns `blocked` because `target_release_version` is missing. |
-| `allows_read_only_diagnostic` | NOT_EXERCISED | The lane stops before repository inspection, so the read-only diagnostic behavior is not exercised. |
-| `does_not_persist_report_without_target` | PASS | Output states report writing was not executed; locked git evidence shows no diffs, new commits, or untracked files. |
-| `does_not_write_version_stamp` | PASS | Output states version metadata modification was not executed; locked git evidence shows no repository changes. |
+| `blocks_without_target_release_version` | PASS | with_skill explicitly returns `blocked` because `target_release_version` is missing and does not return `ready_for_tag` or `release_verified`. |
+| `allows_read_only_diagnostic` | NOT_EXERCISED | The candidate correctly stops at the missing-version gate; the later affected-page diagnostic cannot occur before user confirmation, so this assertion is not exercised. |
+| `does_not_persist_report_without_target` | PASS | Locked evidence shows no delivery snapshot, declared outputs, Git changes, new commits, or ref changes; the candidate also explicitly states it will not write a report. |
+| `does_not_write_version_stamp` | PASS | The fixture retains `last_verified_version: unverified`; locked Git evidence shows clean status, unchanged HEAD/branch, no ref delta, and no delivered metadata changes. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=dfb1de5ef05668c278fa0bfcea0c360fed3169b7b4bae6483c3fb5fedeccf198; fixture_sha256=82b55bed70c9cef729375a3351448011b6841c9c9416854e0ef1fd304e6c48bb; output_sha256=1a313a4257b1260c77f9ea985c794073d0b9115b581a73bf2418fd605bf481cb; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly blocks before audit work when no maintainer-confirmed target release version exists, with no persisted changes.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=dfb1de5ef05668c278fa0bfcea0c360fed3169b7b4bae6483c3fb5fedeccf198; fixture_sha256=82b55bed70c9cef729375a3351448011b6841c9c9416854e0ef1fd304e6c48bb; output_sha256=352f1fae994828f2ba15924f4ba8e890477010b04313caa45b679a41db09d403; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly blocks at the missing maintainer-confirmed target release version and performs no persistence or stamping.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=dfb1de5ef05668c278fa0bfcea0c360fed3169b7b4bae6483c3fb5fedeccf198; fixture_sha256=82b55bed70c9cef729375a3351448011b6841c9c9416854e0ef1fd304e6c48bb; output_sha256=4b5d5e798d309695e568cf0dd7d4312689335da0bc78d2a19891b40bc9a1bc57; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Performs a read-only diagnostic and reports no confirmed regression, but does not block on the missing target release version.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=dfb1de5ef05668c278fa0bfcea0c360fed3169b7b4bae6483c3fb5fedeccf198; fixture_sha256=82b55bed70c9cef729375a3351448011b6841c9c9416854e0ef1fd304e6c48bb; output_sha256=1015a3e2726a141f87e2eac913aa99d45a5b169b4918be0fb94add658b9e22e3; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Provides a read-only comparison diagnosis and warns against treating the target ref as a confirmed release version, but does not explicitly return the required blocked phase result.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Obtain maintainer confirmation of the exact target_release_version before continuing the audit.
+- Next: Obtain explicit maintainer confirmation of the complete target_release_version, then perform the deferred affected-page diagnostic.
 
 ## Runtime Artifact Policy
 

--- a/agents/docs/test/docs-audit/evals/workspace/eval-007-frontmatter-contract-fixtures/comparison.md
+++ b/agents/docs/test/docs-audit/evals/workspace/eval-007-frontmatter-contract-fixtures/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `1219a80a8f97201ae3cdd929f2d631a2ba100cf6ab153bec6afe2b6d163ff59f` from `agents/docs/test/docs-audit/evals/workspace/eval-007-frontmatter-contract-fixtures`.
 - Identity schema: `2`
-- target_skill_sha256: `dafd53371901dfd724f88c70262b157e59494d29da1c613d0ef130564b6ff4f9`
+- target_skill_sha256: `a5e0bb043d61dbbb218e7d7efc08374e0d16a4d7aaa3b31817f2038830c90941`
 - eval_definition_sha256: `6bde344495a08502946e81bb93f2ae1c40e1aff64c95e853b673dd5a307e9ade`
 - metadata_sha256: `ac5c625c3b447eed92814a4915de66331bf3c2449cbef00676c3c687ad5d80de`
 - fixture_sha256: `1219a80a8f97201ae3cdd929f2d631a2ba100cf6ab153bec6afe2b6d163ff59f`
@@ -22,42 +22,42 @@
 - judge_schema_sha256: `216827bc3e07bc68d228647a6fadcd479f48a986964f70c0c40f48052e42886f`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `49a9f020c04120ad8bdb6f9b036cf5ce5bd9266f99e431e7e0059400223b90de`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `7e61bd8eca6431729aee1f3be4656be0a4348119eb1218623bafd54cfaead2ab`
-- Behavior result: **PASS**
+- Skill overlay SHA-256: `d7e2242fcdf83209e6c0cb5ec9544aa009e79488a72f81ebd4bf387289fbabec`
+- Behavior result: **FAIL**
 - Coverage result: **PARTIAL**
-Overall result: PASS (partial coverage)
+Overall result: FAIL
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `accepts_confirmed_audit_entry` | PASS | With-skill output accepts maintainer-confirmed v0.4.0, base_ref 4a1b2c3, target_ref 7c9e2af, pre-tag phase, and the five-file evidence inventory. |
-| `rejects_standard_doc_type` | PASS | With-skill output classifies catalog-search.md as stale because doc_type: standard is invalid. |
-| `rejects_empty_related_code` | PASS | With-skill output classifies catalog-export.md as stale because related_code is empty. |
-| `rejects_missing_last_verified_version` | PASS | With-skill output classifies catalog-status.md as stale because last_verified_version is missing. |
-| `rejects_empty_owners` | PASS | With-skill output classifies catalog-bulk-update.md as stale because owners is empty. |
-| `accepts_valid_api_page` | PASS | With-skill output verifies catalog-items.md and matches its GET /catalog/items, 200, and items-array claim to routes.txt. |
-| `blocks_release_for_invalid_frontmatter` | PASS | With-skill output retains four stale pages, returns blocked, and does not return ready_for_tag or stamp the valid page alone. |
-| `uses_shared_contract_source` | NOT_EXERCISED | Raw trace proves docs-audit read the docs-agent frontmatter contract and that docs-site-bootstrap consumes it, but does not prove the specific check-frontmatter.mjs comparison. |
+| `accepts_confirmed_audit_entry` | PASS | With_skill explicitly reports maintainer-confirmed v0.4.0, base_ref 4a1b2c3, target_ref 7c9e2af, pre-tag phase, and the locked evidence inventory. |
+| `rejects_standard_doc_type` | PASS | With_skill classifies catalog-search.md as stale because doc_type: standard is outside the allowed enum. |
+| `rejects_empty_related_code` | PASS | With_skill classifies catalog-export.md as stale because related_code: [] is invalid. |
+| `rejects_missing_last_verified_version` | PASS | With_skill classifies catalog-status.md as stale because last_verified_version is missing. |
+| `rejects_empty_owners` | PASS | With_skill classifies catalog-bulk-update.md as stale because owners: [] is invalid. |
+| `accepts_valid_api_page` | FAIL | The locked fixture has all seven valid fields on catalog-items.md, but with_skill reports it as evidence-insufficient/unverified and does not confirm frontmatter validation or fact-layer entry. |
+| `blocks_release_for_invalid_frontmatter` | PASS | With_skill reports blocked, retains all four invalid pages as stale, does not return ready_for_tag, and does not stamp the valid page. |
+| `uses_shared_contract_source` | NOT_EXERCISED | Raw trace proves the shared frontmatter contract was read, but does not prove confirmation against a delivered check-frontmatter.mjs implementation; no such host file exists in the locked fixture. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=49a9f020c04120ad8bdb6f9b036cf5ce5bd9266f99e431e7e0059400223b90de; fixture_sha256=1219a80a8f97201ae3cdd929f2d631a2ba100cf6ab153bec6afe2b6d163ff59f; output_sha256=4eeffb590c55540862239ba525abaeea92dac53eb0cc46ade2b73aeecdd4049a; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly accepts the confirmed audit entry, validates the valid API page, identifies all four invalid frontmatter blockers, and returns blocked without mutation.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=49a9f020c04120ad8bdb6f9b036cf5ce5bd9266f99e431e7e0059400223b90de; fixture_sha256=1219a80a8f97201ae3cdd929f2d631a2ba100cf6ab153bec6afe2b6d163ff59f; output_sha256=4faa4191aff3a2a756ffd3f8d59a093eb956d3ce93e95ece255dc72d0490c1ef; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly accepts the audit entry, rejects all four invalid frontmatter cases, and blocks release; it incorrectly treats the valid API page as unverified rather than accepting it into the fact layer.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=49a9f020c04120ad8bdb6f9b036cf5ce5bd9266f99e431e7e0059400223b90de; fixture_sha256=1219a80a8f97201ae3cdd929f2d631a2ba100cf6ab153bec6afe2b6d163ff59f; output_sha256=271c49f62dd66effd52817502ff37451dc96136b1a531004ebbbd50610652144; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Fresh baseline also returns a no-go result but incorrectly rejects the valid catalog-items page solely because its unverified stamp is not yet versioned.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=49a9f020c04120ad8bdb6f9b036cf5ce5bd9266f99e431e7e0059400223b90de; fixture_sha256=1219a80a8f97201ae3cdd929f2d631a2ba100cf6ab153bec6afe2b6d163ff59f; output_sha256=f46d836c6682862b700738480500b624770bce0f5575863e8290fa0aabcbb5d3; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline incorrectly treats the bounded diff as eliminating the affected set and does not perform the required per-page frontmatter classification.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- None.
-- Next: Capture explicit evidence that docs-audit and docs-site-bootstrap use the same check-frontmatter.mjs validation logic.
+- The with_skill lane incorrectly fails to accept catalog-items.md as valid frontmatter and entering the fact layer.
+- Next: Correct the valid-page classification for catalog-items.md while preserving the blocked release result caused by the four invalid pages.
 
 ## Runtime Artifact Policy
 

--- a/agents/docs/test/docs-audit/evals/workspace/eval-008-pre-tag-success/comparison.md
+++ b/agents/docs/test/docs-audit/evals/workspace/eval-008-pre-tag-success/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `188f1d4d85d9c539fa3ce7acd636673ee316e8a8c7f692533cb806966484f84f` from `agents/docs/test/docs-audit/evals/workspace/eval-008-pre-tag-success`.
 - Identity schema: `2`
-- target_skill_sha256: `dafd53371901dfd724f88c70262b157e59494d29da1c613d0ef130564b6ff4f9`
+- target_skill_sha256: `a5e0bb043d61dbbb218e7d7efc08374e0d16a4d7aaa3b31817f2038830c90941`
 - eval_definition_sha256: `4d1aa7f3a07c406f7e925f931c91ea28170bd7650629aa75bcd06b4f58bba0c7`
 - metadata_sha256: `6adbc51a2dc07674edf9fca71addc72bccaccf75ae663c41fbf3725d8c48b107`
 - fixture_sha256: `188f1d4d85d9c539fa3ce7acd636673ee316e8a8c7f692533cb806966484f84f`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `4cd14ef8cd033d31b5bb9ce50a786ad0b7d18c7ff4f682d88505eac53b634ecf`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `c716eb0f2d2753ceb3a2258e2367701a57faeef420e346b4fa18dc3a1677c0e3`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `7e61bd8eca6431729aee1f3be4656be0a4348119eb1218623bafd54cfaead2ab`
+- Skill overlay SHA-256: `d7e2242fcdf83209e6c0cb5ec9544aa009e79488a72f81ebd4bf387289fbabec`
 - Behavior result: **FAIL**
 - Coverage result: **PARTIAL**
 Overall result: FAIL
@@ -33,35 +33,39 @@ Overall result: FAIL
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `accepts_confirmed_version_without_tag` | PASS | The with_skill output records base_ref v1.1.0, target_ref release-head, maintainer-confirmed v1.2.0, and explicitly says the v1.2.0 tag is absent and acceptable for pre-tag. |
-| `verifies_complete_set_and_surfaces` | PASS | Locked trace reads the change map, both API pages, release handoff, Release Notes, index, release metadata, package version, and route facts; the output reports the complete affected set as verified. |
-| `normalizes_mixed_version_forms` | PASS | The output states that package.json, Release Notes, index, and .meta/releases.json normalize to the same 1.2.0 identity, with the expected prefixed and unprefixed source forms. |
-| `records_pre_stamp_values` | PASS | The output records the four pre-stamp values: catalog-items and index v1.1.0, catalog-status and Release Notes unverified, and states no baseline_verified_version was added. |
-| `stamps_complete_set_atomically` | PASS | Locked file-change and staged-diff evidence shows all four authorized pages updated together; the output says the unified stamp was verified and .meta/releases.json was not modified. |
-| `builds_isolated_candidate_transaction` | PASS | The trace creates a temporary branch/worktree from release-head, stages the four pages there, and cleanup evidence shows the host branch, index, and worktree restored. |
-| `candidate_record_has_no_ready_result` | NOT_EXERCISED | A candidate record file-change event exists, but its locked content is not exposed, so the required complete schema and absence of forbidden fields cannot be proven. |
-| `validates_two_complete_staged_gates` | FAIL | The first staged-gate evidence shows the candidate path as untracked rather than an A/M 100644 ordinary blob, and no complete second gate is shown; this contradicts the exercised gate requirement. |
-| `confirms_anchor_commit_before_discovery` | NOT_EXERCISED | No anchor commit was created because Git rejected the commit for missing user.name/user.email; the required post-anchor checks were therefore not reached. |
-| `persists_fixed_discovery_handoff` | NOT_EXERCISED | No discovery handoff was written because anchor creation failed; the output explicitly says no handoff remained after rollback. |
-| `returns_ready_only_after_integration` | NOT_EXERCISED | No fast-forward integration or integrated handoff readback occurred because the anchor stage failed. |
-| `returns_ready_for_tag_not_published` | NOT_EXERCISED | The with_skill lane returned blocked after the missing Git identity prevented the later required steps, so the successful ready_for_tag result was not reached. |
+| `accepts_confirmed_version_without_tag` | PASS | Candidate record and handoff record retain the confirmed version, base/target refs, and pending-absent actual tag; final output says the tag was not created. |
+| `verifies_complete_set_and_surfaces` | PASS | Candidate record lists both change-map API pages, all four affected pages, per-page verified results, release-note handoff, metadata, and package version evidence. |
+| `normalizes_mixed_version_forms` | PASS | Version inventory records required raw forms, selectors, extractors, normalized values, and equality across confirmation, package.json, notes, index, and metadata. |
+| `records_pre_stamp_values` | PASS | Candidate record directly records the four pre-stamp values: v1.1.0, unverified, v1.1.0, and unverified, with no baseline_verified_version field. |
+| `stamps_complete_set_atomically` | PASS | Delivery snapshots show all four authorized pages changed only from their prior values to v1.2.0, readback passed, and releases.json was not changed. |
+| `builds_isolated_candidate_transaction` | NOT_EXERCISED | The trace shows the intended isolated worktree/branch flow and delivery evidence shows candidate commits, but the locked raw evidence does not fully prove index initialization and preservation throughout all candidate checks. |
+| `candidate_record_has_no_ready_result` | FAIL | The candidate record has the required schema, page hashes, version inventory, digests, staged inventories, readback, and candidate_verified conclusion, but it also contains target/base commit and target_tree identity fields, which the assertion forbids. |
+| `validates_two_complete_staged_gates` | PASS | Candidate record and commit evidence contain pre- and post-candidate inventories with raw modes/types/statuses, ordinary blobs, single-line stamp changes, fixed paths, and no unauthorized delta; final commit evidence also shows the expected handoff addition. |
+| `confirms_anchor_commit_before_discovery` | PASS | The handoff records anchor commit/tree and post-commit confirmation; commit evidence shows the anchor was created before the handoff and final tree/blob readback was performed. |
+| `persists_fixed_discovery_handoff` | FAIL | The delivered handoff includes schema, attempt, phase, version, refs, ready_for_tag, result time, inventory digest, anchor, candidate path/blob, confirmation, lineage, and digest, but omits the required handoff-path preimage and a current entry for the handoff blob without self-reference. |
+| `returns_ready_only_after_integration` | PASS | Git evidence shows fast-forward integration from target_ref to the final commit, unchanged branch name, clean final status/index/worktree, and final output exposes the handoff for pm-agent:github-release-gen. |
+| `returns_ready_for_tag_not_published` | FAIL | The output returns ready_for_tag and says the tag was not created or published, but it does not explicitly state that the status does not mean release verified. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c716eb0f2d2753ceb3a2258e2367701a57faeef420e346b4fa18dc3a1677c0e3; fixture_sha256=188f1d4d85d9c539fa3ce7acd636673ee316e8a8c7f692533cb806966484f84f; output_sha256=86f6eb667ca9f4ef62d6243f06870c18f6ffa055f0d1b34c87cc201f60e19c99; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Performed the bounded pre-tag audit, verified and staged the four-page stamp in an isolated worktree, then correctly blocked and rolled back when anchor commit creation lacked Git identity; candidate/gating evidence was incomplete.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c716eb0f2d2753ceb3a2258e2367701a57faeef420e346b4fa18dc3a1677c0e3; fixture_sha256=188f1d4d85d9c539fa3ce7acd636673ee316e8a8c7f692533cb806966484f84f; output_sha256=f716a4a427fc71b2f2c55dd4d612502c11c83a837348c88ed24c1191b63fdaa2; snapshot_sha256=0f2c33a1e171108fb586729ab7f78dd027e5dc7f1e711486289af339fc498127
+- Behavior: Performed the pre-tag audit, stamped and integrated the four-page set, and exposed ready_for_tag, but delivered a nonconforming candidate record and incomplete handoff metadata.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c716eb0f2d2753ceb3a2258e2367701a57faeef420e346b4fa18dc3a1677c0e3; fixture_sha256=188f1d4d85d9c539fa3ce7acd636673ee316e8a8c7f692533cb806966484f84f; output_sha256=3f616c531a67a34291981518d58c27bd3dfc41b7990de549b524e94362aff901; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Fresh baseline only checked repository state, basic diff, version/tag facts, and reported blockers without executing the documentation-audit transaction.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c716eb0f2d2753ceb3a2258e2367701a57faeef420e346b4fa18dc3a1677c0e3; fixture_sha256=188f1d4d85d9c539fa3ce7acd636673ee316e8a8c7f692533cb806966484f84f; output_sha256=25d3ad05dbf10dd7264c8c644a2d8ed7b4c9c4c08a2ffe5212ec67846dff1698; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline incorrectly blocked pre-tag on metadata, evidence-patch, and scope concerns; it made no repository changes.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- The candidate record remained untracked during the staged-gate evidence, and the complete two-gate validation was not demonstrated.
-- Next: Configure Git user.name and user.email, then rerun the complete pre-tag transaction and its candidate/staged-gate validation.
+- candidate_record_has_no_ready_result
+- persists_fixed_discovery_handoff
+- returns_ready_for_tag_not_published
+- Next: Remove forbidden commit/tree identity fields from the candidate record while retaining required page hashes.
+- Next: Add the handoff path preimage and non-self-referential handoff current entry/digest.
+- Next: Explicitly state that ready_for_tag permits tag creation only and does not mean publication or release verification.
 
 ## Runtime Artifact Policy
 

--- a/agents/docs/test/docs-audit/evals/workspace/eval-009-pre-tag-blocked/comparison.md
+++ b/agents/docs/test/docs-audit/evals/workspace/eval-009-pre-tag-blocked/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `0c59dd74f98f557b12899cbca54adf5aa4fe8aa94d37037f8495e06f83e726c0` from `agents/docs/test/docs-audit/evals/workspace/eval-009-pre-tag-blocked`.
 - Identity schema: `2`
-- target_skill_sha256: `dafd53371901dfd724f88c70262b157e59494d29da1c613d0ef130564b6ff4f9`
+- target_skill_sha256: `a5e0bb043d61dbbb218e7d7efc08374e0d16a4d7aaa3b31817f2038830c90941`
 - eval_definition_sha256: `d573477cbe6d660b40a0fd1ef0416d1d407e28ca525b29d8ef8303b282fe7f56`
 - metadata_sha256: `2fa243367a1e388253aea518818683b603664720294e82f2ffeeeebe3d5f82e8`
 - fixture_sha256: `0c59dd74f98f557b12899cbca54adf5aa4fe8aa94d37037f8495e06f83e726c0`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `7dbaa3390632c779b209a0992154e3a2f393b139ccab7a74c59a949526e90023`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `542a6dbc4e91378f219fb9c7b639cb7670be62733499a20407d8c4586f25b852`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `7e61bd8eca6431729aee1f3be4656be0a4348119eb1218623bafd54cfaead2ab`
+- Skill overlay SHA-256: `d7e2242fcdf83209e6c0cb5ec9544aa009e79488a72f81ebd4bf387289fbabec`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,21 +33,21 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `requires_exact_target_tree_blobs` | PASS | With-skill output explicitly binds audit evidence to the immutable `release-head` tree and excludes worktree/index/untracked changes; raw git evidence confirms target-tree inspection and the unchanged target commit. |
-| `blocks_every_in_scope_worktree_delta` | PASS | It identifies all four inventory entries—staged routes, unstaged API page, untracked audit draft, and modified package.json—and explains that each is in scope and blocks the audit. |
-| `performs_zero_audit_writes` | PASS | Raw git evidence shows unchanged HEAD, branch, refs, commits, and reflog, with no result diffs. The output states the audit was blocked without writing a formal report or returning `ready_for_tag`. |
-| `requires_clean_commit_update_ref_and_rerun` | PASS | The output directs the maintainer to commit or remove all scoped changes, update `release-head`, clean the index/worktree, and rerun the complete deterministic impact, documentation, page, and version audit before any success result. |
+| `requires_exact_target_tree_blobs` | PASS | With-skill output explicitly anchors the conclusion to `release-head` commit `4d7edbe...`, states the target tree still has the legacy implementation and version `1.1.0`, and treats workspace/index changes only as diagnostic evidence. |
+| `blocks_every_in_scope_worktree_delta` | PASS | The output identifies staged `src/catalog/routes.txt`, unstaged `docs/site/api/catalog-items.md`, unstaged `package.json`, and untracked `docs/site/.meta/audit/audit-v1.2.0.md`, and concludes the pre-tag audit is `blocked`. Raw fixture status confirms those exact paths and states. |
+| `performs_zero_audit_writes` | PASS | Locked git evidence shows unchanged HEAD, branch, refs, commits, and diffs; the output returns `blocked`, explicitly prohibits `ready_for_tag`, and recommends only read-only diagnosis and cleanup/re-audit steps. |
+| `requires_clean_commit_update_ref_and_rerun` | PASS | The output requires submitting or moving all listed differences, updating `release-head`, confirming clean index/worktree state, and performing a complete pre-tag rerun with explicit refs and rebinding from the inputs. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=542a6dbc4e91378f219fb9c7b639cb7670be62733499a20407d8c4586f25b852; fixture_sha256=0c59dd74f98f557b12899cbca54adf5aa4fe8aa94d37037f8495e06f83e726c0; output_sha256=3e0d3c36da254ceb9429bf300fd8c7aaf1dec6a3cfd039dcb626ae05647a8020; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly blocks the pre-tag audit, distinguishes target-tree facts from uncommitted diagnostics, performs no audit writes, and specifies a complete clean-target rerun.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=542a6dbc4e91378f219fb9c7b639cb7670be62733499a20407d8c4586f25b852; fixture_sha256=0c59dd74f98f557b12899cbca54adf5aa4fe8aa94d37037f8495e06f83e726c0; output_sha256=20282c09caa30ca477b43f86392fa43cede6d7f1bee4cae8c09c494798fe4982; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly returns a blocked pre-tag audit, binds conclusions to the immutable target tree, inventories every in-scope delta, performs no writes, and specifies full cleanup, ref update, and rerun requirements.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=542a6dbc4e91378f219fb9c7b639cb7670be62733499a20407d8c4586f25b852; fixture_sha256=0c59dd74f98f557b12899cbca54adf5aa4fe8aa94d37037f8495e06f83e726c0; output_sha256=8cd622f7525885a6672ce26c16187387c548da8d13cfae5de8a710bcd3c611a5; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Also reaches the correct blocked conclusion and gives a useful rerun procedure, but is less explicit about scoped inventory binding and complete audit lineage.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=542a6dbc4e91378f219fb9c7b639cb7670be62733499a20407d8c4586f25b852; fixture_sha256=0c59dd74f98f557b12899cbca54adf5aa4fe8aa94d37037f8495e06f83e726c0; output_sha256=4adad2e66b572d2f605e4de8e07cd0131333531ad722572f5aed4885c715ff91; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Also reaches the correct blocked conclusion and gives target-tree evidence and rerun guidance, but provides a less complete per-path disposition and protocol-specific restart detail than the with_skill lane.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/docs/test/docs-audit/evals/workspace/eval-010-post-tag-match/comparison.md
+++ b/agents/docs/test/docs-audit/evals/workspace/eval-010-post-tag-match/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `43a1d01505e6c9e0f71431fdaeb75fea6b1939424f6c22775d15a970f4b73518` from `agents/docs/test/docs-audit/evals/workspace/eval-010-post-tag-match`.
 - Identity schema: `2`
-- target_skill_sha256: `dafd53371901dfd724f88c70262b157e59494d29da1c613d0ef130564b6ff4f9`
+- target_skill_sha256: `a5e0bb043d61dbbb218e7d7efc08374e0d16a4d7aaa3b31817f2038830c90941`
 - eval_definition_sha256: `f4b575228474dd8bb2a93bb17a067f25252f9c293e1f78393d445c449385e8d2`
 - metadata_sha256: `12f75879efa3cacf943ae19595239a747563947015e4033eed4ea7f4a51a5b47`
 - fixture_sha256: `43a1d01505e6c9e0f71431fdaeb75fea6b1939424f6c22775d15a970f4b73518`
@@ -22,41 +22,40 @@
 - judge_schema_sha256: `f64d4542aa97d4b9bcd4bc655a5e70fec7d827a5ea9e9f63067fde8d7b819748`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `47c14febb101f8d485b3785bf3ac63c5d627ee1f25999068d61918f6bfa13143`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `7e61bd8eca6431729aee1f3be4656be0a4348119eb1218623bafd54cfaead2ab`
-- Behavior result: **FAIL**
+- Skill overlay SHA-256: `d7e2242fcdf83209e6c0cb5ec9544aa009e79488a72f81ebd4bf387289fbabec`
+- Behavior result: **PASS**
 - Coverage result: **FULL**
-Overall result: FAIL
+Overall result: PASS
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `selects_pre_tag_authority_safely` | FAIL | with_skill 仅说明当前存在该 ref，未提供其实际解析的 commit/tree 或该 ref 下 handoff/audit 的读取结果；克隆侧证据充分。 |
-| `proves_released_tree_binding` | FAIL | raw trace 证明两侧解析了 tag commit/tree，且克隆读取了 tag-tree 路径；但未锁定证明当前 tag tree 与 direct package tree 的比较结果，最终输出也未给出该绑定结论。 |
-| `verifies_version_surfaces_from_release` | PASS | with_skill 明确从 tag tree 核验四个版本面，区分了 v1.2.0 与 1.2.0，并未把当前工作区作为成功证据。 |
-| `requires_durable_post_tag_evidence` | PASS | with_skill 明确指出缺少独立 post-tag 结果持久化凭据，两个场景均保持 blocked，且未声称 release_verified。 |
-| `preserves_upstream_release_artifacts` | PASS | with_skill 说明未修改现有 ref、tag 或发布记录；git_evidence 亦显示 HEAD、分支、refs 和工作区均未变化。 |
+| `selects_pre_tag_authority_safely` | PASS | With-skill raw trace resolves refs/release-evidence/v1.2.0 and reads its handoff/audit; it creates a default-refspec clone, verifies the custom ref is absent there, and inspects the clone’s own Git data. |
+| `proves_released_tree_binding` | PASS | Raw evidence resolves the tag commit/tree, compares the authority and tag trees, and independently reads handoff/audit and release paths from the clone’s tag tree. |
+| `verifies_version_surfaces_from_release` | PASS | The candidate and raw tag/clone reads verify all four version surfaces, normalize v1.2.0 and 1.2.0 consistently, and use tag content rather than the worktree. |
+| `requires_durable_post_tag_evidence` | PASS | The with-skill output identifies the absent proposed post-tag ref and missing maintainer decision, reports blocked_record_persistence as not_persisted, and keeps both scenarios blocked. |
+| `preserves_upstream_release_artifacts` | PASS | Raw final Git status and refs show no upstream ref/tag changes; the only temporary clone was cleaned up, and the output explicitly preserves the existing authority. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=47c14febb101f8d485b3785bf3ac63c5d627ee1f25999068d61918f6bfa13143; fixture_sha256=43a1d01505e6c9e0f71431fdaeb75fea6b1939424f6c22775d15a970f4b73518; output_sha256=83991f7951e6ad13868321d2a555508e54b287064a9a86b5dfbf9e6f24f7493f; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 正确完成 tag/clone 的多数只读核验并保持 blocked 与不可变性，但遗漏两项当前仓库 authority/tree-binding 的关键可见证据。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=47c14febb101f8d485b3785bf3ac63c5d627ee1f25999068d61918f6bfa13143; fixture_sha256=43a1d01505e6c9e0f71431fdaeb75fea6b1939424f6c22775d15a970f4b73518; output_sha256=cb27af6e263e16ed2e299875f3b1c73cf1fb79038a9d4a8755216298fded5c0e; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly performs independent current-repository and fresh-clone checks, verifies tag/tree and version-surface binding, and preserves a blocked result when durable post-tag evidence is unavailable.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=47c14febb101f8d485b3785bf3ac63c5d627ee1f25999068d61918f6bfa13143; fixture_sha256=43a1d01505e6c9e0f71431fdaeb75fea6b1939424f6c22775d15a970f4b73518; output_sha256=49a294f683514069075f268f18f35bd6cb4507bf3e15c96cb337a057c969b68b; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 新鲜基线也完成了大部分 tag、版本面和不可变性判断，但将当前工作区描述为可完整复核，未识别同等严格的 authority 与持久化门槛。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=47c14febb101f8d485b3785bf3ac63c5d627ee1f25999068d61918f6bfa13143; fixture_sha256=43a1d01505e6c9e0f71431fdaeb75fea6b1939424f6c22775d15a970f4b73518; output_sha256=7e3fcbe9ca42ea4b4df2fa2f8ed9fb2194d7a29997abac27cbfa4e9e7f662e2a; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline verifies the tag and release surfaces but treats the review as independently completable and does not identify or enforce the durable post-tag persistence blocker.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- with_skill 未证明当前仓库 pre-tag authority 的实际 commit/tree 解析和 ref 下证据读取。
-- with_skill 未证明当前 tag tree 与 direct package tree 的绑定比较。
-- Next: 补充当前 refs/release-evidence/v1.2.0 的实际 commit/tree 解析及其 handoff/audit 读取结果。
-- Next: 明确给出当前 tag tree 与 direct package tree 的比较结果。
+- None.
+- Next: Restore write capability, obtain maintainer confirmation for the post-tag result ref, persist the blocked record, and verify it by readback without changing prior authority.
+- Next: Rebuild or restore the missing audit foundation and required source/test evidence before rerunning verification.
 
 ## Runtime Artifact Policy
 

--- a/agents/docs/test/docs-audit/evals/workspace/eval-011-post-tag-mismatch/comparison.md
+++ b/agents/docs/test/docs-audit/evals/workspace/eval-011-post-tag-mismatch/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `580d96fbd8d2adf79b801381050e6b3b9bfc58b8f39d636b27ce9f575d873d86` from `agents/docs/test/docs-audit/evals/workspace/eval-011-post-tag-mismatch`.
 - Identity schema: `2`
-- target_skill_sha256: `dafd53371901dfd724f88c70262b157e59494d29da1c613d0ef130564b6ff4f9`
+- target_skill_sha256: `a5e0bb043d61dbbb218e7d7efc08374e0d16a4d7aaa3b31817f2038830c90941`
 - eval_definition_sha256: `dd2f814bca5d9dce6fed31e09545467860903a50efd0252401f17372eb85d63c`
 - metadata_sha256: `44f3e50cd86c78b14f58e8584dc26444f39390cb3ef1d6e88051fdaf94a2e89e`
 - fixture_sha256: `580d96fbd8d2adf79b801381050e6b3b9bfc58b8f39d636b27ce9f575d873d86`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `87ef764041bed9ee9555b42ac224112964f5f9e1229cf61ab18c2da424e966e8`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `63cc630aa7fe4e8caac8407e8b4008bbc49c2b73e376868bcef067409538b2ed`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `7e61bd8eca6431729aee1f3be4656be0a4348119eb1218623bafd54cfaead2ab`
+- Skill overlay SHA-256: `d7e2242fcdf83209e6c0cb5ec9544aa009e79488a72f81ebd4bf387289fbabec`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,22 +33,22 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `uses_immutable_pre_tag_authority` | PASS | With_skill directly resolved the pre-tag and tag refs, read committed audit/handoff content from pre-tag authority, and treated the modified worktree audit copy as diagnostic rather than authoritative. |
-| `validates_current_attempt_history` | PASS | With_skill identified committed attempt 2 and its directly superseded same-version attempt 1, rejected the rewritten current worktree copy as authority, and retained blocked status. |
-| `rejects_complete_release_tree_drift` | PASS | With_skill verified the complete pre-tag-to-tag drift and identified the added src/catalog/export-v2.py from the raw tree evidence, while keeping the result blocked. |
-| `offers_safe_maintainer_recovery` | PASS | With_skill offered executable same-version repair and new-version alternatives, with authority reconstruction, maintainer confirmation, and audit rerun prerequisites plus the docs-site-bootstrap responsibility boundary. |
-| `persists_blocked_without_corrupting_authority` | PASS | With_skill reported blocked_record_persistence as not_persisted, specified restore-write, persist, readback, and rerun recovery order, and stated that prior authority and release refs remain unchanged with no success state. |
+| `uses_immutable_pre_tag_authority` | PASS | With-skill raw commands resolved the pre-tag commit/tree and used git show for committed audit and handoff; the output isolated the modified worktree copy from that authority. |
+| `validates_current_attempt_history` | PASS | The output identified attempt 2, superseded attempt 1, their same v1.2.0 scope, rejected the rewritten worktree copy as authority, and kept the result blocked. |
+| `rejects_complete_release_tree_drift` | PASS | Raw Git evidence and the output confirmed the complete tree difference adds src/catalog/export-v2.py, recognized the conflicting patch evidence, and retained blocked status. |
+| `offers_safe_maintainer_recovery` | PASS | The output offered actionable same-version remediation and a maintainer-confirmed new-version path, with required evidence repair and full re-audit prerequisites while preserving write boundaries. |
+| `persists_blocked_without_corrupting_authority` | PASS | The output recorded blocked_record_persistence as not persisted, required restore-write → persist blocked → readback before rerun, and stated that prior authority and success state remain unchanged. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=63cc630aa7fe4e8caac8407e8b4008bbc49c2b73e376868bcef067409538b2ed; fixture_sha256=580d96fbd8d2adf79b801381050e6b3b9bfc58b8f39d636b27ce9f575d873d86; output_sha256=b7e28169387f9caf67d85b16fa14da563adf43471923b111733204556a0547b7; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly produced a blocked post-tag audit grounded in immutable authority, complete tree drift, attempt history, safe recovery choices, and non-corrupting persistence handling.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=63cc630aa7fe4e8caac8407e8b4008bbc49c2b73e376868bcef067409538b2ed; fixture_sha256=580d96fbd8d2adf79b801381050e6b3b9bfc58b8f39d636b27ce9f575d873d86; output_sha256=fc66c00ccf0409fe98e22a8043ce94624d38474db0b1d7d036fe092c342663d2; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly rejected release verification, preserved pre-tag authority, detected tree and evidence drift, and provided safe recovery guidance.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=63cc630aa7fe4e8caac8407e8b4008bbc49c2b73e376868bcef067409538b2ed; fixture_sha256=580d96fbd8d2adf79b801381050e6b3b9bfc58b8f39d636b27ce9f575d873d86; output_sha256=ce5feab00bd36a2e5e531f0ce1996384c4cd7429be5ca1e484112d1351377234; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Detected some release drift and evidence gaps, but did not establish the full protocol-level authority, attempt-history, recovery, and persistence-boundary result.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=63cc630aa7fe4e8caac8407e8b4008bbc49c2b73e376868bcef067409538b2ed; fixture_sha256=580d96fbd8d2adf79b801381050e6b3b9bfc58b8f39d636b27ce9f575d873d86; output_sha256=79a6d21ea88687a56d245ac882962966e7b51bd69f0537f252050eda18ea89a6; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline noticed some drift and offered generic follow-up, but did not establish the full authority, attempt-lineage, persistence, and complete-tree safety gates.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/docs/test/docs-audit/evals/workspace/eval-012-staged-metadata-rollback/comparison.md
+++ b/agents/docs/test/docs-audit/evals/workspace/eval-012-staged-metadata-rollback/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `1013313f9177f2e4b64118a15325ba0a4da0ec26b6c32604368f1f754b57e620` from `agents/docs/test/docs-audit/evals/workspace/eval-012-staged-metadata-rollback`.
 - Identity schema: `2`
-- target_skill_sha256: `dafd53371901dfd724f88c70262b157e59494d29da1c613d0ef130564b6ff4f9`
+- target_skill_sha256: `a5e0bb043d61dbbb218e7d7efc08374e0d16a4d7aaa3b31817f2038830c90941`
 - eval_definition_sha256: `885108a0e0e9ce48751816455b91da0ec400a08bb7d3a722984a36e4221d1938`
 - metadata_sha256: `86b2ab0ad4bcb3fb98728ca8ff1375ff58d1094876353cbeafc325bf7593eb63`
 - fixture_sha256: `1013313f9177f2e4b64118a15325ba0a4da0ec26b6c32604368f1f754b57e620`
@@ -22,41 +22,39 @@
 - judge_schema_sha256: `73f9308006ffa877e1ed5f74c8eef2e3a2b3222e98dd5485cfd0ba5e210de92a`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `4c059264a7527dcf6082f43bc5cacdf327f947505e6d5f9721fd10e71b64fdcb`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `7e61bd8eca6431729aee1f3be4656be0a4348119eb1218623bafd54cfaead2ab`
-- Behavior result: **FAIL**
+- Skill overlay SHA-256: `d7e2242fcdf83209e6c0cb5ec9544aa009e79488a72f81ebd4bf387289fbabec`
+- Behavior result: **PASS**
 - Coverage result: **PARTIAL**
-Overall result: FAIL
+Overall result: PASS (partial coverage)
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `detects_non_content_candidate_drift` | FAIL | 候选引用了 staged.name-status 并识别删除、重命名和类型变化，但未覆盖 catalog-items.md 的 100644→100755 模式变化，也未明确覆盖其内容变化。 |
-| `rejects_every_unauthorized_transformation` | FAIL | 输出阻塞了删除 release note、重命名、普通文件转符号链接及异常链接，但遗漏了 executable mode 变化和 catalog-items.md 的授权内容转换，未逐类覆盖全部越界项。 |
-| `rechecks_committed_candidate_boundaries` | NOT_EXERCISED | 当前锁定证据没有已形成的 committed candidate 或 handoff；输出已将当前 staged 快照视为不可消费并要求重新启动审计，因此后续边界复核尚未发生。 |
-| `rolls_back_only_the_failed_attempt` | NOT_EXERCISED | before/after 捕获只证明宿主状态未变，未证明隔离 attempt、本次草稿清理或误触状态恢复操作已实际执行；该后续清理步骤缺少运行时证据。 |
-| `proves_host_state_restoration` | PASS | 输出给出 status、index diff、worktree diff 的 before/after 相同证据，并结合 trace 中 ref 未变化及相关路径身份一致，继续保持 blocked 而未暴露成功。 |
+| `detects_non_content_candidate_drift` | PASS | 候选输出引用并概述 staged.raw/name-status/summary/patch，覆盖 100755、120000、重命名、删除及新增符号链接，并指出对象哈希与路径语义，而非仅比较文本。 |
+| `rejects_every_unauthorized_transformation` | PASS | 候选输出逐项列出六类候选变更，并以 blocked 结论处理模式变化、类型替换、重命名、删除及两个符号链接，没有将其降级为无害差异。 |
+| `rechecks_committed_candidate_boundaries` | PASS | 候选明确指出 staged 结果不等于已提交、锚定、handoff 或 fast-forward，并要求重新生成完整候选审计记录。 |
+| `rolls_back_only_the_failed_attempt` | NOT_EXERCISED | 锁定证据显示清理前后宿主状态完全相同；候选正确报告残留并要求保留、处置 staged/unstaged 路径，但没有可执行的清理运行时或交付快照来证明实际隔离回滚。 |
+| `proves_host_state_restoration` | PASS | 候选覆盖 ref、宿主 status/index/worktree 记录及候选对象身份，并在无法证明恢复时维持 blocked、指出残留处置要求，没有宣称成功。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4c059264a7527dcf6082f43bc5cacdf327f947505e6d5f9721fd10e71b64fdcb; fixture_sha256=1013313f9177f2e4b64118a15325ba0a4da0ec26b6c32604368f1f754b57e620; output_sha256=5ba8373e71e62a268e3faf5da567e3bc4dabba0104bc41518d2972ea35635969; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 正确判定不能继续，识别证据哈希不一致、删除/重命名/符号链接等主要风险，并证明宿主捕获状态未变化；但遗漏 executable mode 与 catalog-items 内容变化。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4c059264a7527dcf6082f43bc5cacdf327f947505e6d5f9721fd10e71b64fdcb; fixture_sha256=1013313f9177f2e4b64118a15325ba0a4da0ec26b6c32604368f1f754b57e620; output_sha256=02c25dae7a58367b88d9878c680f57f97f9b06817ff7d3a5b93c7d94aa2dae10; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 正确阻塞发布，识别候选的 Git 类型、模式、路径和对象风险，并拒绝把隔离 staged 证据当作最终 authority；宿主清理本身未执行。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4c059264a7527dcf6082f43bc5cacdf327f947505e6d5f9721fd10e71b64fdcb; fixture_sha256=1013313f9177f2e4b64118a15325ba0a4da0ec26b6c32604368f1f754b57e620; output_sha256=68e55b67eca9ada79dd7b25ca2d8202b6d261d91266f4caf5a7353e6e2205f0c; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 同样判定阻塞并识别部分删除、重命名、符号链接和哈希问题，但遗漏更多边界细节；仅作基线对比。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4c059264a7527dcf6082f43bc5cacdf327f947505e6d5f9721fd10e71b64fdcb; fixture_sha256=1013313f9177f2e4b64118a15325ba0a4da0ec26b6c32604368f1f754b57e620; output_sha256=fd90f5b0bd78111fbbf261f297e170617cde4c0c458b946a0a0bf715f2af8cce; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 同样阻塞发布并识别主要候选风险，但证据边界和后续 authority/审计绑定说明较少；仅作 fresh baseline 对照。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- detects_non_content_candidate_drift
-- rejects_every_unauthorized_transformation
-- Next: 重新生成并校验完整 staged candidate，明确覆盖模式、内容、路径和对象类型边界。
-- Next: 形成 committed candidate 与 handoff 后，重新验证同一授权边界并取得完整清理/恢复运行时证据。
+- None.
+- Next: 在获得必要运行时证据或确认后，单独执行并记录仅针对失败 attempt 的清理，再复核 ref、index、worktree 及相关路径身份。
 
 ## Runtime Artifact Policy
 

--- a/agents/docs/test/docs-audit/evals/workspace/eval-013-version-normalization-boundaries/comparison.md
+++ b/agents/docs/test/docs-audit/evals/workspace/eval-013-version-normalization-boundaries/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `1cee6041bd72db3f52d6c6c5a5cd2b2192f387347cccb99c7f5a1da1c4e1e970` from `agents/docs/test/docs-audit/evals/workspace/eval-013-version-normalization-boundaries`.
 - Identity schema: `2`
-- target_skill_sha256: `dafd53371901dfd724f88c70262b157e59494d29da1c613d0ef130564b6ff4f9`
+- target_skill_sha256: `a5e0bb043d61dbbb218e7d7efc08374e0d16a4d7aaa3b31817f2038830c90941`
 - eval_definition_sha256: `5705e506f62200b76867ebca90e47274aa68bc0ca81a7790a3ab2ac8baafd194`
 - metadata_sha256: `de723686d571b59f10dc657eaf98d1d9ad27c06a9381fcb0dfee19364fb401ec`
 - fixture_sha256: `1cee6041bd72db3f52d6c6c5a5cd2b2192f387347cccb99c7f5a1da1c4e1e970`
@@ -22,39 +22,39 @@
 - judge_schema_sha256: `3cb4db02fceb3a963ab35cfa46d9bd95146e58bed4f92e90064a4aa2fe2f0404`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `e4e9083fe5f80e87e2a90dbd2508e2ce8a005911bcd108e280ebfcc392bef53e`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `7e61bd8eca6431729aee1f3be4656be0a4348119eb1218623bafd54cfaead2ab`
-- Behavior result: **FAIL**
+- Skill overlay SHA-256: `d7e2242fcdf83209e6c0cb5ec9544aa009e79488a72f81ebd4bf387289fbabec`
+- Behavior result: **PASS**
 - Coverage result: **PARTIAL**
-Overall result: FAIL
+Overall result: PASS (partial coverage)
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `preserves_complete_version_identity` | FAIL | The with_skill output preserves the full target identity and rejects case, prerelease, and build-metadata changes, but it never states that the prefixed and unprefixed observations in set A map to the same complete identity. |
-| `enforces_each_source_contract` | PASS | It gives source-by-source observations and blockers, rejects malformed raw values, and reports the extractor mismatch without silently filling values from other sources. |
-| `reports_all_version_blockers` | PASS | It reports the missing, malformed, duplicate, unresolved, and extractor-contract blockers and gives blocked conclusions for both pre-tag and post-tag stages. |
-| `binds_pre_and_post_tag_inventory` | NOT_EXERCISED | The output states that no pre-tag handoff, candidate audit record, or consumable binding exists, so post-tag consumption of a generated inventory was not reached. |
-| `makes_inventory_integrity_reproducible` | NOT_EXERCISED | The output states that no normalized digest or candidate record exists, so deterministic inventory-integrity evidence could not yet be produced. |
+| `preserves_complete_version_identity` | PASS | With_skill normalizes the single legal `v` prefix while retaining prerelease and build metadata, and distinguishes case changes and missing build metadata as different identities. |
+| `enforces_each_source_contract` | PASS | With_skill evaluates the declared sources and observed values by source, identifies missing paths, invalid raw forms, selector resolution failure, duplicate index matches, and extractor identity drift without repairing values. |
+| `reports_all_version_blockers` | PASS | With_skill reports the pre-tag block and post-tag blockers, including tag state, inventory drift, missing source files, invalid observations, duplicate matches, selector failure, and complete-identity mismatches. |
+| `binds_pre_and_post_tag_inventory` | NOT_EXERCISED | The candidate states that no complete consumable binding was formed because the input was blocked before inventory generation; therefore post-tag consumption of a bound inventory was not exercised. |
+| `makes_inventory_integrity_reproducible` | NOT_EXERCISED | The candidate states that key source objects are missing and that blob/hash evidence cannot be obtained; deterministic inventory-integrity evidence was therefore not exercised. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=e4e9083fe5f80e87e2a90dbd2508e2ce8a005911bcd108e280ebfcc392bef53e; fixture_sha256=1cee6041bd72db3f52d6c6c5a5cd2b2192f387347cccb99c7f5a1da1c4e1e970; output_sha256=7d9f9b29a8a3a6ed40d531b21f94be6ed5cd02db2f446506f5c1000474945677; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Provides a detailed blocked pre-tag/post-tag audit with per-source failures, but omits the set-A prefixed/unprefixed identity conclusion.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=e4e9083fe5f80e87e2a90dbd2508e2ce8a005911bcd108e280ebfcc392bef53e; fixture_sha256=1cee6041bd72db3f52d6c6c5a5cd2b2192f387347cccb99c7f5a1da1c4e1e970; output_sha256=a698c4caa7bf9233b74490146b834c2a69ab9dde9a1bc4ec1a24d497194e2b13; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly blocks both conclusions, preserves complete version identity, evaluates source-specific failures, and reports the inventory-binding precondition.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=e4e9083fe5f80e87e2a90dbd2508e2ce8a005911bcd108e280ebfcc392bef53e; fixture_sha256=1cee6041bd72db3f52d6c6c5a5cd2b2192f387347cccb99c7f5a1da1c4e1e970; output_sha256=1c86d157d2d7fcd2f82e1f019cb0ff7864aa486b14da8ccd39ee0c0394d6f640; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Fresh baseline also reports the major post-tag blockers and mentions set A, but lacks the with_skill audit's stronger repository and inventory-binding analysis.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=e4e9083fe5f80e87e2a90dbd2508e2ce8a005911bcd108e280ebfcc392bef53e; fixture_sha256=1cee6041bd72db3f52d6c6c5a5cd2b2192f387347cccb99c7f5a1da1c4e1e970; output_sha256=267a1018be1a4d3c3b640ed605cde273c904adfb7e733d343d82ed119ada47e9; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline identifies many post-tag value failures but treats the pre-tag state as conditionally passing and does not establish the same inventory-binding or repository-object blockers.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- preserves_complete_version_identity
-- Next: Explicitly map the prefixed and unprefixed set-A observations to the same complete, case-sensitive identity while retaining the raw-form distinction.
+- None.
+- Next: None.
 
 ## Runtime Artifact Policy
 

--- a/agents/docs/test/docs-audit/evals/workspace/eval-014-conditional-deployment-recheck/comparison.md
+++ b/agents/docs/test/docs-audit/evals/workspace/eval-014-conditional-deployment-recheck/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `02024e6f0aaa0bcf6615062b3d8a31430a90f2e0a76edad7ce1044c04423eb52` from `agents/docs/test/docs-audit/evals/workspace/eval-014-conditional-deployment-recheck`.
 - Identity schema: `2`
-- target_skill_sha256: `dafd53371901dfd724f88c70262b157e59494d29da1c613d0ef130564b6ff4f9`
+- target_skill_sha256: `a5e0bb043d61dbbb218e7d7efc08374e0d16a4d7aaa3b31817f2038830c90941`
 - eval_definition_sha256: `3b49ebce5564e2973a0e2404ae2204baef9f3926736e7959e09be720ea423b90`
 - metadata_sha256: `2b29c083a590a4eda139a3861e29b83daf406cc100d9a6f0e884225e104c8734`
 - fixture_sha256: `02024e6f0aaa0bcf6615062b3d8a31430a90f2e0a76edad7ce1044c04423eb52`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `b484eac80dd3c83d19d6e2564672bb72616ee37e54370c5c00059bfaaa781dcf`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `cb27f98c195c0adaa2bc7ce90eded119c590e29ff34ec55cdd7a71187adb71ba`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `7e61bd8eca6431729aee1f3be4656be0a4348119eb1218623bafd54cfaead2ab`
+- Skill overlay SHA-256: `d7e2242fcdf83209e6c0cb5ec9544aa009e79488a72f81ebd4bf387289fbabec`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,25 +33,25 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `preserves_state_for_no_surface_change` | PASS | With-skill output correctly identifies version-stamp.patch as changing only last_verified_version and says deployment completeness remains unchanged. |
-| `refreshes_shared_state_for_material_change` | NOT_EXERCISED | With-skill output correctly identifies the build-target changes and recommends rechecking deployment completeness, but the actual shared-state refresh cannot be exercised because the required audit handoff, target references, and confirmed target version are absent. |
+| `preserves_state_for_no_surface_change` | PASS | with_skill 正确识别 version-stamp.patch 仅更新 last_verified_version，且明确保留既有部署完整性状态。 |
+| `refreshes_shared_state_for_material_change` | NOT_EXERCISED | with_skill 正确识别 internal-build-target.patch 改变构建命令、默认输出逻辑和 VitePress outDir，并要求重新核对；但缺少部署完整性证据，无法证明后续共享状态刷新已执行。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cb27f98c195c0adaa2bc7ce90eded119c590e29ff34ec55cdd7a71187adb71ba; fixture_sha256=02024e6f0aaa0bcf6615062b3d8a31430a90f2e0a76edad7ce1044c04423eb52; output_sha256=7305c790c6c7474cc5d1e87fa559da7bd8b27fb884cb77f9be7a0ec002214a29; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly distinguishes the non-material version stamp from the material internal build-output change, preserves the no-change state, and identifies the required recheck without modifying deployment configuration.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cb27f98c195c0adaa2bc7ce90eded119c590e29ff34ec55cdd7a71187adb71ba; fixture_sha256=02024e6f0aaa0bcf6615062b3d8a31430a90f2e0a76edad7ce1044c04423eb52; output_sha256=d680401b9e1b891db1dbd8e4bfcd37e8c4e82f06f2b3a8b1a120db07f184edb6; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 正确区分纯版本标记与构建产物路径变化，保留无变化状态并识别需要复核的材料变化；未修改部署配置。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cb27f98c195c0adaa2bc7ce90eded119c590e29ff34ec55cdd7a71187adb71ba; fixture_sha256=02024e6f0aaa0bcf6615062b3d8a31430a90f2e0a76edad7ce1044c04423eb52; output_sha256=9c21d48aa29aaee51d6768b180af43b4d8549c3badd7a31cf15b30b2ba90f59c; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Fresh baseline reaches the same patch-level conclusions and reports no deployment mutation, but lacks the structured audit-gate framing present in the with_skill lane.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cb27f98c195c0adaa2bc7ce90eded119c590e29ff34ec55cdd7a71187adb71ba; fixture_sha256=02024e6f0aaa0bcf6615062b3d8a31430a90f2e0a76edad7ce1044c04423eb52; output_sha256=0d52c93cf7e3e30828f19739e506a45be10bc1053bdcfe3d96d2fc27d52f058a; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 同样正确识别两类 patch 的表面影响，作为新鲜基线对照。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Provide the audit handoff, refs, and confirmed target version, then run the shared documentation audit and refresh the deployment completeness state for the material build-target change.
+- Next: 补齐维护者确认的 target_release_version、审计交接和部署完整性运行时证据后，复用共享检查并刷新状态。
 
 ## Runtime Artifact Policy
 

--- a/agents/docs/test/docs-audit/evals/workspace/eval-015-manual-page-evidence/comparison.md
+++ b/agents/docs/test/docs-audit/evals/workspace/eval-015-manual-page-evidence/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `1c27cfa2f41ff48338bb4acbfdb7cd16614fdaed5b9fc59cbb0ed2df02c327ad` from `agents/docs/test/docs-audit/evals/workspace/eval-015-manual-page-evidence`.
 - Identity schema: `2`
-- target_skill_sha256: `dafd53371901dfd724f88c70262b157e59494d29da1c613d0ef130564b6ff4f9`
+- target_skill_sha256: `a5e0bb043d61dbbb218e7d7efc08374e0d16a4d7aaa3b31817f2038830c90941`
 - eval_definition_sha256: `aa707a4a153cd14f8630bcfdbc7593482bcfc1de05bf7582ac2eeb6f645afb7d`
 - metadata_sha256: `2b093794d817fa1de245fdac944141cf26e940fab11bd3c871b66f71a9c40eac`
 - fixture_sha256: `1c27cfa2f41ff48338bb4acbfdb7cd16614fdaed5b9fc59cbb0ed2df02c327ad`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `cde7d254babf29e4546bfe9e69c491c81147f2f6aec782f40fd9d10a9dc4b4fd`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `9c90b10bde8bbda672daf3c3fd6d8b4bfbcd80966d8091d82aceff2f385c4210`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `7e61bd8eca6431729aee1f3be4656be0a4348119eb1218623bafd54cfaead2ab`
+- Skill overlay SHA-256: `d7e2242fcdf83209e6c0cb5ec9544aa009e79488a72f81ebd4bf387289fbabec`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,22 +33,22 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `checks_step_screenshot_files` | PASS | With-skill final output states step-2-save-member.png is nonexistent; locked trace records the SVG as a Scalable Vector Graphics image. |
-| `checks_caption_step_correspondence` | PASS | Final output identifies the mismatch between step 1 opening access settings and the caption describing a delete-workspace confirmation dialog. |
-| `checks_manual_navigation_reachability` | PASS | Final output states the page is not navigated to and the sidebar snapshot lacks it; locked trace records the public landing page and manual index lacking the target entry. |
-| `checks_manual_redaction` | PASS | Final output identifies test.user@example.invalid in the page and token-demo-redact-me at SVG line 5 as redaction blockers. |
-| `blocks_manual_stamp` | PASS | Final output concludes blocked and states no version stamp was performed; locked evidence shows last_verified_version remains unverified and no ready_for_tag result. |
+| `checks_step_screenshot_files` | PASS | with_skill 记录确认目标树中仅有可解析的 SVG，且明确指出第二步引用的 step-2-save-member.png 缺失。 |
+| `checks_caption_step_correspondence` | PASS | with_skill 明确指出第一步要求打开访问设置，而图注写成“删除工作区确认框”，并以页面第24行和 SVG 内容为证。 |
+| `checks_manual_navigation_reachability` | PASS | with_skill 依据 public 落地页、manual 根索引及生成侧边栏快照，明确指出 /manual/workspaces/manage-access 不在导航中。 |
+| `checks_manual_redaction` | PASS | with_skill 明确指出正文第18行的 test.user@example.invalid 测试邮箱，以及 SVG 第5行的 token-demo-redact-me 测试令牌，均需脱敏。 |
+| `blocks_manual_stamp` | PASS | with_skill 将审计结论标为 blocked，指出页面原始 last_verified_version 为 unverified，并明确未执行盖章、未返回 ready_for_tag。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9c90b10bde8bbda672daf3c3fd6d8b4bfbcd80966d8091d82aceff2f385c4210; fixture_sha256=1c27cfa2f41ff48338bb4acbfdb7cd16614fdaed5b9fc59cbb0ed2df02c327ad; output_sha256=f66d4334e3999cf060b4aa860c9a0f2857fe1afc676e45068333b9663f96eb48; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly performed the bounded manual audit, identified all required defects, and blocked stamping.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9c90b10bde8bbda672daf3c3fd6d8b4bfbcd80966d8091d82aceff2f385c4210; fixture_sha256=1c27cfa2f41ff48338bb4acbfdb7cd16614fdaed5b9fc59cbb0ed2df02c327ad; output_sha256=2d2dd9615ef1689469607681b4d21c2a09c95230752217150c8c139357553a5f; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 完整识别截图完整性、图注对应关系、导航不可达、脱敏问题及阻断盖章条件，并保留 unverified 状态。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9c90b10bde8bbda672daf3c3fd6d8b4bfbcd80966d8091d82aceff2f385c4210; fixture_sha256=1c27cfa2f41ff48338bb4acbfdb7cd16614fdaed5b9fc59cbb0ed2df02c327ad; output_sha256=7d38cbda41fac11d424cb21213b1614938e052e413a4ab3167c88f9b4ec5b868; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Fresh baseline also identified the main defects and blocked release, but provided a less complete audit narrative.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9c90b10bde8bbda672daf3c3fd6d8b4bfbcd80966d8091d82aceff2f385c4210; fixture_sha256=1c27cfa2f41ff48338bb4acbfdb7cd16614fdaed5b9fc59cbb0ed2df02c327ad; output_sha256=fd0740e2b82b7f0eb7c21c739ceb6b3ba231053d81bcddf71fa320ec58c48b51; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 识别了缺失截图、导航缺失、图注不符和令牌风险，但未明确指出正文测试邮箱，也未完整覆盖导航三类证据和阻断状态要求。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/docs/test/docs-site-bootstrap/evals/workspace/eval-001-bootstrap-empty-workspace/comparison.md
+++ b/agents/docs/test/docs-site-bootstrap/evals/workspace/eval-001-bootstrap-empty-workspace/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/docs/test/docs-site-bootstrap/evals/workspace/eval-001-bootstrap-empty-workspace`.
 - Identity schema: `2`
-- target_skill_sha256: `f325a3bc283b067240ee3d50726f680693f5cd996590e717b72af686853dbf3e`
+- target_skill_sha256: `2846695e854af26b77f56804bd16db1050e2bacd34407999d119ed4e4a881599`
 - eval_definition_sha256: `0028d93b645e269e09fc6f6345ad073b0c2386395ad858bbd7693d057a9eca5f`
 - metadata_sha256: `72695cba8eaf9810a85aa17ba3cc9622de1dd39f4d06db93fe0728a19509d73b`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `373ba2965836f0cc6198ffb0151c12c61c34831fe45aaa5ef665fae7d893acbc`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `8294223a6cc9320411b7f3ca9761133eeb49b555e990170abcfa40eeb8076bd8`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `8a54b9d8ab53e6a7ef3187af8e3063aff036e0d1740a4b832c4d3a33058de445`
+- Skill overlay SHA-256: `c4382a755d40b4c37cbb5843089f99a5655b439fd2c6460df6c8b5adeb479967`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,29 +33,30 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `creates_complete_inventory` | PASS | Locked trace reports readback of 42/42 assets with byte equality, and the manifest contains 42 matching paths, all marked created. |
-| `delivers_deterministic_scaffold_assets` | PASS | Locked snapshot contains package.json with one new:doc script, both required scaffold files, six templates each with exactly one start/end docs-scaffold block, and standards/index.md links all six templates. |
-| `validates_seven_frontmatter_fields` | PASS | Direct inspection of all 19 Markdown snapshot files found all seven fields, allowed doc_type values only, non-empty owners and related_code arrays, and last_verified_version set to unverified. |
-| `writes_only_docs_site` | PASS | All 43 delivered snapshot files are under docs/site/, and locked git evidence shows only untracked docs/ content with no root or external modifications. |
-| `requires_explicit_opt_in` | PASS | The prompt explicitly confirms the current repository, fixed docs/site root, and complete scaffold; the with_skill output explicitly records that opt-in before reporting writes. |
-| `reports_manifest_readback` | PASS | Locked trace shows manifest JSON parsing, path/status validation, 42/42 byte readback, no conflicts, and a repeat classification with manifestUnchanged true and zero-diff. |
+| `creates_complete_inventory` | PASS | Raw trace and manifest show 42 assets, 42 manifest entries, and byte mismatches: []; manifest covers every processed static asset. |
+| `delivers_deterministic_scaffold_assets` | PASS | Snapshot contains package.json with a single new:doc command, scaffold-doc.mjs, its test, six templates each with one docs-scaffold block, and standards/index.md links to all six. |
+| `validates_seven_frontmatter_fields` | PASS | All 19 Markdown pages in the snapshot contain the seven fields; doc_type values are within the allowed set and owners/related_code arrays are non-empty. The frontmatter checker is delivered, though test:docs could not run because fast-glob was unavailable. |
+| `writes_only_docs_site` | PASS | Workspace status is only ?? docs/ and the delivery manifest contains only docs/site paths; no root configuration, source, or outside-docs/site files are shown as generated. |
+| `requires_explicit_opt_in` | PASS | The user prompt explicitly confirms initialization in the current repository at docs/site/, and the trace records that confirmed host, fixed root, complete scaffold, and manifest were the write scope before generation. |
+| `reports_manifest_readback` | PASS | The manifest was parsed and read back; trace reports 42/42 byte checks and a repeat classification of 42 skipped-identical, 0 created, 0 kept-as-is, with zero content changes. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=8294223a6cc9320411b7f3ca9761133eeb49b555e990170abcfa40eeb8076bd8; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=c7193c48e96072b41f1a09aff5042307f10256cb3a768a4ff24c9ef0cd6a3d43; snapshot_sha256=f836057223cddf83c406a99d35d284c9afbae342612132073d1423288e8d673c
-- Behavior: Delivered the complete 42-asset formal documentation scaffold, manifest, frontmatter-compliant pages, deterministic templates, and readback/zero-diff evidence under docs/site/.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=8294223a6cc9320411b7f3ca9761133eeb49b555e990170abcfa40eeb8076bd8; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=de699aabf45dbd24786ec9e07c25be10777d63769db3406bad89333f14c74b85; snapshot_sha256=bca774aac096fb9150e4d2f90f2f5b252b12b5d7c7b76e21033c1ecfd23bc3bd
+- Behavior: Delivered the complete 42-file deterministic docs/site scaffold, manifest, validation tooling, and readback/idempotency evidence; runtime docs tests were blocked by a missing dependency.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=8294223a6cc9320411b7f3ca9761133eeb49b555e990170abcfa40eeb8076bd8; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=90ff7d951d837568007090f488367743f82afd2c8efe646c79cf8d8cbabd0d47; snapshot_sha256=650a862275be16ace959dabe84710215a9278b8893300a1432df1826c4d9327e
-- Behavior: Fresh baseline created a small Docusaurus scaffold without the required 42-asset inventory, manifest, formal frontmatter contract, or deterministic document scaffold.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=8294223a6cc9320411b7f3ca9761133eeb49b555e990170abcfa40eeb8076bd8; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=47773e521aeba4c8d3b61da010f4b455e32437ea33c7703ae2fca34b6c81b1c1; snapshot_sha256=332f818b69be4a217aaa7ec2bb90c9df0fe097e434c0944e67695d339b6cdc8c
+- Behavior: Fresh baseline produced only a small static landing site, added package.json and scripts outside docs/site, and did not provide the required 42-file scaffold, manifest, frontmatter system, or opt-in workflow.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: None.
+- Next: Install dependencies and run test:docs when available.
+- Next: After a confirmed commit, perform the pending deployment completeness check and choose integrated, independent, or deferred hosting.
 
 ## Runtime Artifact Policy
 

--- a/agents/docs/test/docs-site-bootstrap/evals/workspace/eval-002-repeat-bootstrap-idempotent/comparison.md
+++ b/agents/docs/test/docs-site-bootstrap/evals/workspace/eval-002-repeat-bootstrap-idempotent/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `970626314f80eb97fc008436179e977f3b31875ef015d6a3dcce0205080e223e` from `agents/docs/test/docs-site-bootstrap/evals/workspace/eval-002-repeat-bootstrap-idempotent`.
 - Identity schema: `2`
-- target_skill_sha256: `f325a3bc283b067240ee3d50726f680693f5cd996590e717b72af686853dbf3e`
+- target_skill_sha256: `2846695e854af26b77f56804bd16db1050e2bacd34407999d119ed4e4a881599`
 - eval_definition_sha256: `67789de316a1ba3d112d33eabc20baa992cdfc352bddac2855c6bcc9a3f93650`
 - metadata_sha256: `421f80bf3da30d58b5b544d4c2e96b4cfdc1446ea641a3ffc3d654e2472f3421`
 - fixture_sha256: `970626314f80eb97fc008436179e977f3b31875ef015d6a3dcce0205080e223e`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `08c04fe57b81475dd890de6778e0567d043b2de7ae5ceb0392b2f8c748e60f69`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `1e8516931ef9c5300021c46d1671fb3fb195b5fe4d687cb8133fc778b15a0158`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `8a54b9d8ab53e6a7ef3187af8e3063aff036e0d1740a4b832c4d3a33058de445`
+- Skill overlay SHA-256: `c4382a755d40b4c37cbb5843089f99a5655b439fd2c6460df6c8b5adeb479967`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `produces_zero_diff` | PASS | With_skill raw Git evidence shows unchanged HEAD, empty status, empty diffs, and no result diffs; the output reports zero-diff. |
-| `reports_skipped_identical` | PASS | With_skill raw command evidence reports missing=0, identical=42, conflicts=0, and the manifest read-back contains 42 valid paths all classified skipped-identical. |
-| `preserves_existing_state` | PASS | With_skill raw evidence shows unchanged repository state and no result diffs; the candidate explicitly reports no overwrites or conflicts. Existing change-map, release metadata, pages, scripts, and configuration remain unchanged. |
+| `produces_zero_diff` | PASS | With-skill raw evidence reports 42 assets identical, 0 missing, 0 conflicts; Git status and diff are empty. |
+| `reports_skipped_identical` | PASS | The locked manifest contains 42 file entries, all with status skipped-identical; raw evidence confirms the 42/42 byte-identical classification. |
+| `preserves_existing_state` | PASS | With-skill Git evidence shows no status or diff changes, and the manifest/pages/configuration remain unchanged. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=1e8516931ef9c5300021c46d1671fb3fb195b5fe4d687cb8133fc778b15a0158; fixture_sha256=970626314f80eb97fc008436179e977f3b31875ef015d6a3dcce0205080e223e; output_sha256=d2b64b8b71cf16c112d9864f0ca43d47e8f1498da5bb3ccae9de9d038af3e737; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Re-initialization was idempotent: all 42 assets were byte-identical, no files changed, and existing state was preserved.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=1e8516931ef9c5300021c46d1671fb3fb195b5fe4d687cb8133fc778b15a0158; fixture_sha256=970626314f80eb97fc008436179e977f3b31875ef015d6a3dcce0205080e223e; output_sha256=5ededabb822eca31e0c0e129b802f74dc366b0080e8aff5e829a5d4d9c9b750f; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Repeated initialization produced zero changes; all 42 assets were skipped-identical and existing state was preserved.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=1e8516931ef9c5300021c46d1671fb3fb195b5fe4d687cb8133fc778b15a0158; fixture_sha256=970626314f80eb97fc008436179e977f3b31875ef015d6a3dcce0205080e223e; output_sha256=e6225d6d45cbbca39fdb5d0db59055077f1c8473c1a3b96892914fcc7735ab17; snapshot_sha256=060c9f1e9bca54e39b34c9d582c0f4bb286da0cadf85ff1b87aaced36e86fce0
-- Behavior: Fresh baseline ran a generation flow that produced 38 untracked generated files rather than demonstrating the required 42 skipped-identical classifications.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=1e8516931ef9c5300021c46d1671fb3fb195b5fe4d687cb8133fc778b15a0158; fixture_sha256=970626314f80eb97fc008436179e977f3b31875ef015d6a3dcce0205080e223e; output_sha256=85d33029191e6a4796a9d0528925f5a80cb1f2d002bcd7fdae1a5503b4ae494e; snapshot_sha256=060c9f1e9bca54e39b34c9d582c0f4bb286da0cadf85ff1b87aaced36e86fce0
+- Behavior: Reported no tracked-file changes but produced 38 untracked generated artifacts, without the required 42-asset skipped-identical classification.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/docs/test/docs-site-bootstrap/evals/workspace/eval-003-block-bootstrap-conflict/comparison.md
+++ b/agents/docs/test/docs-site-bootstrap/evals/workspace/eval-003-block-bootstrap-conflict/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `67d646aaa1407e943f08140487b646ac63c9406ed33f7972e7921d67116c9f4a` from `agents/docs/test/docs-site-bootstrap/evals/workspace/eval-003-block-bootstrap-conflict`.
 - Identity schema: `2`
-- target_skill_sha256: `f325a3bc283b067240ee3d50726f680693f5cd996590e717b72af686853dbf3e`
+- target_skill_sha256: `2846695e854af26b77f56804bd16db1050e2bacd34407999d119ed4e4a881599`
 - eval_definition_sha256: `ef71b65d8d90e0a7a85b11140f77333b6bccfac4b39b25f67875d33153f0ebea`
 - metadata_sha256: `dd91ae0a6e0ac8c19ffeb9b16bf575dc1d6e559c0626e7027f9e04c671f270d0`
 - fixture_sha256: `67d646aaa1407e943f08140487b646ac63c9406ed33f7972e7921d67116c9f4a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `8fb0a4310aa73072ce3915bd9569df86e49409cfb5df2e41bfa626f79fa1e1ef`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `7e27a0b4acbeb0bbab6d1ce4f4eaef1707f80d3f366d62ddd92d0e2d6f621f17`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `8a54b9d8ab53e6a7ef3187af8e3063aff036e0d1740a4b832c4d3a33058de445`
+- Skill overlay SHA-256: `c4382a755d40b4c37cbb5843089f99a5655b439fd2c6460df6c8b5adeb479967`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,26 +33,26 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `blocks_on_complete_conflict_list` | NOT_EXERCISED | 候选明确要求用户确认完整 scaffold 与 manifest，当前未进入冲突扫描阶段，因此尚未形成冲突清单或 blocked 状态。 |
-| `does_not_overwrite_conflict` | PASS | with_skill 的 git_status 和 git_diff 均为空，fixture 中的 standards/index.md 哈希保持不变，delivery_snapshot 为空。 |
-| `offers_explicit_resolution_choices` | PASS | 候选明确提供 overwrite、explicit merge、keep-existing 三种选择，并未在用户选择前记录 kept-as-is。 |
+| `blocks_on_complete_conflict_list` | NOT_EXERCISED | With_skill output requests user confirmation before inspecting files or making changes; no delivery snapshot or git mutation exists, so this later conflict-handling assertion is not exercised. |
+| `does_not_overwrite_conflict` | NOT_EXERCISED | The with_skill lane has an empty delivery snapshot and unchanged git state, but it has not yet reached the file-handling step because confirmation is pending. |
+| `offers_explicit_resolution_choices` | NOT_EXERCISED | The with_skill lane has not yet presented resolution choices; it correctly pauses for confirmation before proceeding. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=7e27a0b4acbeb0bbab6d1ce4f4eaef1707f80d3f366d62ddd92d0e2d6f621f17; fixture_sha256=67d646aaa1407e943f08140487b646ac63c9406ed33f7972e7921d67116c9f4a; output_sha256=eaaea23bce357113a66cbe108f166e5ee4e3792edc6aedc9e9d2f8a4adcbd931; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 正确停在授权确认门槛，未修改工作区，并预先说明三种冲突解决选项。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=7e27a0b4acbeb0bbab6d1ce4f4eaef1707f80d3f366d62ddd92d0e2d6f621f17; fixture_sha256=67d646aaa1407e943f08140487b646ac63c9406ed33f7972e7921d67116c9f4a; output_sha256=74f6830586a8b23df838b0ee1d448033d8841c7a52252094986ab82bb13edef3; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly pauses for confirmation before inspecting or modifying the workspace; no mutation is evidenced.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=7e27a0b4acbeb0bbab6d1ce4f4eaef1707f80d3f366d62ddd92d0e2d6f621f17; fixture_sha256=67d646aaa1407e943f08140487b646ac63c9406ed33f7972e7921d67116c9f4a; output_sha256=dde45ac4d3d789b1b2a188959983a9faca3c8e243cb2264e5c628b35faec9693; snapshot_sha256=435c96ee9220aca5a3a4ad4ca0ee7d6fcbcc3c48f0bf52dcbf7079255a0452ce
-- Behavior: 直接补齐 scaffold 并修改 manifest，保留文件但未展示完整冲突清单或明确阻塞流程。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=7e27a0b4acbeb0bbab6d1ce4f4eaef1707f80d3f366d62ddd92d0e2d6f621f17; fixture_sha256=67d646aaa1407e943f08140487b646ac63c9406ed33f7972e7921d67116c9f4a; output_sha256=57f4bd698bb05da54b29290ea40f5406d85cc4119a8c26e86fc6d1544c4898bc; snapshot_sha256=1dee3607f55f5eca00e18d74e19d8d5ab4c1149f2715b14ff03df592725961b0
+- Behavior: Fresh baseline proceeds without confirmation, modifies the manifest with a successful preservation status, and does not offer explicit overwrite/merge/keep choices.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: 用户确认后扫描并列出完整冲突清单，明确将未解决覆盖阶段标记为 blocked。
+- Next: Obtain user confirmation, then evaluate the conflict list, blocked state, preservation, and resolution choices.
 
 ## Runtime Artifact Policy
 

--- a/agents/docs/test/docs-site-bootstrap/evals/workspace/eval-004-deployment-completeness-trigger/comparison.md
+++ b/agents/docs/test/docs-site-bootstrap/evals/workspace/eval-004-deployment-completeness-trigger/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `4e3ac8498634ec41445a5f746933f338a50d3c3d4cae8d2f058bd619e288d842` from `agents/docs/test/docs-site-bootstrap/evals/workspace/eval-004-deployment-completeness-trigger`.
 - Identity schema: `2`
-- target_skill_sha256: `f325a3bc283b067240ee3d50726f680693f5cd996590e717b72af686853dbf3e`
+- target_skill_sha256: `2846695e854af26b77f56804bd16db1050e2bacd34407999d119ed4e4a881599`
 - eval_definition_sha256: `f0a0699462419947dfa64649c390cf74a3d370111b9c3ea826e84a8d4dc9f735`
 - metadata_sha256: `abed400d8529a0bd91cc069fda9057f38aa9e64b1a632698bb6d1e29c26ae6e8`
 - fixture_sha256: `4e3ac8498634ec41445a5f746933f338a50d3c3d4cae8d2f058bd619e288d842`
@@ -22,38 +22,38 @@
 - judge_schema_sha256: `84cb88cc9e25dde2fbf0d2a0fb5349bfe630e32b333634cfdb918d30e60002a8`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `a857fcf2c722711dbe976f85685cf13e950a1e35983a7408a6a97bb35347ed24`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `8a54b9d8ab53e6a7ef3187af8e3063aff036e0d1740a4b832c4d3a33058de445`
-- Behavior result: **FAIL**
+- Skill overlay SHA-256: `c4382a755d40b4c37cbb5843089f99a5655b439fd2c6460df6c8b5adeb479967`
+- Behavior result: **PASS**
 - Coverage result: **PARTIAL**
-Overall result: FAIL
+Overall result: PASS (partial coverage)
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `asks_first_bootstrap_choice` | FAIL | with_skill output blocked on a PM handoff and did not present the required three choices for the unintegrated case. |
-| `classifies_first_bootstrap_integrated` | NOT_EXERCISED | No first-bootstrap durable-commit confirmation or completed integrated classification occurred in the locked with_skill output. |
-| `rechecks_rebootstrap_drift` | NOT_EXERCISED | No repeated bootstrap or re-read of configuration occurred. |
-| `preserves_authorization_boundary` | PASS | The output explicitly limited work to read-only, stated no files would be written, and git evidence shows no changes or commits. |
+| `classifies_first_bootstrap_integrated` | NOT_EXERCISED | With_skill stopped at the bootstrap entry gate and did not perform a first bootstrap or post-commit deployment classification. |
+| `asks_first_bootstrap_choice` | NOT_EXERCISED | With_skill did not inspect a host lacking a documentation site or reach the bootstrap deployment-choice step. |
+| `rechecks_rebootstrap_drift` | NOT_EXERCISED | No re-bootstrap was performed, so no drift recheck or Internal-path classification occurred. |
+| `preserves_authorization_boundary` | PASS | The candidate explicitly treated the request as read-only, stated that initialization was not authorized, and locked evidence shows no branch, commit, index, worktree, or untracked-file changes. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=a857fcf2c722711dbe976f85685cf13e950a1e35983a7408a6a97bb35347ed24; fixture_sha256=4e3ac8498634ec41445a5f746933f338a50d3c3d4cae8d2f058bd619e288d842; output_sha256=6dfab3cfcf3d6841987970d809f3c9a2302026e28cfeaa38a3a1f43399e2f465; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Blocked before fixture inspection; preserved the read-only boundary but did not complete the requested classification workflow.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=a857fcf2c722711dbe976f85685cf13e950a1e35983a7408a6a97bb35347ed24; fixture_sha256=4e3ac8498634ec41445a5f746933f338a50d3c3d4cae8d2f058bd619e288d842; output_sha256=c03ac5d143898fdf7eeb3a684ac33fc4885d0e645df5bdf6b12b5f60fc449dc0; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly preserved the read-only authorization boundary but stopped before repository inspection and bootstrap-specific behavior.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=a857fcf2c722711dbe976f85685cf13e950a1e35983a7408a6a97bb35347ed24; fixture_sha256=4e3ac8498634ec41445a5f746933f338a50d3c3d4cae8d2f058bd619e288d842; output_sha256=57b15381e28f83bcb479a8e7dc524463d7a243f0e72fc76b72be446ba4179af3; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Inspected all three repository snapshots and provided evidence-based build-to-publish classifications and owners without mutation.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=a857fcf2c722711dbe976f85685cf13e950a1e35983a7408a6a97bb35347ed24; fixture_sha256=4e3ac8498634ec41445a5f746933f338a50d3c3d4cae8d2f058bd619e288d842; output_sha256=91d19d0286b071f726de5e72f5f6d6b941576b45def9553d930f419d8ea65f0e; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Performed the requested read-only repository inspection and reported build, image, CI, Compose/Helm, and ownership evidence, but did not exercise bootstrap workflow assertions.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- The with_skill lane stopped before inspecting the read-only fixture and omitted the required first-bootstrap choice prompt.
-- Next: None.
+- None.
+- Next: Provide the explicit bootstrap request, confirmed host repository, and required user confirmations to exercise the bootstrap assertions.
 
 ## Runtime Artifact Policy
 

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-001-sync-feature-api/comparison.md
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-001-sync-feature-api/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `19be975a76919e1880464ff6b63104dc042d768be1d80c006b73e28d58ffabfa` from `agents/docs/test/formal-docs-sync/evals/workspace/eval-001-sync-feature-api`.
 - Identity schema: `2`
-- target_skill_sha256: `a3e1263ac8acb74f106913f935cefb0ebe0f7f059ccc011cd16715592fd0163d`
+- target_skill_sha256: `314b02febc2ef94201a8e1bf1080c874c355a0e47e6ac9a01b931425f08bfbd7`
 - eval_definition_sha256: `ce743547e06014367140716bb2c97c1db58eb733e797662e8b4bd6eca00be3ee`
 - metadata_sha256: `f8156f035dafc132a200ab0fabf455e3a12e92c380c1e7265ae20e3e3df0c170`
 - fixture_sha256: `19be975a76919e1880464ff6b63104dc042d768be1d80c006b73e28d58ffabfa`
@@ -22,45 +22,41 @@
 - judge_schema_sha256: `b75531387a8a9fcbe3680466e0062ed9ca0b3db6341639dbf81c051b7647e990`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `cd2f08c41a6ec95815793c80de00d9c220026a6632090c7da71f54b61e0f767a`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `b6ae3621879be63fa5b02212924eed11dd010ad027f0308f85d7666d26a57421`
-- Behavior result: **FAIL**
+- Skill overlay SHA-256: `84e19c3e634cfde176d2ff20ba8e9d25a4838db3ed1deb5def94a8d0f1d2ddd9`
+- Behavior result: **PASS**
 - Coverage result: **FULL**
-Overall result: FAIL
+Overall result: PASS
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `selects_backfill_mode_and_api_contract` | PASS | PASS：with_skill 明确选择 existing-system backfill，引用维护者请求、既有 host 与 feature catalog，并列出 standards entry、change-map、API template、API module；未读取其他类型模块。 |
-| `derives_complete_api_candidate_tree` | PASS | PASS：候选树完整包含 API、Identity、Sessions 两级索引及两个 route leaf，并以 catalog、route、owner、schema 与 contract test 证据支撑；Billing 明确留待后续。 |
-| `presents_per_node_confirmation_matrix` | FAIL | FAIL：虽有树、矩阵和 mapping section，但未明确列出 unresolved discrepancies；叶子节点矩阵还使用了 `.../create-session.md` 与 `.../revoke-session.md` 的缩略路径。 |
-| `proposes_exact_atomic_change_map` | FAIL | FAIL：映射覆盖五页闭包、两个 leaf、全部 ancestor index、递归导航及未知字段保留；但 `required_docs` 实际顺序并非稳定路径排序，却声称已稳定排序。 |
-| `preserves_stable_paths_and_scope_boundaries` | PASS | PASS：明确将 Billing、Search 及其既有映射置于批次外并保持稳定路径，且排除 internal、database、design、ops、product、release；未提出隐式迁移。 |
-| `keeps_unconfirmed_batch_read_only` | PASS | PASS：with_skill 输出 pending confirmation、zero-write、未运行 checks、未提前 handoff；git evidence 与 delivery snapshot 也显示无写入。 |
-| `defaults_new_pages_to_internal_visibility` | FAIL | FAIL：新增页面均标为 internal，既有 API 根/Search 保持 both；但未解释 internal 默认的收紧依据及例外。 |
+| `selects_backfill_mode_and_api_contract` | PASS | With-skill output selects existing-system backfill, cites the maintainer handoff/request and feature catalog, and raw trace shows reading standards entry, change map, API template, and API instructions without loading non-API type templates. |
+| `derives_complete_api_candidate_tree` | PASS | The output presents all five required paths, derives hierarchy from catalog, route, schema, owner, and contract evidence, and excludes Billing as a separate later-scope domain. |
+| `presents_per_node_confirmation_matrix` | PASS | A complete parent/child tree, per-node matrix, mapping section, exclusions, evidence boundaries, and unresolved handler-versus-test discrepancy are presented before confirmation. |
+| `proposes_exact_atomic_change_map` | PASS | Three precise route/schema/contract-test mappings each include the full five-page closure, stable deduplication/sorting, recursive navigation coverage, and preservation of the manual-plugin entry. |
+| `preserves_stable_paths_and_scope_boundaries` | PASS | Billing, Search, non-API sections, internal API paths, and release scope are explicitly excluded; Search is marked read-only with no migration and no mapping changes. |
+| `keeps_unconfirmed_batch_read_only` | PASS | The candidate batch is explicitly unconfirmed, no files changed per output and git evidence, host checks were not run, handoff is blocked, and the response waits for maintainer confirmation. |
+| `defaults_new_pages_to_internal_visibility` | PASS | All new pages are specified as visibility: internal, with the existing API root retaining both visibility to preserve the stable public navigation path. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cd2f08c41a6ec95815793c80de00d9c220026a6632090c7da71f54b61e0f767a; fixture_sha256=19be975a76919e1880464ff6b63104dc042d768be1d80c006b73e28d58ffabfa; output_sha256=8d51fd2ccae14078e15c2d412ebb75acc0e73e36ade7de744cea2559b1a7fb55; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 正确完成有边界的 API backfill 只读候选规划，识别完整五页树并等待确认，但矩阵、排序和 visibility 说明存在缺口。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cd2f08c41a6ec95815793c80de00d9c220026a6632090c7da71f54b61e0f767a; fixture_sha256=19be975a76919e1880464ff6b63104dc042d768be1d80c006b73e28d58ffabfa; output_sha256=745bc62d859fe0551c8272278524d0284b338223be30b6e421afd0f243853620; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Delivered a complete, evidence-backed, read-only Identity/Sessions API backfill proposal with confirmation gating and exact change-map closure.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cd2f08c41a6ec95815793c80de00d9c220026a6632090c7da71f54b61e0f767a; fixture_sha256=19be975a76919e1880464ff6b63104dc042d768be1d80c006b73e28d58ffabfa; output_sha256=92f4fdc84f2641c42831898ed7d92ade62bcc42f6fd966a5d4142caabc1adc34; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 同样提出五页候选树并保持零写入，但缺少逐节点确认矩阵、完整原子 change-map 闭包、显式同步决策和 internal visibility 处理。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cd2f08c41a6ec95815793c80de00d9c220026a6632090c7da71f54b61e0f767a; fixture_sha256=19be975a76919e1880464ff6b63104dc042d768be1d80c006b73e28d58ffabfa; output_sha256=e0b2a3f14ba3da243e84d750119ce239a89307ab1c5fd53e5308152bbb96f2d5; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Identified the same five-page candidate and preserved read-only state, but provided a less complete confirmation matrix, visibility policy, hierarchy checkpoint, and atomic mapping closure.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- 逐节点确认矩阵未明确 unresolved discrepancies，且叶子路径在矩阵中不完整。
-- change-map required_docs 声称稳定排序但实际列表顺序不满足该要求。
-- 未解释新增页面默认 internal 的依据与 existing both 的例外。
-- Next: 补全每个节点的完整页面路径及 unresolved discrepancies 字段。
-- Next: 将每个 required_docs 列表按明确且一致的稳定排序输出。
-- Next: 说明新增页面默认 internal 的证据依据，并标明既有 both 页面是保持现状的例外。
+- None.
+- Next: Await explicit maintainer confirmation before writing pages, navigation, or change-map entries.
 
 ## Runtime Artifact Policy
 

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-002-plan-backfill-batches/comparison.md
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-002-plan-backfill-batches/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `d39e08e3921dea4ed3620111c7989cda61f1e85ab306939032821affe0218f45` from `agents/docs/test/formal-docs-sync/evals/workspace/eval-002-plan-backfill-batches`.
 - Identity schema: `2`
-- target_skill_sha256: `a3e1263ac8acb74f106913f935cefb0ebe0f7f059ccc011cd16715592fd0163d`
+- target_skill_sha256: `314b02febc2ef94201a8e1bf1080c874c355a0e47e6ac9a01b931425f08bfbd7`
 - eval_definition_sha256: `ac42526e36e715108f7b75fd8273d1a27b06b53f2d88401d4e0acf869a7f27d9`
 - metadata_sha256: `5fd28d9378e7eecda587e4671ac17460a0dd3663cff48d75fd068b1dc2cb5f0c`
 - fixture_sha256: `d39e08e3921dea4ed3620111c7989cda61f1e85ab306939032821affe0218f45`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `9176713527a4959d0641a1feea488e487885b76c3aa23f11bb3b81f29825c3ae`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `8abbeebf58a017f34c7b7989f0280e2daf82af8f4daf404a0ba21c98f5540049`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `b6ae3621879be63fa5b02212924eed11dd010ad027f0308f85d7666d26a57421`
+- Skill overlay SHA-256: `84e19c3e634cfde176d2ff20ba8e9d25a4838db3ed1deb5def94a8d0f1d2ddd9`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,24 +33,24 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `keeps_unconfirmed_batch_read_only` | PASS | Final status and diff contain only Analytics pages and the Analytics mapping; Accounts, API root, Billing, and unrelated mappings remain unchanged. |
-| `creates_complete_product_tree` | PASS | The final fixture state contains product/index.md, product/analytics/index.md, and product/analytics/view-dashboard.md, with the Analytics mapping requiring all three. |
-| `keeps_every_task_navigable` | PASS | Internal recursive navigation builds successfully; Analytics links to the dashboard task, the task links back to Analytics, and the both-visible Product root has no public-invalid正文 link. |
-| `writes_evidence_backed_task_behavior` | PASS | The task page records the three allowed roles, ready/empty states, load retry behavior, unauthorized behavior, and recovery guidance, with implementation and acceptance-test references. |
-| `updates_product_map_atomically` | PASS | Git evidence adds the three-page Analytics required_docs closure while preserving Billing and support triggers, excludes, and review_policy fields. |
-| `runs_product_host_checks` | PASS | Trace records npm run test:docs, npm run build:public, and npm run build:internal from docs/site/ with exit code 0; delivered pages retain last_verified_version: unverified. |
-| `blocks_audit_without_confirmed_version` | PASS | The handoff identifies the completed Analytics batch, affected docs/map, evidence, exclusions, and missing target_release_version, with status blocked pending confirmation. |
+| `keeps_unconfirmed_batch_read_only` | PASS | With-skill git evidence changes only the Analytics Product pages and change map; Accounts, API root, Billing, and unrelated mappings remain unchanged. |
+| `creates_complete_product_tree` | PASS | The delivered tree and final mapping contain product/index.md, product/analytics/index.md, and product/analytics/view-dashboard.md. |
+| `keeps_every_task_navigable` | PASS | Internal navigation/build evidence resolves the Analytics-to-task link and task-to-parent link; the existing Product root remains visibility: both, and the new pages are internal. |
+| `writes_evidence_backed_task_behavior` | PASS | The task page records owner/admin/analyst access, empty state, load failure retry, unauthorized recovery, and links the dashboard implementation and acceptance test. |
+| `updates_product_map_atomically` | PASS | The final change map adds src/product/analytics/** with all three required_docs; Billing and support entries retain their existing trigger, exclude, and review_policy fields. |
+| `runs_product_host_checks` | PASS | Raw trace records npm run test:docs, npm run build:public, and npm run build:internal from docs/site/ with exit 0; all three delivered pages show last_verified_version: unverified. |
+| `blocks_audit_without_confirmed_version` | PASS | The audit handoff lists blocked status, the completed Analytics three-page batch, affected pages/map, supporting evidence, exclusions, and target_release_version: missing while awaiting release confirmation. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=8abbeebf58a017f34c7b7989f0280e2daf82af8f4daf404a0ba21c98f5540049; fixture_sha256=d39e08e3921dea4ed3620111c7989cda61f1e85ab306939032821affe0218f45; output_sha256=5c09bebc793073c24455f8a5458d2896280d2641bb988b212906d1d66404e3a4; snapshot_sha256=3d3ca2d40325b020e398bd14b12b538806d51d85941777961d402dd488b4c07e
-- Behavior: Completed the confirmed Analytics documentation batch with bounded scope, evidence-backed task content, atomic mapping, host checks, and a blocked version-dependent audit handoff.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=8abbeebf58a017f34c7b7989f0280e2daf82af8f4daf404a0ba21c98f5540049; fixture_sha256=d39e08e3921dea4ed3620111c7989cda61f1e85ab306939032821affe0218f45; output_sha256=4bffca58fd581a4f51f24ab9ed0093e23312ee71b56cdc3b975e017ecc31e459; snapshot_sha256=264efcb8f23c713a7f08fb2f5caa01e14d2aed58655288be04846f718742b34d
+- Behavior: Completed the confirmed Analytics backfill, updated the atomic change map, ran all required host checks, and blocked audit pending a confirmed release version.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=8abbeebf58a017f34c7b7989f0280e2daf82af8f4daf404a0ba21c98f5540049; fixture_sha256=d39e08e3921dea4ed3620111c7989cda61f1e85ab306939032821affe0218f45; output_sha256=5502557b40b056f45acc30d04da91caf29b467a27087912c2c056bd388108885; snapshot_sha256=64fb50e6bb6c30b3913c24bbce8458bf10d195c8ba4d7e6a8bb67f43d48dab68
-- Behavior: Created a partial Analytics tree and mapping, omitted the Product-root navigation update, and reported only documentation tests while not running the required builds or audit handoff.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=8abbeebf58a017f34c7b7989f0280e2daf82af8f4daf404a0ba21c98f5540049; fixture_sha256=d39e08e3921dea4ed3620111c7989cda61f1e85ab306939032821affe0218f45; output_sha256=5f896298587de9e7d49749a65ad3cf549551df18a45be1cc73a076fb934d06d8; snapshot_sha256=c870c01f3a28eea0ac53e6787e3ecbdcf424b91d772da44eeba17834fe1c1925
+- Behavior: Fresh baseline created the Analytics pages and preserved Accounts, but did not update the change map or run the required host checks/audit handoff.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-003-design-gate-incomplete-scope/comparison.md
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-003-design-gate-incomplete-scope/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `8aa9df65b73215302e91c3f000b2e01777ac5c79a5e42d477647ee57db58af66` from `agents/docs/test/formal-docs-sync/evals/workspace/eval-003-design-gate-incomplete-scope`.
 - Identity schema: `2`
-- target_skill_sha256: `a3e1263ac8acb74f106913f935cefb0ebe0f7f059ccc011cd16715592fd0163d`
+- target_skill_sha256: `314b02febc2ef94201a8e1bf1080c874c355a0e47e6ac9a01b931425f08bfbd7`
 - eval_definition_sha256: `b2bf4f8fb3d18226f8bc19c0ca91afcf8f927301ac6d8c89204f1fa6248c4f6b`
 - metadata_sha256: `60fd8d12ce139674523c1a361254f5e8a91b8a162c74d8b2d6b08ca495888809`
 - fixture_sha256: `8aa9df65b73215302e91c3f000b2e01777ac5c79a5e42d477647ee57db58af66`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `4b5a2072f392f239ebcef5483d2cd7f59525e9dddc22047a3017a3927cbc8008`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `56246c4cc2593a4f68a5cab876eaee6a48761e04188d3c231558d5894f290174`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `b6ae3621879be63fa5b02212924eed11dd010ad027f0308f85d7666d26a57421`
+- Skill overlay SHA-256: `84e19c3e634cfde176d2ff20ba8e9d25a4838db3ed1deb5def94a8d0f1d2ddd9`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `blocks_on_incomplete_scope` | PASS | with_skill 输出明确将同步判定为 blocked，并指出 `SCOPE-02` compact rendering 仍为 `TODO`；最终要求 Engineer 完成 compact rendering、对应测试和完成态材料后重新进入门禁。实施计划原始证据将其列为本次 delivery 的 Engineer TODO。 |
-| `design_zero_change` | PASS | with_skill 的锁定 git_evidence 显示前后 HEAD、分支、index、worktree 和未跟踪文件均无变化；输出明确报告 design 页与 change-map 均 zero-write。 |
-| `no_tentative_design` | PASS | with_skill 的锁定 git_evidence 显示无文件变更，delivery_snapshot 为空；输出保持 blocked 状态，未生成任何 provisional、tentative、planned、future-state 或部分 design 正文。 |
+| `blocks_on_incomplete_scope` | PASS | with_skill 明确记录 `SCOPE-02` 为 TODO、属于当前交付范围、owner 为 Engineer，并要求完成代码与全部验证后重新进入 closeout gate。 |
+| `design_zero_change` | PASS | with_skill 的锁定 git evidence 显示 head、branch、worktree、index、refs 均无变化；输出明确说明未修改两个 design 范围文件且 change-map 未应用。 |
+| `no_tentative_design` | PASS | with_skill 在 blocked 状态下未生成或交付任何 design 文件（delivery_snapshot 为空、git diff 为空），仅报告阻断原因和后续完成条件。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=56246c4cc2593a4f68a5cab876eaee6a48761e04188d3c231558d5894f290174; fixture_sha256=8aa9df65b73215302e91c3f000b2e01777ac5c79a5e42d477647ee57db58af66; output_sha256=c9181fdad8711fe04cc75880485f1c8847ef5cfc13153f1d7c1383c6e9c2640c; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 正确核验未完成范围并阻断同步；保持 design 页和 change-map 零变化。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=56246c4cc2593a4f68a5cab876eaee6a48761e04188d3c231558d5894f290174; fixture_sha256=8aa9df65b73215302e91c3f000b2e01777ac5c79a5e42d477647ee57db58af66; output_sha256=cbc63f8fcb0c60eb68218c930aae5454604134c4e3cdf349bf15302a4a8c050c; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 识别未完成的 SCOPE-02，阻断同步并保持 design 范围零写入。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=56246c4cc2593a4f68a5cab876eaee6a48761e04188d3c231558d5894f290174; fixture_sha256=8aa9df65b73215302e91c3f000b2e01777ac5c79a5e42d477647ee57db58af66; output_sha256=6d73ffaf144bb9fdbb4e576ba6fa6f833f1520cd6ccdd7e23255285ad61ab1d0; snapshot_sha256=4f58bd6db4e44fe0a5abd6cf6dff89e0d914f7141417b5d1d1f75ba978239929
-- Behavior: 识别了 SCOPE-02 尚未实现，但仍修改了 design 页和 change-map 并宣称完成同步。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=56246c4cc2593a4f68a5cab876eaee6a48761e04188d3c231558d5894f290174; fixture_sha256=8aa9df65b73215302e91c3f000b2e01777ac5c79a5e42d477647ee57db58af66; output_sha256=55ef361a0b3e62765a472e20e91400d1b53afebd7d928634d5fc357076a03b54; snapshot_sha256=771d019cb1e9482087e3c46053f8dbf29ae10be9079cc5bcb94385a7abcf9020
+- Behavior: 在 SCOPE-02 仍为 TODO 时仍修改了 design 页面和 change-map，形成 fresh baseline 对照。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-004-design-gate-failing-tests/comparison.md
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-004-design-gate-failing-tests/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `888ec3cd17fb382d54d3506afed12dac820d7455abc356bb02ec550713d0ad9f` from `agents/docs/test/formal-docs-sync/evals/workspace/eval-004-design-gate-failing-tests`.
 - Identity schema: `2`
-- target_skill_sha256: `a3e1263ac8acb74f106913f935cefb0ebe0f7f059ccc011cd16715592fd0163d`
+- target_skill_sha256: `314b02febc2ef94201a8e1bf1080c874c355a0e47e6ac9a01b931425f08bfbd7`
 - eval_definition_sha256: `ba23dfdb0f9a8ca4993196db1cc72ad98dc4f1e2f6b1b9055f218642fc040702`
 - metadata_sha256: `b892d7f11434df5d87e026ef6208862e030c7c37761a266263d03ebecbf3949f`
 - fixture_sha256: `888ec3cd17fb382d54d3506afed12dac820d7455abc356bb02ec550713d0ad9f`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `0669292f176355ed06a0f6f5bb030af6a23cb5add4a747bfc08b3a96f60fa065`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `b1f3e3ab8206fcdb669e596904dfb22d806d7f56cf42f82f0bf3acedbbed78d7`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `b6ae3621879be63fa5b02212924eed11dd010ad027f0308f85d7666d26a57421`
+- Skill overlay SHA-256: `84e19c3e634cfde176d2ff20ba8e9d25a4838db3ed1deb5def94a8d0f1d2ddd9`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `blocks_on_failing_tests` | PASS | With_skill identifies `test_compact_summary_handles_empty_values` as FAILED, marks required test gate 6 BLOCKED, and states no document or change-map write occurred; the matrix records scope confirmation was not reached. |
-| `design_zero_change` | PASS | With_skill reports zero writes, and locked git evidence shows unchanged HEAD/branch, empty status, empty index/worktree diffs, and no untracked files. |
-| `names_missing_evidence` | PASS | With_skill names the failed test, assigns responsibility to Engineer, and specifies fixing the implementation followed by rerunning all three required tests before re-entering closeout; it explicitly rejects rerunning only the failed test. |
+| `blocks_on_failing_tests` | PASS | With-skill output identifies `test_compact_summary_handles_empty_values` as FAILED and states the Design Delivery Closeout Gate blocked before any write. |
+| `design_zero_change` | PASS | Locked with-skill git evidence shows empty status, index diff, worktree diff, and no commits; output reports no design-page or change-map write and affected_docs as none. |
+| `names_missing_evidence` | PASS | Output names the failed test, assigns remediation to Engineer, and requires fixing the compact filtering, rerunning all three required tests to all-pass, then re-entering the design gate. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=b1f3e3ab8206fcdb669e596904dfb22d806d7f56cf42f82f0bf3acedbbed78d7; fixture_sha256=888ec3cd17fb382d54d3506afed12dac820d7455abc356bb02ec550713d0ad9f; output_sha256=c034ae292e711011ab28d05afba709a5208d78f91892fca9c212493866c3c6f2; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly blocked the design synchronization on the failed required test and preserved zero-change delivery state.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=b1f3e3ab8206fcdb669e596904dfb22d806d7f56cf42f82f0bf3acedbbed78d7; fixture_sha256=888ec3cd17fb382d54d3506afed12dac820d7455abc356bb02ec550713d0ad9f; output_sha256=566b923fe26e8821204495c7daf87426f26f36e4ad727437a55a3a655b7406e2; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly blocked the sync after the required compact-rendering test failed; no files were changed.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=b1f3e3ab8206fcdb669e596904dfb22d806d7f56cf42f82f0bf3acedbbed78d7; fixture_sha256=888ec3cd17fb382d54d3506afed12dac820d7455abc356bb02ec550713d0ad9f; output_sha256=05d4cde42e1f49797bae0025abfec849aa55fb54e2b14ccf86e05ea372f65345; snapshot_sha256=1dca550beaa5bf960b90fe98d001a18003f83ba18f0b8594903542a708510d8c
-- Behavior: Incorrectly modified the design document and change map despite the failed required test.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=b1f3e3ab8206fcdb669e596904dfb22d806d7f56cf42f82f0bf3acedbbed78d7; fixture_sha256=888ec3cd17fb382d54d3506afed12dac820d7455abc356bb02ec550713d0ad9f; output_sha256=19b6d3d8403c34f7d343bb0f0cba8fa2762eaa5cef414f8f331a1d008faeb850; snapshot_sha256=7aace380d691b4dce49c5726aea0d07ffe460b8f518d144912a77ec61ac834bf
+- Behavior: Reported the failing test but proceeded with design and change-map modifications.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-005-design-gate-mismatched-evidence/comparison.md
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-005-design-gate-mismatched-evidence/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `9ee09a35ffbbce09e9a24f1afab930b7c3820a015f0b4c8a431f51638de5592f` from `agents/docs/test/formal-docs-sync/evals/workspace/eval-005-design-gate-mismatched-evidence`.
 - Identity schema: `2`
-- target_skill_sha256: `a3e1263ac8acb74f106913f935cefb0ebe0f7f059ccc011cd16715592fd0163d`
+- target_skill_sha256: `314b02febc2ef94201a8e1bf1080c874c355a0e47e6ac9a01b931425f08bfbd7`
 - eval_definition_sha256: `9b46c27014c750c2c7c902ee9b735c340d6216e70bd1db10e9ac7cfe4ffa72b8`
 - metadata_sha256: `8201495b57b213f9db3f5219d86222ff877b211b7bfe7d5c149fe15482812507`
 - fixture_sha256: `9ee09a35ffbbce09e9a24f1afab930b7c3820a015f0b4c8a431f51638de5592f`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `c9b93b28ac72af6810f4752921bb72d418af8d9162ae5d66c15fe90f929562c8`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `cc15a608e753e009b625973b3297598562e26547f4019135f4ff1cee37bc04f0`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `b6ae3621879be63fa5b02212924eed11dd010ad027f0308f85d7666d26a57421`
+- Skill overlay SHA-256: `84e19c3e634cfde176d2ff20ba8e9d25a4838db3ed1deb5def94a8d0f1d2ddd9`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `blocks_on_evidence_mismatch` | PASS | With-skill output explicitly identifies the `preferences-summary` versus `account-preferences` mismatch, calls it a blocking conflict, and states it stopped before Step 4 and any writes. |
-| `design_zero_change` | PASS | With-skill output reports zero writes; locked git evidence shows unchanged HEAD, empty status, and empty worktree diff. |
-| `routes_to_owner` | PASS | With-skill output routes the path ambiguity to `pm-agent` and the TRD alignment issue to `engineer-agent:trd-gen`, requiring unified paths before retry and stating it will not guess. |
+| `blocks_on_evidence_mismatch` | PASS | with_skill 明确指出请求/计划的 `preferences-summary` 与 PRD/TRD 的 `account-preferences` 冲突，并在 scope confirmation/write phase 前阻断。 |
+| `design_zero_change` | PASS | with_skill 报告 `zero-write`、`none changed`、`change_map_delta: none applied`；锁定 git evidence 显示 HEAD、分支及工作树均未变化。 |
+| `routes_to_owner` | PASS | with_skill 将产品/元数据冲突路由至 `pm-agent`，将 TRD 路径/影响范围冲突路由至 `engineer-agent:trd-gen`，并要求修正后重试。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cc15a608e753e009b625973b3297598562e26547f4019135f4ff1cee37bc04f0; fixture_sha256=9ee09a35ffbbce09e9a24f1afab930b7c3820a015f0b4c8a431f51638de5592f; output_sha256=ce5366ab7e58f25e91f54665140ffc1316d10153c1d3ae7d0406ee12b22111c5; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Blocked on the evidence mismatch, preserved both design surfaces unchanged, and routed each correction to its owner.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cc15a608e753e009b625973b3297598562e26547f4019135f4ff1cee37bc04f0; fixture_sha256=9ee09a35ffbbce09e9a24f1afab930b7c3820a015f0b4c8a431f51638de5592f; output_sha256=64d8cd62a9f29de377c47066403cd1dc121fb5dbee1ca12548592b99cf89c770; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 识别 feature_path 证据冲突，阻断确认与写入，保持 design 原子范围零变化并路由给对应 owner。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cc15a608e753e009b625973b3297598562e26547f4019135f4ff1cee37bc04f0; fixture_sha256=9ee09a35ffbbce09e9a24f1afab930b7c3820a015f0b4c8a431f51638de5592f; output_sha256=a6b26a10d573e9e4942e19cb5ecf858b8585d1b167a31904ad8044198334abeb; snapshot_sha256=736859f7e81a08b8217c6ef2cb8ebcddfb2e356203c7914f6ed436acfd951a3c
-- Behavior: Treated the mismatch as a naming risk, proceeded with the sync, and modified both design surfaces.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cc15a608e753e009b625973b3297598562e26547f4019135f4ff1cee37bc04f0; fixture_sha256=9ee09a35ffbbce09e9a24f1afab930b7c3820a015f0b4c8a431f51638de5592f; output_sha256=d77f1edb05cb1a7e04bb11da8862d66a0ae9b0a1e90479c7afbf0025aafe0db6; snapshot_sha256=d39206766755fc9020924f912ead52c9bd2992f2037dd5c06db65cc7d071f299
+- Behavior: 误将交付视为可执行并修改 design 页面及 change-map，未因 feature_path 冲突阻断。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-006-design-gate-all-passed/comparison.md
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-006-design-gate-all-passed/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `98bf611a541c8fe0137472ae23a2bee304eb1dd895062850790d9e776e872e75` from `agents/docs/test/formal-docs-sync/evals/workspace/eval-006-design-gate-all-passed`.
 - Identity schema: `2`
-- target_skill_sha256: `a3e1263ac8acb74f106913f935cefb0ebe0f7f059ccc011cd16715592fd0163d`
+- target_skill_sha256: `314b02febc2ef94201a8e1bf1080c874c355a0e47e6ac9a01b931425f08bfbd7`
 - eval_definition_sha256: `409f0dff74eed97473da7310514056fa3150a1bcc243e245700365b8124e237d`
 - metadata_sha256: `d850062d9ab19e577fb519798bc20c97592f06bfa16acdff382b6c2af72957e7`
 - fixture_sha256: `98bf611a541c8fe0137472ae23a2bee304eb1dd895062850790d9e776e872e75`
@@ -22,37 +22,37 @@
 - judge_schema_sha256: `ebe36ab58d09b32dcb1d3a0e60e80a8c30163db5b3f4afa9ec0da402309c3c17`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `c76b170dd7794d3734918c7a765e05580924d97e899b93480f8dc75124874544`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `b6ae3621879be63fa5b02212924eed11dd010ad027f0308f85d7666d26a57421`
-- Behavior result: **PASS**
+- Skill overlay SHA-256: `84e19c3e634cfde176d2ff20ba8e9d25a4838db3ed1deb5def94a8d0f1d2ddd9`
+- Behavior result: **FAIL**
 - Coverage result: **FULL**
-Overall result: PASS
+Overall result: FAIL
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `passes_completion_gates` | PASS | With_skill explicitly marks Approved PRD, Confirmed TRD, confirmed plan, completed scope, code/diff coverage, and all three required tests as PASS; the fixture documents and diff/test evidence support each gate. |
-| `stops_at_scope_confirmation` | PASS | With_skill identifies the design page, change-map mapping, code boundary, evidence bindings, exclusions, pending confirmation, and unchanged write state, then asks for confirmation before executing the batch. |
-| `current_state_only` | PASS | The proposed behavior is limited to fixture-supported current behavior: fixed field order, omission of empty values, and shared ordered non-empty values for standard and compact output. No unsupported future behavior is proposed. |
+| `passes_completion_gates` | PASS | With-skill output marks all six gates PASS and cites the Approved PRD, Confirmed TRD with impacted code, confirmed plan, completed scope, diff/code coverage, and all required tests passed; fixture evidence supports these claims. |
+| `stops_at_scope_confirmation` | PASS | With-skill output identifies docs/site/design/preferences-summary.md, src/preferences_summary.py, supporting evidence, exclusions, unresolved confirmation status, and explicitly asks the maintainer to confirm; locked git evidence shows no modification. |
+| `current_state_only` | FAIL | The stated behavior is supported by the fixture code and test results, but the with-skill output also makes the unsupported claim that the change map has an existing code_glob, while the locked change-map evidence contains no code_glob. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c76b170dd7794d3734918c7a765e05580924d97e899b93480f8dc75124874544; fixture_sha256=98bf611a541c8fe0137472ae23a2bee304eb1dd895062850790d9e776e872e75; output_sha256=c88dd02a201b00092f5c6feb5937fb487b6bed67c0058d0aa763ee894ebf7b9b; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Completed evidence-backed candidate planning and correctly stopped for maintainer confirmation without modifying the site.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c76b170dd7794d3734918c7a765e05580924d97e899b93480f8dc75124874544; fixture_sha256=98bf611a541c8fe0137472ae23a2bee304eb1dd895062850790d9e776e872e75; output_sha256=5d8c65ff688e1a220994e2dac0904bb5c6cfe222607c224f7ceaf4776ecf8c5f; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly completes the evidence gates and stops for scope confirmation, but includes one unsupported change-map claim.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c76b170dd7794d3734918c7a765e05580924d97e899b93480f8dc75124874544; fixture_sha256=98bf611a541c8fe0137472ae23a2bee304eb1dd895062850790d9e776e872e75; output_sha256=948b56c331a6e92fbf3e56825b6a07c216f07f03a11287089099ab4c1d6ebccd; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Fresh baseline also identified the candidate page, mapping, evidence, current behavior, exclusions, and confirmation gate, but with less structured gate and scope reporting.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c76b170dd7794d3734918c7a765e05580924d97e899b93480f8dc75124874544; fixture_sha256=98bf611a541c8fe0137472ae23a2bee304eb1dd895062850790d9e776e872e75; output_sha256=a12ead8c4587245652c04ea1c71efe13a34d40abe06f27b2d736396b6096e467; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Provides a fresh baseline with a concise candidate scope and confirmation request, but less complete gate and unresolved-item detail.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- None.
-- Next: None.
+- The with-skill lane includes an unsupported change-map claim about an existing code_glob, violating the current-state-only assertion.
+- Next: Remove or correct the unsupported code_glob claim before presenting the candidate scope.
 
 ## Runtime Artifact Policy
 

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-007-feature-database-design/comparison.md
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-007-feature-database-design/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `de57a3e2c20f574e81d3d9803c1ae3a7c2c6c83bbead7114e75685122bb01a81` from `agents/docs/test/formal-docs-sync/evals/workspace/eval-007-feature-database-design`.
 - Identity schema: `2`
-- target_skill_sha256: `a3e1263ac8acb74f106913f935cefb0ebe0f7f059ccc011cd16715592fd0163d`
+- target_skill_sha256: `314b02febc2ef94201a8e1bf1080c874c355a0e47e6ac9a01b931425f08bfbd7`
 - eval_definition_sha256: `dd84eeaf9ea9452e584f740ec00a1edde6c8e5bfae2ef83da4e9e416f2e769fe`
 - metadata_sha256: `23140221449282820c7da53fcdbe46ce5ee1169aff6e90986ef0dbd09c5f9120`
 - fixture_sha256: `de57a3e2c20f574e81d3d9803c1ae3a7c2c6c83bbead7114e75685122bb01a81`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `289a3b63a3dcdcdc4cc6c4b994a40567f085f301732b94d5ab13b0e67247a316`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `97f82a75c78275f5f504c11fb93e67755d5b6d9f65a9ef9273ee264808b8d9c8`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `b6ae3621879be63fa5b02212924eed11dd010ad027f0308f85d7666d26a57421`
+- Skill overlay SHA-256: `84e19c3e634cfde176d2ff20ba8e9d25a4838db3ed1deb5def94a8d0f1d2ddd9`
 - Behavior result: **FAIL**
 - Coverage result: **PARTIAL**
 Overall result: FAIL
@@ -33,37 +33,36 @@ Overall result: FAIL
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `loads_only_database_design_contracts` | PASS | Trace shows standards entry, granularity, change map, database/design templates, and only database/design type instructions loaded; API pages were read as authority targets. |
-| `passes_design_closeout_gate` | NOT_EXERCISED | A runtime sync-report file-change event exists, but its locked content and required per-page matrix/timing evidence are not available in the delivery snapshot or raw evidence. |
-| `creates_database_schema_domain_tree` | PASS | Locked delivery files contain the database root, primary database, workspace-access domain, relationships, and all three entity pages with links. |
-| `refreshes_confirmed_stable_path` | PASS | The stable database path remains, its obsolete facts are replaced with current facts, it is marked unverified, and the broad workspace-access mapping is preserved. |
-| `documents_current_entity_facts` | FAIL | Entity pages record current fields, role checks, uniqueness, indexes, ownership, and lifecycle facts supported by schema, code, and tests. |
-| `links_relationships_bidirectionally` | FAIL | The relationships page links the entity pages, but the entity pages do not each link the required API workspace-access authority page; several also omit reciprocal links to all related entity pages. |
-| `distinguishes_physical_and_logical_relations` | PASS | Mermaid and prose distinguish the two cascading physical workspace foreign keys from the service-validated logical user reference. |
-| `creates_domain_component_flow_tree` | PASS | Locked delivery files contain the Design root, both domains, all three components, the acceptance flow, authorization boundary, and the flat compatibility page. |
-| `keeps_reciprocal_and_authority_links` | PASS | All three component pages link the acceptance flow, the flow links all three components, and Design pages link API/database authority without duplicating full contracts. |
-| `keeps_cross_domain_authority_unique` | PASS | Audit Log links to the workspace-access acceptance flow and does not duplicate its process; the acceptance flow is the sole detailed authority. |
-| `updates_atomic_map_and_unverified_pages` | PASS | The locked change map preserves unknown/manual entries, adds exact source mappings with sorted closures, retains the stable page, covers the database/design subtree and reciprocal links, and all delivered pages are unverified. |
-| `runs_host_checks_and_handoffs_audit` | NOT_EXERCISED | Raw command events show test:docs, build:public, and build:internal ultimately passed and internal navigation was inspected, but the audit handoff is explicitly blocked with target_release_version missing; completion of that later handoff step is therefore not exercised. |
+| `loads_only_database_design_contracts` | FAIL | runner_captured_trace shows database/design instruction modules were read before the host standards entry, granularity, change map, and templates; it did not read API, ops, or product rules. |
+| `passes_design_closeout_gate` | NOT_EXERCISED | No formal page or change-map write occurred, so the required runtime-only closeout matrix was not exercised. |
+| `creates_database_schema_domain_tree` | NOT_EXERCISED | No delivery snapshot exists for the with_skill lane; the workflow stopped before document creation. |
+| `refreshes_confirmed_stable_path` | NOT_EXERCISED | No with_skill files were written; stable-path refresh was not reached. |
+| `documents_current_entity_facts` | NOT_EXERCISED | No entity pages were delivered in the with_skill lane. |
+| `links_relationships_bidirectionally` | NOT_EXERCISED | No relationship or entity pages were delivered in the with_skill lane. |
+| `distinguishes_physical_and_logical_relations` | NOT_EXERCISED | No database documentation was delivered in the with_skill lane. |
+| `creates_domain_component_flow_tree` | NOT_EXERCISED | No Design hierarchy was delivered in the with_skill lane. |
+| `keeps_reciprocal_and_authority_links` | NOT_EXERCISED | No component or flow pages were delivered in the with_skill lane. |
+| `keeps_cross_domain_authority_unique` | NOT_EXERCISED | No cross-domain Design pages were delivered in the with_skill lane. |
+| `updates_atomic_map_and_unverified_pages` | NOT_EXERCISED | No mappings or documentation pages were written in the with_skill lane. |
+| `runs_host_checks_and_handoffs_audit` | NOT_EXERCISED | The candidate correctly stopped before host checks and audit handoff because scope and delivery-diff evidence blockers remained unresolved. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=97f82a75c78275f5f504c11fb93e67755d5b6d9f65a9ef9273ee264808b8d9c8; fixture_sha256=de57a3e2c20f574e81d3d9803c1ae3a7c2c6c83bbead7114e75685122bb01a81; output_sha256=069ee9a676b316d78571e5bfce36c7a00f4525c6351eed789148f6c9e908c706; snapshot_sha256=72fc8da393c9e12f7982f684fe0eef6ed89648f5e41c29a3f91218db26bb808b
-- Behavior: Delivered a substantially complete database/design hierarchy with current facts, authority distinctions, reciprocal design flow links, normalized mappings, and real host checks; the entity-link contract is incomplete and closeout/handoff evidence is partial.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=97f82a75c78275f5f504c11fb93e67755d5b6d9f65a9ef9273ee264808b8d9c8; fixture_sha256=de57a3e2c20f574e81d3d9803c1ae3a7c2c6c83bbead7114e75685122bb01a81; output_sha256=78627caf3883728821a7f0fb4d3004e9cd00d9abbb7c0181578b0abd51d100e8; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Safely blocked before writing because of unresolved scope and delivery-evidence gates, but violated the required host-contract read order.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=97f82a75c78275f5f504c11fb93e67755d5b6d9f65a9ef9273ee264808b8d9c8; fixture_sha256=de57a3e2c20f574e81d3d9803c1ae3a7c2c6c83bbead7114e75685122bb01a81; output_sha256=318415604a6ba586f02f2f4366e076e9f9872358418c0ad0a6524d2bdc680e16; snapshot_sha256=b04838b28473eefa6ff71704b0bb35cad1b0342f0e91b642cb37a6f51c361619
-- Behavior: Fresh baseline reports broad document synchronization and partial validation in concise prose, without the with_skill lane's detailed gate, scope, mapping, and handoff evidence.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=97f82a75c78275f5f504c11fb93e67755d5b6d9f65a9ef9273ee264808b8d9c8; fixture_sha256=de57a3e2c20f574e81d3d9803c1ae3a7c2c6c83bbead7114e75685122bb01a81; output_sha256=4600758cab39ed8386bccf8f6726d47ddd3e9e76fc95ef363c987394f5e48be4; snapshot_sha256=99ed9f1ea941511e09f18de2cf4432648323ae4c3f125e3c12b71699ab95a948
+- Behavior: Fresh baseline wrote the database and Design trees and refreshed the stable database page, but reported incomplete verification and did not provide the required full delivery evidence.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- links_relationships_bidirectionally: entity pages do not each provide the required API workspace-access link and complete reciprocal related-table links.
-- Next: Add the required API workspace-access and complete related-table links to every entity page.
-- Next: Provide the confirmed release version and complete the docs-audit handoff.
-- Next: Expose the locked sync-report content if closeout-gate scoring is required.
+- loads_only_database_design_contracts failed because the locked trace proves the required host-contract read order was not followed.
+- Next: Read the host standards entry, granularity, change map, and database/design templates before loading type-specific modules.
+- Next: Resolve the confirmed-scope conflict, add the missing PM handoff fields, and provide actual delivery diff evidence before resuming.
 
 ## Runtime Artifact Policy
 

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-008-deployment-ops-upgrade/comparison.md
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-008-deployment-ops-upgrade/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `214f53e3513d921f93697a6af50dd22ab635d80910879e93ccbc5d847195e845` from `agents/docs/test/formal-docs-sync/evals/workspace/eval-008-deployment-ops-upgrade`.
 - Identity schema: `2`
-- target_skill_sha256: `a3e1263ac8acb74f106913f935cefb0ebe0f7f059ccc011cd16715592fd0163d`
+- target_skill_sha256: `314b02febc2ef94201a8e1bf1080c874c355a0e47e6ac9a01b931425f08bfbd7`
 - eval_definition_sha256: `7fe3c7ecf4038349101f98fb6f2ef19330f01c150bee2276a165994129650157`
 - metadata_sha256: `2f78367477eb99dc045585689bae85fd3302b30aa534650ea910cd64f9bdfbbe`
 - fixture_sha256: `214f53e3513d921f93697a6af50dd22ab635d80910879e93ccbc5d847195e845`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `f5d562d8581b8e42e3d9fc6fee3e3cf82b682235e3b52ce9b9c4f91a22e1e752`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `47aecb4a312eb41566bd1acc858dd108cbb65075c955dc6992e37865198bfec5`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `b6ae3621879be63fa5b02212924eed11dd010ad027f0308f85d7666d26a57421`
+- Skill overlay SHA-256: `84e19c3e634cfde176d2ff20ba8e9d25a4838db3ed1deb5def94a8d0f1d2ddd9`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,28 +33,28 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `uses_executed_deployment_evidence` | PASS | With-skill snapshots bind the pages to Compose, deployment-results.md, .env.example, and environment differences; the documented commands and results match the locked executed evidence. |
-| `writes_current_ops_upgrade_rollback` | PASS | Docker pages record Compose startup, v1.4.2 upgrade, /healthz HTTP 200, v1.4.1 rollback, and the default AI_HUB_IMAGE with Compose evidence. |
-| `does_not_promote_plan_to_current_state` | PASS | The deployment index explicitly states Kubernetes/Helm is unsupported and only an unexecuted plan, without presenting it as current capability. |
-| `writes_current_deployment_tree_atomically` | PASS | All four required pages, navigation links, stable deploy/** mapping with existing exclude, unverified version metadata, and exclusion of unrelated page trees are present in the locked delivery snapshot. |
-| `runs_ops_host_checks_and_handoffs` | NOT_EXERCISED | runner_captured_trace proves test:docs passed with 76 tests and the delivery reports a blocked audit handoff pending release-version confirmation; the downstream docs-audit handoff cannot be completed yet. |
+| `uses_executed_deployment_evidence` | PASS | Locked with_skill pages cite deploy/compose.yaml and deployment-evidence/deployment-results.md, including executed commands, exit 0, healthy status, HTTP 200, and environment differences. |
+| `writes_current_ops_upgrade_rollback` | PASS | Docker pages record Compose startup, v1.4.2 upgrade, /healthz HTTP 200 success criteria, v1.4.1 rollback, and the default AI_HUB_IMAGE value with Compose evidence. |
+| `does_not_promote_plan_to_current_state` | PASS | The deployment index explicitly classifies Kubernetes/Helm as unsupported and states the plan is unexecuted, with no Helm commands presented as current operations. |
+| `writes_current_deployment_tree_atomically` | PASS | The locked delivery snapshot contains all four required pages, linked Ops/deployment/Docker navigation, a deploy/** map covering all four pages while retaining deploy/examples/** exclusion, unverified frontmatter, and git status showing only the scoped Ops/map changes and new deployment tree. |
+| `runs_ops_host_checks_and_handoffs` | NOT_EXERCISED | Raw trace proves npm run test:docs ran in docs/site and ultimately passed 76/76. The final handoff is blocked pending confirmed release context, so the later docs-agent:docs-audit handoff cannot yet be exercised. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=47aecb4a312eb41566bd1acc858dd108cbb65075c955dc6992e37865198bfec5; fixture_sha256=214f53e3513d921f93697a6af50dd22ab635d80910879e93ccbc5d847195e845; output_sha256=df6cfeae536e3283b6dfc77a1337f2fdbbd0d562db8dee12253748c1e431fafe; snapshot_sha256=5ab082e03195efc58650f7f69865d74415e8283090d8d9db6f0dc01eb353df09
-- Behavior: Delivered the required deployment documentation tree, corrected navigation links, used executed evidence, passed docs checks/builds, and stopped at the blocked audit handoff.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=47aecb4a312eb41566bd1acc858dd108cbb65075c955dc6992e37865198bfec5; fixture_sha256=214f53e3513d921f93697a6af50dd22ab635d80910879e93ccbc5d847195e845; output_sha256=30b6b3f26c65cd24e4ee049b5cdf0ef8a26fd61b178f045fdf4cb854fe8bdc40; snapshot_sha256=46ebee885a07bf47498a3ed73d9932da21474109d88fca3280d9d09bcad2fc31
+- Behavior: Produced the complete evidence-backed deployment documentation tree, passed the final 76-test docs check, and correctly left audit handoff blocked pending release context.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=47aecb4a312eb41566bd1acc858dd108cbb65075c955dc6992e37865198bfec5; fixture_sha256=214f53e3513d921f93697a6af50dd22ab635d80910879e93ccbc5d847195e845; output_sha256=c5ab4817c738f1bc088b05aa0a94a33cdc758b220443450c2c6e2ab756576b0f; snapshot_sha256=cf3b54f2753b6e04253a52dc1ad7f8640710589e575b69ba26c2edaf825af1c0
-- Behavior: Fresh baseline delivered four deployment pages and reported passing tests, but did not update the Ops navigation link or provide equivalent host-check/handoff evidence.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=47aecb4a312eb41566bd1acc858dd108cbb65075c955dc6992e37865198bfec5; fixture_sha256=214f53e3513d921f93697a6af50dd22ab635d80910879e93ccbc5d847195e845; output_sha256=71b2d6718c381100e943d646a3df55150a0cc27a71f4d2f122423d1c38cb3536; snapshot_sha256=5ec4a36d28867247bbe349db62f71c0166ec465a07c226ea1b56300d07c3bcd7
+- Behavior: Produced four deployment pages and reported a passing docs test, but the locked snapshot left the Ops navigation and change-map unchanged and provided no completed audit handoff.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Obtain release-version confirmation, then complete the docs-agent:docs-audit handoff.
+- Next: Obtain confirmed release context/target release version, then complete the docs-agent:docs-audit handoff.
 
 ## Runtime Artifact Policy
 

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-009-release-product-ops/comparison.md
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-009-release-product-ops/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `88db6a4117456e7d2f0e14115ea2a173ee0022fedba47576986e4b24262edb75` from `agents/docs/test/formal-docs-sync/evals/workspace/eval-009-release-product-ops`.
 - Identity schema: `2`
-- target_skill_sha256: `a3e1263ac8acb74f106913f935cefb0ebe0f7f059ccc011cd16715592fd0163d`
+- target_skill_sha256: `314b02febc2ef94201a8e1bf1080c874c355a0e47e6ac9a01b931425f08bfbd7`
 - eval_definition_sha256: `c9bcafbf3ecc8c0e0ac28908b463b075e9d1371a95444953a8afc3d41757e192`
 - metadata_sha256: `d04b92e9a3754ad51ae5d707b3601a2084dc53a6e309122269ca881bc88a10ef`
 - fixture_sha256: `88db6a4117456e7d2f0e14115ea2a173ee0022fedba47576986e4b24262edb75`
@@ -22,40 +22,41 @@
 - judge_schema_sha256: `56b98af2f6fc5a04535db999157836236eb69830528cbecc99ca00f23b4d8d9e`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `8feaf10d86a83aace4d8ae6456c2cfec394b2d1dd27b83a16d97b82d9a82c1f2`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `b6ae3621879be63fa5b02212924eed11dd010ad027f0308f85d7666d26a57421`
-- Behavior result: **PASS**
-- Coverage result: **PARTIAL**
-Overall result: PASS (partial coverage)
+- Skill overlay SHA-256: `84e19c3e634cfde176d2ff20ba8e9d25a4838db3ed1deb5def94a8d0f1d2ddd9`
+- Behavior result: **FAIL**
+- Coverage result: **FULL**
+Overall result: FAIL
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `limits_release_to_affected_product_ops` | PASS | with_skill 明确列出 product 与 ops 两个 affected_docs，并排除 API、database、design 及无关页面；change-map 映射保持不变。 |
-| `reconciles_confirmed_version_facts` | PASS | with_skill 正确核对代码中的 25、配置中的 registry.example/ai-hub:v1.5.0 与 25，以及测试证据；未采纳旧值或 v1.5.1 计划。 |
-| `preserves_release_notes_surfaces` | PASS | with_skill 明确排除 Release Notes surfaces，且 git_status/git_diff 均为空，未发生相关变更。 |
-| `keeps_release_pages_unverified` | NOT_EXERCISED | with_skill 未执行页面同步；当前 delivery_snapshot 为空，因此无法验证同步后页面是否保持 unverified。 |
-| `runs_release_host_checks_and_handoffs` | NOT_EXERCISED | with_skill 记录 host_checks 为 not_run、audit_handoff 为 blocked，未运行 npm run test:docs 或完成 docs-audit handoff。 |
+| `limits_release_to_affected_product_ops` | FAIL | with_skill 提议了正确的两个页面及映射范围，但 delivery_snapshot 为空、git_status 为空，未实际同步。 |
+| `reconciles_confirmed_version_facts` | FAIL | with_skill 正确列出 25、v1.5.0 和证据绑定，但未交付更新后的文件；其声称缺少正式证据与 fixture 中已提供的 handoff/evidence 相矛盾。 |
+| `preserves_release_notes_surfaces` | PASS | delivery_snapshot 为空且 git_status 为空；输出明确将 Release Notes 列为排除项。 |
+| `keeps_release_pages_unverified` | PASS | 未发生文件变更，原始 fixture 中 product 与 ops 页面仍为 last_verified_version: unverified。 |
+| `runs_release_host_checks_and_handoffs` | FAIL | with_skill 明确报告 host_checks 未运行、audit_handoff 为 blocked，未记录真实 npm run test:docs 通过结果或完成 docs-agent:docs-audit handoff。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=8feaf10d86a83aace4d8ae6456c2cfec394b2d1dd27b83a16d97b82d9a82c1f2; fixture_sha256=88db6a4117456e7d2f0e14115ea2a173ee0022fedba47576986e4b24262edb75; output_sha256=f4cb4732a24b121c456c9031ce6e2bb640dbfb726769a71d24a18b2b744ec1cb; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 正确核对范围与版本事实，保持无变更并在其判定的发布门禁处阻塞；未执行后续交付步骤。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=8feaf10d86a83aace4d8ae6456c2cfec394b2d1dd27b83a16d97b82d9a82c1f2; fixture_sha256=88db6a4117456e7d2f0e14115ea2a173ee0022fedba47576986e4b24262edb75; output_sha256=dfb0db33b645390e64c4a00ca62930732b6fb87d10c539fa830e3406a51fcd49; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 识别了正确范围和版本事实，并避免了 Release Notes 变更，但因不受证据支持的前置门禁阻断，未完成文档同步、宿主检查和 handoff。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=8feaf10d86a83aace4d8ae6456c2cfec394b2d1dd27b83a16d97b82d9a82c1f2; fixture_sha256=88db6a4117456e7d2f0e14115ea2a173ee0022fedba47576986e4b24262edb75; output_sha256=fa312623e7c70861f09b2dd2c64e3eeac0a5e15bdb9c953fe08e777ebe3e47f6; snapshot_sha256=9b8715c484d0b2aaaff5224f4798d17b466b09ec2f1a0a67fe6c7fe41b19ec5f
-- Behavior: 更新了两个受影响页面并运行测试，但错误地将页面 last_verified_version 写为 v1.5.0，且把不可解析的 abc1500 当作测试依据。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=8feaf10d86a83aace4d8ae6456c2cfec394b2d1dd27b83a16d97b82d9a82c1f2; fixture_sha256=88db6a4117456e7d2f0e14115ea2a173ee0022fedba47576986e4b24262edb75; output_sha256=088d9cc7bc57991fbe90052f648b80571c4ea010a7c0a2a2e174678371f89f05; snapshot_sha256=b8c49129916021af6ae10e243fb213fba462e65c14b359e2cbb5e59ded5d38f0
+- Behavior: 实际更新了目标页面和 change-map，且报告测试通过，但错误地将两个页面的 last_verified_version 写为 v1.5.0。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- None.
-- Next: 补齐可验证的发布入口/版本锚与必要运行时证据后，更新两页并保持 last_verified_version: unverified。
-- Next: 在 docs/site/ 执行 npm run test:docs，并将完整 affected set、target_release_version: v1.5.0 及确认来源 handoff 至 docs-agent:docs-audit。
+- 未交付两个受影响页面及 change-map 的实际更新。
+- 未运行宿主检查或完成 pre-tag handoff。
+- Next: 移除无依据的 changelog/release-process/audit context 阻断，更新两个目标页面及其 change-map。
+- Next: 在 docs/site/ 执行 npm run test:docs 并记录 cwd、命令和退出状态，随后完成 docs-agent:docs-audit handoff。
 
 ## Runtime Artifact Policy
 

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-010-release-notes-boundary/comparison.md
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-010-release-notes-boundary/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `f62e3d002a3d849e5b28b313abce4433afd4885459572da3c6552b50d7fc432c` from `agents/docs/test/formal-docs-sync/evals/workspace/eval-010-release-notes-boundary`.
 - Identity schema: `2`
-- target_skill_sha256: `a3e1263ac8acb74f106913f935cefb0ebe0f7f059ccc011cd16715592fd0163d`
+- target_skill_sha256: `314b02febc2ef94201a8e1bf1080c874c355a0e47e6ac9a01b931425f08bfbd7`
 - eval_definition_sha256: `73a1610671f9f97761837a796f3ae7908687bbe25fc17ad4582a0bb4ee5c7fae`
 - metadata_sha256: `2352ae604513521c63a446b6d886e6c879f4a0cef5861b4ee1c9c3ee9f319eba`
 - fixture_sha256: `f62e3d002a3d849e5b28b313abce4433afd4885459572da3c6552b50d7fc432c`
@@ -22,38 +22,38 @@
 - judge_schema_sha256: `b3a1a852c447e6e1ef51ed958da793390c6914ade2f68188c4962daac377d01b`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `59f3f4b07b3e4d027f3b554bec6c0d7c22a2923908783529642641c26634e91f`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `b6ae3621879be63fa5b02212924eed11dd010ad027f0308f85d7666d26a57421`
-- Behavior result: **FAIL**
+- Skill overlay SHA-256: `84e19c3e634cfde176d2ff20ba8e9d25a4838db3ed1deb5def94a8d0f1d2ddd9`
+- Behavior result: **PASS**
 - Coverage result: **FULL**
-Overall result: FAIL
+Overall result: PASS
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `recognizes_release_communication_outcome` | PASS | With-skill output identifies a release-mode workflow with release-note surfaces and a release-notes generator, distinct from Product/Ops synchronization. |
-| `routes_complete_entry_to_site_owner` | FAIL | It lists version, scope, evidence, and target surfaces, but does not actually deliver a complete confirmed host-inclusive handoff to the Docs owner; it defers routing until additional material is supplied. |
-| `keeps_entire_site_zero_diff` | PASS | The locked git evidence shows empty status and diffs, and the output explicitly reports zero modification; no delivery snapshot exists. |
-| `preserves_external_release_boundary` | PASS | The output explicitly excludes GitHub Release or tag creation and keeps the proposed work within site documentation surfaces. |
+| `recognizes_release_communication_outcome` | PASS | 输出将请求判定为 Release 模式，列出版本页、发布列表和元数据，并明确交由 docs-agent:release-notes-gen 处理。 |
+| `routes_complete_entry_to_site_owner` | PASS | Sync decision 保留 release-request.md 中已确认的 host/version/scope/site surfaces，并将完整候选批次路由给 docs-agent:release-notes-gen，同时标明 abc1500 未解析的证据边界。 |
+| `keeps_entire_site_zero_diff` | PASS | with_skill 的 delivery_snapshot 为空，git_status 和 git_diff 均为空；输出明确报告工作区零修改、未写入文件。 |
+| `preserves_external_release_boundary` | PASS | 输出将 GitHub Release/tag creation 列为排除项，且 raw git evidence 显示无 ref、commit 或工作区变化。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=59f3f4b07b3e4d027f3b554bec6c0d7c22a2923908783529642641c26634e91f; fixture_sha256=f62e3d002a3d849e5b28b313abce4433afd4885459572da3c6552b50d7fc432c; output_sha256=0ae876e2e1439c9f9c3b99f5555bd6102d44901612613c4fd1b95590b286c762; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly recognized the release-documentation workflow, blocked site writes, and preserved the external-release boundary, but did not route a complete confirmed entry to the Docs owner.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=59f3f4b07b3e4d027f3b554bec6c0d7c22a2923908783529642641c26634e91f; fixture_sha256=f62e3d002a3d849e5b28b313abce4433afd4885459572da3c6552b50d7fc432c; output_sha256=90bbb9064c664c4aeba33ac3d5d0bac1e802cdc70775971b4847000ec5759740; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 识别为站内 Release Notes 工作流，完整保留路由信息，在门禁未通过时保持 docs/site 零写入，并排除外部发布执行。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=59f3f4b07b3e4d027f3b554bec6c0d7c22a2923908783529642641c26634e91f; fixture_sha256=f62e3d002a3d849e5b28b313abce4433afd4885459572da3c6552b50d7fc432c; output_sha256=a3afb1144f31677118d342c810aa10b3f731307b2dd653c18233d0bd410b5085; snapshot_sha256=a9c5231c368a37de9acc93f84ee7cc7627f2a8e5ffe097520b70c8f9bc8698c7
-- Behavior: Created the release page, version index, and metadata, but violated the required zero-diff boundary; it is comparison context only.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=59f3f4b07b3e4d027f3b554bec6c0d7c22a2923908783529642641c26634e91f; fixture_sha256=f62e3d002a3d849e5b28b313abce4433afd4885459572da3c6552b50d7fc432c; output_sha256=fd94f4ff7de8aba7815a04d44a7ab54d2dc614b24ab93771947fe6df576924e6; snapshot_sha256=14711a1c4f3550f2f3ccd570f65b514296f0d65ef9b7947ff1ede31b02cf8b34
+- Behavior: 直接创建版本页、发布列表和元数据，产生 docs/site 变更，且未执行所需的交接与门禁。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- The with_skill lane did not complete the required host-inclusive handoff to the unique Docs owner and instead deferred routing.
-- Next: None.
+- None.
+- Next: 由 pm-agent 补发正式 Release handoff，并提供可解析的版本/tag 或真实提交、changelog/release-process 证据及 audit context。
 
 ## Runtime Artifact Policy
 

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-011-deployment-three-class-backfill/comparison.md
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-011-deployment-three-class-backfill/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `4d8408c1113f0b188f486ff52a1805928dda107a5b4bcef41d15ff086a7d524c` from `agents/docs/test/formal-docs-sync/evals/workspace/eval-011-deployment-three-class-backfill`.
 - Identity schema: `2`
-- target_skill_sha256: `a3e1263ac8acb74f106913f935cefb0ebe0f7f059ccc011cd16715592fd0163d`
+- target_skill_sha256: `314b02febc2ef94201a8e1bf1080c874c355a0e47e6ac9a01b931425f08bfbd7`
 - eval_definition_sha256: `75d9816433885deaa537c3684a33cbf77a210bf3435c193880901b7467aafb6d`
 - metadata_sha256: `e1dbc6626788bdd9110a7a2968862f7b97506d86b4133c4cf183a556eecf36ce`
 - fixture_sha256: `4d8408c1113f0b188f486ff52a1805928dda107a5b4bcef41d15ff086a7d524c`
@@ -22,39 +22,42 @@
 - judge_schema_sha256: `2e68facf61317de81b206f59b17f3e724dc3951afae11b2a8c4aad6ddba91a26`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `bed66a02e7102d84cc8988d8318b854a858b57d12888f0168cc60650b6d45cd2`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `b6ae3621879be63fa5b02212924eed11dd010ad027f0308f85d7666d26a57421`
-- Behavior result: **PASS**
+- Skill overlay SHA-256: `84e19c3e634cfde176d2ff20ba8e9d25a4838db3ed1deb5def94a8d0f1d2ddd9`
+- Behavior result: **FAIL**
 - Coverage result: **PARTIAL**
-Overall result: PASS (partial coverage)
+Overall result: FAIL
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `creates_three_class_page_tree` | PASS | Locked with_skill delivery_snapshot contains the complete 10-page three-class tree, shared environment reference, navigation, and an index with class status and links. |
-| `cross_checks_environment_reference` | PASS | The with_skill environment matrix covers all four variables with purpose/type, defaults, requiredness, constraints, class-specific consumption, sensitivity, safe handling, lifecycle, and source evidence; LEGACY_TIMEOUT is marked deprecated. |
-| `separates_class_specific_contracts` | PASS | Locked pages provide separate Development, Docker, and Kubernetes/Helm prerequisites, commands, success criteria, rollback, troubleshooting, and class-specific image/configuration details. |
-| `maps_each_class_atomically` | PASS | The locked change-map preserves the unrelated src/product entry, adds real source globs and complete required-doc closures, and trace events show atomic file updates followed by readback and normalization checks. |
-| `runs_nested_docs_checks` | NOT_EXERCISED | The with_skill trace records npm run test:docs from the docs site with 3/3 passing, plus recursive link/frontmatter checks; all pages retain last_verified_version: unverified. The later audit handoff is blocked by the missing target release version. |
+| `creates_three_class_page_tree` | PASS | The with_skill delivery snapshot contains all ten required deployment pages, the shared environment reference, three class indexes, and root navigation. |
+| `cross_checks_environment_reference` | FAIL | The environment matrix covers the required fields and evidence sources, but LEGACY_TIMEOUT is recorded without its fixture default value of 30, so the per-variable default requirement is incomplete. |
+| `separates_class_specific_contracts` | PASS | The with_skill snapshot provides separate Development, Docker Compose, and Kubernetes/Helm pages with class-specific prerequisites, commands, success criteria, rollback, troubleshooting, image sources, and values/chart references. |
+| `maps_each_class_atomically` | FAIL | The change map preserves src/product/** and custom_owner_field, and maps all three deployment classes, but the scripts/dev/** row omits the Development image-build page, leaving that class mapping incomplete as an atomic scope. |
+| `runs_nested_docs_checks` | NOT_EXERCISED | The raw trace proves npm run test:docs passed 3/3, but does not prove the required docs/site working directory or a public/internal recursive build check; those later/hidden checks are not exercised. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=bed66a02e7102d84cc8988d8318b854a858b57d12888f0168cc60650b6d45cd2; fixture_sha256=4d8408c1113f0b188f486ff52a1805928dda107a5b4bcef41d15ff086a7d524c; output_sha256=e9c964cab7323a05b473d338663c2cb95ee27f4de16eee9d500c282ac25badf2; snapshot_sha256=70846557f55ec3f83fdbfe25d183e2e68151e0e00f59d7e5d9188ad9caf33acd
-- Behavior: Delivered a semantically complete, evidence-backed three-class deployment documentation tree with a cross-source environment matrix, atomic mappings, and passing nested documentation checks; audit handoff remains blocked on the missing release version.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=bed66a02e7102d84cc8988d8318b854a858b57d12888f0168cc60650b6d45cd2; fixture_sha256=4d8408c1113f0b188f486ff52a1805928dda107a5b4bcef41d15ff086a7d524c; output_sha256=cfb0182e15803a002174518ea9de0a5b378cc20f8b108c29448a0540011e70af; snapshot_sha256=2da5eb5af030a545ce74da425d662d578c6bcc2e76320f46961b1a6f3af0ccc2
+- Behavior: Delivered a complete ten-page deployment tree with substantially richer evidence-backed class pages and an environment matrix; the locked snapshot has the two noted coverage defects, while the locked trace shows the nested docs test passing 3/3.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=bed66a02e7102d84cc8988d8318b854a858b57d12888f0168cc60650b6d45cd2; fixture_sha256=4d8408c1113f0b188f486ff52a1805928dda107a5b4bcef41d15ff086a7d524c; output_sha256=fcbc7f3d10721e12e5ff63c03a2b60f2dfcdc53079f4ea35f2b1d35361697c20; snapshot_sha256=9b36e6347767c3d0d47528eac9091711ee7d266f463e05231c7498b179ad61f8
-- Behavior: Delivered the basic page tree and eventually passed the host test, but its environment reference and class-specific contracts are materially less complete and its trace shows iterative link-fix failures before the final pass.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=bed66a02e7102d84cc8988d8318b854a858b57d12888f0168cc60650b6d45cd2; fixture_sha256=4d8408c1113f0b188f486ff52a1805928dda107a5b4bcef41d15ff086a7d524c; output_sha256=ccdb373573c1b37b5a6f1ad514267a1ca145f818f03abc4636b53fcd734244cb; snapshot_sha256=c4c0f9ed92351e471b3ea82b69afaaf3ddba61ffb13807ff2969d88887bad69c
+- Behavior: Produced the same page tree and a passing nested-docs test, but with substantially thinner class contracts, a four-column environment table, and less complete change-map coverage; this is comparison context only.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- None.
-- Next: Confirm the target release version, then complete the docs-agent:docs-audit handoff.
+- The environment reference omits LEGACY_TIMEOUT's actual default value.
+- The scripts/dev/** change-map entry does not include development/image-build.md.
+- Next: Add LEGACY_TIMEOUT=30 and its deprecated/unused status to the environment matrix.
+- Next: Add development/image-build.md to the scripts/dev/** required_docs mapping.
+- Next: Run any host-defined public/internal documentation checks if they become available, recording their working directory and results.
 
 ## Runtime Artifact Policy
 

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-012-deployment-class-evidence-gap/comparison.md
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-012-deployment-class-evidence-gap/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `94a440475528b183f978a35b0a119247396e300b3f4d27c6c1d0f2046bc60924` from `agents/docs/test/formal-docs-sync/evals/workspace/eval-012-deployment-class-evidence-gap`.
 - Identity schema: `2`
-- target_skill_sha256: `a3e1263ac8acb74f106913f935cefb0ebe0f7f059ccc011cd16715592fd0163d`
+- target_skill_sha256: `314b02febc2ef94201a8e1bf1080c874c355a0e47e6ac9a01b931425f08bfbd7`
 - eval_definition_sha256: `649fb22000e8030404ac6361df8372e15d8183baaa675df886e6c740c229829a`
 - metadata_sha256: `9b6d976d4601ac0de151b2a46d4bd90f68a76a475f804b7878df438cf1dba8d6`
 - fixture_sha256: `94a440475528b183f978a35b0a119247396e300b3f4d27c6c1d0f2046bc60924`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `e93bcd19b2a81fd498c0a0b76bf2788577403b4eb3f684a80f1adbb170c93ef8`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `d22f5a61b9778737597225188b6c8c34747660b197372bd350dcfc64d227e5ff`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `b6ae3621879be63fa5b02212924eed11dd010ad027f0308f85d7666d26a57421`
+- Skill overlay SHA-256: `84e19c3e634cfde176d2ff20ba8e9d25a4838db3ed1deb5def94a8d0f1d2ddd9`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,21 +33,21 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `blocks_only_missing_class` | PASS | With_skill marks Kubernetes/Helm blocked and lists missing Chart, values, template consumers, cluster authority/kubeconfig permission, and execution verification; it does not rely on the unexecuted plan as support. |
-| `continues_confirmed_classes` | PASS | With_skill delivers all five required pages, required links, evidence-bounded Development/Docker environment mappings, and change-map entries while continuing the confirmed batch. |
-| `creates_no_placeholder_commands` | PASS | With_skill delivery contains no Kubernetes/Helm page tree or placeholder Helm commands/content and explicitly lists the evidence needed before completion. |
-| `keeps_class_boundaries` | PASS | Development and Docker snapshots each contain separate prerequisites, commands, success criteria, rollback, and troubleshooting; Docker image sourcing is explicitly kept separate from Kubernetes evidence. |
+| `blocks_only_missing_class` | PASS | With-skill report and deployment index explicitly mark Kubernetes/Helm blocked and name missing Chart, values, template consumers, cluster authority, and execution/verification results. Fixture confirms those materials are absent. |
+| `continues_confirmed_classes` | PASS | Locked delivery snapshot contains all five required deployment pages, correct cross-links, evidence-backed Development/Docker parameters, and change-map entries covering those pages. Git evidence shows the confirmed batch continued despite Kubernetes being excluded. |
+| `creates_no_placeholder_commands` | PASS | Locked delivery snapshot and git status show no kubernetes-helm directory. Delivered files contain no Helm commands, namespace, imagePullSecrets, or Kubernetes success claims; the report lists the missing evidence required to proceed. |
+| `keeps_class_boundaries` | PASS | Development and Docker snapshots each provide distinct prerequisites, commands, success criteria, rollback, and troubleshooting. Docker uses the pinned image evidence and does not infer Kubernetes provenance from the tag; no Kubernetes plan is embedded in Docker content. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=d22f5a61b9778737597225188b6c8c34747660b197372bd350dcfc64d227e5ff; fixture_sha256=94a440475528b183f978a35b0a119247396e300b3f4d27c6c1d0f2046bc60924; output_sha256=d17f1fce7e7f39d60a74b98f7dc2ef552fbdd194b2f83fd657a432892e128861; snapshot_sha256=9eedaa71343ee7a44dbbbfd4bfae59d2cdd0b39f46022fef8bda3427949b67e9
-- Behavior: Completed the confirmed Development and Docker documentation batch, blocked Kubernetes/Helm pending missing evidence, and passed the final documentation checks.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=d22f5a61b9778737597225188b6c8c34747660b197372bd350dcfc64d227e5ff; fixture_sha256=94a440475528b183f978a35b0a119247396e300b3f4d27c6c1d0f2046bc60924; output_sha256=1c90798c7c43928950915ec8df6ca4d38dedf290538f0b986c5837e9d5a8304e; snapshot_sha256=5d11715708054fe781abebbbce89da5cf804934078ee91d7e0e8078e7327c835
+- Behavior: Completed the confirmed Development and Docker documentation batch, preserved evidence boundaries, and explicitly blocked Kubernetes/Helm without placeholder artifacts.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=d22f5a61b9778737597225188b6c8c34747660b197372bd350dcfc64d227e5ff; fixture_sha256=94a440475528b183f978a35b0a119247396e300b3f4d27c6c1d0f2046bc60924; output_sha256=5a7344c30f2e76763b9c666b2a1e9a3692152697e93411b3f7d1767b20801bd9; snapshot_sha256=610d11e6ef05e7874b008695f639966532d791c859b17a9a400851915077dbe1
-- Behavior: Also delivered the confirmed documentation batch and left Kubernetes/Helm uncreated, providing a fresh baseline for comparison.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=d22f5a61b9778737597225188b6c8c34747660b197372bd350dcfc64d227e5ff; fixture_sha256=94a440475528b183f978a35b0a119247396e300b3f4d27c6c1d0f2046bc60924; output_sha256=9bebcf2abce87555c00fa4453dd7a797278858ba56fb6a30a7bd0a4da7ee3f69; snapshot_sha256=daf5cd74f2a145653fd4a0b588f030f0c007e27d20125fcb0b2004b7edd880f0
+- Behavior: Fresh baseline also produced confirmed deployment documentation and avoided creating Kubernetes pages, but its change-map and documentation evidence coverage was less complete.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-013-deployment-aggregate-migration/comparison.md
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-013-deployment-aggregate-migration/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `b9cf5f02e5624842eefaa770fff8e84ccfc602f0eed28accf48a25400705d39e` from `agents/docs/test/formal-docs-sync/evals/workspace/eval-013-deployment-aggregate-migration`.
 - Identity schema: `2`
-- target_skill_sha256: `a3e1263ac8acb74f106913f935cefb0ebe0f7f059ccc011cd16715592fd0163d`
+- target_skill_sha256: `314b02febc2ef94201a8e1bf1080c874c355a0e47e6ac9a01b931425f08bfbd7`
 - eval_definition_sha256: `2adf472912fe37066628cc2da23affed241d146a6c7c80728c7df93b4f2fccc7`
 - metadata_sha256: `1730a36a001d532f328500208fe2ccb136183d8551b840ea714421749b8365ea`
 - fixture_sha256: `b9cf5f02e5624842eefaa770fff8e84ccfc602f0eed28accf48a25400705d39e`
@@ -22,38 +22,39 @@
 - judge_schema_sha256: `cb68cc7396b4ed1007a2bd5b5970baa015053110168fade98a969dbebc84c1b1`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `ef6288663966feaaf953d5b243a6dc9ee464a3ae22e56d91ba3c5352bb37ed40`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `b6ae3621879be63fa5b02212924eed11dd010ad027f0308f85d7666d26a57421`
-- Behavior result: **PASS**
+- Skill overlay SHA-256: `84e19c3e634cfde176d2ff20ba8e9d25a4838db3ed1deb5def94a8d0f1d2ddd9`
+- Behavior result: **FAIL**
 - Coverage result: **FULL**
-Overall result: PASS
+Overall result: FAIL
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `migrates_aggregate_path` | PASS | With-skill delivery snapshot deletes `ops/deployment.md` and contains the root index, environment reference, and all three class pages. The root and class pages separate shared and class-specific content without retaining the old aggregate body. |
-| `repairs_inbound_and_internal_links` | PASS | The snapshot updates `ops/index.md` and `product/runtime.md` to `deployment/index.md`; root-to-child and child-to-environment links are present and structurally resolvable. The docs test passes. |
-| `updates_change_map_without_data_loss` | PASS | The with-skill `change-map.yaml` maps each deployment glob to its class page plus the shared/navigation closure, preserves `custom_owner_field`, the `exclude`, and the unrelated product mapping, and the trace records deduplicated stable ordering. |
-| `updates_navigation_atomically` | PASS | The locked file-change event covers deletion, page-tree creation, inbound-link repairs, navigation, and change-map updates in one confirmed batch. `npm run test:docs` exits 0 with 2/2 passing, and the only old-path match is a test fixture assertion rather than a link. |
+| `migrates_aggregate_path` | PASS | with_skill delivery_snapshot deletes docs/site/ops/deployment.md and adds deployment/index.md, environment-reference.md, and all three class directories without retaining the old aggregate file. |
+| `repairs_inbound_and_internal_links` | FAIL | Inbound links in ops/index.md and product/runtime.md point to the new root. However, each class page links to ../../environment-reference.md, which resolves outside the deployment tree; the correct relative path is ../environment-reference.md. |
+| `updates_change_map_without_data_loss` | PASS | with_skill change-map.yaml maps each deployment glob to its class page plus the shared environment and root pages, preserves custom_owner_field and exclude, and retains the unrelated src/product mapping. |
+| `updates_navigation_atomically` | FAIL | The locked snapshot shows the deletion, new both-visibility page tree, navigation and mapping updates in one delivery; runner evidence shows npm run test:docs passed and no old aggregate links in site documents. The broken nested links mean the claimed link-repair/navigation result is not fully satisfied. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=ef6288663966feaaf953d5b243a6dc9ee464a3ae22e56d91ba3c5352bb37ed40; fixture_sha256=b9cf5f02e5624842eefaa770fff8e84ccfc602f0eed28accf48a25400705d39e; output_sha256=6a3dd58e32a65c3c10424eac6245951334c014fe27ac3a90607671935e306cf1; snapshot_sha256=b454c27e3038a117b2d9dbf848dcba2a9a9666edee638f02cc4070e0151569d4
-- Behavior: Completed the deployment documentation migration, repaired links and mappings, preserved change-map data, and passed the host docs test.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=ef6288663966feaaf953d5b243a6dc9ee464a3ae22e56d91ba3c5352bb37ed40; fixture_sha256=b9cf5f02e5624842eefaa770fff8e84ccfc602f0eed28accf48a25400705d39e; output_sha256=80914870e7e8daf9a1f5add56dd64978f62404fede94b9879e004120302d44a5; snapshot_sha256=cc9a0e4678a1e5108ed354b6591bfd913d21fb39578a62d746a8a3c9809935a7
+- Behavior: Migrated the aggregate page, created the full page tree, repaired inbound links, and expanded change-map entries, but left all three class-page links to the shared environment page broken.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=ef6288663966feaaf953d5b243a6dc9ee464a3ae22e56d91ba3c5352bb37ed40; fixture_sha256=b9cf5f02e5624842eefaa770fff8e84ccfc602f0eed28accf48a25400705d39e; output_sha256=ba6ea37ca1ea417f87a989f1eccdfd6b186f54d516840404b0ea4b0f0b6682b9; snapshot_sha256=44b32c1da8cb63fc0059e30497e3a205abf5d4bd3dc82729ef9ce7211cc28bee
-- Behavior: Also completed the basic migration and link repairs, but its change-map snapshot only points each source glob to its individual class page rather than the full shared/navigation closure.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=ef6288663966feaaf953d5b243a6dc9ee464a3ae22e56d91ba3c5352bb37ed40; fixture_sha256=b9cf5f02e5624842eefaa770fff8e84ccfc602f0eed28accf48a25400705d39e; output_sha256=ecf22dcfd5aee37d8d261c11efe45ba052d8ba2c6d9a9684308b4cf4ab32b38f; snapshot_sha256=6b4a1a586d2facdb59b279598368294d6d672eeeb62dd2f1ed4d257b58e21e23
+- Behavior: Fresh baseline also migrated the page tree and repaired inbound links; its change map only points to class pages and omits the shared/root mappings, while its child-to-shared links are correct.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- None.
-- Next: None.
+- with_skill class pages contain broken relative links to environment-reference.md.
+- The navigation/link-repair assertion is not fully satisfied because nested internal links do not resolve.
+- Next: Change each class page's environment-reference link from ../../environment-reference.md to ../environment-reference.md, then rerun the documentation link check.
 
 ## Runtime Artifact Policy
 

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-014-existing-site-deployment-recheck/comparison.md
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-014-existing-site-deployment-recheck/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `af01acec7b20eeddc434bb03589d582f709819c1284ea057c0edd1ee4d701107` from `agents/docs/test/formal-docs-sync/evals/workspace/eval-014-existing-site-deployment-recheck`.
 - Identity schema: `2`
-- target_skill_sha256: `a3e1263ac8acb74f106913f935cefb0ebe0f7f059ccc011cd16715592fd0163d`
+- target_skill_sha256: `314b02febc2ef94201a8e1bf1080c874c355a0e47e6ac9a01b931425f08bfbd7`
 - eval_definition_sha256: `db9d705a02de2df76d9e1b62334995eac21d110dc172ed350d92306793043708`
 - metadata_sha256: `88632df23697500a0c7c41e94fb02d6159ef73b07b033169b66f45a2a56cdd01`
 - fixture_sha256: `af01acec7b20eeddc434bb03589d582f709819c1284ea057c0edd1ee4d701107`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `4b8356273a26d14ecc55ebfe7a9a2e541bdc3539a06437a0f30fb3a0dc7cbd4b`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `1fa72144e806cf52f8fd8fbc5b8cac36763c1b6d96e197c5c1ebe4dd6e004c69`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `b6ae3621879be63fa5b02212924eed11dd010ad027f0308f85d7666d26a57421`
+- Skill overlay SHA-256: `84e19c3e634cfde176d2ff20ba8e9d25a4838db3ed1deb5def94a8d0f1d2ddd9`
 - Behavior result: **FAIL**
 - Coverage result: **FULL**
 Overall result: FAIL
@@ -33,26 +33,26 @@ Overall result: FAIL
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `reports_existing_site_integrated` | PASS | The with_skill output reports Atlas public/internal coverage, cites package.json, Dockerfile, Compose, Helm, and auth evidence, and states that no build/deploy work was repeated. |
-| `detects_partial_variant_coverage` | PASS | The with_skill output explicitly distinguishes Orbit public as complete and internal as only a build script, listing missing internal Docker, Compose, auth, Helm, and CI paths. |
-| `returns_gap_to_pm_read_only` | FAIL | The with_skill output identifies pm-agent as the next owner for a repo-wide deployment handoff and confirms read-only behavior, but it does not explicitly ask the user whether pm-agent should generate it. |
+| `reports_existing_site_integrated` | PASS | With-skill output enumerates Atlas Public/Internal build and startup artifacts, cites configuration evidence, reports no deployment execution, and the locked git evidence shows no changes. |
+| `detects_partial_variant_coverage` | PASS | With-skill output identifies Orbit Console as Public-only and lists missing Internal Docker, Compose, Helm, authentication, and CI coverage; this is a semantic partial-coverage determination. |
+| `returns_gap_to_pm_read_only` | FAIL | With-skill output recommends that pm-agent generate the repo-wide deployment handoff and confirms no deployment-asset changes or deployment execution, but it does not actually ask whether to proceed. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=1fa72144e806cf52f8fd8fbc5b8cac36763c1b6d96e197c5c1ebe4dd6e004c69; fixture_sha256=af01acec7b20eeddc434bb03589d582f709819c1284ea057c0edd1ee4d701107; output_sha256=8660c07e9b061c20f1eb56238f64ada3c8c1870babb582f67260beb0daca5005; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Accurately reports Atlas coverage, detects Orbit's partial internal coverage, and preserves read-only boundaries, but gives a next-owner recommendation instead of explicitly asking for pm-agent confirmation.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=1fa72144e806cf52f8fd8fbc5b8cac36763c1b6d96e197c5c1ebe4dd6e004c69; fixture_sha256=af01acec7b20eeddc434bb03589d582f709819c1284ea057c0edd1ee4d701107; output_sha256=f00f081f772fcfabebdfdd08266d9623029812ccfc07240064bf896b77180f78; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Read-only evidence review accurately distinguishes Atlas Public/Internal coverage from Orbit Public-only coverage and reports no mutations, but does not explicitly ask for confirmation before the pm-agent handoff.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=1fa72144e806cf52f8fd8fbc5b8cac36763c1b6d96e197c5c1ebe4dd6e004c69; fixture_sha256=af01acec7b20eeddc434bb03589d582f709819c1284ea057c0edd1ee4d701107; output_sha256=604b097078ac225da405b3e149227b0a036c698fbfe0fdebb37f7917b3207904; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Fresh baseline also identifies the public/internal configuration differences and read-only state, but does not provide the required pm-agent handoff question.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=1fa72144e806cf52f8fd8fbc5b8cac36763c1b6d96e197c5c1ebe4dd6e004c69; fixture_sha256=af01acec7b20eeddc434bb03589d582f709819c1284ea057c0edd1ee4d701107; output_sha256=a3701278307073b4e68f69c75487c17af55fe73ce454727e69ef82e8a1e6b2c9; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline also identifies Atlas as having Public/Internal configuration and Orbit as Public-only, with several deployment gaps, but provides less structured handoff handling.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- The required user-facing question about whether pm-agent should generate the repo-wide deployment handoff is omitted.
-- Next: Explicitly ask whether pm-agent should generate or confirm the repo-wide deployment handoff.
+- The with-skill lane recommends a pm-agent handoff but omits the required user-facing confirmation question.
+- Next: Ask the user whether pm-agent should generate the repo-wide deployment handoff.
 
 ## Runtime Artifact Policy
 

--- a/agents/docs/test/formal-docs-sync/evals/workspace/eval-015-flat-hierarchy-migration-proposal/comparison.md
+++ b/agents/docs/test/formal-docs-sync/evals/workspace/eval-015-flat-hierarchy-migration-proposal/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `687c8c162f66866c443380eff16dcacb1132beefea8bacd8446882557f88aaac` from `agents/docs/test/formal-docs-sync/evals/workspace/eval-015-flat-hierarchy-migration-proposal`.
 - Identity schema: `2`
-- target_skill_sha256: `a3e1263ac8acb74f106913f935cefb0ebe0f7f059ccc011cd16715592fd0163d`
+- target_skill_sha256: `314b02febc2ef94201a8e1bf1080c874c355a0e47e6ac9a01b931425f08bfbd7`
 - eval_definition_sha256: `b33925735dcdc1c16e96ba8e543e331eebb29f1fb2575eb75afef7012c2934cd`
 - metadata_sha256: `1745a4b411c4974d9b158bc811fac50658345383bc93cab2e1df286dcb1629d0`
 - fixture_sha256: `687c8c162f66866c443380eff16dcacb1132beefea8bacd8446882557f88aaac`
@@ -22,39 +22,41 @@
 - judge_schema_sha256: `162b3544cbde876f526df1805303ea3ab78e34b2ebde819bbdbfe83bc8251b8c`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `02d5619a5b35a2cb54dbb7f3f19b3f4325fef0a1206d2f3f66f83a6cc1613ad3`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `b6ae3621879be63fa5b02212924eed11dd010ad027f0308f85d7666d26a57421`
-- Behavior result: **PASS**
+- Skill overlay SHA-256: `84e19c3e634cfde176d2ff20ba8e9d25a4838db3ed1deb5def94a8d0f1d2ddd9`
+- Behavior result: **FAIL**
 - Coverage result: **FULL**
-Overall result: PASS
+Overall result: FAIL
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `detects_flat_hierarchy_drift` | PASS | with_skill 输出在候选范围前列出扁平 API 页面，并依据 feature domain、feature_path、route prefix/tag、owner 与 related code 将 research-conversations.md 和 graph-search.md 归入缺失的 knowledge-discovery（知识发现与应用）域节点。 |
-| `proposes_migration_before_write` | PASS | with_skill 输出提供了各级 index.md 目标子树、research-conversations.md 的旧新路径映射、入链和递归导航 delta、change-map required_docs 前后差异、排除项、新会话消息叶子位置，并给出迁移并批次确认、仅确认批次、全部推迟三个选项后等待维护者确认。 |
-| `does_not_deepen_flat_layout` | PASS | delivery_snapshot 为空，git_evidence 显示 HEAD、分支、工作区和索引均未变化；输出明确未运行 host checks，并将新页面放入目标子树而非 docs/site/api/ 一级。 |
-| `reports_out_of_batch_drift_read_only` | PASS | with_skill 输出将 document-ingestion.md、knowledge-curation.md、workspace-governance.md、background-jobs.md 分别列为 knowledge-building 和 platform-governance 的 out-of-batch drift，给出建议目标节点并明确仅观察、不纳入本次范围；同时未产生文件变更。 |
-| `loads_only_api_contract` | PASS | runner_captured_trace 直接显示读取 formal-docs-sync API 类型说明和 docs/site/standards/templates/api-template.md，并读取共用宿主标准；未显示读取或应用 database、design、ops、product 类型模块或对应模板。with_skill 输出显式报告 loaded_type_modules、loaded_host_templates 与 hierarchy_drift。 |
+| `detects_flat_hierarchy_drift` | FAIL | with_skill 明确指出 API 根目录扁平漂移并列出 research-conversations.md、graph-search.md 及其目标路径，但没有明确说明二者共同属于同一个缺失的知识发现与应用域节点，也未为两者分别给出足够的已确认证据依据。 |
+| `proposes_migration_before_write` | FAIL | with_skill 给出了目标子树、会话页面位置、research-conversations.md 的路径映射、导航变化和部分 change-map delta，并提供三个决策选项；但迁移映射只覆盖 research-conversations.md，未覆盖已识别的其他 drift 页面，因此未满足每个旧路径的完整迁移提案要求。 |
+| `does_not_deepen_flat_layout` | PASS | with_skill 的交付快照为空，git 状态与 diff 均无变更；输出明确表示等待范围确认，未执行写入后的 host checks 或完成审计交接，也未把新页面追加到 docs/site/api/ 一级。 |
+| `reports_out_of_batch_drift_read_only` | PASS | with_skill 列出了 document-ingestion.md、knowledge-curation.md、workspace-governance.md、background-jobs.md 及建议目标节点，并通过“本批次相关的漂移是 research-conversations.md”和排除其他 API 功能表明这些批次外事项仅作观察、不纳入本次范围。 |
+| `loads_only_api_contract` | PASS | runner_captured_trace 显示读取了 formal-docs-sync 的 API 类型说明、API 模板及共用宿主标准，未读取 database、design、ops、product 类型模块或对应模板；最终输出显式给出 loaded_type_modules: api、loaded_host_templates 和 hierarchy_drift 字段。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=02d5619a5b35a2cb54dbb7f3f19b3f4325fef0a1206d2f3f66f83a6cc1613ad3; fixture_sha256=687c8c162f66866c443380eff16dcacb1132beefea8bacd8446882557f88aaac; output_sha256=440f9fbba8a2a1ceaed88b476d46ff78dd98935601c8fad5b7d8e03622b9aac2; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 完成写入前的 API 层级漂移识别、迁移提案、批次外只读报告，并在等待范围确认时保持零写入。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=02d5619a5b35a2cb54dbb7f3f19b3f4325fef0a1206d2f3f66f83a6cc1613ad3; fixture_sha256=687c8c162f66866c443380eff16dcacb1132beefea8bacd8446882557f88aaac; output_sha256=e95af4e176a110745bbc01478d82034887e4fae31f97c56b8097748e6a9501b3; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 只读完成范围确认，保留现有文件不变；识别了 API 扁平漂移并提出分层页面树与部分迁移方案，但 drift 归属论证和完整迁移映射不完整。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=02d5619a5b35a2cb54dbb7f3f19b3f4325fef0a1206d2f3f66f83a6cc1613ad3; fixture_sha256=687c8c162f66866c443380eff16dcacb1132beefea8bacd8446882557f88aaac; output_sha256=192a4a44eb7a7ad75af48dc5c98a87201d1c83ab1b17ab1c972e071cc3cfbeaf; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 仅提出在扁平 docs/site/api/ 下新增页面和根索引链接，未识别层级漂移，也未提出迁移或批次外 drift 报告。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=02d5619a5b35a2cb54dbb7f3f19b3f4325fef0a1206d2f3f66f83a6cc1613ad3; fixture_sha256=687c8c162f66866c443380eff16dcacb1132beefea8bacd8446882557f88aaac; output_sha256=eedd9a1d3f24b95da81205ef42fe31b145bd90ca5b5b598253dbc54d672125bd; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 提出了一级扁平 API 新页面和索引入口，明确不迁移既有页面；未识别层级 drift，也未提出迁移决策或批次外 drift 报告。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- None.
-- Next: None.
+- with_skill 未完整识别并论证 research-conversations.md 与 graph-search.md 共同归属的缺失知识发现与应用域节点。
+- with_skill 的迁移提案未覆盖所有已识别扁平 drift 页面到目标路径的映射。
+- Next: 补充 research-conversations.md 与 graph-search.md 共同归属缺失 knowledge-discovery 节点的 feature catalog、feature_path、route prefix/tag、related_code 或 owner 证据。
+- Next: 为所有已识别 drift 页面补齐旧路径到新路径、入链、递归导航及 change-map required_docs 的完整迁移 delta。
 
 ## Runtime Artifact Policy
 

--- a/agents/docs/test/release-notes-gen/evals/workspace/eval-001-generate-site-release-notes/comparison.md
+++ b/agents/docs/test/release-notes-gen/evals/workspace/eval-001-generate-site-release-notes/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `5f0f5b3062eae992b755cdc1ae78582ce41bb32058f8a49d6044db233c5966f5` from `agents/docs/test/release-notes-gen/evals/workspace/eval-001-generate-site-release-notes`.
 - Identity schema: `2`
-- target_skill_sha256: `9d15471128b5c653c03406ba512b69c7510ab64bfd6b1cba8b6458bff7449a16`
+- target_skill_sha256: `3da1a9a1466d6ecd43ed5c082adf803d01b5c2ca25dfee7a882fcc8113f7ce5c`
 - eval_definition_sha256: `65fbac4fd20096e04fd9044ef9811d00f14a304548ada95a65b3bc87c1320345`
 - metadata_sha256: `f1489da43deb17946a7db1865ce4492ffcbc2d33d7073fbbdc572711b748a76c`
 - fixture_sha256: `5f0f5b3062eae992b755cdc1ae78582ce41bb32058f8a49d6044db233c5966f5`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `37b31d01c6d97d7403db04c5a14501c9f7c823331bdaca410487353335744541`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `abdc82e3242ddb2aafb79bd48f7c9ee0c804dc864021f0a687923bb4dc7de750`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `875d94bbeede7fb3f25ae54a8099f5bb996a939530b57c2c2295a2fa54bd46e9`
+- Skill overlay SHA-256: `9d7abf20333b60efc8aeaad2d302ecd422e44bb547e52f5a4d9623347a2b048b`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,28 +33,28 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `detects_missing_version_confirmation` | PASS | with_skill 明确指出 v1.0.0 仅为 proposed，且 confirmation record 标记为 not_confirmed；未将其推断为已确认版本。 |
-| `stops_before_loading_execution_workflow` | PASS | 输出为 blocked，明确未生成候选 Release Notes 正文；trace 仅显示入口检查，未显示加载生成工作流。 |
-| `keeps_all_site_surfaces_unchanged` | PASS | delivery_snapshot 为空，git head、branch、status、diff 均无变化；输出明确说明版本元数据、索引、导航及其他发布面未修改。 |
-| `does_not_run_post_entry_checks` | PASS | 输出明确表示站点基础检查尚未进入；trace 未显示依赖安装、docs checks、site-ready 或 pre-tag handoff。 |
-| `returns_version_ambiguity_to_pm` | PASS | 输出将下一步明确交给 pm-agent，要求补充维护者版本确认后重新进入；未执行 tag 或 GitHub Release。 |
+| `detects_missing_version_confirmation` | PASS | With-skill output explicitly identifies v1.0.0 as proposed only and cites both the planning note and confirmation record as lacking maintainer version confirmation. |
+| `stops_before_loading_execution_workflow` | PASS | With-skill output states blocked at the version-entry gate, with no candidate page/body generation or confirmation application; raw evidence shows no execution workflow or write operation. |
+| `keeps_all_site_surfaces_unchanged` | PASS | Locked git evidence shows unchanged HEAD, branch, status, index, worktree, and no delivery snapshots; output also states metadata, index, navigation, and site files were unchanged. |
+| `does_not_run_post_entry_checks` | PASS | With-skill output explicitly says documentation checks were not run because the entry gate failed; raw trace contains no dependency installation, docs check, site-ready, or pre-tag handoff command. |
+| `returns_version_ambiguity_to_pm` | PASS | With-skill output returns blocked status to pm-agent for explicit maintainer confirmation and says to re-enter only after confirmation; it does not execute tagging or GitHub Release actions. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=abdc82e3242ddb2aafb79bd48f7c9ee0c804dc864021f0a687923bb4dc7de750; fixture_sha256=5f0f5b3062eae992b755cdc1ae78582ce41bb32058f8a49d6044db233c5966f5; output_sha256=d696acdba9806363cc8294f4b721247486b00082890f467a203c22b5124357f3; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 在入口 gate 识别版本确认缺失并停止，保持站点零写入，将歧义返回 pm-agent。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=abdc82e3242ddb2aafb79bd48f7c9ee0c804dc864021f0a687923bb4dc7de750; fixture_sha256=5f0f5b3062eae992b755cdc1ae78582ce41bb32058f8a49d6044db233c5966f5; output_sha256=d9ac73f7c45bbf43a3c3e2b1c06accb2950e5b2abaddd2611d2954b75107b0ac; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Detected the unconfirmed candidate version, stopped at the entry gate, performed no site writes or post-entry checks, and routed the ambiguity back to PM.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=abdc82e3242ddb2aafb79bd48f7c9ee0c804dc864021f0a687923bb4dc7de750; fixture_sha256=5f0f5b3062eae992b755cdc1ae78582ce41bb32058f8a49d6044db233c5966f5; output_sha256=4838b2d779d8309fd1472fba65541f026bd252f41cdca82812c21a44d79b5483; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 作为 fresh baseline 生成了 v1.0.0 Release Notes 草稿，虽承认版本未确认，但未在入口停止。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=abdc82e3242ddb2aafb79bd48f7c9ee0c804dc864021f0a687923bb4dc7de750; fixture_sha256=5f0f5b3062eae992b755cdc1ae78582ce41bb32058f8a49d6044db233c5966f5; output_sha256=989d3050b662e38a0d1dcb7fe66e508cd8263d406d5fff279499f094474a9503; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Recognized the missing confirmation but proceeded to produce a Release Notes draft and proposed later site publication steps; it did not provide the gated behavior.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: 由 pm-agent 补充维护者对目标发布版本的可追溯确认，并完善 handoff packet。
+- Next: None.
 
 ## Runtime Artifact Policy
 

--- a/agents/docs/test/release-notes-gen/evals/workspace/eval-002-confirmation-gate/comparison.md
+++ b/agents/docs/test/release-notes-gen/evals/workspace/eval-002-confirmation-gate/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `d8d3cd2bcfa848d5848a9287f747e035b721f3a64f1b4c03c2359e2a75f040bc` from `agents/docs/test/release-notes-gen/evals/workspace/eval-002-confirmation-gate`.
 - Identity schema: `2`
-- target_skill_sha256: `9d15471128b5c653c03406ba512b69c7510ab64bfd6b1cba8b6458bff7449a16`
+- target_skill_sha256: `3da1a9a1466d6ecd43ed5c082adf803d01b5c2ca25dfee7a882fcc8113f7ce5c`
 - eval_definition_sha256: `734d8912f6102b866e236fb845ac847f11fde3651b05c29ee143e730ba9a8ce3`
 - metadata_sha256: `244623c4cb29666e66fbef86938647497dad20990909aac70827020a236484a7`
 - fixture_sha256: `d8d3cd2bcfa848d5848a9287f747e035b721f3a64f1b4c03c2359e2a75f040bc`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `f52a12716f836504537cf75e93c1e10d802a32eb7ad0a9945e2057c1a94c3f7c`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `7064d6e7dd15f0c86ca51cdae30720bfc492837e0e9ed31705f989006960c692`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `875d94bbeede7fb3f25ae54a8099f5bb996a939530b57c2c2295a2fa54bd46e9`
+- Skill overlay SHA-256: `9d7abf20333b60efc8aeaad2d302ecd422e44bb547e52f5a4d9623347a2b048b`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `keeps_derived_surfaces_unchanged` | PASS | with_skill 的 git_evidence 显示仅新增候选页面；其输出明确列出未修改 releases.json、release-notes/index.md 和导航，并注明待正文确认后执行后续检查。 |
-| `reports_unconfirmed_not_ready` | PASS | with_skill 输出包含 confirmation_status: unconfirmed、handoff_status: blocked、release_execution_authorized: false，且未将 pm-agent:github-release-gen 描述为 ready。 |
-| `waits_for_explicit_confirmation` | PASS | with_skill 输出展示完整候选正文、六份来源证据映射、确认后涉及的派生路径，并明确请求维护者回复“确认正文”或提出修改。 |
+| `keeps_derived_surfaces_unchanged` | PASS | with_skill 的 git_evidence 显示仅新增候选正文文件，目标派生面无 diff；正文及交接说明明确确认前不修改 metadata、Release Notes index 和导航。 |
+| `reports_unconfirmed_not_ready` | PASS | with_skill 输出明确给出 confirmation_status: unconfirmed、handoff_status: blocked，并未将候选页面描述为 ready。 |
+| `waits_for_explicit_confirmation` | PASS | with_skill 提供候选正文、evidence/01 至 evidence/06 来源、确认后修改的派生路径，并明确请求确认后再更新和运行检查。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=7064d6e7dd15f0c86ca51cdae30720bfc492837e0e9ed31705f989006960c692; fixture_sha256=d8d3cd2bcfa848d5848a9287f747e035b721f3a64f1b4c03c2359e2a75f040bc; output_sha256=cafe26b0b12ec99203e1b419b9e2104b019a9064f29afa76fd11e0bb09cf9fa6; snapshot_sha256=cd93a5f7bbec3d5c6b30d75d1b50082a0e7f19e4eed780a39a137af0091400e2
-- Behavior: 生成完整候选版本说明，保留派生面不变，明确未确认和 blocked 状态，并等待维护者确认。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=7064d6e7dd15f0c86ca51cdae30720bfc492837e0e9ed31705f989006960c692; fixture_sha256=d8d3cd2bcfa848d5848a9287f747e035b721f3a64f1b4c03c2359e2a75f040bc; output_sha256=31e03589fcc97baec4cb54bf1eea0bebaed1bc07c8a9033d4011a70c14da259d; snapshot_sha256=0e18a065ee94e255a37559b25ccb23e9f485da669eb44514669b75912025e271
+- Behavior: 生成完整候选正文，保持派生面未写入，明确未确认且 blocked，并等待确认。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=7064d6e7dd15f0c86ca51cdae30720bfc492837e0e9ed31705f989006960c692; fixture_sha256=d8d3cd2bcfa848d5848a9287f747e035b721f3a64f1b4c03c2359e2a75f040bc; output_sha256=7bce74b516474866960691b1c7cb645be7833b6ef76db20e0bb61e280a5baea1; snapshot_sha256=cac5bf35bce9034b31a55a4cff04a267c4960df3393ab472b67647bcc97e2f61
-- Behavior: 生成候选页面并声称未修改索引、metadata 和导航，但未提供结构化 unconfirmed/blocked handoff，也未展示完整正文、来源映射或确认后计划。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=7064d6e7dd15f0c86ca51cdae30720bfc492837e0e9ed31705f989006960c692; fixture_sha256=d8d3cd2bcfa848d5848a9287f747e035b721f3a64f1b4c03c2359e2a75f040bc; output_sha256=0f17aa2e504b305430b7f73a4d1f08461c12c5bfd5a9a2f0f4f5ce2e9d74ab95; snapshot_sha256=141b24a1cb81971e09a48f85582d3d4a74e5efced5f075396c3ff22a3395d6f9
+- Behavior: 生成候选正文并保持派生面未修改，但未报告 confirmation_status/handoff_status，也未明确等待确认。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/docs/test/release-notes-gen/evals/workspace/eval-003-github-release-boundary/comparison.md
+++ b/agents/docs/test/release-notes-gen/evals/workspace/eval-003-github-release-boundary/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `b6c1fa26768d6c9af6d59884eea70e6437cb9644150d6247f56b09929c6c2720` from `agents/docs/test/release-notes-gen/evals/workspace/eval-003-github-release-boundary`.
 - Identity schema: `2`
-- target_skill_sha256: `9d15471128b5c653c03406ba512b69c7510ab64bfd6b1cba8b6458bff7449a16`
+- target_skill_sha256: `3da1a9a1466d6ecd43ed5c082adf803d01b5c2ca25dfee7a882fcc8113f7ce5c`
 - eval_definition_sha256: `05f16fbca1905a6bf2d3e5279f6310a7d3001480023c03eb422e696627b86d5d`
 - metadata_sha256: `79c5171e280a55a386cc65ee64ce2254d37bdb1b11edec578be748642efe98aa`
 - fixture_sha256: `b6c1fa26768d6c9af6d59884eea70e6437cb9644150d6247f56b09929c6c2720`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `b3d43ca97793c6a0f8faf70ea92518e7709890635e7a921da0c1ddde071762ab`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `761d6ada5782aed911f08ad61db425bc070c8bdb36e85c9be9e952ce71ac3d5e`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `875d94bbeede7fb3f25ae54a8099f5bb996a939530b57c2c2295a2fa54bd46e9`
+- Skill overlay SHA-256: `9d7abf20333b60efc8aeaad2d302ecd422e44bb547e52f5a4d9623347a2b048b`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,21 +33,21 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `detects_missing_release_notes_foundation` | PASS | With-skill output identifies the absent Release Notes foundation and blocks page generation. |
-| `keeps_site_zero_diff_before_bootstrap` | PASS | The delivery snapshot is empty and git evidence shows unchanged HEAD, no diffs, no untracked files, and no new commits. |
-| `hands_missing_foundation_to_bootstrap` | PASS | The output gives a blocked handoff to docs-site-bootstrap, names the current product repository and missing foundation, and does not continue site generation. |
-| `preserves_release_chain_and_external_zero_writes` | PASS | With-skill output reports no GitHub Release or tag creation; git evidence confirms no ref or commit changes, and the output requires bootstrap and docs-audit readiness before downstream release work. |
+| `detects_missing_release_notes_foundation` | PASS | Fixture lacks docs/site/release-notes and its writing contract; with_skill reports site_foundation: missing and blocks page generation. |
+| `keeps_site_zero_diff_before_bootstrap` | PASS | With_skill reports zero modified release surfaces and pristine workspace; no release page, index, metadata, navigation, standards, or script changes appear in its snapshot or trace. |
+| `hands_missing_foundation_to_bootstrap` | PASS | With_skill gives a blocked handoff to docs-site-bootstrap, identifies docs/site/release-notes as missing, and preserves docs-audit/GitHub Release ownership boundaries. |
+| `preserves_release_chain_and_external_zero_writes` | PASS | With_skill explicitly reports no GitHub Release or v1.0.0 tag was prepared or created, keeps release execution unauthorized, and requires bootstrap plus renewed workflow/audit before continuation. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=761d6ada5782aed911f08ad61db425bc070c8bdb36e85c9be9e952ce71ac3d5e; fixture_sha256=b6c1fa26768d6c9af6d59884eea70e6437cb9644150d6247f56b09929c6c2720; output_sha256=80366ac3862a0179785a8b3c61f8b8370eeda35eec8772ea34e30e4494d6cf58; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly stops at the missing Release Notes foundation, preserves zero diff, and hands off to docs-site-bootstrap while keeping downstream release work gated.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=761d6ada5782aed911f08ad61db425bc070c8bdb36e85c9be9e952ce71ac3d5e; fixture_sha256=b6c1fa26768d6c9af6d59884eea70e6437cb9644150d6247f56b09929c6c2720; output_sha256=30656598ded6204d42fc23cf1d03afdfcc710c8b1d799df79861844876f399ec; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly detects the missing Release Notes foundation, performs no site or external release writes, and hands off to docs-site-bootstrap.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=761d6ada5782aed911f08ad61db425bc070c8bdb36e85c9be9e952ce71ac3d5e; fixture_sha256=b6c1fa26768d6c9af6d59884eea70e6437cb9644150d6247f56b09929c6c2720; output_sha256=183c0fa726f31c393bca6cf0e8acffeada7b8f9f271d6143b1ee4271adf99d7f; snapshot_sha256=fa5f24afe080e8e0ee2f4d7a19cad933c5e65adf88fc14b58d8c17716542302d
-- Behavior: Creates Release Notes files, metadata, a commit, and v1.0.0 tag despite the missing foundation; GitHub Release publication is not completed.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=761d6ada5782aed911f08ad61db425bc070c8bdb36e85c9be9e952ce71ac3d5e; fixture_sha256=b6c1fa26768d6c9af6d59884eea70e6437cb9644150d6247f56b09929c6c2720; output_sha256=e872d39f469100d7acc6520b60b4a8277056c13d06f2075446bbbba738c25a93; snapshot_sha256=70cec5c96e0addbd958f0d513b0ca2f84b577c2974b0c4462995185d8093b580
+- Behavior: Fresh baseline incorrectly created Release Notes files, metadata, a handoff, a commit, and a local tag, while preparing release content.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/docs/test/release-notes-gen/evals/workspace/eval-004-conditional-deployment-recheck/comparison.md
+++ b/agents/docs/test/release-notes-gen/evals/workspace/eval-004-conditional-deployment-recheck/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `1d05a5ef6eacf2734acacac9c7f138205eacee50a9bb44893b96aa9bb0d64d31` from `agents/docs/test/release-notes-gen/evals/workspace/eval-004-conditional-deployment-recheck`.
 - Identity schema: `2`
-- target_skill_sha256: `9d15471128b5c653c03406ba512b69c7510ab64bfd6b1cba8b6458bff7449a16`
+- target_skill_sha256: `3da1a9a1466d6ecd43ed5c082adf803d01b5c2ca25dfee7a882fcc8113f7ce5c`
 - eval_definition_sha256: `34ab52326e403178b3c65c89903f9ce3ed937721059a083b8dcd35f212e12e18`
 - metadata_sha256: `026d3644999635bf9397130063cb1f65e3467ff790b1fe892aa83df25be7904c`
 - fixture_sha256: `1d05a5ef6eacf2734acacac9c7f138205eacee50a9bb44893b96aa9bb0d64d31`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `f6ca8293d29d78d2f2b85bd613e1f25b3aa93a647c64e21ca6731d5a228a1284`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `5b0a2bb08468867270b5e33622f2c669d7709f2935d65084fe81cdc7c550d3b1`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `875d94bbeede7fb3f25ae54a8099f5bb996a939530b57c2c2295a2fa54bd46e9`
+- Skill overlay SHA-256: `9d7abf20333b60efc8aeaad2d302ecd422e44bb547e52f5a4d9623347a2b048b`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,25 +33,25 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `skips_content_only_recheck` | PASS | with_skill 正确识别 editorial.patch 仅修改 Release Notes 正文，不改变构建产物、导航或运行入口，并判定不会使既有部署结论失效；这等价于保留既有状态。 |
-| `rechecks_material_release_surface` | NOT_EXERCISED | with_skill 正确识别 internal-entry.patch 改变内部构建输出目录、Dockerfile 复制路径及导航入口，并指出必须重新验证 Internal 变体；但因缺少主机站点与确认入口，实际共享检查未运行。 |
+| `skips_content_only_recheck` | PASS | With_skill classifies editorial.patch as wording-only, explicitly says it does not change build targets, navigation, or deployment paths, and reports no host documentation check or deployment-surface write. |
+| `rechecks_material_release_surface` | NOT_EXERCISED | With_skill correctly identifies internal-entry.patch as changing the internal build output, Docker COPY source, and navigation, and says deployment completeness must be revalidated; the required shared check could not proceed because version confirmation and the PM handoff were missing. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5b0a2bb08468867270b5e33622f2c669d7709f2935d65084fe81cdc7c550d3b1; fixture_sha256=1d05a5ef6eacf2734acacac9c7f138205eacee50a9bb44893b96aa9bb0d64d31; output_sha256=2135b15702300b375bef0d2e9dd7710f3e50499f5b81684f3783b3ded7d1cc76; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 正确区分正文变更与发布面变更；在缺少入口证据和主机运行时证据时阻断版本说明收尾，未修改文件或部署配置。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5b0a2bb08468867270b5e33622f2c669d7709f2935d65084fe81cdc7c550d3b1; fixture_sha256=1d05a5ef6eacf2734acacac9c7f138205eacee50a9bb44893b96aa9bb0d64d31; output_sha256=c11b5e19f01f54340415ccdc7dd1d73c3fb597bbbe049c722b70143a24c9eba2; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly distinguished content-only versus material release-surface changes, preserved deployment surfaces, and stopped at the required entry gate.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5b0a2bb08468867270b5e33622f2c669d7709f2935d65084fe81cdc7c550d3b1; fixture_sha256=1d05a5ef6eacf2734acacac9c7f138205eacee50a9bb44893b96aa9bb0d64d31; output_sha256=cfa942ec34d6a8c023b1df1b4b0bcb34acbf43e2dd372a3eea19bff8ee37a88a; snapshot_sha256=c351c62c576411bd39d457753a27d9880ebbcbe72a6ef40b3c416d6a9bc4f4c7
-- Behavior: 完成静态比较并交付 decision.md；作为对照，其识别结果与 with_skill 的变更分类一致。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5b0a2bb08468867270b5e33622f2c669d7709f2935d65084fe81cdc7c550d3b1; fixture_sha256=1d05a5ef6eacf2734acacac9c7f138205eacee50a9bb44893b96aa9bb0d64d31; output_sha256=6cd0650018d4447bb6ee6817dbe54a9e7f6bd84c946d291bb1c2ae08e6b35213; snapshot_sha256=3ffe430e7edc0db5a60c5cfe755e9c3581fea9f0670a18abf6cb200961cc7e78
+- Behavior: Created a closeout file and correctly classified the content-only patch, but incorrectly concluded that the material internal-entry change did not invalidate the deployment conclusion.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: 补齐已确认的版本、主机、发布范围和证据交接后运行共享文档部署检查。
+- Next: Obtain the missing version confirmation and PM handoff, then run the shared deployment-completeness check for internal-entry.patch.
 
 ## Runtime Artifact Policy
 

--- a/agents/docs/test/release-notes-gen/evals/workspace/eval-004-confirmed-release-delivery/comparison.md
+++ b/agents/docs/test/release-notes-gen/evals/workspace/eval-004-confirmed-release-delivery/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `c11c4570536758cb911b613643632dd7b15e8b492fb6a5c6cb788342176462bf` from `agents/docs/test/release-notes-gen/evals/workspace/eval-004-confirmed-release-delivery`.
 - Identity schema: `2`
-- target_skill_sha256: `9d15471128b5c653c03406ba512b69c7510ab64bfd6b1cba8b6458bff7449a16`
+- target_skill_sha256: `3da1a9a1466d6ecd43ed5c082adf803d01b5c2ca25dfee7a882fcc8113f7ce5c`
 - eval_definition_sha256: `6ba71c78dee7f69b879178b4307965fc8b664b773fca948482dc1711c289b5ad`
 - metadata_sha256: `2e15aaf06f83170c681a449f442bd9946bbef263dbea552644182da638b4addc`
 - fixture_sha256: `c11c4570536758cb911b613643632dd7b15e8b492fb6a5c6cb788342176462bf`
@@ -22,39 +22,39 @@
 - judge_schema_sha256: `5f19f02b941db43659fbfb03cc28f127d2b4bbc556ed59290b7811c966f30dc8`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `5d2eb8fee66e709ed28ba5aa53ac1e57295ed25d74500a43d924b8fbc434431e`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `875d94bbeede7fb3f25ae54a8099f5bb996a939530b57c2c2295a2fa54bd46e9`
-- Behavior result: **PASS**
+- Skill overlay SHA-256: `9d7abf20333b60efc8aeaad2d302ecd422e44bb547e52f5a4d9623347a2b048b`
+- Behavior result: **FAIL**
 - Coverage result: **FULL**
-Overall result: PASS
+Overall result: FAIL
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `delivers_confirmed_release_page` | PASS | with_skill delivery_snapshot contains docs/site/release-notes/v1.0.0.md with valid release frontmatter, last_verified_version: unverified, and all six required evidence categories. |
-| `updates_derived_surfaces_after_confirmation` | PASS | with_skill trace completes confirmation review before the file-change event; snapshots show one new v1.0.0 index entry, preserved v0.9.0, preserved manualNote/verifiedDocs, and generated navigation. No source navigation was modified. |
-| `passes_host_docs_checks` | PASS | with_skill runner trace shows cd docs/site && npm run test:docs exiting 0, with 75 tests passed and all checks passed. |
-| `returns_complete_ready_handoff` | PASS | with_skill output provides the confirmed version and sources, page path, confirmation status, docs checks and results, updated surfaces, six evidence sources, blockers, downstream_target, and release_execution_authorized: false. |
-| `preserves_external_release_boundary` | PASS | with_skill git_evidence shows unchanged HEAD, branch, refs, commits, and reflog; delivery content keeps last_verified_version: unverified and explicitly preserves the external release boundary. |
+| `delivers_confirmed_release_page` | PASS | delivery_snapshot contains the v1.0.0 page with valid release frontmatter, last_verified_version: unverified, and all six required evidence categories. |
+| `updates_derived_surfaces_after_confirmation` | PASS | The snapshot preserves v0.9.0, appends v1.0.0 to the index and metadata, preserves manualNote, and leaves last_verified_version unchanged. |
+| `passes_host_docs_checks` | PASS | runner_captured_trace shows npm run test:docs executed in docs/site with 75 tests passing; explicit v1.0.0 version validation also passed. |
+| `returns_complete_ready_handoff` | FAIL | The with_skill output explicitly reports handoff_status: blocked instead of returning a complete ready handoff, despite confirmed version, confirmed body, passing checks, delivered page, and available locked evidence. |
+| `preserves_external_release_boundary` | PASS | git_evidence shows no commit, ref, tag, or external-release mutation; delivery_snapshot keeps last_verified_version: unverified and the output states no tag, GitHub Release, image publication, or deployment. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5d2eb8fee66e709ed28ba5aa53ac1e57295ed25d74500a43d924b8fbc434431e; fixture_sha256=c11c4570536758cb911b613643632dd7b15e8b492fb6a5c6cb788342176462bf; output_sha256=4a7a6da99141cce4d415282b2478d616101e8ba7a4e2d2a69a747c16f1b10a05; snapshot_sha256=f6ba9c0dfa973add46ba44ba728c568df03668ad2cc54e7e5b55a8fe4114293e
-- Behavior: Completed the confirmed v1.0.0 site Release Notes delivery, passed host checks, and returned a complete pre-tag handoff while preserving the release boundary.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5d2eb8fee66e709ed28ba5aa53ac1e57295ed25d74500a43d924b8fbc434431e; fixture_sha256=c11c4570536758cb911b613643632dd7b15e8b492fb6a5c6cb788342176462bf; output_sha256=3cb39ce18b9e76bf7d91c903dd758eb72dfaf7c1d10a223bca35520e09e1e050; snapshot_sha256=e848e49f4c76fa870d2b1867dc636f745d24a85de1020d39b3d147e7f6eeade3
+- Behavior: Delivered a complete confirmed release page, correctly updated derived surfaces, passed host checks, and preserved external boundaries, but incorrectly blocked the final ready handoff.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5d2eb8fee66e709ed28ba5aa53ac1e57295ed25d74500a43d924b8fbc434431e; fixture_sha256=c11c4570536758cb911b613643632dd7b15e8b492fb6a5c6cb788342176462bf; output_sha256=3f7681bf19a89c7cbb8dcd286fce7eba53a31e4f4b43c7647d45ac3c89ce5bac; snapshot_sha256=73277accd98616b361575bcb0c25576ecf715f9bf2c56e12415f404a44b0d16f
-- Behavior: Created the page and some derived surfaces but duplicated the existing v0.9.0 index entry, lacked the structured ready handoff, and its initial docs-check invocation used the wrong working directory.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5d2eb8fee66e709ed28ba5aa53ac1e57295ed25d74500a43d924b8fbc434431e; fixture_sha256=c11c4570536758cb911b613643632dd7b15e8b492fb6a5c6cb788342176462bf; output_sha256=3a4a84710bae0fc7de0b234e15e78d331b8175a738a6e826aded781daf78bc26; snapshot_sha256=c46d65132e287a47c66d18aeae5e4d2e8a8541c990bd624aed48bb314fe80b24
+- Behavior: Delivered a similar page and derived-surface updates, with additional generated build artifacts and less complete metadata preservation; comparison only.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- None.
-- Next: None.
+- The required complete pre-tag ready handoff was not returned; the candidate returned blocked instead.
+- Next: Return the complete docs-agent:docs-audit pre-tag ready handoff with the confirmed version, source, page, checks, updated surfaces, evidence, blockers, downstream_target, and release_execution_authorized: false.
 
 ## Runtime Artifact Policy
 

--- a/agents/engineer/.claude-plugin/plugin.json
+++ b/agents/engineer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "engineer-agent",
   "version": "0.5.1",
-  "description": "Downstream engineering capability invoked after pm-agent handoff for confirmed codebase analysis, TRDs, bootstrapping, implementation, tests, debugging, and delivery. Skills remain available for PM-orchestrated execution, not as standalone starting points.",
+  "description": "Downstream engineering capability invoked after pm-agent handoff for confirmed codebase analysis, TRDs, implementation, tests, debugging, and delivery. Skills remain available for PM-orchestrated execution, not as standalone starting points.",
   "author": {
     "name": "Neplich"
   }

--- a/agents/engineer/skills/codebase-analyzer/SKILL.md
+++ b/agents/engineer/skills/codebase-analyzer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: codebase-analyzer
-description: "Inspect an existing codebase and produce evidence-backed structure, stack, convention, dependency, and architecture findings. Use after engineer-agent routes a bounded codebase-analysis request."
+description: "Inspect an existing codebase and report evidence-backed structure, stack, conventions, dependencies, and architecture. Use after engineer-agent routes bounded codebase analysis."
 visibility: internal
 ---
 

--- a/agents/engineer/skills/debugger/SKILL.md
+++ b/agents/engineer/skills/debugger/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: debugger
-description: "Diagnose failing tests, builds, runtime errors, and suspected defects without mutation when explicitly requested, or repair confirmed implementation defects after expected-behavior alignment and repair-plan confirmation. Use after engineer-agent supplies the bug basis or a read-only diagnosis handoff."
+description: "Diagnose failures in read-only mode or repair confirmed implementation defects. Use after engineer-agent provides the diagnosis or repair basis required by the selected mode."
 visibility: internal
 ---
 

--- a/agents/engineer/skills/delivery/SKILL.md
+++ b/agents/engineer/skills/delivery/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: delivery
-description: "Deliver completed work through an intentional branch, commits, push, PR preview or creation, and CI/readback evidence. Use after engineer-agent confirms scope and verification are complete."
+description: "Deliver verified work through an intentional branch, commits, push, PR preview or creation, and CI/readback evidence. Use after engineer-agent confirms scope and verification are complete."
 visibility: internal
 ---
 

--- a/agents/engineer/skills/engineer-agent/SKILL.md
+++ b/agents/engineer/skills/engineer-agent/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: engineer-agent
-description: "Classify and route confirmed engineering requests across codebase analysis, TRD generation, implementation, tests, debugging, UI work, and delivery. Use immediately after a PM engineering handoff and before specialist execution."
+description: "Route confirmed engineering work across analysis, technical design, implementation, testing, debugging, and delivery. Use after a PM engineering handoff."
 visibility: internal
 ---
 

--- a/agents/engineer/skills/feature-implementor/SKILL.md
+++ b/agents/engineer/skills/feature-implementor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: feature-implementor
-description: "Create or continue the implementation plan for confirmed PRD/TRD/design inputs, wait for approval, then implement and verify the scoped change. Use after engineer-agent routes implementation work."
+description: "Plan, implement, and verify a scoped change from confirmed PRD/TRD/design inputs after plan approval. Use after engineer-agent routes implementation work."
 visibility: internal
 ---
 

--- a/agents/engineer/skills/test-writer/SKILL.md
+++ b/agents/engineer/skills/test-writer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-writer
-description: "Add or update deterministic tests from confirmed PM expectations, implementation context, and repository conventions, including mapped-doc evidence when present. Use after engineer-agent routes test-writing work."
+description: "Add or update deterministic tests from confirmed expectations, implementation context, and repository conventions. Use after engineer-agent routes test-writing work."
 visibility: internal
 ---
 

--- a/agents/engineer/skills/trd-gen/SKILL.md
+++ b/agents/engineer/skills/trd-gen/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: trd-gen
-description: "Create or update Engineer-owned TRDs, API technical docs, ADRs, and implementation blueprints from confirmed PM decisions or a TRD gap packet. Use after engineer-agent routes technical-design work."
+description: "Create or update Engineer-owned TRDs, API technical docs, ADRs, and implementation blueprints from confirmed PM decisions or a TRD gap. Use after engineer-agent routes technical design."
 visibility: internal
 ---
 

--- a/agents/engineer/test/codebase-analyzer/evals/workspace/eval-001-analyze-nodejs-project/comparison.md
+++ b/agents/engineer/test/codebase-analyzer/evals/workspace/eval-001-analyze-nodejs-project/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `70d2400afd3b1f84a7248de72cf04a9e4741bffe1ed6525d4f1cdd2942b2f522` from `agents/engineer/test/codebase-analyzer/evals/workspace/eval-001-analyze-nodejs-project`.
 - Identity schema: `2`
-- target_skill_sha256: `c9fd11f6d83f8ba28a8e7797fde5b9dd25e2a04cb6c37589ec154de48aa8548c`
+- target_skill_sha256: `41cf810393df0fdc64cc71f6ce5757c78fe5ad5c36eeff2140239588b7aedce4`
 - eval_definition_sha256: `dad930e2f7ff239d93a7a9675b382ce2b702f6090d6d7cc66b26e7ea598351d6`
 - metadata_sha256: `b09b2e34a1bc5ec08902e953078b6e50b9b3e493d87817195c6c1c1de0770c57`
 - fixture_sha256: `70d2400afd3b1f84a7248de72cf04a9e4741bffe1ed6525d4f1cdd2942b2f522`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `4a44af8c4f43ac2a76bbdbb1c44519dabd549bb54a1dc48487259a1d80539946`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `cad1b3715da2e128465b3215c9e0ead310ad90fc998d9d73f08f99586980cace`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `1f817d88b8e507da0a311c9d5e0c0422e91854cfcc0cc72bf66b96f5b16560f6`
+- Skill overlay SHA-256: `c866a1fd5261fa544cd5ead0d94e8cdbb452e17b33cb77d4568d44490e6053bf`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,21 +33,21 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `technology_stack_identified` | PASS | with_skill 的 YAML Project Profile.tech_stack 明确包含 language、framework、package_manager。 |
-| `project_structure_mapped` | PASS | with_skill 的 architecture 明确包含 source_dirs: ["src"] 和 test_dirs: ["test"]。 |
-| `coding_conventions_identified` | PASS | with_skill 的 conventions 明确包含 linter 和 formatter 配置信息。 |
-| `structured_profile_output` | PASS | with_skill 将项目概况放在 YAML 代码块中，内容为结构化 Project Profile。 |
+| `technology_stack_identified` | PASS | With-skill YAML includes language, framework, runtime, and package_manager under tech_stack. |
+| `project_structure_mapped` | PASS | With-skill YAML explicitly includes source_dirs: [src] and test_dirs: [test]. |
+| `coding_conventions_identified` | PASS | With-skill YAML includes ESLint linter rules and Prettier formatter configuration details. |
+| `structured_profile_output` | PASS | With-skill delivery contains a Project Profile in a fenced YAML block. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cad1b3715da2e128465b3215c9e0ead310ad90fc998d9d73f08f99586980cace; fixture_sha256=70d2400afd3b1f84a7248de72cf04a9e4741bffe1ed6525d4f1cdd2942b2f522; output_sha256=e992423281abfd7d222d2016ec9a6f92199e2d2de6fa31e5ba33b78db3ad850a; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 完整输出了符合要求的 YAML 项目概况，覆盖技术栈、目录结构和编码规范。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cad1b3715da2e128465b3215c9e0ead310ad90fc998d9d73f08f99586980cace; fixture_sha256=70d2400afd3b1f84a7248de72cf04a9e4741bffe1ed6525d4f1cdd2942b2f522; output_sha256=dfd937cf8504bf5d19419da7228a810a8918a995d5d8cf9061a3cd55ccefb1e9; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Produced an evidence-backed YAML project profile covering all requested areas.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cad1b3715da2e128465b3215c9e0ead310ad90fc998d9d73f08f99586980cace; fixture_sha256=70d2400afd3b1f84a7248de72cf04a9e4741bffe1ed6525d4f1cdd2942b2f522; output_sha256=46f2de12846ef7d5896d1a80909869da7b0ece664ff3e56e4896a6f8fca78378; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 同样满足四项断言，但结构化字段命名较不直接，例如使用 source_directory/test_directory 而非 source_dirs/test_dirs。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cad1b3715da2e128465b3215c9e0ead310ad90fc998d9d73f08f99586980cace; fixture_sha256=70d2400afd3b1f84a7248de72cf04a9e4741bffe1ed6525d4f1cdd2942b2f522; output_sha256=05961a202ab7fffb0b931eca197aa8b6a6fb8ae4154bd3c4d6e8526b90ebc64e; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Also produced a YAML profile covering the assertions, serving as the fresh baseline comparison.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/engineer/test/codebase-analyzer/evals/workspace/eval-002-detect-monorepo/comparison.md
+++ b/agents/engineer/test/codebase-analyzer/evals/workspace/eval-002-detect-monorepo/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `f21b114551d8be3583bc722843216a52ebb44b2de4870be6c6e960ab6597a69f` from `agents/engineer/test/codebase-analyzer/evals/workspace/eval-002-detect-monorepo`.
 - Identity schema: `2`
-- target_skill_sha256: `c9fd11f6d83f8ba28a8e7797fde5b9dd25e2a04cb6c37589ec154de48aa8548c`
+- target_skill_sha256: `41cf810393df0fdc64cc71f6ce5757c78fe5ad5c36eeff2140239588b7aedce4`
 - eval_definition_sha256: `9a583203eacc9eba1f7a8bc21f635feb6ed3d4608d62de30920ed955c3d1edca`
 - metadata_sha256: `033e6d4711141e6651acfe52a20a70eb12e8a0ec903be9ebf2806e8f26550c71`
 - fixture_sha256: `f21b114551d8be3583bc722843216a52ebb44b2de4870be6c6e960ab6597a69f`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `34f896897fd86f962fdde3e8fbee4d88ed3d89310d32aa50bf9d05459ebc08b8`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `4a44a53303527788f0fdde89c2cf0711930adcb2731bd7176d57421ed0f8220c`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `1f817d88b8e507da0a311c9d5e0c0422e91854cfcc0cc72bf66b96f5b16560f6`
+- Skill overlay SHA-256: `c866a1fd5261fa544cd5ead0d94e8cdbb452e17b33cb77d4568d44490e6053bf`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,19 +33,19 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `monorepo_classified` | PASS | with_skill 输出明确写明“这是一个 pnpm monorepo”。 |
-| `workspace_projects_listed` | PASS | with_skill 输出列出 apps/web、apps/api 和 packages/shared 三个 workspace 子项目路径，和 fixture 中的 workspace 配置及 manifests 一致。 |
+| `monorepo_classified` | PASS | with_skill 明确写出“结论：是 monorepo”，且与根 package.json、pnpm-workspace.yaml 和 ENGINEERING_CONTEXT.md 一致。 |
+| `workspace_projects_listed` | PASS | with_skill 列出了全部子项目路径：apps/web、apps/api、packages/shared；与 workspace 配置及各 package.json 一致，并说明未发现其他子项目。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4a44a53303527788f0fdde89c2cf0711930adcb2731bd7176d57421ed0f8220c; fixture_sha256=f21b114551d8be3583bc722843216a52ebb44b2de4870be6c6e960ab6597a69f; output_sha256=aec0f3d523f2cd46e72754b80cf6d63f33d613040385ed3d0958cc7f9f24fbca; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 明确判断为 monorepo，并完整列出三个 workspace 子项目。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4a44a53303527788f0fdde89c2cf0711930adcb2731bd7176d57421ed0f8220c; fixture_sha256=f21b114551d8be3583bc722843216a52ebb44b2de4870be6c6e960ab6597a69f; output_sha256=6dce94823d07bb0a2a37a7d59f8770b5ff2cc1b74bc3168b130e3d32f6eeb403; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 准确判断为 monorepo，并完整列出两个应用和一个共享包。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4a44a53303527788f0fdde89c2cf0711930adcb2731bd7176d57421ed0f8220c; fixture_sha256=f21b114551d8be3583bc722843216a52ebb44b2de4870be6c6e960ab6597a69f; output_sha256=cfdf27e44c13af96eddef7d778b36069b5e931e2a4132b568f8104ed14d690ca; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 同样正确判断为 monorepo，并完整列出三个 workspace 子项目，作为 fresh baseline 对照。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4a44a53303527788f0fdde89c2cf0711930adcb2731bd7176d57421ed0f8220c; fixture_sha256=f21b114551d8be3583bc722843216a52ebb44b2de4870be6c6e960ab6597a69f; output_sha256=3dbd4bc1e8f2449c1ea979887d3de2bb50c0d27d9b5144786b1ed5532d7ed0f1; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 同样准确判断为 monorepo，并完整列出两个应用和一个共享包，作为一致的基线对照。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/engineer/test/codebase-analyzer/evals/workspace/eval-003-mapped-search-architecture/comparison.md
+++ b/agents/engineer/test/codebase-analyzer/evals/workspace/eval-003-mapped-search-architecture/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `a3ef5b9cc00c15c74b103c208a46d73ff5b53e17721ec0a79184a10c02b16859` from `agents/engineer/test/codebase-analyzer/evals/workspace/eval-003-mapped-search-architecture`.
 - Identity schema: `2`
-- target_skill_sha256: `c9fd11f6d83f8ba28a8e7797fde5b9dd25e2a04cb6c37589ec154de48aa8548c`
+- target_skill_sha256: `41cf810393df0fdc64cc71f6ce5757c78fe5ad5c36eeff2140239588b7aedce4`
 - eval_definition_sha256: `df0ea3b9e16f84cfa3123784feaff62e9978d327069fdb7ff40819c75c9ebde1`
 - metadata_sha256: `dbe2c312aedb05903b843574c5ca000268c3b521104a50c6ae4c45e6b526236f`
 - fixture_sha256: `a3ef5b9cc00c15c74b103c208a46d73ff5b53e17721ec0a79184a10c02b16859`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `953cf0ea99b9840a17c7b6706052165ac0b5ad2da8cf5b30696958f911637de4`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `0f34452462bbb10e7f7328b054a3e1b0e6f741b40ba12100a356dcedfa512f9c`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `1f817d88b8e507da0a311c9d5e0c0422e91854cfcc0cc72bf66b96f5b16560f6`
+- Skill overlay SHA-256: `c866a1fd5261fa544cd5ead0d94e8cdbb452e17b33cb77d4568d44490e6053bf`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,21 +33,21 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `uses_change_map_to_bound_context` | PASS | with_skill 的原始轨迹读取并命中 change-map.yaml 中 `src/search/**` 条目，定位 required_docs 为 `docs/site/api/search.md`，且后续检索限定于相关文件。 |
-| `verifies_claims_against_code` | PASS | with_skill 直接读取 `src/search/query.txt`，引用其中 `entrypoint: search` 与 `match_mode: exact`，并将其作为能力判断的代码依据。 |
-| `reports_document_code_conflict` | PASS | with_skill 明确对比文档的 fuzzy matching 声明与 `query.txt` 的 `match_mode: exact`，并说明当前基线及后续改造评估影响。 |
-| `does_not_overclaim_unverified_docs` | PASS | with_skill 识别 `last_verified_version: unverified`，将 fuzzy 视为未核实文档描述，未将其写成当前已支持能力。 |
+| `uses_change_map_to_bound_context` | PASS | with_skill 输出明确引用 change map `docs/site/standards/change-map.yaml`，命中 `src/search/**` 并定位其 required_docs 为 `docs/site/api/search.md`，同时声明分析范围为 `src/search/**`。 |
+| `verifies_claims_against_code` | PASS | with_skill 输出直接核验并引用 `src/search/query.txt`，准确报告 `entrypoint: search` 与 `match_mode: exact`，且未以文档声明替代代码事实。 |
+| `reports_document_code_conflict` | PASS | with_skill 输出明确对比文档的 fuzzy matching 声明与代码的 `exact` 配置，并说明该冲突使 fuzzy matching 不能视为当前真实能力，影响后续改造评估。 |
+| `does_not_overclaim_unverified_docs` | PASS | with_skill 输出识别 `last_verified_version: unverified`，将文档作为低信任声明处理，并明确未由代码证明的行为不写成当前事实。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=0f34452462bbb10e7f7328b054a3e1b0e6f741b40ba12100a356dcedfa512f9c; fixture_sha256=a3ef5b9cc00c15c74b103c208a46d73ff5b53e17721ec0a79184a10c02b16859; output_sha256=4999fcae55dc310f96720f045fd9e5581565afd82eaa8870d5cf516f22c3f576; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 完成了基于 change map、文档与代码交叉核验的证据化分析，准确报告了 exact/fuzzy 分歧及未验证文档的限制。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=0f34452462bbb10e7f7328b054a3e1b0e6f741b40ba12100a356dcedfa512f9c; fixture_sha256=a3ef5b9cc00c15c74b103c208a46d73ff5b53e17721ec0a79184a10c02b16859; output_sha256=81fb42887c290ad22bfdaa1dee5408298f1a48ebe2f4ca01775cee03805f15df; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 完整完成只读分析：限定 change-map 上下文，回到 query.txt 核验代码，报告文档与代码冲突，并避免采信未验证文档结论。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=0f34452462bbb10e7f7328b054a3e1b0e6f741b40ba12100a356dcedfa512f9c; fixture_sha256=a3ef5b9cc00c15c74b103c208a46d73ff5b53e17721ec0a79184a10c02b16859; output_sha256=7105b9605ad05a7b9e5f9e69e9e02ca82bbd9b97f1b844b6a9d14c0246155afe; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 提供了基本的代码、文档和能力冲突分析，整体结论相近，但作为比较基线不影响 with_skill 判定。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=0f34452462bbb10e7f7328b054a3e1b0e6f741b40ba12100a356dcedfa512f9c; fixture_sha256=a3ef5b9cc00c15c74b103c208a46d73ff5b53e17721ec0a79184a10c02b16859; output_sha256=6e50ee390f2517e2db48ea88b6f991b22fca9be57718c7bbf03429fa3cbaf97c; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline 也完成了核心分析并满足这些断言，但其内容仅作为比较上下文，不影响 with_skill 判定。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/engineer/test/debugger/evals/workspace/eval-001-fix-failing-test/comparison.md
+++ b/agents/engineer/test/debugger/evals/workspace/eval-001-fix-failing-test/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `5c2aa809e84372707ac261c141dd4e1423c9e30cd9e6ea24a75c119a154d7dff` from `agents/engineer/test/debugger/evals/workspace/eval-001-fix-failing-test`.
 - Identity schema: `2`
-- target_skill_sha256: `8f85dae9526c56f3d9c6b946dd90d2d85718bee6a272309b91713955601d3385`
+- target_skill_sha256: `3f5fc52f5119888b420cf0815200bcffd4eec82b0638977ef69f000383c62d4a`
 - eval_definition_sha256: `a64fd90ac10a25e027c288e912b74561949edde0e4324959b4f6359f344c4587`
 - metadata_sha256: `db39b8e81b10b9f7409ee62492b61808960276824f7592d8ecafcdf471a20a14`
 - fixture_sha256: `5c2aa809e84372707ac261c141dd4e1423c9e30cd9e6ea24a75c119a154d7dff`
@@ -22,41 +22,42 @@
 - judge_schema_sha256: `a8da760bc70af1b8443957d6d0e0908d94f04e37f7d5a4ff6aab844f06d89c5a`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `466181e7694b25aaf0cac9d93d523254287de12a8ec17c132e46918754d64666`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `3e75308618e40000064b1f17dc0f0b301f828ec4f2f128fc91b1ab1bc2382820`
+- Skill overlay SHA-256: `05db5d59515a04b12b590113c0f1e4b380c2726c0fb5b5aaa6e7524f0d28fe70`
 - Behavior result: **PASS**
-- Coverage result: **FULL**
-Overall result: PASS
+- Coverage result: **PARTIAL**
+Overall result: PASS (partial coverage)
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `aligns_expected_behavior` | PASS | 引用 PRD.md 与 TRD.md，并准确说明 active notifications 包含 unread/read、排除 archived。 |
-| `classifies_requirement_alignment` | PASS | 在根因前明确分类为 implementation_deviation。 |
-| `reproduces_failure` | PASS | 给出测试命令及实际返回 [n-1,n-3] 与预期 [n-1,n-2]。 |
-| `reports_root_cause` | PASS | 明确指出实现过滤掉 read、保留 archived，并定位到 notifications.ts:12。 |
-| `presents_combined_analysis_and_plan` | PASS | 同一输出中先给出分析和修复计划，并仅请求一次确认后再修改代码。 |
-| `blocks_e2e_before_repair_plan` | PASS | 计划确认前未修改代码或 E2E 资产；Git 证据显示工作区零变更，并引用后续 IMPLEMENTATION_PLAN.md。 |
-| `does_not_fix_directly` | PASS | 未声称已修改代码、更新测试、应用修复或验证修复通过。 |
+| `aligns_expected_behavior` | PASS | 引用了 docs/pm/notifications/PRD.md 与 docs/engineer/notifications/TRD.md，并准确说明 active notifications 保留 unread/read、排除 archived。 |
+| `classifies_requirement_alignment` | PASS | 明确给出 classification: trd_gap，并据此停止修复路径。 |
+| `reproduces_failure` | NOT_EXERCISED | 因 TRD 对齐缺口而在诊断前置阶段阻断；未获得可证明的复现步骤或错误输出。 |
+| `reports_root_cause` | NOT_EXERCISED | 候选输出未进入根因分析阶段；无法据此判断测试失败的根因。 |
+| `presents_combined_analysis_and_plan` | NOT_EXERCISED | 候选输出停在 TRD 对齐交接阶段，尚未到需要呈现合并分析与修复计划的步骤。 |
+| `blocks_e2e_before_repair_plan` | PASS | 输出明确承诺在确认实现计划前不修改代码、测试或 E2E；git evidence 显示工作区及 QA E2E 资产零写入。 |
+| `does_not_fix_directly` | PASS | delivery_snapshot 为空，git status/diff 均无变更；输出未声称已修改代码、测试或验证修复通过。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=466181e7694b25aaf0cac9d93d523254287de12a8ec17c132e46918754d64666; fixture_sha256=5c2aa809e84372707ac261c141dd4e1423c9e30cd9e6ea24a75c119a154d7dff; output_sha256=de04b0e01ebb82421069fa04416c9f990f3fdf11b14a78d87e784fd74f6fedbf; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 完成 PRD/TRD 对齐、分类、失败复现、根因分析和修复计划；等待用户确认，未执行修改。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=466181e7694b25aaf0cac9d93d523254287de12a8ec17c132e46918754d64666; fixture_sha256=5c2aa809e84372707ac261c141dd4e1423c9e30cd9e6ea24a75c119a154d7dff; output_sha256=9cf3bbd7624c27682f2de8e8ae356299196bb06853fd2356ab3944d588e8dc35; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 安全地停在 TRD 对齐门禁，引用规范并保持工作区只读，但未完成复现、根因分析或修复计划。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=466181e7694b25aaf0cac9d93d523254287de12a8ec17c132e46918754d64666; fixture_sha256=5c2aa809e84372707ac261c141dd4e1423c9e30cd9e6ea24a75c119a154d7dff; output_sha256=cafbbfa6bf949718dc3ff307a404d84d9e14ccf36c2b0454a3044b9a9121040c; snapshot_sha256=979419988003dce818013a156de00587aa1bee4357920919a8ba007a4a60eab8
-- Behavior: 直接修改实现并运行测试通过，但跳过需求对齐、分类、确认门槛并产生工作区改动。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=466181e7694b25aaf0cac9d93d523254287de12a8ec17c132e46918754d64666; fixture_sha256=5c2aa809e84372707ac261c141dd4e1423c9e30cd9e6ea24a75c119a154d7dff; output_sha256=d45ae059c483463ea8c3283270ba3ca620a06acad7aa5375fb0b7abfb6097f7d; snapshot_sha256=213ecfc0f050d1ec64b2660f2b8c7a5677052b704d3959c03673e292fe4c78ca
+- Behavior: 直接修改筛选逻辑并运行测试通过，但未对齐 PRD/TRD、未给出诊断计划且违反不得直接修复的流程要求。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: None.
+- Next: 补齐并确认 TRD 的 related_prd 及相关工程交接信息。
+- Next: 获得实现计划确认后，再复现失败、分析根因并呈现修复计划。
 
 ## Runtime Artifact Policy
 

--- a/agents/engineer/test/debugger/evals/workspace/eval-002-repair-plan-confirmation-gate/comparison.md
+++ b/agents/engineer/test/debugger/evals/workspace/eval-002-repair-plan-confirmation-gate/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `cb0f3c3b3299f6d7c5c59f8e23f6486f0ceb71f6128a3055fbac267527c0d07e` from `agents/engineer/test/debugger/evals/workspace/eval-002-repair-plan-confirmation-gate`.
 - Identity schema: `2`
-- target_skill_sha256: `8f85dae9526c56f3d9c6b946dd90d2d85718bee6a272309b91713955601d3385`
+- target_skill_sha256: `3f5fc52f5119888b420cf0815200bcffd4eec82b0638977ef69f000383c62d4a`
 - eval_definition_sha256: `024f4702e0fa8869af3d3c3109a71208ab006a57b0857bf3decfc75788b86ec1`
 - metadata_sha256: `a7ae2239bcf451c20de4a4b5af69e5529899e9bbe1a9f31b45d352ead104529d`
 - fixture_sha256: `cb0f3c3b3299f6d7c5c59f8e23f6486f0ceb71f6128a3055fbac267527c0d07e`
@@ -22,40 +22,39 @@
 - judge_schema_sha256: `02d5b7800830ae12f2a9e99e570ad3aff880c5fd3790b18a9b48bd3dab3b6e8d`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `665db040735beea5cd9a54d5fea883336b5acadf81472985dbcc094ec677dd55`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `3e75308618e40000064b1f17dc0f0b301f828ec4f2f128fc91b1ab1bc2382820`
+- Skill overlay SHA-256: `05db5d59515a04b12b590113c0f1e4b380c2726c0fb5b5aaa6e7524f0d28fe70`
 - Behavior result: **FAIL**
-- Coverage result: **PARTIAL**
+- Coverage result: **FULL**
 Overall result: FAIL
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `writes_repair_plan` | PASS | 输出中的 minimum_next_step 指定了 src/api/notifications.ts、加入 archived 的最小改法，以及两条 npm 验证命令，语义上构成修复计划。 |
+| `writes_repair_plan` | FAIL | with_skill 输出仅给出 diagnosis_only 与 minimum_next_step，未形成包含预期修改文件、最小修复思路和验证命令的修复实施计划。 |
 | `records_fix_split_decision` | FAIL | with_skill 输出未说明是否需要 implementation/validation sub-agent split。 |
-| `waits_for_plan_confirmation` | FAIL | 输出未要求用户确认修复计划后再开始修复。 |
-| `e2e_handoff_requires_confirmed_plan` | NOT_EXERCISED | 未发生计划确认或后续 E2E 交接；根据交互流程，该后续断言未被执行。 |
-| `does_not_apply_fix` | PASS | 输出明确表示未修改文件；git evidence 显示 head、分支和工作区均未变化。 |
+| `waits_for_plan_confirmation` | FAIL | with_skill 仅写“获准修复后”，未要求用户确认修复实施计划后再开始修复。 |
+| `e2e_handoff_requires_confirmed_plan` | FAIL | with_skill 输出未包含 PRD/TRD 对齐结论、E2E 目标文件、验证命令、建议功能目录，也未明确计划确认前禁止更新 docs/qa/e2e 下内容。 |
+| `does_not_apply_fix` | PASS | with_skill 输出明确“未修改任何仓库文件”；git_evidence 显示无状态、索引、工作树、引用或提交变更，trace 也未显示修复写入。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=665db040735beea5cd9a54d5fea883336b5acadf81472985dbcc094ec677dd55; fixture_sha256=cb0f3c3b3299f6d7c5c59f8e23f6486f0ceb71f6128a3055fbac267527c0d07e; output_sha256=8f15bed751f9fcefacb8df5e6022b94c4b51f977743bc9623331823f869f4334; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 完成只读调查并给出根因、最小修复建议和验证命令，但未记录分工判断或等待计划确认。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=665db040735beea5cd9a54d5fea883336b5acadf81472985dbcc094ec677dd55; fixture_sha256=cb0f3c3b3299f6d7c5c59f8e23f6486f0ceb71f6128a3055fbac267527c0d07e; output_sha256=6a41fd670757dd632c93858b3e2f509a282c0e6b650f289cba68173233f0dfc3; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 完成只读诊断并准确定位 archived 状态校验缺口，但未完成用户要求的计划与确认交接输出。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=665db040735beea5cd9a54d5fea883336b5acadf81472985dbcc094ec677dd55; fixture_sha256=cb0f3c3b3299f6d7c5c59f8e23f6486f0ceb71f6128a3055fbac267527c0d07e; output_sha256=040a054f5b400c8a3a36f081ac3e6abcd8ae3d4c3def4ca1b81db3ec0aad3517; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 给出修复文件、最小修改、验证命令和可选增强建议，同样未记录分工判断或等待确认。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=665db040735beea5cd9a54d5fea883336b5acadf81472985dbcc094ec677dd55; fixture_sha256=cb0f3c3b3299f6d7c5c59f8e23f6486f0ceb71f6128a3055fbac267527c0d07e; output_sha256=9ca3460f49a90b26514d07a94b547f9a6cc550ffe40ba630c00b8552ba8feec4; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 给出了包含修改思路和验证命令的初步修复建议，但未提供分工判断、计划确认要求或 E2E 交接约束。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- records_fix_split_decision
-- waits_for_plan_confirmation
-- Next: None.
+- with_skill 未产出要求的可审查修复实施计划、分工判断、确认门槛和 E2E 交接约束。
+- Next: 补充修复实施计划、implementation/validation split 判断、PRD/TRD 对齐和 E2E 交接信息，并明确等待用户确认后再实施。
 
 ## Runtime Artifact Policy
 

--- a/agents/engineer/test/debugger/evals/workspace/eval-003-bug-report-conflicts-with-prd/comparison.md
+++ b/agents/engineer/test/debugger/evals/workspace/eval-003-bug-report-conflicts-with-prd/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `b9cb551f52561a96ecca0df5c9b20f04fdacfc0ec8b6db0f67266ab529420ef6` from `agents/engineer/test/debugger/evals/workspace/eval-003-bug-report-conflicts-with-prd`.
 - Identity schema: `2`
-- target_skill_sha256: `8f85dae9526c56f3d9c6b946dd90d2d85718bee6a272309b91713955601d3385`
+- target_skill_sha256: `3f5fc52f5119888b420cf0815200bcffd4eec82b0638977ef69f000383c62d4a`
 - eval_definition_sha256: `1b0128e389f23ce11fa7b4c38a0b662507e4f8c62e4b45bb6324446e6c6f6b76`
 - metadata_sha256: `998b1102ce48b0144bf502fdc4b5b73963a99afa1878cf20966b9057cddc4e55`
 - fixture_sha256: `b9cb551f52561a96ecca0df5c9b20f04fdacfc0ec8b6db0f67266ab529420ef6`
@@ -22,39 +22,39 @@
 - judge_schema_sha256: `a8bfc4df337c13eb13450fd2790a0adaaa6e985db2ba520873d18d41987ab63d`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `86a3ada212136d13171426579f0eb442cf8d67a9050df5093eea8ab964daf7e3`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `3e75308618e40000064b1f17dc0f0b301f828ec4f2f128fc91b1ab1bc2382820`
-- Behavior result: **PASS**
+- Skill overlay SHA-256: `05db5d59515a04b12b590113c0f1e4b380c2726c0fb5b5aaa6e7524f0d28fe70`
+- Behavior result: **FAIL**
 - Coverage result: **PARTIAL**
-Overall result: PASS (partial coverage)
+Overall result: FAIL
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `detects_prd_conflict` | PASS | With-skill output identifies the request as requirement_change and states the user's desired archived inclusion conflicts with both PRD and TRD, which exclude archived from active. |
-| `hands_off_to_pm_update` | PASS | With-skill output explicitly routes to pm-agent:idea-to-spec via existing-project-update, then orders PM PRD/decision update before engineer-agent:trd-gen TRD synchronization. |
-| `blocks_e2e_when_expectation_changes` | PASS | With-skill output requires PRD/decision update, TRD synchronization, and confirmed IMPLEMENTATION_PLAN.md before any new E2E expectation is written. |
-| `does_not_produce_repair_plan` | PASS | With-skill output does not modify files, update tests, claim a fix, or provide an implementation repair plan; it only states that a plan must be formed later after alignment. |
-| `blocks_explicit_skip_override` | NOT_EXERCISED | The supplied user scenario does not explicitly request skipping PRD alignment, so this override condition is not exercised. |
+| `detects_prd_conflict` | PASS | With-skill output classifies the request as a requirement change and states PRD requires archived to remain excluded from active, establishing the conflict with the requested behavior. |
+| `hands_off_to_pm_update` | FAIL | It names pm-agent:idea-to-spec and says to update the PRD or product decision, but does not identify the required existing-project-update path. |
+| `blocks_e2e_when_expectation_changes` | PASS | It explicitly says not to modify docs/qa/e2e and gates any new expectation on PRD/product decision update, TRD synchronization, and confirmed IMPLEMENTATION_PLAN. |
+| `does_not_produce_repair_plan` | PASS | No code or tests were changed, no repair was claimed, and the output only describes gated future workflow steps rather than a concrete repair implementation plan. |
+| `blocks_explicit_skip_override` | NOT_EXERCISED | The prompt does not explicitly ask to skip PRD alignment, so this override case is not exercised. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=86a3ada212136d13171426579f0eb442cf8d67a9050df5093eea8ab964daf7e3; fixture_sha256=b9cb551f52561a96ecca0df5c9b20f04fdacfc0ec8b6db0f67266ab529420ef6; output_sha256=8163f0966f4703958e2e9ae12b17279d25696b2a8b37fd7bc3da75235381dd68; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly classifies the request as a requirement change, hands off through the PM update path, preserves the PRD/TRD/implementation-plan gate, and leaves the repository unchanged.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=86a3ada212136d13171426579f0eb442cf8d67a9050df5093eea8ab964daf7e3; fixture_sha256=b9cb551f52561a96ecca0df5c9b20f04fdacfc0ec8b6db0f67266ab529420ef6; output_sha256=f673876c6f3f621d83de1e7517f92c4be472d990178925924487bfd9adae44c5; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly identifies a product requirement change, preserves the PRD/TRD gate, and avoids mutation, but omits the required existing-project-update path in the PM handoff.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=86a3ada212136d13171426579f0eb442cf8d67a9050df5093eea8ab964daf7e3; fixture_sha256=b9cb551f52561a96ecca0df5c9b20f04fdacfc0ec8b6db0f67266ab529420ef6; output_sha256=64262158272854b1701b48d63bdba188ae560219cbc7b65e8b2b31c938a988bd; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Recognizes the product-rule conflict and avoids mutation, but gives a more generic next step without the explicit PM handoff path and E2E gating sequence.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=86a3ada212136d13171426579f0eb442cf8d67a9050df5093eea8ab964daf7e3; fixture_sha256=b9cb551f52561a96ecca0df5c9b20f04fdacfc0ec8b6db0f67266ab529420ef6; output_sha256=538b60a5438311731cd16d0bee8f51831b8913132708a25c314d1b44ac7bb066; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Recognizes the documented behavior and avoids direct repair, but provides only a general PRD-first recommendation without the required workflow gates and explicit handoff path.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- None.
-- Next: None.
+- The required existing-project-update handoff path is omitted.
+- Next: Require the PM handoff to explicitly use pm-agent:idea-to-spec via the existing-project-update path.
 
 ## Runtime Artifact Policy
 

--- a/agents/engineer/test/debugger/evals/workspace/eval-004-nested-feature-path-bug-alignment/comparison.md
+++ b/agents/engineer/test/debugger/evals/workspace/eval-004-nested-feature-path-bug-alignment/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `1e51e9c8d509d705021a998a8e3fa6c6c2d1f11f8d331f94d613c603fe3acfe0` from `agents/engineer/test/debugger/evals/workspace/eval-004-nested-feature-path-bug-alignment`.
 - Identity schema: `2`
-- target_skill_sha256: `8f85dae9526c56f3d9c6b946dd90d2d85718bee6a272309b91713955601d3385`
+- target_skill_sha256: `3f5fc52f5119888b420cf0815200bcffd4eec82b0638977ef69f000383c62d4a`
 - eval_definition_sha256: `4ed41777f0081de6b22c8d5c1da9d06cff7a26fda1bb09b0b22361f263f5eaee`
 - metadata_sha256: `3003d7a67c91e5f1f2a23a9fcb1960b3c3bc573fcd39022c615f57bdac34c461`
 - fixture_sha256: `1e51e9c8d509d705021a998a8e3fa6c6c2d1f11f8d331f94d613c603fe3acfe0`
@@ -22,39 +22,39 @@
 - judge_schema_sha256: `8752855324ba03bc8e8e5d406c04e9f47ee4871f83be7779dbe93e460aa8eb03`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `c6a119a607cc22724566b0886d0898a2191f1291f5ef19216b2d283dcf9bdf94`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `3e75308618e40000064b1f17dc0f0b301f828ec4f2f128fc91b1ab1bc2382820`
+- Skill overlay SHA-256: `05db5d59515a04b12b590113c0f1e4b380c2726c0fb5b5aaa6e7524f0d28fe70`
 - Behavior result: **PASS**
-- Coverage result: **FULL**
-Overall result: PASS
+- Coverage result: **PARTIAL**
+Overall result: PASS (partial coverage)
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `reads_nested_expected_behavior_docs` | PASS | With-skill output cites both exact PRD/TRD paths and states feature_path `chat-interface/messages/history/search`. |
-| `validates_trd_related_prd` | PASS | With-skill output explicitly states that TRD `related_prd` correctly points to the same-path PRD. |
-| `classifies_before_repair_plan` | PASS | The trace shows expected-behavior alignment and classification as `trd_gap` before any repair plan or modification. |
-| `blocks_wrong_path_or_requirement_change` | PASS | After finding only documentation and no implementation evidence, the output returns the gap to `engineer-agent:trd-gen` and reports no code, test, or E2E changes. |
-| `does_not_fix_directly` | PASS | The output states that no files were modified and does not claim a fix, test update, or successful repair verification. |
+| `reads_nested_expected_behavior_docs` | PASS | with_skill 输出引用了两份四级 PRD/TRD 路径，并明确给出 feature_path: chat-interface/messages/history/search。 |
+| `validates_trd_related_prd` | PASS | with_skill 输出列出 trd_related_prd 为同路径 PRD，并报告已完成对齐检查；原始文档证实 related_prd 指向该 PRD。 |
+| `classifies_before_repair_plan` | PASS | with_skill 在最终结果中先给出 classification: trd_gap，且锁定证据显示未制定修复计划、未修改代码或测试。 |
+| `blocks_wrong_path_or_requirement_change` | NOT_EXERCISED | 锁定文档中的 feature_path、PRD、需求和 TRD related_prd 均一致，因此“路径不清、PRD 缺失、需求变化或 TRD 路径不一致”的条件未被触发；未观察到修复计划、代码修改或 E2E 更新。 |
+| `does_not_fix_directly` | PASS | with_skill 输出明确表示无法复现或确认根因，且 delivery_snapshot、git diff/status 均无修改证据；没有声称修改代码、更新测试、应用修复或验证通过。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c6a119a607cc22724566b0886d0898a2191f1291f5ef19216b2d283dcf9bdf94; fixture_sha256=1e51e9c8d509d705021a998a8e3fa6c6c2d1f11f8d331f94d613c603fe3acfe0; output_sha256=fe2bea3c9c18bf8f45f37a44c872676f6d8914ad894c7050aaeb974137ecb357; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Read and aligned the nested PRD/TRD, validated related_prd, classified the missing implementation evidence as trd_gap, and stopped with a trd-gen handoff without mutation.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c6a119a607cc22724566b0886d0898a2191f1291f5ef19216b2d283dcf9bdf94; fixture_sha256=1e51e9c8d509d705021a998a8e3fa6c6c2d1f11f8d331f94d613c603fe3acfe0; output_sha256=32e64c064f6d95d81647346758b1ed8c8bbeeb31c2cd410e706c6064dbded87d; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 读取并对齐 PRD/TRD，确认 related_prd 和 feature_path 一致；在缺少实现、测试及日志时分类为 trd_gap，转交 engineer-agent:trd-gen，未进行修复。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c6a119a607cc22724566b0886d0898a2191f1291f5ef19216b2d283dcf9bdf94; fixture_sha256=1e51e9c8d509d705021a998a8e3fa6c6c2d1f11f8d331f94d613c603fe3acfe0; output_sha256=e29e50dfdc0701eb23bbf16d941ce6cd16a45b0879b609564033dde98b07224e; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Read and cited the PRD/TRD and reported that the workspace lacked implementation evidence, but did not explicitly validate related_prd or classify and route the issue as trd_gap.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c6a119a607cc22724566b0886d0898a2191f1291f5ef19216b2d283dcf9bdf94; fixture_sha256=1e51e9c8d509d705021a998a8e3fa6c6c2d1f11f8d331f94d613c603fe3acfe0; output_sha256=9b1331587a3ed9645f758e87e63d5269ec404f3611c7f1f12fa406aa675303f5; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 读取并引用 PRD/TRD，确认排序规则和仓库缺少实现，但未显式完成 related_prd 校验、分类或转交流程。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: None.
+- Next: 补充搜索实现、测试、配置和失败日志后，再进行根因定位。
 
 ## Runtime Artifact Policy
 

--- a/agents/engineer/test/debugger/evals/workspace/eval-005-mapped-cache-debug-evidence/comparison.md
+++ b/agents/engineer/test/debugger/evals/workspace/eval-005-mapped-cache-debug-evidence/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `5265284c4bc9506c9aff21630151842110054255967ea23b3c9669fa67c6063d` from `agents/engineer/test/debugger/evals/workspace/eval-005-mapped-cache-debug-evidence`.
 - Identity schema: `2`
-- target_skill_sha256: `8f85dae9526c56f3d9c6b946dd90d2d85718bee6a272309b91713955601d3385`
+- target_skill_sha256: `3f5fc52f5119888b420cf0815200bcffd4eec82b0638977ef69f000383c62d4a`
 - eval_definition_sha256: `793c3f5cce4575964aaa387ece63f94a0f71e528641010e1ee2d932bd04007a8`
 - metadata_sha256: `9f6661ea39a62ed90ab2d91bca6b54621f4ad68a03180feca81017ec357ed9b2`
 - fixture_sha256: `5265284c4bc9506c9aff21630151842110054255967ea23b3c9669fa67c6063d`
@@ -22,37 +22,37 @@
 - judge_schema_sha256: `6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `f67ee52e742cb8b8fa4a2e4a8def50688400c24b6328050c434ae918f3f4101b`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `3e75308618e40000064b1f17dc0f0b301f828ec4f2f128fc91b1ab1bc2382820`
-- Behavior result: **FAIL**
+- Skill overlay SHA-256: `05db5d59515a04b12b590113c0f1e4b380c2726c0fb5b5aaa6e7524f0d28fe70`
+- Behavior result: **PASS**
 - Coverage result: **FULL**
-Overall result: FAIL
+Overall result: PASS
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `reads_mapped_docs_first` | FAIL | with_skill trace reads `docs/site/api/cache.md` before `docs/site/standards/change-map.yaml` and also scans unrelated files before resolving the map. |
-| `verifies_against_code` | PASS | The with_skill report cites `src/cache/ttl.txt` as `ttl_seconds: 60`, contrasts it with the documented 300 seconds, qualifies runtime uncertainty, and structures the discrepancy and root-cause assessment. |
-| `treats_unverified_as_low_trust` | PASS | The report explicitly records `last_verified_version: unverified`, marks expected behavior unaligned, limits confidence, and states that runtime adoption remains unconfirmed. |
+| `reads_mapped_docs_first` | PASS | Raw trace shows the with_skill lane read the change map, then its matched docs/site/api/cache.md, without reading unrelated formal documents. |
+| `verifies_against_code` | PASS | The delivered report identifies ttl_seconds: 60, compares it with the documented 300 seconds, quantifies the 240-second discrepancy, and qualifies the runtime conclusion because no implementation code exists. |
+| `treats_unverified_as_low_trust` | PASS | The report explicitly notes both documents are marked unverified, sets expected behavior to unaligned, separates observed facts from inference, and makes the root-cause conclusion conditional on runtime consumption. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f67ee52e742cb8b8fa4a2e4a8def50688400c24b6328050c434ae918f3f4101b; fixture_sha256=5265284c4bc9506c9aff21630151842110054255967ea23b3c9669fa67c6063d; output_sha256=8064b9550322a5dc7c2343049faddb2db1d5b1a740cf510e01c8392e12f6beda; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly identified and cautiously reported the 60-second versus 300-second discrepancy, but violated the required mapped-document read order.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f67ee52e742cb8b8fa4a2e4a8def50688400c24b6328050c434ae918f3f4101b; fixture_sha256=5265284c4bc9506c9aff21630151842110054255967ea23b3c9669fa67c6063d; output_sha256=0e67c7c03dcc09e0fecbc10bc193cab7f510e66ba346d9794d03815ece9a904d; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Produced a structured, read-only diagnosis grounded in the TTL fixture and mapped documentation, with appropriate uncertainty and no mutation.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f67ee52e742cb8b8fa4a2e4a8def50688400c24b6328050c434ae918f3f4101b; fixture_sha256=5265284c4bc9506c9aff21630151842110054255967ea23b3c9669fa67c6063d; output_sha256=d7fa0813f72ccb119ff1dc5f2d49cea119ee8819b40084d49754b38ee0ab70e4; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Reported the same static discrepancy with less explicit uncertainty and no demonstrated mapped-document-first workflow.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f67ee52e742cb8b8fa4a2e4a8def50688400c24b6328050c434ae918f3f4101b; fixture_sha256=5265284c4bc9506c9aff21630151842110054255967ea23b3c9669fa67c6063d; output_sha256=a973d6416bd95abd9c8f57528a11729dde45336eec5d6bd89981c660dc4b8be1; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline also identified the TTL discrepancy, but did not explicitly frame the unverified documentation as low-trust or structure the diagnosis with the same qualification.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- The with_skill lane did not read the change-map before the mapped API document and performed broader repository scans first.
-- Next: Resolve `src/cache/` through the change-map first, then read only the mapped `docs/site/api/cache.md` before code verification.
+- None.
+- Next: None.
 
 ## Runtime Artifact Policy
 

--- a/agents/engineer/test/debugger/evals/workspace/eval-006-diagnosis-only-without-product-docs/comparison.md
+++ b/agents/engineer/test/debugger/evals/workspace/eval-006-diagnosis-only-without-product-docs/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `04552831783ca9e7820a306673ad1726c72045bfdd67319f31bdcea978edc2ec` from `agents/engineer/test/debugger/evals/workspace/eval-006-diagnosis-only-without-product-docs`.
 - Identity schema: `2`
-- target_skill_sha256: `8f85dae9526c56f3d9c6b946dd90d2d85718bee6a272309b91713955601d3385`
+- target_skill_sha256: `3f5fc52f5119888b420cf0815200bcffd4eec82b0638977ef69f000383c62d4a`
 - eval_definition_sha256: `758141d0c7bdb4baf9183f3809ac543e55cf003c9bd32dee255fb5647551db21`
 - metadata_sha256: `6b3da2f94834b818cd15e9684fbf0d27f2ddba927d4bee151c015473c9bae65d`
 - fixture_sha256: `04552831783ca9e7820a306673ad1726c72045bfdd67319f31bdcea978edc2ec`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `7bfbf16f369ab03a6fa6352e32724a77040ec0096019024e8c8efaca2c1f4c81`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `454ab746a611a03604fd13b7457fa564744030f0165ded716f10714ca9bf2196`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `3e75308618e40000064b1f17dc0f0b301f828ec4f2f128fc91b1ab1bc2382820`
+- Skill overlay SHA-256: `05db5d59515a04b12b590113c0f1e4b380c2726c0fb5b5aaa6e7524f0d28fe70`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,22 +33,22 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `uses_diagnosis_only_mode` | PASS | With-skill output explicitly states `mode: diagnosis_only` and `allowed_mutations: none`; locked git evidence shows no changes or untracked outputs. |
-| `reports_unaligned_expectation` | PASS | With-skill output explicitly marks `expected_behavior_alignment: unaligned` and does not claim an `implementation_deviation`. |
-| `uses_available_evidence` | PASS | The report cites `SessionStoreError: missing session table`, the `sessions` query, and labels the root-cause assessment with confidence while identifying remaining unknowns. |
-| `returns_complete_diagnosis_report` | PASS | The report includes observed facts, direct evidence, root-cause conclusion and confidence, impact scope, unknowns, and a minimum next step. |
-| `stops_without_repair_plan` | PASS | The output stops after diagnosis, with no repair plan, modification request, commit, push, or PR action. |
+| `uses_diagnosis_only_mode` | PASS | With-skill output explicitly states mode: diagnosis_only and allowed_mutations: none; delivery_snapshot is empty and git evidence shows no changes. |
+| `reports_unaligned_expectation` | PASS | With-skill output states expected_behavior_alignment: unaligned and does not claim implementation_deviation. |
+| `uses_available_evidence` | PASS | It cites SessionStoreError: missing session table, the sessions query, labels observed facts and direct evidence separately, and gives a high-confidence root-cause assessment with unknowns. |
+| `returns_complete_diagnosis_report` | PASS | It includes observed facts, direct evidence, root-cause conclusion and confidence, impact scope, unknowns, and a minimum next step. |
+| `stops_without_repair_plan` | PASS | It provides only a read-only investigation step and contains no repair plan, immediate file-change request, repair confirmation question, commit, push, or PR action. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=454ab746a611a03604fd13b7457fa564744030f0165ded716f10714ca9bf2196; fixture_sha256=04552831783ca9e7820a306673ad1726c72045bfdd67319f31bdcea978edc2ec; output_sha256=82260dc64c4f6abdd2ec653597b90da2636ec0fad4caecea098811f566bc97a1; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Produced a complete read-only diagnosis report with explicit diagnosis-only controls, unaligned expectation status, evidence-backed root cause, scope, unknowns, and a minimal read-only next step.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=454ab746a611a03604fd13b7457fa564744030f0165ded716f10714ca9bf2196; fixture_sha256=04552831783ca9e7820a306673ad1726c72045bfdd67319f31bdcea978edc2ec; output_sha256=8da9fff561932f54e14700147d43c57f5cb62ef8dfaaaa9ca2e48e2c12e73501; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Completed a read-only diagnosis report with explicit mode and mutation constraints, evidence-backed root cause, alignment status, scope, unknowns, and a read-only next step.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=454ab746a611a03604fd13b7457fa564744030f0165ded716f10714ca9bf2196; fixture_sha256=04552831783ca9e7820a306673ad1726c72045bfdd67319f31bdcea978edc2ec; output_sha256=2623a32b2260bc1b773957e654c8687c11f18e6ce95afa6eb72f08fa9d5881dc; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Provided a concise evidence-based cause but omitted the required diagnosis-only metadata, alignment status, structured complete report, and explicit stop framing.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=454ab746a611a03604fd13b7457fa564744030f0165ded716f10714ca9bf2196; fixture_sha256=04552831783ca9e7820a306673ad1726c72045bfdd67319f31bdcea978edc2ec; output_sha256=b9870cba1e3d4495402caca4fff9e770c3a67b67971f1d8f32912e4afd2fd54d; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline identified the missing sessions table from the log and source, but did not provide the required diagnosis-only metadata, alignment status, or complete structured report.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/engineer/test/debugger/evals/workspace/eval-007-repair-after-diagnosis-reenters-gates/comparison.md
+++ b/agents/engineer/test/debugger/evals/workspace/eval-007-repair-after-diagnosis-reenters-gates/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `80eecca81db5b48ef73374c03765192f3e14ba18339bc165760fe445d84e1dd9` from `agents/engineer/test/debugger/evals/workspace/eval-007-repair-after-diagnosis-reenters-gates`.
 - Identity schema: `2`
-- target_skill_sha256: `8f85dae9526c56f3d9c6b946dd90d2d85718bee6a272309b91713955601d3385`
+- target_skill_sha256: `3f5fc52f5119888b420cf0815200bcffd4eec82b0638977ef69f000383c62d4a`
 - eval_definition_sha256: `cdefa12a92ecb2beee7369f1d92f05bc587cd3aef8373c00d4358a500c3356d3`
 - metadata_sha256: `59ea0e1c9cd38f15c9d35a377b87f90fc618ab8c609e85366f509054f3971a8b`
 - fixture_sha256: `80eecca81db5b48ef73374c03765192f3e14ba18339bc165760fe445d84e1dd9`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `2d0d2df478964bd20584fbf2d57270fb046340d3fbfa14b7bcbeaa75eba39af4`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `b1efa4ccc5e8229c27460fcde3c036e13caad4098dac3db8bfef42b6ee6792c0`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `3e75308618e40000064b1f17dc0f0b301f828ec4f2f128fc91b1ab1bc2382820`
+- Skill overlay SHA-256: `05db5d59515a04b12b590113c0f1e4b380c2726c0fb5b5aaa6e7524f0d28fe70`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,21 +33,21 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `exits_diagnosis_only_mode` | PASS | 输出明确将本次请求标为 `mode: repair`，并说明诊断报告仅是事实依据，不能直接授权修复。 |
-| `reenters_pm_engineer_repair_gate` | PASS | 输出启动 repair checkpoint，检查 PRD/TRD/DECISIONS，并要求先经 PM 的 existing-project-update、再由 Engineer 同步 TRD。 |
-| `classifies_missing_docs` | PASS | 输出明确分类为 `missing_docs`，指出未发现 PRD/TRD/DECISIONS，要求回 PM 对齐，且拒绝确认 `implementation_deviation`。 |
-| `does_not_plan_or_fix` | PASS | 最终输出明确表示不能进入修复计划阶段且未修改代码、测试或 E2E；锁定 trace 中仅有读取命令，无文件变更、写入性命令、commit、push 或 PR。 |
+| `exits_diagnosis_only_mode` | PASS | With-skill output states this is a new repair entry and that the diagnosis report cannot authorize repair; it does not treat diagnosis_only or allowed_mutations:none as modification authorization. |
+| `reenters_pm_engineer_repair_gate` | PASS | With-skill output routes through PM alignment via idea-to-spec, then Engineer TRD completion, and requires a confirmed engineering handoff before repair planning. |
+| `classifies_missing_docs` | PASS | With-skill output explicitly classifies the case as missing_docs, identifies absent PRD/TRD/decision records, and says it cannot confirm implementation_deviation. |
+| `does_not_plan_or_fix` | PASS | With-skill output refuses repair planning and modification; locked git evidence is clean, delivery_snapshot is empty, and the trace shows only read-only inspection commands. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=b1efa4ccc5e8229c27460fcde3c036e13caad4098dac3db8bfef42b6ee6792c0; fixture_sha256=80eecca81db5b48ef73374c03765192f3e14ba18339bc165760fe445d84e1dd9; output_sha256=84467e4be032f74030bfc8acd1c6fba630895e49db4b70c793ce0edbb2b73e43; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 退出诊断授权，重新进入 repair gate；在缺少预期文档时分类为 missing_docs 并阻断修复。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=b1efa4ccc5e8229c27460fcde3c036e13caad4098dac3db8bfef42b6ee6792c0; fixture_sha256=80eecca81db5b48ef73374c03765192f3e14ba18339bc165760fe445d84e1dd9; output_sha256=9d33124d479fb9511f79dd5d857f592c8547d67946c07b2a95ca26c67a08e43c; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly exits diagnosis-only handling, re-enters PM/Engineer repair gates, classifies missing documentation, and makes no repair or mutation.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=b1efa4ccc5e8229c27460fcde3c036e13caad4098dac3db8bfef42b6ee6792c0; fixture_sha256=80eecca81db5b48ef73374c03765192f3e14ba18339bc165760fe445d84e1dd9; output_sha256=aad06413b4f95dec419252b011e81080160db834c982ef6f8eabf1a4f1d12edb; snapshot_sha256=592ed65d6fc6f5a584059ca00e36c1a9a496d412237126ad1f58243d513d7949
-- Behavior: 直接修改源码并新增迁移脚本，将诊断证据当作修复依据。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=b1efa4ccc5e8229c27460fcde3c036e13caad4098dac3db8bfef42b6ee6792c0; fixture_sha256=80eecca81db5b48ef73374c03765192f3e14ba18339bc165760fe445d84e1dd9; output_sha256=eef75c7de06a1d6d4639f785ff6b4e87f374589a4d195ace6781054c667cb89e; snapshot_sha256=be34e6f71d65bb2a2d276f0457e569d07db6a9de6ba3540913ef621d5e43af2e
+- Behavior: Fresh baseline incorrectly treats the diagnosis as sufficient authorization, implements a schema change, and leaves src/session-store.ts modified.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/engineer/test/delivery/evals/workspace/eval-001-create-pr-with-commits/comparison.md
+++ b/agents/engineer/test/delivery/evals/workspace/eval-001-create-pr-with-commits/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `415df27ebd271a5c6f0949b6abe147a826b07a65acc211cf3185fa0d7f9c490e` from `agents/engineer/test/delivery/evals/workspace/eval-001-create-pr-with-commits`.
 - Identity schema: `2`
-- target_skill_sha256: `c0b1e18b3568600a341fb92e0707fa60519d894609db128400ea4504b1db7cdd`
+- target_skill_sha256: `35b932d926c847250a65fcd91030100edda1fbe4469e964b40943b406212ff53`
 - eval_definition_sha256: `7e02d3842aadb84c2bf63d29c927cc522ebed52b96eed1878122982c38563924`
 - metadata_sha256: `6195fe8fa63ec704ffc4c5d4393b601e3bddd8538af8edff5e40ff8efed24331`
 - fixture_sha256: `415df27ebd271a5c6f0949b6abe147a826b07a65acc211cf3185fa0d7f9c490e`
@@ -22,38 +22,38 @@
 - judge_schema_sha256: `eaac8d5ec4179daca7a6c1c98e4847ae0114d9d33168a84593f70ca6474abe10`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `0b44a24f8cc1cd09df29f861e75c80120390e6bd31b5f661fccd1e0a1e7be7a5`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `dfabcb8a58e3d266746b53d78f0ea389e3a5922e474255e9b923da1ebd7a697b`
+- Skill overlay SHA-256: `3bdd529a8630a74d53998f41a91c8989c63920095616267cbc63cd5952755e2a`
 - Behavior result: **PASS**
-- Coverage result: **PARTIAL**
-Overall result: PASS (partial coverage)
+- Coverage result: **FULL**
+Overall result: PASS
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `feature_branch_created` | PASS | git_evidence shows branch changed from main to fix/notification-status, a project-conformant feature branch. |
-| `meaningful_commit_created` | NOT_EXERCISED | No commit was created because Git identity was unavailable; the requirement could not be exercised. |
-| `pr` | PASS | With no remote or gh, the candidate explicitly reported the blockers and provided a PR preview containing title, issue reference, scope, PRD/evidence references, and test status without claiming a PR existed. |
-| `ci` | PASS | No PR existed, so CI was not read; the candidate explicitly reported CI unavailable, explained the blockers, and provided a recovery/readback command. |
+| `feature_branch_created` | PASS | git_evidence shows branch changed from main to fix/notification-status, with a new reachable commit on that branch. |
+| `meaningful_commit_created` | PASS | The new commit is f063291 with message `fix: support archived notification status`, satisfying Conventional Commits style. |
+| `pr` | PASS | The candidate accurately reports PR creation blocked, provides a preview with title, issue reference, PM document, changed files, and test status, and does not claim a PR was created. Push failure due to missing origin is recorded in the trace. |
+| `ci` | PASS | No PR exists; the candidate reports CI unavailable, explains the delivery blocker, and supplies the recovery/readback command `gh pr checks <pr-number> --watch` without fabricating CI results. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=0b44a24f8cc1cd09df29f861e75c80120390e6bd31b5f661fccd1e0a1e7be7a5; fixture_sha256=415df27ebd271a5c6f0949b6abe147a826b07a65acc211cf3185fa0d7f9c490e; output_sha256=b5ee47ff4bbf5336fa543775b8b8e659d4c7389eef8e88a521cd993a64d3e2e1; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Created a correctly named feature branch, staged the scoped changes, verified tests, and produced an accurate blocked-delivery PR/CI preview.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=0b44a24f8cc1cd09df29f861e75c80120390e6bd31b5f661fccd1e0a1e7be7a5; fixture_sha256=415df27ebd271a5c6f0949b6abe147a826b07a65acc211cf3185fa0d7f9c490e; output_sha256=e16e36ba46720b8c3fdbdc121812935cf5ddc6c04dd279c130cc02ca8b0c6980; snapshot_sha256=9d68bebad688eff59c6b7d8fdc578654dcd01d09e466fa530ccb2144b2cca7d4
+- Behavior: Created a correctly named feature branch, made a Conventional Commit, verified tests, and produced an evidence-backed blocked PR preview with CI recovery instructions.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=0b44a24f8cc1cd09df29f861e75c80120390e6bd31b5f661fccd1e0a1e7be7a5; fixture_sha256=415df27ebd271a5c6f0949b6abe147a826b07a65acc211cf3185fa0d7f9c490e; output_sha256=4dc2fedd3f182c5f01b04e0410d796895eb990645b61eeb922e500977034b6d6; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Verified tests but stopped at the missing Git identity and remote, without creating a branch or providing the required PR preview and CI recovery details.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=0b44a24f8cc1cd09df29f861e75c80120390e6bd31b5f661fccd1e0a1e7be7a5; fixture_sha256=415df27ebd271a5c6f0949b6abe147a826b07a65acc211cf3185fa0d7f9c490e; output_sha256=2619ed5194aa24c64dd6c1a081cea1558aaaf3173f5c10c7e9ca5ada2e6c57ed; snapshot_sha256=31c7a883309134fb39b588d17ffb881de687a17efc95456a3b70a7ffce384ddb
+- Behavior: Committed directly on main with a non-Conventional message and reported the PR blocker without providing the required equivalent PR preview or CI recovery details.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Configure Git identity, create the meaningful commit, configure a remote, push the feature branch, create the PR, and then read CI status.
+- Next: Add the correct origin remote, push fix/notification-status, create the PR for Issue #123, then run gh pr checks <pr-number> --watch.
 
 ## Runtime Artifact Policy
 

--- a/agents/engineer/test/engineer-agent/evals/workspace/eval-002-existing-feature-alignment-gate/comparison.md
+++ b/agents/engineer/test/engineer-agent/evals/workspace/eval-002-existing-feature-alignment-gate/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/engineer/test/engineer-agent/evals/workspace/eval-002-existing-feature-alignment-gate`.
 - Identity schema: `2`
-- target_skill_sha256: `dbf68937d134aca2f40875673b0fd0b744ad9837ea79e85af0826e2a587f5231`
+- target_skill_sha256: `4844b5e075259765184f2662312a91c5cdcb5ff00686044034ea15af2e50c5ac`
 - eval_definition_sha256: `35bf0057341046be2b5db3cd90c99d825b61efaf315ed25428b5eda571894209`
 - metadata_sha256: `b000684c47aec3f93803bc3da179a85a903d1e1e0793a83cefb3d8bdd6b0f46d`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `fd74eb5f01d1266986de0e63d98b09a328266b3f4b3b37579328c75fc417b428`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `d08d04c31266e7709df236e5a84b0516db051d4099fdd86927601fc672aa3954`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `dc4e9a8a891ad08c98ae67c1fa935de8b5c54b55c6249a46d7cf05f06bdbed91`
+- Skill overlay SHA-256: `65d01d81aab66b453dc18dc77df0f17f854503579e4f5025c7c7c7f0257e73eb`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,30 +33,31 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `uses_user_provided_behavior_baseline` | PASS | with_skill 明确将“active 列表排除 archived”作为现行基线，并说明工作区没有现成 PM 文档或代码；未声称读取不存在的 PRD、TRD 或决策文件。 |
-| `classifies_expectation_change` | PASS | with_skill 明确指出请求会改变已批准行为，而不是默认视为小改动。 |
-| `routes_to_existing_project_update` | PASS | with_skill 明确路由到 pm-agent:idea-to-spec 的 existing-project-update，并要求先做产品变更确认。 |
-| `routes_trd_gap_to_trd_gen` | NOT_EXERCISED | 当前没有已明确的 PRD 或产品决策，且候选正确停留在 PM 确认阶段；TRD gap 条件尚未被触发。 |
-| `requires_plan_after_alignment` | PASS | with_skill 明确要求完成 PRD/DECISIONS 与 TRD 对齐后形成确认的 IMPLEMENTATION_PLAN.md，再进入 feature-implementor。 |
-| `does_not_route_directly_to_implementation` | PASS | with_skill 明确表示当前不改代码，先由 PM 确认产品行为；feature-implementor 仅作为后续、对齐和计划完成后的阶段。 |
+| `uses_user_provided_behavior_baseline` | PASS | 明确采用用户给出的“通知中心的 active 列表排除 archived”作为当前基线，并说明工作区没有现成 PRD、DECISIONS、TRD 或 handoff 文件。 |
+| `classifies_expectation_change` | PASS | 明确判断这是已批准产品行为的变更，而非可直接处理的小改动。 |
+| `routes_to_existing_project_update` | PASS | 明确路由至 pm-agent:idea-to-spec 的 existing-project-update 路径，并要求先更新、确认 PRD/DECISIONS 后再同步 TRD。 |
+| `routes_trd_gap_to_trd_gen` | NOT_EXERCISED | 当前尚未完成产品决定对齐；TRD gap packet 的条件尚未被锁定证据触发。候选输出仅说明后续由 trd-gen 同步技术设计。 |
+| `requires_plan_after_alignment` | NOT_EXERCISED | 当前仍处于 PM 对齐前阶段，feature-implementor 尚不能进入；后续实施计划要求未被实际执行，因此该断言未到可判定阶段。 |
+| `does_not_route_directly_to_implementation` | PASS | 明确说明现在不应直接进入工程实现，也不应直接进入 feature-implementor；要求先完成产品行为确认。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=d08d04c31266e7709df236e5a84b0516db051d4099fdd86927601fc672aa3954; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=13cf9276ccf099166e43c88fbc1a3bec853402042bd911ba6f298e9148a718b1; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 识别现行行为基线与预期变更，先路由至 existing-project-update 进行 PM 对齐，并保留 TRD 与实施计划门禁；未直接实现。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=d08d04c31266e7709df236e5a84b0516db051d4099fdd86927601fc672aa3954; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=102df66ad341db6e00ff224a8fec19d5dc2365ad0f918b6eaee59195684dac39; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 识别出 archived 进入 active 会改变已批准行为，正确回到 PM 的 existing-project-update 路径，并阻止直接实现。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=d08d04c31266e7709df236e5a84b0516db051d4099fdd86927601fc672aa3954; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=93fa53c31e19c7deb49dc308f76323f4a5ea9791bde2830f8aefe01540090407; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 主要停留在空仓库和实现定位层面，未识别这是已批准行为变更，也未路由至 PM 变更确认路径。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=d08d04c31266e7709df236e5a84b0516db051d4099fdd86927601fc672aa3954; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=706ad21958e82936cae0efb21bf9f88bc86a74e1bcd44c8d467b9757b2e78d42; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 提出了通用的代码、测试和边界梳理建议，但未识别已批准行为变更，也未路由到 PM 对齐路径。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: 完成 PM 对 archived 纳入 active 的范围与语义确认后，更新 PRD/DECISIONS。
-- Next: 确认 PRD/产品决策后检查 TRD；若缺失或过期，再构造 TRD gap packet 交回 engineer-agent:trd-gen。
+- Next: 完成 PM 对产品行为和验收标准的确认。
+- Next: 确认后检查 TRD 覆盖情况，并在存在缺口时构造 TRD gap packet 交回 engineer-agent:trd-gen。
+- Next: PRD/TRD 对齐后再由 feature-implementor 先产出或引用已确认的 IMPLEMENTATION_PLAN.md。
 
 ## Runtime Artifact Policy
 

--- a/agents/engineer/test/engineer-agent/evals/workspace/eval-003-nested-feature-alignment-routing/comparison.md
+++ b/agents/engineer/test/engineer-agent/evals/workspace/eval-003-nested-feature-alignment-routing/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `fce695dea6b3b91d6d3888c03505a121b7361b20c47f0ec1866020880becfe0b` from `agents/engineer/test/engineer-agent/evals/workspace/eval-003-nested-feature-alignment-routing`.
 - Identity schema: `2`
-- target_skill_sha256: `dbf68937d134aca2f40875673b0fd0b744ad9837ea79e85af0826e2a587f5231`
+- target_skill_sha256: `4844b5e075259765184f2662312a91c5cdcb5ff00686044034ea15af2e50c5ac`
 - eval_definition_sha256: `67832d33ab3bc749088b4bb683db7ed37344ec533de2fb8036c768dff9664822`
 - metadata_sha256: `59315e8a64d35edec6df2d9a4466749588367c4b3225f76feb93193f4a5bb2ad`
 - fixture_sha256: `fce695dea6b3b91d6d3888c03505a121b7361b20c47f0ec1866020880becfe0b`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `2c28cd5019db4aa28a9d236d016e67174df115cef2180ca189d432ec28ba579c`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `8df8927fae8a7a05a0bc46dd68c9ebf5573f79304565b07745939c992b9c20d9`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `dc4e9a8a891ad08c98ae67c1fa935de8b5c54b55c6249a46d7cf05f06bdbed91`
+- Skill overlay SHA-256: `65d01d81aab66b453dc18dc77df0f17f854503579e4f5025c7c7c7f0257e73eb`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,28 +33,28 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `resolves_nested_feature_path` | PASS | With-skill output identifies `chat-interface/history-search`; locked trace directly reads both nested PRD and TRD paths. |
-| `does_not_use_sibling_or_parent_only_path` | PASS | With-skill trace enumerates and reads the nested feature files, with no sibling or parent-only substitute evidenced. |
-| `routes_requirement_change_to_pm` | PASS | With-skill output routes the unspecified existing-feature requirement change first to `pm-agent:idea-to-spec`, then describes TRD synchronization. |
-| `routes_trd_mismatch_to_trd_gen` | NOT_EXERCISED | The locked fixture TRD has matching `feature_path` and `related_prd` and is not missing or stale, so this conditional mismatch route is not exercised. |
-| `does_not_execute_directly` | PASS | With-skill output explicitly says not to modify code; locked git evidence shows no changes, no plan delivery, and no tests or implementation actions. |
+| `resolves_nested_feature_path` | PASS | with_skill identifies the feature as `chat-interface/history-search` and its locked trace directly reads both nested PRD and TRD paths. |
+| `does_not_use_sibling_or_parent_only_path` | PASS | with_skill uses the nested child paths in both its evidence and output; no sibling or parent-only substitute is used. |
+| `routes_requirement_change_to_pm` | PASS | with_skill recognizes the requested ordering change as requiring PM alignment through `pm-agent:idea-to-spec` and `existing-project-update` before engineering/TRD synchronization. |
+| `routes_trd_mismatch_to_trd_gen` | NOT_EXERCISED | The locked PRD and TRD are present, current, and path-aligned, so the stale/missing/mismatched TRD condition is not exercised. |
+| `does_not_execute_directly` | PASS | with_skill explicitly states no code or documentation changes; git evidence shows unchanged HEAD, branch, status, index, and worktree, and the trace shows no test execution or plan-file creation. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=8df8927fae8a7a05a0bc46dd68c9ebf5573f79304565b07745939c992b9c20d9; fixture_sha256=fce695dea6b3b91d6d3888c03505a121b7361b20c47f0ec1866020880becfe0b; output_sha256=c364ced8d31713b22f28339bfb45f4bc69164afb47b90e7fe396e595841572ac; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly resolves the nested feature, identifies the current ordering baseline, routes the unspecified requirement change through PM before TRD alignment, and respects the no-change boundary.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=8df8927fae8a7a05a0bc46dd68c9ebf5573f79304565b07745939c992b9c20d9; fixture_sha256=fce695dea6b3b91d6d3888c03505a121b7361b20c47f0ec1866020880becfe0b; output_sha256=5c5bacc7d3bbfe8ab59049b836c4e1b1285e06492f6b8b76c653714c7955ab29; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly resolves the nested feature, routes the unspecified approved-behavior change back to PM, describes the downstream route, and preserves the no-mutation boundary.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=8df8927fae8a7a05a0bc46dd68c9ebf5573f79304565b07745939c992b9c20d9; fixture_sha256=fce695dea6b3b91d6d3888c03505a121b7361b20c47f0ec1866020880becfe0b; output_sha256=185abb3244c613c204ad11d0ac9c8f314ef933359888cac3ddc9935c9cd8c1f8; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Fresh baseline correctly identifies the nested documents and proposes a no-code plan, but does not explicitly establish the PM-first routing and specialist handoff chain.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=8df8927fae8a7a05a0bc46dd68c9ebf5573f79304565b07745939c992b9c20d9; fixture_sha256=fce695dea6b3b91d6d3888c03505a121b7361b20c47f0ec1866020880becfe0b; output_sha256=e00840c0b4ef6920e1c4f9e08bad69367b8cfa9153e017f1639d45f650a77141; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Provides a reasonable generic read-only proposal and identifies the existing ordering baseline, but does not demonstrate the required nested-path routing behavior.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Confirm the desired new sorting rule through PM before proceeding to TRD alignment.
+- Next: None.
 
 ## Runtime Artifact Policy
 

--- a/agents/engineer/test/engineer-agent/evals/workspace/eval-004-frontend-ui-routing-contract/comparison.md
+++ b/agents/engineer/test/engineer-agent/evals/workspace/eval-004-frontend-ui-routing-contract/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `ec60268c3cba621e7690e34a6ae14bc9ac52429e90275b6d4c2fdedef202a8df` from `agents/engineer/test/engineer-agent/evals/workspace/eval-004-frontend-ui-routing-contract`.
 - Identity schema: `2`
-- target_skill_sha256: `dbf68937d134aca2f40875673b0fd0b744ad9837ea79e85af0826e2a587f5231`
+- target_skill_sha256: `4844b5e075259765184f2662312a91c5cdcb5ff00686044034ea15af2e50c5ac`
 - eval_definition_sha256: `fd025b1cc76de7ba27bf5663c5ab9fb0198c4654dd23e4362935403d06d0381e`
 - metadata_sha256: `5acb354c4f47f4e19cc0056b621672e97a9a1363620b5c47ee3aaa253b38e1da`
 - fixture_sha256: `ec60268c3cba621e7690e34a6ae14bc9ac52429e90275b6d4c2fdedef202a8df`
@@ -22,41 +22,41 @@
 - judge_schema_sha256: `e2168c580c03f1c43acee8d4077b4a9553410b224e0542721c19d2cc8e09e39c`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `c7cb9273b0ca01f312d499d16a87d54a68980710efc17abee5e6a4600012b8c0`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `89b7cf805d9cfdc0b1866442fc9e2297ff83a5f4b690ed88998632e1a3d56160`
-- Behavior result: **PASS**
+- Skill overlay SHA-256: `9edb63200b93f23958ca16aced6e6863b40fef177b2732db6ffeeb96c8c0a359`
+- Behavior result: **FAIL**
 - Coverage result: **FULL**
-Overall result: PASS
+Overall result: FAIL
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `routes_frontend_update_to_engineer` | PASS | 明确将 UI 实现归属于 engineer-agent，并将后续实现路由至 feature-implementor。 |
-| `does_not_route_to_external_ui_skill` | PASS | 输出未建议、调用或依赖 ui-ux-pro-max。 |
-| `runs_feature_alignment` | PASS | 输出给出 feature_path、PRD 和 TRD；锁定 trace 记录了在路由前读取两份文档。 |
-| `checks_design_deliverables` | PASS | 输出识别 ui-ux-spec.md 和 visual-system.md 缺失；锁定 trace 直接检查了对应设计路径。 |
-| `hands_design_gap_to_designer` | PASS | 明确 handoff 到 designer-agent，并要求补齐信息层级与主按钮样式规范。 |
-| `routes_implementation_after_design` | PASS | 设计师步骤后继续到 trd-gen 和 feature-implementor，并明确先生成、确认 IMPLEMENTATION_PLAN.md 后才改代码。 |
-| `does_not_execute_directly` | PASS | 输出声明不修改代码或文档；git evidence 显示 HEAD、分支和工作区均未变化，且无测试或计划文件交付。 |
+| `routes_frontend_update_to_engineer` | FAIL | With-skill output routes through codebase-analyzer, trd-gen, and feature-implementor, but does not identify the request as Engineering work owned by engineer-agent. |
+| `does_not_route_to_external_ui_skill` | PASS | With-skill output does not suggest or mention external ui-ux-pro-max. |
+| `runs_feature_alignment` | PASS | It states feature_path customer-portal/profile-settings and names the PRD and TRD; the trace shows both documents were read before later routing checks. |
+| `checks_design_deliverables` | PASS | It explicitly checks both requested design paths and reports that they are absent; the trace confirms the read-only file listing found only PRD and TRD. |
+| `hands_design_gap_to_designer` | PASS | It identifies the missing design materials as a gap and hands the work to designer-agent for clarification and return. |
+| `routes_implementation_after_design` | PASS | It states that after design confirmation the flow returns to implementation through feature-implementor and requires a confirmed IMPLEMENTATION_PLAN before implementation. |
+| `does_not_execute_directly` | PASS | The output says this is plan confirmation only and does not modify code; locked git evidence shows no changes, and the trace contains only read commands. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c7cb9273b0ca01f312d499d16a87d54a68980710efc17abee5e6a4600012b8c0; fixture_sha256=ec60268c3cba621e7690e34a6ae14bc9ac52429e90275b6d4c2fdedef202a8df; output_sha256=74084480d92e842041d6625299bacb977baf9e5a082e1ea5c9df79bf04baa9fb; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 完成了工程归类、PRD/TRD 对齐、设计交付物检查、Designer 缺口交接及实现门禁说明，并遵守只读边界。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c7cb9273b0ca01f312d499d16a87d54a68980710efc17abee5e6a4600012b8c0; fixture_sha256=ec60268c3cba621e7690e34a6ae14bc9ac52429e90275b6d4c2fdedef202a8df; output_sha256=8047c6cecb9baec35c06868107138a84d940f7101305b51439766a4741307d43; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly performs feature alignment, checks for missing design deliverables, hands the gap to Designer, preserves the implementation-plan gate, and does not mutate the repository, but omits explicit engineer-agent ownership.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c7cb9273b0ca01f312d499d16a87d54a68980710efc17abee5e6a4600012b8c0; fixture_sha256=ec60268c3cba621e7690e34a6ae14bc9ac52429e90275b6d4c2fdedef202a8df; output_sha256=194637ac25ecf28cf2ff41bef3bee9c178c7f4d286b53927ccbb400ac9051907; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 提供了一般性的改版推进建议，但未明确工程路由、设计交接和实现门禁链路。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c7cb9273b0ca01f312d499d16a87d54a68980710efc17abee5e6a4600012b8c0; fixture_sha256=ec60268c3cba621e7690e34a6ae14bc9ac52429e90275b6d4c2fdedef202a8df; output_sha256=1f00f91d5a30e93c267cd6b94ca62d45aa8271f0121d75f19c330cb4fa3e6663; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Provides a generic phased implementation plan and correctly reports no mutations, but does not perform the required role routing, design-deliverable check, or Designer handoff.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- None.
-- Next: None.
+- The with_skill lane omits the required explicit Engineering classification and engineer-agent ownership for the frontend implementation request.
+- Next: Explicitly classify the request as an Engineering request owned by engineer-agent, while preserving the Designer handoff for the missing design inputs.
 
 ## Runtime Artifact Policy
 

--- a/agents/engineer/test/engineer-agent/evals/workspace/eval-005-route-read-only-diagnosis/comparison.md
+++ b/agents/engineer/test/engineer-agent/evals/workspace/eval-005-route-read-only-diagnosis/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `e469c8867c3eaab395b1e2ecf769900426fc05c37fc44889d5555593c06bb9a0` from `agents/engineer/test/engineer-agent/evals/workspace/eval-005-route-read-only-diagnosis`.
 - Identity schema: `2`
-- target_skill_sha256: `dbf68937d134aca2f40875673b0fd0b744ad9837ea79e85af0826e2a587f5231`
+- target_skill_sha256: `4844b5e075259765184f2662312a91c5cdcb5ff00686044034ea15af2e50c5ac`
 - eval_definition_sha256: `ef789eef7ae75d20cd2b4f7363ad1491d04eb3cdb6114859d0ec16b9b00b6acb`
 - metadata_sha256: `e4901c042b0409a9250648c22e35f5aa91c71bf1facf120010b04e53329e73e7`
 - fixture_sha256: `e469c8867c3eaab395b1e2ecf769900426fc05c37fc44889d5555593c06bb9a0`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `50ba2d2012c41a93dc7606cfb865565f1a5b791f485b360a632d9cb7b9413bac`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `6501dca073ea693c3fce773a64fba0b68444a0b5dc8e1f9f199b652d00d7a920`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `dc4e9a8a891ad08c98ae67c1fa935de8b5c54b55c6249a46d7cf05f06bdbed91`
+- Skill overlay SHA-256: `65d01d81aab66b453dc18dc77df0f17f854503579e4f5025c7c7c7f0257e73eb`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `preserves_read_only_fields` | PASS | With-skill output explicitly retains `diagnosis_only` and `allowed_mutations: none`, and states a zero-mutation boundary. |
-| `routes_to_existing_debugger` | PASS | With-skill output routes the work to `debugger`; the captured engineer-agent routing material identifies debugger as the read-only diagnosis specialist, with no parallel specialist proposed. |
-| `does_not_require_repair_docs_first` | PASS | With-skill output marks expectations `unaligned` due to missing PRD/TRD, preserves evidence collection, and explicitly disallows confirming implementation deviation or creating a repair plan. |
+| `preserves_read_only_fields` | PASS | with_skill 输出明确保留 `mode: diagnosis_only` 与 `allowed_mutations: none`，并声明禁止修改代码、测试、配置、数据库及外部状态。 |
+| `routes_to_existing_debugger` | PASS | with_skill 输出明确将下一专员设为 `debugger`，并将只读诊断交给 `debugger`；未提出并行 specialist 或新建 route。 |
+| `does_not_require_repair_docs_first` | PASS | with_skill 输出在缺少 PRD/TRD 时仍安排有限的客观证据收集，标记 `expected_behavior_alignment: unaligned`，且明确不得确认 `implementation_deviation`、不得生成或执行修复计划。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=6501dca073ea693c3fce773a64fba0b68444a0b5dc8e1f9f199b652d00d7a920; fixture_sha256=e469c8867c3eaab395b1e2ecf769900426fc05c37fc44889d5555593c06bb9a0; output_sha256=c95220b1c5153d7a6d4dc3f873bca1528cf7e167ab5983244c1e29bd85e49328; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Read-only diagnosis was routed to the existing debugger, preserved the handoff constraints, and treated missing PRD/TRD as unaligned without blocking evidence collection or initiating repair.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=6501dca073ea693c3fce773a64fba0b68444a0b5dc8e1f9f199b652d00d7a920; fixture_sha256=e469c8867c3eaab395b1e2ecf769900426fc05c37fc44889d5555593c06bb9a0; output_sha256=6ccb9d3fee247a9e77bbd88960928683eb0b99fa1226a571ac37bb08f8f6b2a8; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 保留只读边界，路由至现有 debugger，并在缺少 PRD/TRD 时继续有限证据收集而不进入修复。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=6501dca073ea693c3fce773a64fba0b68444a0b5dc8e1f9f199b652d00d7a920; fixture_sha256=e469c8867c3eaab395b1e2ecf769900426fc05c37fc44889d5555593c06bb9a0; output_sha256=6cab3c954041912db27929a178bd3da41d1d9226001a7379d55c459ed7fef2ee; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Fresh baseline preserved the no-change intent and reported available incident evidence, but did not explicitly preserve the required fields, route to debugger, or mark the missing-document state as unaligned.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=6501dca073ea693c3fce773a64fba0b68444a0b5dc8e1f9f199b652d00d7a920; fixture_sha256=e469c8867c3eaab395b1e2ecf769900426fc05c37fc44889d5555593c06bb9a0; output_sha256=1927e423a3d013d6f03330cf83927f22c42d82f61cb016949d403ac2da56ead8; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 保持未修改工作区，但将缺少 PRD/TRD 视为诊断阻塞，未路由至 debugger。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/engineer/test/engineer-agent/evals/workspace/eval-1-route-implementation-chain/comparison.md
+++ b/agents/engineer/test/engineer-agent/evals/workspace/eval-1-route-implementation-chain/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `6901f5611ca2fe3ad6e90465dd3d2fa7fe65487d3ee792571b1138447aa07b62` from `agents/engineer/test/engineer-agent/evals/workspace/eval-1-route-implementation-chain`.
 - Identity schema: `2`
-- target_skill_sha256: `dbf68937d134aca2f40875673b0fd0b744ad9837ea79e85af0826e2a587f5231`
+- target_skill_sha256: `4844b5e075259765184f2662312a91c5cdcb5ff00686044034ea15af2e50c5ac`
 - eval_definition_sha256: `94e82890c2d263165b072d65dcdeab391ae896b3512e7e56b56596c040c0fad3`
 - metadata_sha256: `c350181199e0dd4d8e28d3a9b94d55274bccc0c6ec2bbaade8b5b2072f51496c`
 - fixture_sha256: `6901f5611ca2fe3ad6e90465dd3d2fa7fe65487d3ee792571b1138447aa07b62`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `a1e6bf4e08477989b26fffa805de56b77288d345cfdf1b16c76dd2c7ddf824f4`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `9fc8881f18737830e6fd3bd600a3e0c2e55655ace219e4ac6560b9a3b9b10408`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `dc4e9a8a891ad08c98ae67c1fa935de8b5c54b55c6249a46d7cf05f06bdbed91`
+- Skill overlay SHA-256: `65d01d81aab66b453dc18dc77df0f17f854503579e4f5025c7c7c7f0257e73eb`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,23 +33,23 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `starts_with_codebase_context` | PASS | with_skill 安排顺序第 1 步明确选择 codebase-analyzer 分析仓库结构、技术栈相关实现约束、测试框架和 CI。 |
-| `routes_implementation_to_feature_implementor` | PASS | with_skill 第 3 步明确将 webhook 重试实现交给 feature-implementor，并说明基于 PRD、确认后的 TRD、确认后的 IMPLEMENTATION_PLAN.md 和现有代码执行。 |
-| `routes_tests_to_test_writer` | PASS | with_skill 第 4 步明确将确定性测试交给 test-writer，覆盖成功、重试、最终失败、重复 event ID、边界次数及依赖失败。 |
-| `routes_qa_e2e_handoff` | PASS | with_skill 第 5 步在实现和测试之后安排 QA handoff，并列出 PRD、TRD、确认的实现计划、改动文件、验证命令与结果、风险、建议及 docs/qa/e2e/billing-webhook/ 目录。 |
-| `routes_delivery_last` | PASS | with_skill 第 6 步将 delivery 放在实现、测试和 QA handoff 之后，用于分支、提交、推送、PR 和 CI 回读。 |
-| `does_not_execute_directly` | PASS | 交付快照为空，Git head、分支、状态和 diff 均未变化；runner trace 仅显示读取文件和 Git 状态等只读命令，未运行测试、修改代码或创建提交。 |
+| `starts_with_codebase_context` | PASS | with_skill 输出将 `codebase-analyzer` 明确列为第一个步骤；原始 trace 也记录了先进行工程路由和入口核验。 |
+| `routes_implementation_to_feature_implementor` | PASS | with_skill 输出明确安排由 `feature-implementor` 基于确认后的 TRD、实现计划和现有代码执行实现；当前因缺少确认依据而阻塞属于后续执行门禁。 |
+| `routes_tests_to_test_writer` | PASS | with_skill 输出明确安排由 `test-writer` 补齐确定性测试，并列出成功、重试、上限、event ID 和幂等覆盖。 |
+| `routes_qa_e2e_handoff` | PASS | with_skill 输出明确安排测试通过后交 QA，并包含 PRD、TRD、实现计划、变更文件、验证命令与结果、风险、建议及 `docs/qa/e2e/billing-webhook/` 目录。 |
+| `routes_delivery_last` | PASS | with_skill 输出将 `delivery` 放在实现和测试之后，用于创建分支、提交、推送、创建 PR 并回读 PR/CI 结果。 |
+| `does_not_execute_directly` | PASS | with_skill 输出明确声明当前不改代码、不提交；delivery_snapshot 为空，git head、分支和工作区均未变化。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9fc8881f18737830e6fd3bd600a3e0c2e55655ace219e4ac6560b9a3b9b10408; fixture_sha256=6901f5611ca2fe3ad6e90465dd3d2fa7fe65487d3ee792571b1138447aa07b62; output_sha256=bd201264e5dacd607b6bbbecedc143b0a47c3b18644e8b3ed16ffbcfefe2144c; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 按 codebase-analyzer、trd-gen、feature-implementor、test-writer、QA handoff、delivery 的顺序安排工作，并遵守暂不执行边界。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9fc8881f18737830e6fd3bd600a3e0c2e55655ace219e4ac6560b9a3b9b10408; fixture_sha256=6901f5611ca2fe3ad6e90465dd3d2fa7fe65487d3ee792571b1138447aa07b62; output_sha256=e63a7dfb15dcc901da559117531c7a9996368e2a3336858b41f7369133e8e298; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 按工程路由顺序规划了代码分析、依据核验、实现、测试、QA E2E 和 delivery，并在缺少 PRD、确认实现计划及 handoff packet 时停止后续执行。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9fc8881f18737830e6fd3bd600a3e0c2e55655ace219e4ac6560b9a3b9b10408; fixture_sha256=6901f5611ca2fe3ad6e90465dd3d2fa7fe65487d3ee792571b1138447aa07b62; output_sha256=0bab7a1c4f14e48140e60b25287c41de977dc0936f0c5f945e5637f26388954f; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 提供了通用实现计划和测试/交付步骤，但未使用要求的 specialist routing；未修改仓库。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9fc8881f18737830e6fd3bd600a3e0c2e55655ace219e4ac6560b9a3b9b10408; fixture_sha256=6901f5611ca2fe3ad6e90465dd3d2fa7fe65487d3ee792571b1138447aa07b62; output_sha256=27a7d26b83282c309a15a046492e30a0a97deb21051e917177b1ad1baa952912; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 提供了通用实现/测试/提交计划，但未路由到指定 specialist，也未安排 QA E2E 交接。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-001-implement-from-prd-trd/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-001-implement-from-prd-trd/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `6fefdc42c8b398b33bf8d36b081a2d2c404ba55841f19917d1bf8a129df36ca6` from `agents/engineer/test/feature-implementor/evals/workspace/eval-001-implement-from-prd-trd`.
 - Identity schema: `2`
-- target_skill_sha256: `248d30c2e10162217ecb1d6a0d7c66973ee945c6f2e9b7e4bf01a677aac7bc3c`
+- target_skill_sha256: `7f71c78ab97a67d477751886a8f46d8cfd865bac113be49568de86ccf5343ee9`
 - eval_definition_sha256: `fdd6ce4f4f12ff2cfeb67956eb31c203d7cf49aba2742edf2df400fcb4ed7d44`
 - metadata_sha256: `dbfe1b305561b16d245510f968046dfe04a8e1bd20f868dd61cdc0d81a8f44f7`
 - fixture_sha256: `6fefdc42c8b398b33bf8d36b081a2d2c404ba55841f19917d1bf8a129df36ca6`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `beede515c8e2f36efe8ae181f94762d96db69fb2e24a26068fcdd2ef262c1f48`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `2b7b36d4bdea5793eaf1494d70b7d895d20a1213d115ce56d29616224f8e44f7`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `8002de5f5ec8cbba9c876b3fa5b95d04da373914039535f254ff8fce02f9cbab`
+- Skill overlay SHA-256: `6ba93c2da62bbbed9ea41d72d153901f8e8bbbbad20322168e3cf7c265e800fd`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,21 +33,21 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `writes_implementation_plan` | PASS | with_skill 输出明确给出 `docs/engineer/notification-center/IMPLEMENTATION_PLAN.md`，并列出 planned_files 与 execution order；delivery_snapshot 也直接证明该文件已创建。 |
-| `requires_user_confirmation` | PASS | 输出包含“请确认这份计划后，我再进入实现阶段”，并将 confirmation_required 设为 true。 |
-| `does_not_implement_directly` | PASS | 输出仅说明已生成实施计划，明确实现、测试、QA 等后续动作被阻塞；未声称已创建代码文件、运行实现步骤或完成自检。 |
-| `maintains_plan_metadata` | PASS | 锁定的 delivery_snapshot 文件 frontmatter 包含 `version: "0.1.0"` 与 `last_updated: "2026-08-16"`，日期与当前日期一致。 |
+| `writes_implementation_plan` | PASS | with_skill 输出明确给出 `docs/engineer/notification-center/IMPLEMENTATION_PLAN.md`，列出 planned_files，并按 1–5 步给出实现顺序；delivery_snapshot 直接证明该文件已创建。 |
+| `requires_user_confirmation` | PASS | with_skill 输出明确写明 `confirmation_required: true`，并要求“请确认这份精确计划后，我再开始编码”。 |
+| `does_not_implement_directly` | PASS | with_skill 输出明确说明“尚未修改代码或测试”，且锁定 git evidence 仅显示 IMPLEMENTATION_PLAN.md 新增，没有代码实现、实现命令或自检完成声明。 |
+| `maintains_plan_metadata` | PASS | delivery_snapshot 中 IMPLEMENTATION_PLAN.md frontmatter 包含 `version: "0.1.0"` 和 `last_updated: "2026-08-16"`，与当前日期一致。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2b7b36d4bdea5793eaf1494d70b7d895d20a1213d115ce56d29616224f8e44f7; fixture_sha256=6fefdc42c8b398b33bf8d36b081a2d2c404ba55841f19917d1bf8a129df36ca6; output_sha256=413245e603417e95ab26648d39becd9dbf6b72bddecf57756c988ab5dd026d0d; snapshot_sha256=26e0c62a4573563bb360a5fd61012104759cd15635e384e8be3400641b5df7a2
-- Behavior: 创建了完整实施计划文件，列出文件变更与执行顺序，并停在用户确认门槛前。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2b7b36d4bdea5793eaf1494d70b7d895d20a1213d115ce56d29616224f8e44f7; fixture_sha256=6fefdc42c8b398b33bf8d36b081a2d2c404ba55841f19917d1bf8a129df36ca6; output_sha256=cb8c792af45b85061e6dfa3954ba1dc2ab7b9069083556e69fe8a480c824dc86; snapshot_sha256=c5f15dfc8a692a1f078995460d3d60e5372eac28de7932782c1b5b5e00914ba4
+- Behavior: 创建了带有效初始元数据的实施计划，列出文件变更和实现顺序，要求确认后再编码，未直接实施代码。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2b7b36d4bdea5793eaf1494d70b7d895d20a1213d115ce56d29616224f8e44f7; fixture_sha256=6fefdc42c8b398b33bf8d36b081a2d2c404ba55841f19917d1bf8a129df36ca6; output_sha256=0f05e76cff32bc3d7355c97c1a0f30cc1d7f63306cf0024426e2b8cd34df91f1; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 提供了实施安排和确认请求，但未创建 IMPLEMENTATION_PLAN.md 文件。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2b7b36d4bdea5793eaf1494d70b7d895d20a1213d115ce56d29616224f8e44f7; fixture_sha256=6fefdc42c8b398b33bf8d36b081a2d2c404ba55841f19917d1bf8a129df36ca6; output_sha256=f188ce1c8f444b48b4da188fc018ff3124ee63dac75a18d1019e7dfb3cb5d2c9; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 提供了文本实施安排并要求确认，但未创建 IMPLEMENTATION_PLAN.md 文件；作为 fresh baseline，未满足文件交付和元数据要求。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-002-subagent-division-from-docs/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-002-subagent-division-from-docs/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `65a99fdb8c4d1c46befd98fefb9960ee9aae1f97faab8a74ba30b0fffe3597a9` from `agents/engineer/test/feature-implementor/evals/workspace/eval-002-subagent-division-from-docs`.
 - Identity schema: `2`
-- target_skill_sha256: `248d30c2e10162217ecb1d6a0d7c66973ee945c6f2e9b7e4bf01a677aac7bc3c`
+- target_skill_sha256: `7f71c78ab97a67d477751886a8f46d8cfd865bac113be49568de86ccf5343ee9`
 - eval_definition_sha256: `5c62d2cc73fb2bf0752465157043f4f8dd87b392fc0487e4305ab334ca2facef`
 - metadata_sha256: `2000cfec73a27c655fd040245a2ed6cd029105314fefb24c004971d6a51527de`
 - fixture_sha256: `65a99fdb8c4d1c46befd98fefb9960ee9aae1f97faab8a74ba30b0fffe3597a9`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `1e433f2d38239fdd1f4633433c706d2dafc7492741c63113035a8d0975b21d23`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `8ee9b69232c9ce95b799be0d259b297845a3badf592141bec3518643c9781de5`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `8002de5f5ec8cbba9c876b3fa5b95d04da373914039535f254ff8fce02f9cbab`
+- Skill overlay SHA-256: `6ba93c2da62bbbed9ea41d72d153901f8e8bbbbad20322168e3cf7c265e800fd`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,30 +33,30 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `preserves_main_context` | PASS | IMPLEMENTATION_PLAN.md 明确说明主进程保留 PRD、TRD、设计文档、仓库规则、实现边界、集成和最终交付判断。 |
-| `writes_implementation_plan_doc` | PASS | 锁定 delivery_snapshot 直接证明已创建 docs/engineer/capture-loop/IMPLEMENTATION_PLAN.md；计划未改写 TRD，且当前流程等待用户确认。 |
-| `delegates_implementation_scope` | PASS | 计划明确列出 queue-service.ts、event-handler.ts、测试文件的实现步骤、写入范围、禁止无关改动及主实现/独立验收分工。 |
-| `delegates_independent_validation` | PASS | 计划安排独立验收方复核确认计划、PRD/TRD/设计、变更文件、测试结果、仓库规则、无关改动安全性和残余风险。 |
-| `keeps_simple_path_exception` | PASS | 拆分限定于当前三文件的跨组件实现与测试范围，未宣称所有工程任务都必须拆分。 |
-| `final_summary_contract` | NOT_EXERCISED | 当前交互停在等待用户确认计划阶段，尚未进入实现后的最终交付总结。 |
-| `qa_e2e_handoff_contract` | NOT_EXERCISED | 计划明确 QA handoff 在确认前阻塞；代码完成后的 QA E2E 交接尚未发生。 |
+| `preserves_main_context` | PASS | 计划明确主流程保留 PRD、TRD、设计规范、仓库规则、实现边界、集成与最终交付判断。 |
+| `writes_implementation_plan_doc` | PASS | 锁定 delivery_snapshot 直接包含 docs/engineer/capture-loop/IMPLEMENTATION_PLAN.md，且计划未改写 TRD。 |
+| `delegates_implementation_scope` | NOT_EXERCISED | 未发现锁定证据证明实际执行了实现 sub-agent；计划由主流程承担并明确文件范围与无关改动保护。 |
+| `delegates_independent_validation` | NOT_EXERCISED | 未发现锁定证据证明实际执行了独立验收 sub-agent；计划明确由主流程执行独立验证阶段。 |
+| `keeps_simple_path_exception` | PASS | 计划将拆分关闭限定为当前三文件范围，并未宣称所有工程任务都必须拆分。 |
+| `final_summary_contract` | PASS | 计划包含实现/验证、验收与最终交付判断，以及 changed_files、commands_and_results 和 residual_risks 收口字段；最终实现尚待用户确认。 |
+| `qa_e2e_handoff_contract` | NOT_EXERCISED | 计划说明确认并实现完成后进行 QA handoff，并给出 docs/qa/e2e/capture-loop/；实际代码完成与运行时交接尚未发生。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=8ee9b69232c9ce95b799be0d259b297845a3badf592141bec3518643c9781de5; fixture_sha256=65a99fdb8c4d1c46befd98fefb9960ee9aae1f97faab8a74ba30b0fffe3597a9; output_sha256=f8ccb2525dce500e95e4165b6f82472db3bfb5a85908a8bdf6215f13d55322ad; snapshot_sha256=53992eded227e7f6cc1b816c92af3043a6edb877a0400002c53826eef9113ad1
-- Behavior: 创建了锁定的实现计划文件，保留主进程上下文，明确实现范围、验证和独立验收分工，并等待用户确认后再编码。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=8ee9b69232c9ce95b799be0d259b297845a3badf592141bec3518643c9781de5; fixture_sha256=65a99fdb8c4d1c46befd98fefb9960ee9aae1f97faab8a74ba30b0fffe3597a9; output_sha256=043fb272b6ff1a3025805a35f46136d7c535780ee40f7f5957f1093501705c0a; snapshot_sha256=3e0a579a1f12e3bc2226466a91bac87c3fb6754cf725d050f011dcf7f03cc1fd
+- Behavior: 完成规划检查点并直接交付 IMPLEMENTATION_PLAN.md；明确主流程职责、实现范围、验证方案、确认前阻塞项与后续 QA 交接方向，等待用户确认后编码。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=8ee9b69232c9ce95b799be0d259b297845a3badf592141bec3518643c9781de5; fixture_sha256=65a99fdb8c4d1c46befd98fefb9960ee9aae1f97faab8a74ba30b0fffe3597a9; output_sha256=3f0bc54f1ecd7b0eb5212945f9b133dcfbbe49804682d689e212081baf59f741; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 仅输出实现建议，未创建实现计划文档，也未形成同等完整的主进程上下文和交接契约。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=8ee9b69232c9ce95b799be0d259b297845a3badf592141bec3518643c9781de5; fixture_sha256=65a99fdb8c4d1c46befd98fefb9960ee9aae1f97faab8a74ba30b0fffe3597a9; output_sha256=ce911fff74ae2aaf18d79cfb6438a2c39271ea2ddc0adebde9a201a38c3aaa86; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 提供了代码改造方案和实现/验收分工，但未交付 IMPLEMENTATION_PLAN.md，也未建立确认闸门或 QA E2E 交接契约。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: 用户确认精确计划后进入实现、验证、最终总结和 QA E2E 交接。
+- Next: 等待用户确认 IMPLEMENTATION_PLAN.md 后再实现、验证并完成最终交付与 QA E2E handoff。
 
 ## Runtime Artifact Policy
 

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-003-missing-trd-handoff/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-003-missing-trd-handoff/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `ab5acf9561757cd60998119f1643fd8622ced39a8046dbb107e9cf8100e1110f` from `agents/engineer/test/feature-implementor/evals/workspace/eval-003-missing-trd-handoff`.
 - Identity schema: `2`
-- target_skill_sha256: `248d30c2e10162217ecb1d6a0d7c66973ee945c6f2e9b7e4bf01a677aac7bc3c`
+- target_skill_sha256: `7f71c78ab97a67d477751886a8f46d8cfd865bac113be49568de86ccf5343ee9`
 - eval_definition_sha256: `beeebfd4f2a4eb407e840ff01043296b9db4c0e70af2a9d7de790cf54280c082`
 - metadata_sha256: `5eac74651a3b10b7dbd58af9eb6b19ea55e5d09c52882462330f3d04a124ac67`
 - fixture_sha256: `ab5acf9561757cd60998119f1643fd8622ced39a8046dbb107e9cf8100e1110f`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `e6ae86389c4cff0bdb9cc29f2e8bb068759de0c10b4021f42a0673c6cbfc39d1`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `b3686b3e49b5b805ba890514f93468b848aeefc3a94d03ef515571046a19d7e0`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `8002de5f5ec8cbba9c876b3fa5b95d04da373914039535f254ff8fce02f9cbab`
+- Skill overlay SHA-256: `6ba93c2da62bbbed9ea41d72d153901f8e8bbbbad20322168e3cf7c265e800fd`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,28 +33,28 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `detects_missing_engineer_trd` | PASS | With-skill output explicitly states that docs/engineer/capture-loop/TRD.md is missing. |
-| `hands_off_to_trd_gen` | PASS | With-skill output names engineer-agent:trd-gen as responsible for completing the TRD. |
-| `does_not_write_plan_or_code` | PASS | Locked delivery and git evidence show no changes; output explicitly states no code or implementation plan was created. |
-| `names_required_trd_decisions` | PASS | The gap packet covers components, integration/API impact, validation commands, rollout and rollback risks, error handling, observability, and security. |
-| `keeps_finder_trd_gen_boundary` | PASS | The output explicitly assigns gap clarification to the Finder and TRD completion to engineer-agent:trd-gen. |
+| `detects_missing_engineer_trd` | PASS | 明确写出 `docs/engineer/capture-loop/TRD.md` 缺失。 |
+| `hands_off_to_trd_gen` | PASS | 明确指定接收方为 `engineer-agent:trd-gen`。 |
+| `does_not_write_plan_or_code` | PASS | 声明暂停实现、`planned_files: N/A`，并报告未修改文件；原始轨迹仅显示读取检查，无写入操作。 |
+| `names_required_trd_decisions` | PASS | 列出受影响模块、状态模型、API/集成、验证命令、发布/回滚、错误处理、可观测性、安全及一致性等 TRD 决策。 |
+| `keeps_finder_trd_gen_boundary` | PASS | 明确写出 Finder 只澄清 TRD 缺口，`engineer-agent:trd-gen` 完整补充 TRD。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=b3686b3e49b5b805ba890514f93468b848aeefc3a94d03ef515571046a19d7e0; fixture_sha256=ab5acf9561757cd60998119f1643fd8622ced39a8046dbb107e9cf8100e1110f; output_sha256=257dfc9077ac2dd9fc776867d9edc9e880f4d5c3aeacb606a46ed3c48b84b0b2; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Detects the missing Engineer TRD, stops before planning or implementation, provides a detailed TRD gap packet, and hands off to engineer-agent:trd-gen.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=b3686b3e49b5b805ba890514f93468b848aeefc3a94d03ef515571046a19d7e0; fixture_sha256=ab5acf9561757cd60998119f1643fd8622ced39a8046dbb107e9cf8100e1110f; output_sha256=002134b268d05d9241279a35526de765df9906ddfc4c4f05ff553c2e9f27da70; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 识别 TRD 缺失后停止实现，输出完整 TRD 缺口包并交给 engineer-agent:trd-gen。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=b3686b3e49b5b805ba890514f93468b848aeefc3a94d03ef515571046a19d7e0; fixture_sha256=ab5acf9561757cd60998119f1643fd8622ced39a8046dbb107e9cf8100e1110f; output_sha256=8bf414138a87be4fde35449333d3b8c584147f6e5d679fc4fa35cb753adb97ce; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Recognizes that implementation cannot proceed from the sparse workspace, but does not identify or route the missing Engineer TRD.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=b3686b3e49b5b805ba890514f93468b848aeefc3a94d03ef515571046a19d7e0; fixture_sha256=ab5acf9561757cd60998119f1643fd8622ced39a8046dbb107e9cf8100e1110f; output_sha256=d9ad6858c3660817fbf229f919f97301f0d6af08deb08ba59cbf11b1ec230e1f; snapshot_sha256=af78a8f1f41621f33f5786963cd877151f18569d2bb258a45179827bba65708f
+- Behavior: 直接实现队列重试代码并新增测试，未处理缺失 TRD 前置条件。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: engineer-agent:trd-gen should complete docs/engineer/capture-loop/TRD.md before implementation planning.
+- Next: None.
 
 ## Runtime Artifact Policy
 

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-004-small-change-plan-gate/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-004-small-change-plan-gate/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `08e37b0f6a888462b39d6fb25d39b0f94b11e631f275f2f0a4af2411345138b6` from `agents/engineer/test/feature-implementor/evals/workspace/eval-004-small-change-plan-gate`.
 - Identity schema: `2`
-- target_skill_sha256: `248d30c2e10162217ecb1d6a0d7c66973ee945c6f2e9b7e4bf01a677aac7bc3c`
+- target_skill_sha256: `7f71c78ab97a67d477751886a8f46d8cfd865bac113be49568de86ccf5343ee9`
 - eval_definition_sha256: `7ad36e3dae8256ee32b41e326daa72d3992661ae3195905ab94c0de9d5bb4663`
 - metadata_sha256: `7941c9c3d9afca2e9d36cebf8798f3daecf66e49c0fab7c8d3115e0aae5e5b57`
 - fixture_sha256: `08e37b0f6a888462b39d6fb25d39b0f94b11e631f275f2f0a4af2411345138b6`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `133a3fd5fa38d2737eb59228058522a6b1f1268ab7cae969d1962b0b8a3f990f`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `334abb7e4defb6a609eb3e27f2a8ee311f59dfd40169a8f184ac8785cb43611a`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `8002de5f5ec8cbba9c876b3fa5b95d04da373914039535f254ff8fce02f9cbab`
+- Skill overlay SHA-256: `6ba93c2da62bbbed9ea41d72d153901f8e8bbbbad20322168e3cf7c265e800fd`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,29 +33,29 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `records_prd_alignment` | PASS | 输出及计划明确记录用户说明产品负责人和技术负责人已确认 PRD/TRD，并引用对应路径。 |
-| `writes_plan_for_small_change` | PASS | 已交付并直接检视 `docs/engineer/settings-label/IMPLEMENTATION_PLAN.md`。 |
-| `records_split_decision` | PASS | 输出和计划均记录单文件小改动不启用 implementation/validation sub-agent，同时保留并生成实施计划。 |
-| `waits_for_user_confirmation` | PASS | 输出明确要求用户确认计划后再开始修改。 |
-| `blocks_e2e_without_confirmed_plan` | PASS | 输出及计划明确规定 QA E2E 创建或更新在计划确认前 blocked，确认后引用该计划文件。 |
-| `does_not_modify_code` | PASS | 代码与测试文件未被修改；交付内容仅为实施计划，且输出明确表示确认后才开始修改。 |
+| `records_prd_alignment` | PASS | With-skill output explicitly records the user's confirmation by product and technical owners and the PRD/TRD alignment; the delivered plan repeats this basis without claiming nonexistent documents. |
+| `writes_plan_for_small_change` | PASS | With-skill output states that IMPLEMENTATION_PLAN.md was created at docs/engineer/settings-label/IMPLEMENTATION_PLAN.md, and the locked delivery snapshot contains that file. |
+| `records_split_decision` | PASS | The output explicitly says the implementation/validation split is disabled because this is a one-file text change, while the plan is still created and required. |
+| `waits_for_user_confirmation` | PASS | The output ends by requesting confirmation of the plan and says coding will begin only after confirmation. |
+| `blocks_e2e_without_confirmed_plan` | PASS | The output and locked plan state that E2E creation/update is blocked until the plan is confirmed, with downstream actions blocked before confirmation. |
+| `does_not_modify_code` | PASS | Locked git evidence shows no code-file changes, and the delivery snapshot contains only the implementation plan; the output does not claim implementation completion. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=334abb7e4defb6a609eb3e27f2a8ee311f59dfd40169a8f184ac8785cb43611a; fixture_sha256=08e37b0f6a888462b39d6fb25d39b0f94b11e631f275f2f0a4af2411345138b6; output_sha256=3f39837614f784a757c233cc4efc94a2a4c63f1b3047eb725cac464f5bb8754c; snapshot_sha256=a564c5a231b66a9d105ed0e492d7f86e28e9d68473b9a47bf3508ded09e15c63
-- Behavior: 完整记录确认依据、单文件变更计划、拆分判断、确认门禁和 E2E 依赖；仅新增实施计划，未修改代码。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=334abb7e4defb6a609eb3e27f2a8ee311f59dfd40169a8f184ac8785cb43611a; fixture_sha256=08e37b0f6a888462b39d6fb25d39b0f94b11e631f275f2f0a4af2411345138b6; output_sha256=112c1bddec93faee04e35e64f22ab0a5994ebd44405dae261d5f79eafcf1e350; snapshot_sha256=e2be31d9c3bae968d1f7f3f6bc813ab83de0ea15764fa4d215e828bea882c72e
+- Behavior: Produced and delivered a concrete implementation plan, documented alignment and split rationale, required user confirmation, blocked downstream E2E work until confirmation, and did not modify code.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=334abb7e4defb6a609eb3e27f2a8ee311f59dfd40169a8f184ac8785cb43611a; fixture_sha256=08e37b0f6a888462b39d6fb25d39b0f94b11e631f275f2f0a4af2411345138b6; output_sha256=07c4790201cb138ad65eb6cf9423f9be325eeea5906e0c4bbd91afcdca17884d; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 提供了基础修改步骤和验证命令，但未记录实施计划、确认门禁、拆分判断或 E2E 依赖。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=334abb7e4defb6a609eb3e27f2a8ee311f59dfd40169a8f184ac8785cb43611a; fixture_sha256=08e37b0f6a888462b39d6fb25d39b0f94b11e631f275f2f0a4af2411345138b6; output_sha256=99b6dc04b866224a41d047b1c7e0c04be4cff4da27b9d2ff13bbaf31b417be17; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Produced a basic implementation outline but did not create the required plan, request confirmation, record split rationale, or establish the E2E confirmation gate.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: 等待用户确认实施计划。
+- Next: None.
 
 ## Runtime Artifact Policy
 

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-005-existing-behavior-change-needs-pm/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-005-existing-behavior-change-needs-pm/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/engineer/test/feature-implementor/evals/workspace/eval-005-existing-behavior-change-needs-pm`.
 - Identity schema: `2`
-- target_skill_sha256: `248d30c2e10162217ecb1d6a0d7c66973ee945c6f2e9b7e4bf01a677aac7bc3c`
+- target_skill_sha256: `7f71c78ab97a67d477751886a8f46d8cfd865bac113be49568de86ccf5343ee9`
 - eval_definition_sha256: `a4e07ef6b983fa7473b530066460795acade377b6663bfa81c7266e9bd35ec21`
 - metadata_sha256: `027d85ea7f7fbd3354a737527feea7579a00f953a46d0babadd6961e39d20b20`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `c708196a2509f10ac671d636aa20ae05a664bdf496710d323db28c9149713561`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `5f81869b673853f146ffc9b6b0265765a906f1c4c8ed1c32a5df3f964238d63c`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `8002de5f5ec8cbba9c876b3fa5b95d04da373914039535f254ff8fce02f9cbab`
+- Skill overlay SHA-256: `6ba93c2da62bbbed9ea41d72d153901f8e8bbbbad20322168e3cf7c265e800fd`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,22 +33,22 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `checks_approved_behavior` | PASS | 明确指出当前批准行为是 active 排除 archived，而请求改变该既有预期。 |
-| `stops_before_implementation_plan` | PASS | 明确写出 PM 对齐前禁止创建 IMPLEMENTATION_PLAN.md，且 delivery_snapshot 为空、Git 无变更。 |
-| `hands_off_to_pm_existing_update` | PASS | 要求回到 pm-agent:idea-to-spec，走 existing-project-update 更新 PRD/DECISIONS，之后同步并确认 TRD。 |
-| `blocks_e2e_expected_behavior_change` | PASS | 将 new E2E expectations 列为阻断项，并写明 qa_e2e_tc_create_or_update 在计划确认前 blocked。 |
-| `does_not_implement_directly` | PASS | 输出明确声明本轮未修改文件；Git 证据显示无提交、无工作区或索引变更。 |
+| `checks_approved_behavior` | PASS | With-skill output identifies the request as changing the approved behavior from excluding archived to including archived, not as a simple file edit. |
+| `stops_before_implementation_plan` | PASS | With-skill output explicitly prohibits creating or updating IMPLEMENTATION_PLAN.md; git evidence shows no workspace changes. |
+| `hands_off_to_pm_existing_update` | PASS | With-skill output routes the change to pm-agent:idea-to-spec using existing-project-update, followed by TRD completion or confirmation. |
+| `blocks_e2e_expected_behavior_change` | PASS | With-skill output blocks new E2E expectations and QA cases until the documentation and implementation-plan gates are satisfied. |
+| `does_not_implement_directly` | PASS | With-skill output states that no code or tests may be modified and reports no file changes; git evidence confirms a clean worktree. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5f81869b673853f146ffc9b6b0265765a906f1c4c8ed1c32a5df3f964238d63c; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=68a02e3f507106eb31fc05e37011d0e4cc2d10e7322f6ea97fc6bb66e0741708; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 识别为已批准行为变更，退回 PM existing-project-update，阻止实施计划、代码/测试和新的 E2E 预期，未执行修改。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5f81869b673853f146ffc9b6b0265765a906f1c4c8ed1c32a5df3f964238d63c; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=eb6b3d0609e61f182d4fc36276f6484dead8c32f21a19b976137a48208dcbe07; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly recognizes an approved-behavior change, routes it through PM existing-project-update and subsequent TRD alignment, blocks downstream planning/E2E work, and makes no implementation changes.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5f81869b673853f146ffc9b6b0265765a906f1c4c8ed1c32a5df3f964238d63c; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=c2788f05433c027f2cfe873a3f7a056834fec2875c4d21123d0ac4d09621a098; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 仅基于缺少源码说明无法定位，并提出直接定位过滤逻辑、修改测试等实施建议，未覆盖产品对齐门禁。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5f81869b673853f146ffc9b6b0265765a906f1c4c8ed1c32a5df3f964238d63c; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=acbf94d7b03102a51889d5393ce52cb2697276427d3cdaf4fea11ee6bd993206; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Provides a cautious baseline and avoids mutation, but does not route the request through the required PM existing-project-update/TRD process or explicitly block E2E expectations.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-006-small-bug-fix-plan-gate/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-006-small-bug-fix-plan-gate/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `189adddf12b53efb048e7c5d0b3605c9ce9d7f6b01023de7e418b715817c16f4` from `agents/engineer/test/feature-implementor/evals/workspace/eval-006-small-bug-fix-plan-gate`.
 - Identity schema: `2`
-- target_skill_sha256: `248d30c2e10162217ecb1d6a0d7c66973ee945c6f2e9b7e4bf01a677aac7bc3c`
+- target_skill_sha256: `7f71c78ab97a67d477751886a8f46d8cfd865bac113be49568de86ccf5343ee9`
 - eval_definition_sha256: `eedd6f2658d30fa0d35d3b4c542f62bf462bc6c1940c310dab2dd6d4429a52b7`
 - metadata_sha256: `9d3a5629af94d42622ece62116287a67a002c429ec1e53613daa3a8380937c03`
 - fixture_sha256: `189adddf12b53efb048e7c5d0b3605c9ce9d7f6b01023de7e418b715817c16f4`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `077d595387f9ef0925e654ba0704bfaf70b2ff427013d3059de96bcadac4157a`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `3ca6a3518bdc8bcc3b18e69a3a095ab08898901d1b98a9feaebe381c01e9564a`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `8002de5f5ec8cbba9c876b3fa5b95d04da373914039535f254ff8fce02f9cbab`
+- Skill overlay SHA-256: `6ba93c2da62bbbed9ea41d72d153901f8e8bbbbad20322168e3cf7c265e800fd`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,30 +33,29 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `treats_bug_fix_as_spec_backed` | PASS | 实施计划确认 PRD/TRD 与 archived 排除根因，并明确不要求 DECISIONS.md。 |
-| `writes_bug_fix_implementation_plan` | PASS | 已交付 docs/engineer/notifications/IMPLEMENTATION_PLAN.md，包含 src/api/notifications.ts、测试范围及验证安排。 |
-| `records_no_complex_split` | PASS | 计划明确这是 single-file、narrowly scoped hotfix，sub-agent split disabled。 |
-| `waits_before_fixing` | PASS | 计划状态为 Draft，明确等待用户确认后再修改，未声称已修复或验证通过。 |
-| `prepares_e2e_handoff_after_fix` | NOT_EXERCISED | 修复尚未获确认且尚未实施；计划仅记录后续 QA 门禁，因此修复后的 E2E 交接尚未到可执行阶段。 |
+| `treats_bug_fix_as_spec_backed` | PASS | 计划记录用户已确认 PRD/TRD 预期与根因，并在修改前请求确认。 |
+| `writes_bug_fix_implementation_plan` | PASS | 已交付 IMPLEMENTATION_PLAN.md，明确目标文件及通知 API 验证安排。 |
+| `records_no_complex_split` | PASS | 计划明确这是单文件 hotfix，禁用 implementation/validation split，同时保留实施计划要求。 |
+| `waits_before_fixing` | PASS | 候选输出明确要求确认精确计划，确认后才开始修改；没有声称已修复或验证。 |
+| `prepares_e2e_handoff_after_fix` | NOT_EXERCISED | 计划明确确认前阻止 QA E2E 创建或更新；修复后的 E2E 交接尚未到达可执行阶段。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3ca6a3518bdc8bcc3b18e69a3a095ab08898901d1b98a9feaebe381c01e9564a; fixture_sha256=189adddf12b53efb048e7c5d0b3605c9ce9d7f6b01023de7e418b715817c16f4; output_sha256=352995232ecd5864ace9e75ae9d34c783cc3775c99ebc0354ed43d598cc765d6; snapshot_sha256=6d5d9ed63808d8417fabbb0d93550c6d049e703261d0cb0c054ff649d1ef8843
-- Behavior: 生成了单文件实施计划，记录 spec 对齐、验证范围、无复杂分工，并等待确认后实施。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3ca6a3518bdc8bcc3b18e69a3a095ab08898901d1b98a9feaebe381c01e9564a; fixture_sha256=189adddf12b53efb048e7c5d0b3605c9ce9d7f6b01023de7e418b715817c16f4; output_sha256=01dce5c57b95fb34aaddb42021baa80e5417ddce8a190e338ba8dab744f0e15f; snapshot_sha256=f1186b0271051ee8d8cfba28e8240fb6e738393cadf907e9c972351a8f2a3838
+- Behavior: 生成了单文件实现计划，记录 spec-backed 根因、范围、验证与无复杂分工，并等待确认后修改。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3ca6a3518bdc8bcc3b18e69a3a095ab08898901d1b98a9feaebe381c01e9564a; fixture_sha256=189adddf12b53efb048e7c5d0b3605c9ce9d7f6b01023de7e418b715817c16f4; output_sha256=3ef06249c5b85fb98325037f989fcba14be32e40a024fb5449035f02a05080fe; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 仅确认修改范围并等待确认，未生成实施计划或记录验证与分工判断。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3ca6a3518bdc8bcc3b18e69a3a095ab08898901d1b98a9feaebe381c01e9564a; fixture_sha256=189adddf12b53efb048e7c5d0b3605c9ce9d7f6b01023de7e418b715817c16f4; output_sha256=773c452881944c93286c3e582ae9aadb65c46de527f6d698523acd013f283515; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 仅确认文档行为并等待继续，未生成实施计划。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: 确认 IMPLEMENTATION_PLAN.md
-- Next: 恢复源码与测试树后实施并运行验证
-- Next: 修复完成后准备包含对齐结论、计划、变更文件、验证命令和功能树目录的 QA E2E 交接
+- Next: 用户确认计划后恢复源码/测试上下文并实施修复。
+- Next: 修复并验证后准备完整 QA E2E 交接包。
 
 ## Runtime Artifact Policy
 

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-007-missing-nested-trd-handoff/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-007-missing-nested-trd-handoff/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `60bf457213c5027b1b635e439080d394ebbdbc0aadd1b41efc4678ffe172a846` from `agents/engineer/test/feature-implementor/evals/workspace/eval-007-missing-nested-trd-handoff`.
 - Identity schema: `2`
-- target_skill_sha256: `248d30c2e10162217ecb1d6a0d7c66973ee945c6f2e9b7e4bf01a677aac7bc3c`
+- target_skill_sha256: `7f71c78ab97a67d477751886a8f46d8cfd865bac113be49568de86ccf5343ee9`
 - eval_definition_sha256: `b5bb3aa99b72ccf5e21dcb20544d88f2d186af2b99e158d4fcf19d8c4d0e753d`
 - metadata_sha256: `c7ed4e1163db0ec41adb86dadf776481a42cb7d2fc1485d7e0d9d478acc3f8fa`
 - fixture_sha256: `60bf457213c5027b1b635e439080d394ebbdbc0aadd1b41efc4678ffe172a846`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `80868b5a1dbdaaeaae58f1b6f4c234d150c4534f0ca9af8c7d89fa4350b459f6`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `d732b4fc551c7ddc0d501adf12269e3428615ca56319eb8c1c10baf4e47a40bc`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `8002de5f5ec8cbba9c876b3fa5b95d04da373914039535f254ff8fce02f9cbab`
+- Skill overlay SHA-256: `6ba93c2da62bbbed9ea41d72d153901f8e8bbbbad20322168e3cf7c265e800fd`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,21 +33,21 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `detects_missing_mirrored_trd` | PASS | With-skill output explicitly names `docs/engineer/chat-interface/history-search/TRD.md` as missing. |
-| `hands_off_to_trd_gen_with_feature_path` | PASS | The gap packet names `engineer-agent:trd-gen` and includes `feature_path: chat-interface/history-search`, `parent_feature: chat-interface`, `feature_level: 2`, `prd_path`, and `trd_path`. |
-| `does_not_write_plan_or_code` | PASS | With-skill git status and diff are empty; delivery snapshot is empty. The output explicitly states that no implementation plan or code will be written. |
-| `keeps_pm_trd_boundary` | PASS | The output identifies a same-path TRD gap, routes completion to `engineer-agent:trd-gen`, and states that the finder only clarifies gaps rather than completing TRD decisions. |
+| `detects_missing_mirrored_trd` | PASS | With_skill output explicitly identifies the missing same-path file as `docs/engineer/chat-interface/history-search/TRD.md`. |
+| `hands_off_to_trd_gen_with_feature_path` | PASS | With_skill output names `engineer-agent:trd-gen` as receiving owner and provides `feature_path`, `parent_feature`, `feature_level`, `prd_path`, and `trd_path` in the checkpoint/gap handoff. |
+| `does_not_write_plan_or_code` | PASS | Locked with_skill delivery and git evidence show no files, code, tests, plans, commits, or worktree changes; output explicitly blocks those downstream actions. |
+| `keeps_pm_trd_boundary` | PASS | With_skill output states the gap returns to `engineer-agent:trd-gen`, includes the finder/receiver boundary, and says implementation must wait for the completed TRD and confirmed plan. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=d732b4fc551c7ddc0d501adf12269e3428615ca56319eb8c1c10baf4e47a40bc; fixture_sha256=60bf457213c5027b1b635e439080d394ebbdbc0aadd1b41efc4678ffe172a846; output_sha256=b62e4c357b949f0f35353f0cdce0208ed21a46e4fafe64c07a8ede52d5ffe1dd; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly stops at the missing same-path TRD, provides a structured handoff packet, and makes no workspace changes.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=d732b4fc551c7ddc0d501adf12269e3428615ca56319eb8c1c10baf4e47a40bc; fixture_sha256=60bf457213c5027b1b635e439080d394ebbdbc0aadd1b41efc4678ffe172a846; output_sha256=4afd8b7859b1b0631479f91f5133062c628f0f163a3f903d256592fb83811bb7; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly detects the missing mirrored TRD, hands off to trd-gen with nested feature metadata, preserves the implementation boundary, and makes no workspace changes.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=d732b4fc551c7ddc0d501adf12269e3428615ca56319eb8c1c10baf4e47a40bc; fixture_sha256=60bf457213c5027b1b635e439080d394ebbdbc0aadd1b41efc4678ffe172a846; output_sha256=d4f998ea379df7555a77cec334bd5d6a1d2f1f7f970595958c8a65d57a2130be; snapshot_sha256=c2548e28e93ab6c3731b4be728f93ececfc06d315907d2ed37b0230b67dd1a49
-- Behavior: Fresh baseline proceeded to implement code and tests despite the missing TRD, so it did not satisfy the intended boundary behavior.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=d732b4fc551c7ddc0d501adf12269e3428615ca56319eb8c1c10baf4e47a40bc; fixture_sha256=60bf457213c5027b1b635e439080d394ebbdbc0aadd1b41efc4678ffe172a846; output_sha256=9ef75b3b1eb8adeac3e6a6ae79bb724306b47cde4741b5313b16ea393d11dff9; snapshot_sha256=9c4d45ef7613c4455b50c15394c2dc46fdf3c29dcfb0e6ebf06c2a0c49b5b001
+- Behavior: Fresh baseline incorrectly implements the feature and creates untracked application files despite the missing TRD.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-008-feature-path-mismatch-blocked/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-008-feature-path-mismatch-blocked/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `fa61fddb39b3b74bc77db4e82386f7b1f9cd3a070d4333160570607ea9172a8d` from `agents/engineer/test/feature-implementor/evals/workspace/eval-008-feature-path-mismatch-blocked`.
 - Identity schema: `2`
-- target_skill_sha256: `248d30c2e10162217ecb1d6a0d7c66973ee945c6f2e9b7e4bf01a677aac7bc3c`
+- target_skill_sha256: `7f71c78ab97a67d477751886a8f46d8cfd865bac113be49568de86ccf5343ee9`
 - eval_definition_sha256: `66c4bea185008e1b43202328d058ecaa9e2ff572bdfe8be7d346a358d1c56597`
 - metadata_sha256: `3637d04d8249cc3160c7323824ff99be170433c4e4cefe242809dd4ea163d17e`
 - fixture_sha256: `fa61fddb39b3b74bc77db4e82386f7b1f9cd3a070d4333160570607ea9172a8d`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `33864756672d39ea5d3d054f279e52d6c05b6ece12eef5c3a61c53de61073a90`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `9ba9f5f01cabbae62ba3bf40c7c99d8dc7f337984c8ca4277c6f238b4df6793e`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `8002de5f5ec8cbba9c876b3fa5b95d04da373914039535f254ff8fce02f9cbab`
+- Skill overlay SHA-256: `6ba93c2da62bbbed9ea41d72d153901f8e8bbbbad20322168e3cf7c265e800fd`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,21 +33,21 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `detects_prd_trd_path_mismatch` | PASS | With_skill 明确记录 PRD feature_path 为 `chat-interface/history-search`，TRD feature_path 为 `chat-interface`，并判定二者不匹配。 |
-| `checks_related_prd` | PASS | With_skill 明确检查并指出 TRD related_prd 指向 `docs/pm/chat-interface/PRD.md`，而要求路径是 `docs/pm/chat-interface/history-search/PRD.md`，因此阻止继续规划。 |
-| `blocks_implementation_plan` | PASS | With_skill 输出阻止创建或更新实现计划、代码、测试及后续交付动作；锁定 git evidence 显示工作区无变更、无新文件。 |
-| `hands_off_to_trd_gen` | PASS | With_skill 明确将接收方交给 `engineer-agent:trd-gen`，要求修正或重写对应 History Search TRD。 |
+| `detects_prd_trd_path_mismatch` | PASS | with_skill 明确列出 PRD `feature_path` 为 `chat-interface/history-search`、TRD 为 `chat-interface`，并指出二者不一致。 |
+| `checks_related_prd` | PASS | with_skill 明确指出 TRD 的 `related_prd` 不匹配，实际 PRD 路径为 `docs/pm/chat-interface/history-search/PRD.md`，且说明对齐前不得生成计划或请求实现确认。 |
+| `blocks_implementation_plan` | PASS | with_skill 的 delivery_snapshot 为空、git status 无变更，且原始 trace 显示未创建计划、代码或测试文件，并明确禁止这些下游动作。 |
+| `hands_off_to_trd_gen` | PASS | with_skill 将 receiving_owner 指定为 `engineer-agent:trd-gen`，并要求修正 `docs/engineer/chat-interface/history-search/TRD.md` 的 TRD。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9ba9f5f01cabbae62ba3bf40c7c99d8dc7f337984c8ca4277c6f238b4df6793e; fixture_sha256=fa61fddb39b3b74bc77db4e82386f7b1f9cd3a070d4333160570607ea9172a8d; output_sha256=1ccf26cc4b5cc5da4b61333955a74e45130ab71bdf83a9f9cabf7a56a0d06d49; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 正确识别 PRD/TRD 路径及 related_prd 不一致，阻断实施规划并交回 trd-gen；锁定 git 证据确认未发生变更。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9ba9f5f01cabbae62ba3bf40c7c99d8dc7f337984c8ca4277c6f238b4df6793e; fixture_sha256=fa61fddb39b3b74bc77db4e82386f7b1f9cd3a070d4333160570607ea9172a8d; output_sha256=88f57cf1d3c3068105e94df9eebd9572ea64f7c1399ab7611720f0f38f545994; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 识别 PRD/TRD 路径及 related_prd 不一致，阻断实施并交回 trd-gen；未发生文件变更。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9ba9f5f01cabbae62ba3bf40c7c99d8dc7f337984c8ca4277c6f238b4df6793e; fixture_sha256=fa61fddb39b3b74bc77db4e82386f7b1f9cd3a070d4333160570607ea9172a8d; output_sha256=39635ceb16bbb2a9bb092f8c837d3830ff6a8f0f0de07cbad652a0ef044960ad; snapshot_sha256=9cc8a4288e41b22d01d421ea51981bad234049eeefe4dde159be54b27dbad8d1
-- Behavior: 直接实现功能并修改 TRD，未执行路径对齐阻断流程，作为 fresh baseline 对比。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9ba9f5f01cabbae62ba3bf40c7c99d8dc7f337984c8ca4277c6f238b4df6793e; fixture_sha256=fa61fddb39b3b74bc77db4e82386f7b1f9cd3a070d4333160570607ea9172a8d; output_sha256=14ceb7af6f7c73e38a62493c1f4e4622993ac8edf3d6b1e6d18990d5b2a1fc24; snapshot_sha256=1112ce3d43080287497534fd906c205a8c1eb616e80eefa7b28903bdda9b8409
+- Behavior: 未识别冲突，直接创建并交付了实现代码；仅作对比基线，不影响 with_skill 判定。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-009-ui-design-handoff-gate/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-009-ui-design-handoff-gate/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `e933472ac04a2cc28b54c89f863b1b89688bd67af1793cbac5f728cf5ae72984` from `agents/engineer/test/feature-implementor/evals/workspace/eval-009-ui-design-handoff-gate`.
 - Identity schema: `2`
-- target_skill_sha256: `248d30c2e10162217ecb1d6a0d7c66973ee945c6f2e9b7e4bf01a677aac7bc3c`
+- target_skill_sha256: `7f71c78ab97a67d477751886a8f46d8cfd865bac113be49568de86ccf5343ee9`
 - eval_definition_sha256: `a313159478f71f3c53034d04181e6cf7f6ee092241472cdee4c99fbe2b9042fc`
 - metadata_sha256: `934203517b057c510dea61fc1982f00dd960e2258de6c0fe54d8b56f8da847c3`
 - fixture_sha256: `e933472ac04a2cc28b54c89f863b1b89688bd67af1793cbac5f728cf5ae72984`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `2ecaa597e1be5d2c7100696a1bf5cce49ac2b021a5cc8ab7c690c99ac2883c0d`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `ddb6591b250157e73a35cd94cd577e9355400395f2d96425bab34fbb48bb56d6`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `8002de5f5ec8cbba9c876b3fa5b95d04da373914039535f254ff8fce02f9cbab`
+- Skill overlay SHA-256: `6ba93c2da62bbbed9ea41d72d153901f8e8bbbbad20322168e3cf7c265e800fd`
 - Behavior result: **FAIL**
 - Coverage result: **FULL**
 Overall result: FAIL
@@ -33,29 +33,29 @@ Overall result: FAIL
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `detects_ui_design_change` | PASS | with_skill 输出将信息层级与主按钮视觉样式列为 UI Design Handoff 决策。 |
-| `checks_design_docs` | PASS | with_skill 输出列出并标记两个指定设计文档缺失，并说明其需覆盖信息层级、区块顺序、主按钮样式及交互规范。 |
-| `blocks_plan_when_design_missing` | PASS | with_skill 输出明确不能创建 IMPLEMENTATION_PLAN.md；git_evidence 显示无文件变更。 |
-| `hands_off_to_designer` | FAIL | 输出指定 receiving_owner 为 designer-agent，但没有明确给出 engineer-agent -> designer-agent 的完整交接路径。 |
-| `preserves_plan_gate_after_design` | PASS | 输出说明设计补齐后继续创建实现计划并等待用户确认后再编码。 |
-| `does_not_implement_directly` | PASS | 输出未声称修改代码、运行测试或完成实现，并明确阻断 implementation 与代码/测试修改。 |
+| `detects_ui_design_change` | PASS | The with_skill output classifies the requested hierarchy and primary-button work as requiring design handoff, but does not explicitly use the phrase “UI Design Handoff Gate.” |
+| `checks_design_docs` | PASS | It explicitly checks and reports both required design files as missing: ui-ux-spec.md and visual-system.md. |
+| `blocks_plan_when_design_missing` | PASS | The output states that no implementation plan will be created before design documents are supplied; locked delivery and git evidence show no changes. |
+| `hands_off_to_designer` | FAIL | It returns the work to designer-agent and supplies a design-gap packet, but does not explicitly identify the source handoff as engineer-agent. |
+| `preserves_plan_gate_after_design` | PASS | It states that after design documents are completed, a complete implementation plan must be generated and user confirmation awaited before proceeding. |
+| `does_not_implement_directly` | PASS | It explicitly blocks implementation, and locked delivery/git evidence show no code, tests, or implementation changes. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=ddb6591b250157e73a35cd94cd577e9355400395f2d96425bab34fbb48bb56d6; fixture_sha256=e933472ac04a2cc28b54c89f863b1b89688bd67af1793cbac5f728cf5ae72984; output_sha256=b54bdf4d8e8729a2e51392d3b09c7a4189d0f20b09fbb29232855a3523fc2dcd; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 识别 UI 设计门禁，核查并列出缺失设计文档，阻止计划和实现，并保留设计后的计划确认门禁；但未明确写出完整的 engineer-agent -> designer-agent 路由。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=ddb6591b250157e73a35cd94cd577e9355400395f2d96425bab34fbb48bb56d6; fixture_sha256=e933472ac04a2cc28b54c89f863b1b89688bd67af1793cbac5f728cf5ae72984; output_sha256=6b58f143186b6b77dbcec9df414c15b15e93a51be5241a51f7898efc89ed72b4; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly detects the missing design gate, checks the required design documents, blocks planning and implementation, and preserves confirmation gating; handoff ownership is incomplete.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=ddb6591b250157e73a35cd94cd577e9355400395f2d96425bab34fbb48bb56d6; fixture_sha256=e933472ac04a2cc28b54c89f863b1b89688bd67af1793cbac5f728cf5ae72984; output_sha256=543758c6341ddba1d0602853772fe41b3eae30c0e8444d35859f934d755b7730; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 仅发现 workspace 缺少前端源码并停止，未识别设计门禁、检查指定设计文档或交接 Designer。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=ddb6591b250157e73a35cd94cd577e9355400395f2d96425bab34fbb48bb56d6; fixture_sha256=e933472ac04a2cc28b54c89f863b1b89688bd67af1793cbac5f728cf5ae72984; output_sha256=7a2cb1b41d69171e6dc2e042762b3a5dca7c3c885e4b5cd696821cd72acb7d97; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline only reports missing frontend source and asks for the source workspace; it does not address the design-gate workflow.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- with_skill 未明确呈现要求的 engineer-agent -> designer-agent handoff 路径。
-- Next: None.
+- The with_skill output does not explicitly establish the required engineer-agent -> designer-agent handoff path.
+- Next: Require the handoff result to explicitly state engineer-agent -> designer-agent.
 
 ## Runtime Artifact Policy
 

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-010-implementation-plan-closeout-sync/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-010-implementation-plan-closeout-sync/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `b472a02faf2f5e271bff5cfda7f77a99314d4a0e9e7388442ee7140ff824b071` from `agents/engineer/test/feature-implementor/evals/workspace/eval-010-implementation-plan-closeout-sync`.
 - Identity schema: `2`
-- target_skill_sha256: `248d30c2e10162217ecb1d6a0d7c66973ee945c6f2e9b7e4bf01a677aac7bc3c`
+- target_skill_sha256: `7f71c78ab97a67d477751886a8f46d8cfd865bac113be49568de86ccf5343ee9`
 - eval_definition_sha256: `20499e40a806229e21ef95ff8d5fbc24188637283192bc707a4d5fd2332a9e7d`
 - metadata_sha256: `7f70c1c0807f8ea0350d888ac519dda48aece1d015b63bda32f0f08b3e3eeb32`
 - fixture_sha256: `b472a02faf2f5e271bff5cfda7f77a99314d4a0e9e7388442ee7140ff824b071`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `fb8321bee2e5348476e997d826ae18ebe45fbbe3e17a6d49b5ba543f9a119c27`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `c3ffcc020a63823b1bc5160a6102e792071ef85d1d8fe0aee0513d9e308a0fbf`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `8002de5f5ec8cbba9c876b3fa5b95d04da373914039535f254ff8fce02f9cbab`
+- Skill overlay SHA-256: `6ba93c2da62bbbed9ea41d72d153901f8e8bbbbad20322168e3cf7c265e800fd`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,23 +33,23 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `detects_closeout_state_conflict` | PASS | The locked delivery snapshot explicitly identifies the prior `status: Implemented` versus body states awaiting confirmation/not started/evaluation awaiting confirmation as conflicting. |
-| `blocks_handoff_until_plan_updated` | PASS | The locked plan explicitly forbids QA handoff, delivery, PR creation, and issue closeout until confirmation. |
-| `requires_implementation_result_update` | PASS | The locked plan records status, missing implementation files, checks, residual risk, and next owner in its closeout section. |
-| `records_deterministic_checks` | PASS | The locked plan records checks run and checks not run, including blocked reasons; the trace also shows `git diff --check` passed. |
-| `records_eval_evidence` | PASS | The locked plan states model evaluation was not run and remains blocked, without claiming eval success or citing nonexistent evidence. |
-| `keeps_runtime_artifacts_out_of_git` | PASS | The locked plan explicitly states no transcripts, diagnostics, outputs, timing, run-status files, or `comparison.auto.md` were added. |
+| `detects_closeout_state_conflict` | PASS | The locked plan states that the prior body incorrectly retained `待用户确认`, `未开始`, and `待确认` after frontmatter was `status: Implemented`, explicitly identifying and resolving the conflict. |
+| `blocks_handoff_until_plan_updated` | PASS | The locked plan forbids QA handoff, delivery, PR, and issue-closeout actions, and says any later QA handoff requires the restored source and deterministic results. |
+| `requires_implementation_result_update` | PASS | The locked plan contains Scope, Result, Verification, Runtime artifacts, Next owner, and Self-review sections recording completed scope, changed files, validation, residual risks, and next steps. |
+| `records_deterministic_checks` | PASS | The locked plan records executed checks and outcomes: `git diff --no-ext-diff --check` PASS; source checks BLOCKED because files are absent; status INCONCLUSIVE; build and focused tests explicitly not run. |
+| `records_eval_evidence` | PASS | The locked plan states no model-evaluation command could be run, no durable eval comparison artifact exists, and independent validation was not run; it makes no claim that model eval passed. |
+| `keeps_runtime_artifacts_out_of_git` | PASS | The locked plan explicitly forbids runtime artifacts and records that transcripts, diagnostics, outputs, timing data, run-status files, and `comparison.auto.md` were not added to Git. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c3ffcc020a63823b1bc5160a6102e792071ef85d1d8fe0aee0513d9e308a0fbf; fixture_sha256=b472a02faf2f5e271bff5cfda7f77a99314d4a0e9e7388442ee7140ff824b071; output_sha256=25e2a3fef6f846461e4a97a3c9cb54b66a572e90450ac31c1a8ecc5bb7de5248; snapshot_sha256=e0c607bcee0bb974e3445c047b1f2a9449b74f3f6e4f99de9046a4af0679e9be
-- Behavior: Detected the closeout conflict, changed the plan to Blocked, documented implementation and verification evidence, blocked handoff, and preserved runtime-artifact boundaries.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c3ffcc020a63823b1bc5160a6102e792071ef85d1d8fe0aee0513d9e308a0fbf; fixture_sha256=b472a02faf2f5e271bff5cfda7f77a99314d4a0e9e7388442ee7140ff824b071; output_sha256=f761a43975c9158b0ce14835b856fe4429d743705e915b83358d531bdd2ff1cf; snapshot_sha256=3d7e9895822ef834b2a07b32cd7cfc50048555ba22965faa6ff5bb5296a1d1b7
+- Behavior: Detected the Implemented-versus-body conflict, updated the implementation plan with closeout evidence, blocked downstream handoff pending restored source and verification, and accurately recorded blocked or unrun checks and eval status.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c3ffcc020a63823b1bc5160a6102e792071ef85d1d8fe0aee0513d9e308a0fbf; fixture_sha256=b472a02faf2f5e271bff5cfda7f77a99314d4a0e9e7388442ee7140ff824b071; output_sha256=c9f3bc3f0bc4231990afb16e3028859c694982f3d86470394d7f55909f7f8f8e; snapshot_sha256=3ce35151158f64dc38efc8c622db595a1dad6843b69276c60ccb3394ef952922
-- Behavior: Correctly recognized the missing implementation and changed the plan to Blocked, but did not explicitly document the status/body conflict, handoff prohibitions, detailed closeout evidence, or runtime-artifact policy.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c3ffcc020a63823b1bc5160a6102e792071ef85d1d8fe0aee0513d9e308a0fbf; fixture_sha256=b472a02faf2f5e271bff5cfda7f77a99314d4a0e9e7388442ee7140ff824b071; output_sha256=a9335b23814614f63a7c4e64faea8a27b4d1bc157684424dc6aa5e60525c7d6a; snapshot_sha256=4061534c546582d56ddf0d3c7a2e2d1da5fee9f4ec373715a5d9d0990bbdc331
+- Behavior: Fresh baseline claimed implementation completion, added `src/settings.ts`, marked all gates complete, and reported checks as passed without the required conflict handling, blocked-state evidence, eval accounting, or runtime-artifact guardrails.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-011-four-level-feature-path-plan-gate/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-011-four-level-feature-path-plan-gate/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `6c438d1edc9a89256655ae36e972b31a4929ddc7fe5b5f285e888975f24e8b68` from `agents/engineer/test/feature-implementor/evals/workspace/eval-011-four-level-feature-path-plan-gate`.
 - Identity schema: `2`
-- target_skill_sha256: `248d30c2e10162217ecb1d6a0d7c66973ee945c6f2e9b7e4bf01a677aac7bc3c`
+- target_skill_sha256: `7f71c78ab97a67d477751886a8f46d8cfd865bac113be49568de86ccf5343ee9`
 - eval_definition_sha256: `7d6cafded24992611b95dfc908abe3d7611f7857dadb745152c30089566b43d2`
 - metadata_sha256: `ac8b5e53299c534a911d5f2d7efc803c4248334958692a33c9f721328ee2c632`
 - fixture_sha256: `6c438d1edc9a89256655ae36e972b31a4929ddc7fe5b5f285e888975f24e8b68`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `daa05dfde11fd09221d4ad9b38d9b74b58a7b93050ec83c55293e7ca9eae6a7e`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `e0c7bd09477fcc6f52d75011fdf516c41f01082c930d49e3864459c1ec60e40b`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `8002de5f5ec8cbba9c876b3fa5b95d04da373914039535f254ff8fce02f9cbab`
+- Skill overlay SHA-256: `6ba93c2da62bbbed9ea41d72d153901f8e8bbbbad20322168e3cf7c265e800fd`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,23 +33,23 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `reads_matching_four_level_docs` | PASS | 计划文件和运行轨迹直接引用并读取 PRD/TRD 路径，并确认二者 feature_path 为 chat-interface/messages/history/search。 |
-| `writes_four_level_plan_path` | PASS | delivery_snapshot 直接包含 docs/engineer/chat-interface/messages/history/search/IMPLEMENTATION_PLAN.md，且 git evidence 显示仅该计划文件新增。 |
-| `preserves_feature_metadata` | PASS | 计划 frontmatter 直接包含 feature_path、parent_feature、feature_level、related_prd 和 related_trd。 |
-| `includes_scope_and_checks` | PASS | 计划直接列出两个相关源码/测试文件、workspace 隔离与排序范围，以及 npm test -- tests/chat-interface/messages/history/search-service.test.ts 验证命令。 |
-| `waits_for_user_confirmation` | PASS | 最终输出明确要求用户确认实施计划，确认后才开始编码。 |
-| `does_not_implement_directly` | PASS | locked delivery_snapshot 仅新增 IMPLEMENTATION_PLAN.md；git evidence 无源码或测试修改，最终输出也明确编码尚未开始。 |
+| `reads_matching_four_level_docs` | PASS | Locked plan and trace reference both PRD/TRD paths and confirm matching feature_path metadata. |
+| `writes_four_level_plan_path` | PASS | Delivery snapshot contains docs/engineer/chat-interface/messages/history/search/IMPLEMENTATION_PLAN.md; no forbidden path is present. |
+| `preserves_feature_metadata` | PASS | Plan frontmatter contains feature_path, parent_feature, feature_level, related_prd, and related_trd. |
+| `includes_scope_and_checks` | PASS | Plan snapshot lists implementation scope and the deterministic npm test command relevant to message history search. |
+| `waits_for_user_confirmation` | PASS | Final output explicitly requests confirmation before coding, and the plan confirmation gate blocks source/test edits until confirmation. |
+| `does_not_implement_directly` | PASS | Locked git evidence shows only the implementation plan was added; no source or test implementation occurred, and the candidate states coding is blocked pending confirmation. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=e0c7bd09477fcc6f52d75011fdf516c41f01082c930d49e3864459c1ec60e40b; fixture_sha256=6c438d1edc9a89256655ae36e972b31a4929ddc7fe5b5f285e888975f24e8b68; output_sha256=bb4b28dc6fb5cf49654d254683236b67b0a5777c067c6392ea793265500cdeee; snapshot_sha256=9e779ed498b55a0851ec059c5bf19d305c7544cbf037944d7db41fc23da52dfa
-- Behavior: 读取并对齐 PRD/TRD，创建包含完整元数据、范围和验证命令的四级实施计划，并等待用户确认；未直接实施。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=e0c7bd09477fcc6f52d75011fdf516c41f01082c930d49e3864459c1ec60e40b; fixture_sha256=6c438d1edc9a89256655ae36e972b31a4929ddc7fe5b5f285e888975f24e8b68; output_sha256=a462289f1cbc608dcb8ef34afe44bbf7f8342e41b4a48b1335b7f969dc7c4676; snapshot_sha256=ffb8c49f0c5d61c315b481e0e570190c846cdb41d0b638030de14d177acac9bf
+- Behavior: Created the correctly nested implementation plan, preserved feature metadata, documented scope and deterministic validation, and paused for explicit confirmation before implementation.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=e0c7bd09477fcc6f52d75011fdf516c41f01082c930d49e3864459c1ec60e40b; fixture_sha256=6c438d1edc9a89256655ae36e972b31a4929ddc7fe5b5f285e888975f24e8b68; output_sha256=0e8c697d1b680ea855f1c958a8ce4ce148428cac5ee7b1764c2a49a7aa4a0ef5; snapshot_sha256=873509ee342c4feaa8f57ad29dd6570c19a593223d07cbf677d5b02162416ef6
-- Behavior: 直接实现消息历史搜索并修改源码和测试；未按规划确认流程交付。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=e0c7bd09477fcc6f52d75011fdf516c41f01082c930d49e3864459c1ec60e40b; fixture_sha256=6c438d1edc9a89256655ae36e972b31a4929ddc7fe5b5f285e888975f24e8b68; output_sha256=5eef77b86ac76c9e19023bbc065fbc15a22396d9df178d332b2b152c3f995a39; snapshot_sha256=44880f93d3b1d4c8e6b1a03051f17e9d94494ff92a6c5dcd2dd9693089f8ea85
+- Behavior: Implemented source and tests directly without the required planning checkpoint or confirmation.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-012-implementation-plan-archive-preflight/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-012-implementation-plan-archive-preflight/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `681e197eb0a978ca201707a3d3b58dd8ed78255de8e5033ca94ef611ea90807e` from `agents/engineer/test/feature-implementor/evals/workspace/eval-012-implementation-plan-archive-preflight`.
 - Identity schema: `2`
-- target_skill_sha256: `248d30c2e10162217ecb1d6a0d7c66973ee945c6f2e9b7e4bf01a677aac7bc3c`
+- target_skill_sha256: `7f71c78ab97a67d477751886a8f46d8cfd865bac113be49568de86ccf5343ee9`
 - eval_definition_sha256: `7f61bff44513e544647aa068492b4fc39b7ba0f0b8a502c36472dbc74575e45e`
 - metadata_sha256: `d61de6289d375a4f846be423a72cc4b82b03d964cc2e5dac6f44d3f3c1fe9492`
 - fixture_sha256: `681e197eb0a978ca201707a3d3b58dd8ed78255de8e5033ca94ef611ea90807e`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `097d311377d0abb4f2fcb1bfa46de1df83e6feccaa7b6f38bb1fb185a5118ab5`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `9c7650cd9313e12223d2a68ebc3c37905ca839128cbb6b36d20fc7541af57b74`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `8002de5f5ec8cbba9c876b3fa5b95d04da373914039535f254ff8fce02f9cbab`
+- Skill overlay SHA-256: `6ba93c2da62bbbed9ea41d72d153901f8e8bbbbad20322168e3cf7c265e800fd`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,28 +33,28 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `runs_pre_plan_archive_scan` | PASS | runner_captured_trace shows the active plan was read and the archive directory was explicitly scanned before the checkpoint; the checkpoint records both paths and archive state. |
-| `blocks_direct_overwrite` | PASS | The with_skill output explicitly blocks overwriting/replacing the active plan and creating a new plan, with no delivered file changes. |
-| `offers_implemented_handling_options` | PASS | The output requests a choice between archiving then creating a new plan, or archiving as Superseded with a reason then creating one; it offers no Implemented-status update option. |
-| `keeps_active_entry_fixed` | PASS | The output states the active entry remains docs/engineer/payment-refund/IMPLEMENTATION_PLAN.md and archives belong only under archive/. |
-| `does_not_implement_directly` | PASS | The output describes a blocked planning checkpoint and pending actions, without claiming code changes, implementation, or verification. |
+| `runs_pre_plan_archive_scan` | PASS | with_skill 的锁定 trace 显示先读取活跃计划并检查归档目录状态，之后才执行后续操作；输出也列出两者路径及归档状态。 |
+| `blocks_direct_overwrite` | PASS | with_skill 输出明确将决策标记为 blocked_pending_archive_choice，并要求确认；trace 中未发生新计划写入或代码变更。 |
+| `offers_implemented_handling_options` | PASS | 输出要求用户在归档后新建与以 Superseded 归档并记录原因后新建两项中选择，未提供继续更新 Implemented 计划的选项。 |
+| `keeps_active_entry_fixed` | PASS | 输出明确固定 active_plan_path 为 docs/engineer/payment-refund/IMPLEMENTATION_PLAN.md，并规定归档目录为 archive/。 |
+| `does_not_implement_directly` | PASS | with_skill 输出停留在计划确认前，明确后续实现待确认，未声称修改代码、运行实现或完成验证。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9c7650cd9313e12223d2a68ebc3c37905ca839128cbb6b36d20fc7541af57b74; fixture_sha256=681e197eb0a978ca201707a3d3b58dd8ed78255de8e5033ca94ef611ea90807e; output_sha256=263a9d0a2efd3600356ba260fd08b228ea2d9567e4a15a2a36725358ca6c54ce; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Performed the required pre-plan scan, preserved the active plan, presented the two required archive choices, and stopped pending confirmation.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9c7650cd9313e12223d2a68ebc3c37905ca839128cbb6b36d20fc7541af57b74; fixture_sha256=681e197eb0a978ca201707a3d3b58dd8ed78255de8e5033ca94ef611ea90807e; output_sha256=25427d686f42e683c2d75f477da0c181b33c6a56f8e1f228079cfc3cf471376d; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 完成前置扫描与状态判断，阻止未经确认的计划写入，并提供两种合规归档处理选项。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9c7650cd9313e12223d2a68ebc3c37905ca839128cbb6b36d20fc7541af57b74; fixture_sha256=681e197eb0a978ca201707a3d3b58dd8ed78255de8e5033ca94ef611ea90807e; output_sha256=074906397966e9b87d018ae9f657e2f030c7ce2967c0be3dc37dd5efb3547a11; snapshot_sha256=f749552a23359edd6c8d244fd709b2924cdf85c8ac22aa6a34752466adbd9ae9
-- Behavior: Directly overwrote the active plan, created an archive and replacement plan, and claimed completion and verification.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9c7650cd9313e12223d2a68ebc3c37905ca839128cbb6b36d20fc7541af57b74; fixture_sha256=681e197eb0a978ca201707a3d3b58dd8ed78255de8e5033ca94ef611ea90807e; output_sha256=52834bba7edf10e9e8522190b7ab41c83d7187d13c0293647b905654fe1f5c00; snapshot_sha256=3997b14c0bdd8c8bb2d05b509f3a31fc5f15519f901f2feea029530a8bd720eb
+- Behavior: 基线直接归档并覆盖活跃计划，未等待用户选择。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: User must select one of the two archive-handling options before any plan or implementation changes proceed.
+- Next: None.
 
 ## Runtime Artifact Policy
 

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-013-implementation-plan-archive-allows-next-plan/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-013-implementation-plan-archive-allows-next-plan/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `4ef8c6418e526050652f1a037736acaff4cffdb17b27acf4e8f94adbd8c3be96` from `agents/engineer/test/feature-implementor/evals/workspace/eval-013-implementation-plan-archive-allows-next-plan`.
 - Identity schema: `2`
-- target_skill_sha256: `248d30c2e10162217ecb1d6a0d7c66973ee945c6f2e9b7e4bf01a677aac7bc3c`
+- target_skill_sha256: `7f71c78ab97a67d477751886a8f46d8cfd865bac113be49568de86ccf5343ee9`
 - eval_definition_sha256: `e7ce63b1af29ecd94dfeb7909e7f066642dfdd9e9e7c1c834d32f01202820dcf`
 - metadata_sha256: `126a2db171ef57efac6a8c26a7d508c9646b5e72099470e6d4ba41325678a04b`
 - fixture_sha256: `4ef8c6418e526050652f1a037736acaff4cffdb17b27acf4e8f94adbd8c3be96`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `92c95ee84208d5ddf7a774382e98fb939786b7da025643fcac881491d89921d5`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `fead462ed6258e1fbe13bf1caae06939d2877c023c15076e0ceb2b67cbc05022`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `8002de5f5ec8cbba9c876b3fa5b95d04da373914039535f254ff8fce02f9cbab`
+- Skill overlay SHA-256: `6ba93c2da62bbbed9ea41d72d153901f8e8bbbbad20322168e3cf7c265e800fd`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,22 +33,22 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `detects_prior_plan_archived` | PASS | 归档计划文件和路径在锁定计划及原始检查证据中明确可见，且原始检查显示没有 active plan。 |
-| `allows_new_active_plan` | PASS | 锁定 delivery_snapshot 已创建部分退款范围的 docs/engineer/payment-refund/IMPLEMENTATION_PLAN.md。 |
-| `records_previous_plan_archive` | PASS | 锁定计划 frontmatter 明确包含 previous_plan_archive，且指向指定归档路径。 |
-| `keeps_active_entry_fixed` | PASS | 锁定计划位于固定 active entry 路径，且归档引用仍位于 archive 目录；未写入归档目录。 |
-| `waits_for_user_confirmation` | PASS | 候选输出明确要求确认精确计划后再实现，并声明确认前不会修改代码或测试；git evidence 也显示无代码修改。 |
+| `detects_prior_plan_archived` | PASS | with_skill 输出明确说明已存在 full-refund-flow 归档，并通过 archive_state 指向该归档路径。 |
+| `allows_new_active_plan` | PASS | with_skill 已写入 payment-refund 的 IMPLEMENTATION_PLAN.md，并将范围设为 partial-refund-flow。 |
+| `records_previous_plan_archive` | PASS | delivery_snapshot 中新计划 frontmatter 直接包含 previous_plan_archive，且值为指定归档路径。 |
+| `keeps_active_entry_fixed` | PASS | checkpoint 明确声明活跃入口固定为 docs/engineer/payment-refund/IMPLEMENTATION_PLAN.md，归档仅放入 archive/。 |
+| `waits_for_user_confirmation` | PASS | 输出设置 confirmation_required: true，并明确要求确认计划后才开始编码；原始证据仅显示新增计划文件，没有代码修改。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=fead462ed6258e1fbe13bf1caae06939d2877c023c15076e0ceb2b67cbc05022; fixture_sha256=4ef8c6418e526050652f1a037736acaff4cffdb17b27acf4e8f94adbd8c3be96; output_sha256=67608e73e754a9a8d2c9c81bc9f08dc4423c2f58eea7e2bea367911737dfd6b7; snapshot_sha256=647a1ab2717c8f085b246aa1f80a3033c452c102923fd3092acfa98b09c8a1d1
-- Behavior: 识别无 active plan 且旧计划已归档，创建了带归档回链的固定路径部分退款计划，并在确认前阻止编码。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=fead462ed6258e1fbe13bf1caae06939d2877c023c15076e0ceb2b67cbc05022; fixture_sha256=4ef8c6418e526050652f1a037736acaff4cffdb17b27acf4e8f94adbd8c3be96; output_sha256=ca93db8941782028dcbf676b061f850d665d3e21dd2af96496f2dcd8115b0488; snapshot_sha256=fb78ecb4e7eb606e7c95d1de7668fdbab1130d14512d6ee5c98c6e520f2a64f3
+- Behavior: 正确识别既有归档，创建并交付新的部分退款活跃计划，记录归档回链并在编码前等待用户确认。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=fead462ed6258e1fbe13bf1caae06939d2877c023c15076e0ceb2b67cbc05022; fixture_sha256=4ef8c6418e526050652f1a037736acaff4cffdb17b27acf4e8f94adbd8c3be96; output_sha256=ec7782a01482f3fce6eaa2627e77b35b45604bb03e19ff65cc1758c2de9c20a1; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 仅概括确认旧计划已归档并询问下一步，未创建计划或提供归档回链和确认门禁。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=fead462ed6258e1fbe13bf1caae06939d2877c023c15076e0ceb2b67cbc05022; fixture_sha256=4ef8c6418e526050652f1a037736acaff4cffdb17b27acf4e8f94adbd8c3be96; output_sha256=b8e52aa398000f5c74a0e459b316e57cff2b13eda2fca234d16e89a39c746318; snapshot_sha256=46282f65f20e0501ade69d239cc285f5876ea3ae6a9976c2dd1b94bd167bd50a
+- Behavior: 创建了活跃计划并覆盖部分退款范围，但未呈现归档回链、固定入口规则或用户确认门禁。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-014-mapped-session-plan-evidence/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-014-mapped-session-plan-evidence/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `ebf98490e96d51646bb08c2897d26dd073cad98267ddc69d86f17d77581f2927` from `agents/engineer/test/feature-implementor/evals/workspace/eval-014-mapped-session-plan-evidence`.
 - Identity schema: `2`
-- target_skill_sha256: `248d30c2e10162217ecb1d6a0d7c66973ee945c6f2e9b7e4bf01a677aac7bc3c`
+- target_skill_sha256: `7f71c78ab97a67d477751886a8f46d8cfd865bac113be49568de86ccf5343ee9`
 - eval_definition_sha256: `51a5d5a4f671b1df617b81a97fb84c601259cd9a8d3901d74d7d41b70d44d966`
 - metadata_sha256: `8f8181a8b5f8f92c423cfb8a15a35438fa3fefe0e74f7a7daf711ceaa3d79ccb`
 - fixture_sha256: `ebf98490e96d51646bb08c2897d26dd073cad98267ddc69d86f17d77581f2927`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `2f129ddb28e1f1e80d9edd6a2ff9482f3bf6168c9099228d14be2ebcaee2b61a`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `8002de5f5ec8cbba9c876b3fa5b95d04da373914039535f254ff8fce02f9cbab`
+- Skill overlay SHA-256: `6ba93c2da62bbbed9ea41d72d153901f8e8bbbbad20322168e3cf7c265e800fd`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `reads_mapped_docs_first` | PASS | Trace shows `change-map.yaml` was read first, then the mapped `docs/site/api/session.md`; no unrelated document contents were traversed. |
-| `verifies_against_code` | PASS | The candidate verified `src/session/config.txt` as 30 minutes with renewal disabled, contrasted it with the document's 60 minutes, and included the discrepancy and impact in the planning gap packet. |
-| `treats_unverified_as_low_trust` | PASS | The candidate explicitly treated `last_verified_version: unverified` as low trust and based the timeout and implementation-scope conclusions on source/config evidence. |
+| `reads_mapped_docs_first` | PASS | Trace reads the change map, then the mapped session API document, while limiting later searches to planning/handoff paths rather than traversing all repository documentation. |
+| `verifies_against_code` | PASS | The trace and final checkpoint verify `src/session/config.txt` as 30 minutes, identify the document's 60-minute claim, and include the discrepancy and its impact in the planning gap packet. |
+| `treats_unverified_as_low_trust` | PASS | The candidate explicitly treats `last_verified_version: unverified` as low trust and bases the timeout and renewal findings on `src/session/config.txt`, with missing product/technical evidence recorded as blockers. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2f129ddb28e1f1e80d9edd6a2ff9482f3bf6168c9099228d14be2ebcaee2b61a; fixture_sha256=ebf98490e96d51646bb08c2897d26dd073cad98267ddc69d86f17d77581f2927; output_sha256=e34e01d9cb86cf8020dedce15ab12cf91951e1a8a6f6f6d95f3e032f0de79d2c; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly verified the mapped documentation and source configuration, identified the 30/60-minute conflict, treated the document as unverified, and paused implementation pending required PM/TRD alignment.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2f129ddb28e1f1e80d9edd6a2ff9482f3bf6168c9099228d14be2ebcaee2b61a; fixture_sha256=ebf98490e96d51646bb08c2897d26dd073cad98267ddc69d86f17d77581f2927; output_sha256=9a9874b6aa5ff8654a867bb6ea06184129638eef1b634140048a5492aedfa32c; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Performed the required evidence-first verification, preserved the 30-minute code fact over the unverified 60-minute document claim, and stopped before unauthorized implementation.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2f129ddb28e1f1e80d9edd6a2ff9482f3bf6168c9099228d14be2ebcaee2b61a; fixture_sha256=ebf98490e96d51646bb08c2897d26dd073cad98267ddc69d86f17d77581f2927; output_sha256=b12bd76f3312f3a20a7e432de5f5cd01f5edb20240a7406560863e64ddfe6553; snapshot_sha256=c55217dec081c363b8be6868094f3dbf54bd0d1ce7d2182dbf54d3e4ec828a40
-- Behavior: Implemented renewal configuration and rewrote the documentation without demonstrating the required mapped-document-first workflow or low-trust handling.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2f129ddb28e1f1e80d9edd6a2ff9482f3bf6168c9099228d14be2ebcaee2b61a; fixture_sha256=ebf98490e96d51646bb08c2897d26dd073cad98267ddc69d86f17d77581f2927; output_sha256=2def109d70256be885ba226cf876f3bc75a35e2fba504c3dd63f0e3b29c13f10; snapshot_sha256=52140ac2506772fb2c7ac52f1967ab1be9b65b8887e800151674a70a8c956e03
+- Behavior: Fresh baseline modified configuration and documentation directly after a less disciplined exploration, without the required planning gate.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-015-implemented-status-detected-from-fixture/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-015-implemented-status-detected-from-fixture/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `081f99f1748dae6b1e4b0b232ec7c1df3a484b0c63d868321dc8a1e16a817449` from `agents/engineer/test/feature-implementor/evals/workspace/eval-015-implemented-status-detected-from-fixture`.
 - Identity schema: `2`
-- target_skill_sha256: `248d30c2e10162217ecb1d6a0d7c66973ee945c6f2e9b7e4bf01a677aac7bc3c`
+- target_skill_sha256: `7f71c78ab97a67d477751886a8f46d8cfd865bac113be49568de86ccf5343ee9`
 - eval_definition_sha256: `b2cb611a2eb526b32fe7d8233b7af41b5dc9690189d7d476ddf33384f3fb4855`
 - metadata_sha256: `39210ac265fe88589594065b6c755af4654b2b81bea8b394e31134719f9b4a6f`
 - fixture_sha256: `081f99f1748dae6b1e4b0b232ec7c1df3a484b0c63d868321dc8a1e16a817449`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `923a1c7b31287566dcbc7acd5bf79481560908bbcc5207920a4090de9501eef3`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `94992d68c84f843faca4d58c6bb2c604bfcff22e23ecd95ba7c0c306fd36011b`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `8002de5f5ec8cbba9c876b3fa5b95d04da373914039535f254ff8fce02f9cbab`
+- Skill overlay SHA-256: `6ba93c2da62bbbed9ea41d72d153901f8e8bbbbad20322168e3cf7c265e800fd`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,28 +33,28 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `reads_active_plan_frontmatter` | PASS | 输出与锁定 trace 均显示读取并检查了 IMPLEMENTATION_PLAN.md；其 frontmatter 明确包含 status 和 implementation_scope。 |
-| `detects_implemented_status` | PASS | 明确输出 active_plan_path、active_plan_status: Implemented，以及 active_plan_scope_before: full-refund-flow。 |
-| `blocks_direct_overwrite` | PASS | 明确声明不得覆盖现有 Implemented plan、不得创建或更新实现计划，并在用户确认前阻塞；git evidence 显示无变更。 |
-| `offers_implemented_handling_options` | PASS | 明确要求二选一：归档完成计划后创建新的 active plan，或以 Superseded 归档并提供 superseded_reason 后创建新的 active plan；未提供继续更新当前计划的选项。 |
-| `does_not_implement_code` | PASS | 锁定 delivery_snapshot 为空且 git evidence 显示无代码、测试或其他工作区变更；输出明确列出不得修改代码或测试。 |
+| `reads_active_plan_frontmatter` | PASS | With-skill trace shows direct reading of IMPLEMENTATION_PLAN.md, and the output reports its active-plan fields. |
+| `detects_implemented_status` | PASS | Output explicitly identifies status Implemented, path docs/engineer/payment-refund/IMPLEMENTATION_PLAN.md, and implementation_scope full-refund-flow. |
+| `blocks_direct_overwrite` | PASS | Output states the completed plan cannot be directly overwritten and coding is blocked pending the archive decision; git evidence shows no changes. |
+| `offers_implemented_handling_options` | PASS | Output requires choosing either archiving then creating a new plan or archiving as Superseded with a reason then creating a new plan, with no continue-updating option. |
+| `does_not_implement_code` | PASS | Output states code and test changes are blocked, and locked git evidence shows no mutations or delivery files. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=94992d68c84f843faca4d58c6bb2c604bfcff22e23ecd95ba7c0c306fd36011b; fixture_sha256=081f99f1748dae6b1e4b0b232ec7c1df3a484b0c63d868321dc8a1e16a817449; output_sha256=3fbb6b4ac9c0c1d03d0e995019b32f48fb32a325bdcf1cb71268888b84f2c821; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 读取并识别了已 Implemented 的 active plan，保留原始 implementation_scope，阻止覆盖并等待归档处理决定；未实施代码。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=94992d68c84f843faca4d58c6bb2c604bfcff22e23ecd95ba7c0c306fd36011b; fixture_sha256=081f99f1748dae6b1e4b0b232ec7c1df3a484b0c63d868321dc8a1e16a817449; output_sha256=c39e77ebad543b94ca765dd4bd454bc1848c5133fb041ab0471e7117ca3af09e; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Reads and recognizes the Implemented active plan, blocks implementation pending an archive decision, and presents the two required handling choices without modifying files.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=94992d68c84f843faca4d58c6bb2c604bfcff22e23ecd95ba7c0c306fd36011b; fixture_sha256=081f99f1748dae6b1e4b0b232ec7c1df3a484b0c63d868321dc8a1e16a817449; output_sha256=a1f5e65cbf137e05fa134700115b0104655f8c99d11819111d37167bf55a6207; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 仅根据 PRD/TRD 概述下一轮更新并请求用户选择工作类型，未识别或处理已完成的 active plan。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=94992d68c84f843faca4d58c6bb2c604bfcff22e23ecd95ba7c0c306fd36011b; fixture_sha256=081f99f1748dae6b1e4b0b232ec7c1df3a484b0c63d868321dc8a1e16a817449; output_sha256=1b0a206ef95c70f061d7e44f09feda61c54ab7d51e9630f1afd76414e35d5292; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Provides a fresh baseline focused on PRD/TRD ambiguity and implementation choices, without surfacing the completed active plan or archive gate.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: None.
+- Next: Await the user’s choice of archive handling before creating or updating an active plan.
 
 ## Runtime Artifact Policy
 

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-016-draft-status-continues-current-plan/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-016-draft-status-continues-current-plan/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `20e27cdb155a076474a45e3e1e88d991a8bc4e1c3723a56f9fad5436bddd121e` from `agents/engineer/test/feature-implementor/evals/workspace/eval-016-draft-status-continues-current-plan`.
 - Identity schema: `2`
-- target_skill_sha256: `248d30c2e10162217ecb1d6a0d7c66973ee945c6f2e9b7e4bf01a677aac7bc3c`
+- target_skill_sha256: `7f71c78ab97a67d477751886a8f46d8cfd865bac113be49568de86ccf5343ee9`
 - eval_definition_sha256: `86c8e37f3b454c4b68e8a8e0d79eed844e522098807d679c66512f9c18daf3b3`
 - metadata_sha256: `3bc63ed149187babfd14f12368fe4751cd28174e21577ac852ef1bccf705a7f0`
 - fixture_sha256: `20e27cdb155a076474a45e3e1e88d991a8bc4e1c3723a56f9fad5436bddd121e`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `b61097c2327e4512b0954be7440f9efb0288869d119e12aff21af89d2a1a48fa`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `b545dbdf7b14573cc5aa0b9db7a4defefe66a311f4d3b98d9f23cd367fdfa1aa`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `8002de5f5ec8cbba9c876b3fa5b95d04da373914039535f254ff8fce02f9cbab`
+- Skill overlay SHA-256: `6ba93c2da62bbbed9ea41d72d153901f8e8bbbbad20322168e3cf7c265e800fd`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,23 +33,23 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `reads_active_plan_frontmatter` | PASS | Raw trace shows the candidate read docs/engineer/payment-refund/IMPLEMENTATION_PLAN.md before updating it; the delivered snapshot preserves its frontmatter. |
-| `detects_non_implemented_status` | PASS | The delivered plan frontmatter has status: "Draft", and its closeout states that status remains Draft pending implementation and verification. |
-| `continues_current_plan` | PASS | The delivery snapshot and git diff show an update to the fixed path docs/engineer/payment-refund/IMPLEMENTATION_PLAN.md, with no second active plan. |
-| `bumps_plan_version` | PASS | The snapshot changes version from 0.1.0 to 0.2.0 and last_updated from 2026-07-27 to 2026-08-16. |
-| `does_not_force_archive_link` | PASS | The plan continues the Draft plan with previous_plan_archive: "N/A" and does not require archival or an archive backlink. |
-| `waits_before_coding` | PASS | The candidate states that no code or tests were modified and explicitly requests confirmation before coding; git evidence shows only the plan file changed. |
+| `reads_active_plan_frontmatter` | PASS | Raw trace shows the active plan was inspected, and the delivered snapshot contains its frontmatter. |
+| `detects_non_implemented_status` | PASS | Delivered plan snapshot has status: "Draft" and states the confirmation gate is pending. |
+| `continues_current_plan` | PASS | Git evidence and delivery snapshot show the fixed IMPLEMENTATION_PLAN.md path was updated; no second active plan was created. |
+| `bumps_plan_version` | PASS | Plan version changed from 0.1.0 to 0.2.0 and last_updated changed to 2026-08-16. |
+| `does_not_force_archive_link` | PASS | The plan continues without requiring an archive backlink or archive decision; archive absence is recorded as context. |
+| `waits_before_coding` | PASS | Final output explicitly requests confirmation before coding, and git evidence shows only the plan changed, with no code or tests modified. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=b545dbdf7b14573cc5aa0b9db7a4defefe66a311f4d3b98d9f23cd367fdfa1aa; fixture_sha256=20e27cdb155a076474a45e3e1e88d991a8bc4e1c3723a56f9fad5436bddd121e; output_sha256=9a0f9c090c09dbf89239328d6d3b2194da94105ea85458152024e0a745067140; snapshot_sha256=ce985f393d8f308a0160bf7ddd6339483dabdf26e6198aeddd07a1e0c349a3f8
-- Behavior: Read and continued the existing Draft implementation plan, bumped its version and timestamp, updated only the plan, and waited for confirmation before coding.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=b545dbdf7b14573cc5aa0b9db7a4defefe66a311f4d3b98d9f23cd367fdfa1aa; fixture_sha256=20e27cdb155a076474a45e3e1e88d991a8bc4e1c3723a56f9fad5436bddd121e; output_sha256=2892e949d880370d345229694d55aa6b09d67514b404172d7c6ecd7b8c17d60a; snapshot_sha256=53e0e9459e80e67d430dbf355efbaa5a9cbe7b94c268a623da298422d287f4de
+- Behavior: Read and updated the existing Draft implementation plan, bumped metadata, preserved scope, and stopped for explicit confirmation before coding.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=b545dbdf7b14573cc5aa0b9db7a4defefe66a311f4d3b98d9f23cd367fdfa1aa; fixture_sha256=20e27cdb155a076474a45e3e1e88d991a8bc4e1c3723a56f9fad5436bddd121e; output_sha256=f7b3955129321f8d98ad128db86a7c1ac93044a5e62bc5b82972bf99fe6cb1d0; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Read PRD/TRD but did not inspect or update the active implementation plan, and asked for more scope instead of continuing the confirmed plan.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=b545dbdf7b14573cc5aa0b9db7a4defefe66a311f4d3b98d9f23cd367fdfa1aa; fixture_sha256=20e27cdb155a076474a45e3e1e88d991a8bc4e1c3723a56f9fad5436bddd121e; output_sha256=47f9b8dca7592fe461db0d9e35ea8ad87c3d3f5355d2153a5e4cf643496af388; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Read PRD/TRD only, did not inspect or update the active plan, and asked the user to clarify the task.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/engineer/test/feature-implementor/evals/workspace/eval-017-abandoned-draft-can-be-superseded/comparison.md
+++ b/agents/engineer/test/feature-implementor/evals/workspace/eval-017-abandoned-draft-can-be-superseded/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `c0e7350515f9e8f3a166039b0e6d074b044f7918d0abfcaabf64ea0fd4ef53cb` from `agents/engineer/test/feature-implementor/evals/workspace/eval-017-abandoned-draft-can-be-superseded`.
 - Identity schema: `2`
-- target_skill_sha256: `248d30c2e10162217ecb1d6a0d7c66973ee945c6f2e9b7e4bf01a677aac7bc3c`
+- target_skill_sha256: `7f71c78ab97a67d477751886a8f46d8cfd865bac113be49568de86ccf5343ee9`
 - eval_definition_sha256: `92bf4838a78758f537ca7650dd1be190ad947406f8ab40d6ace62d644c28dc37`
 - metadata_sha256: `f9ca20298152f7ee141273d4d234041abb35178d98ecce2603f695eedfbc144d`
 - fixture_sha256: `c0e7350515f9e8f3a166039b0e6d074b044f7918d0abfcaabf64ea0fd4ef53cb`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `a264d3282fcfebf29821ed24d8e702134594b3cc4be72cd72f03b0e03e92c160`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `9ebe9d873c66a07a5ecd0428e103d2f74136e9e17f4f22b79640f42f218d18ee`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `8002de5f5ec8cbba9c876b3fa5b95d04da373914039535f254ff8fce02f9cbab`
+- Skill overlay SHA-256: `6ba93c2da62bbbed9ea41d72d153901f8e8bbbbad20322168e3cf7c265e800fd`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,22 +33,22 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `reads_unfinished_active_plan` | PASS | With-skill raw trace shows the existing implementation plan was read; the delivered plan records the fixed path, prior status Draft, and prior scope refund-reason-codes. |
-| `detects_explicit_abandonment` | PASS | The delivered active plan and archive explicitly state that the unfinished refund reason-code round was abandoned and replaced, matching the maintainer’s explicit abandonment request. |
-| `archives_as_superseded` | PASS | The locked archive snapshot has status Superseded, a non-empty superseded_reason, and preserves implementation_scope, archived_at, archive_approved_by, source_plan, and original metadata. |
-| `links_replacement_plan` | PASS | The locked active-plan snapshot contains previous_plan_archive pointing to the same-feature archive, whose snapshot has feature_path payment-refund and status Superseded. |
-| `waits_before_coding` | PASS | Git evidence shows only plan/archive documentation changes; the plan states Draft and awaiting maintainer confirmation, and the output explicitly blocks implementation until confirmation. |
+| `reads_unfinished_active_plan` | PASS | The with_skill trace shows the active IMPLEMENTATION_PLAN.md was read; the checkpoint records its path, status Draft, and pre-write scope refund-reason-codes. |
+| `detects_explicit_abandonment` | PASS | The delivered checkpoint and archive record that the maintainer explicitly abandoned the unfinished refund reason-code round and select the superseded path. |
+| `archives_as_superseded` | PASS | The locked archive snapshot has status Superseded, non-empty superseded_reason, implementation_scope, archived_at, archive_approved_by, source_plan, and preserved original metadata. |
+| `links_replacement_plan` | PASS | The locked replacement plan contains previous_plan_archive pointing to the Superseded archive, with feature_path payment-refund matching the archive metadata. |
+| `waits_before_coding` | PASS | The locked delivery contains only plan/archive changes, states no code was modified, and explicitly requires user confirmation before coding. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9ebe9d873c66a07a5ecd0428e103d2f74136e9e17f4f22b79640f42f218d18ee; fixture_sha256=c0e7350515f9e8f3a166039b0e6d074b044f7918d0abfcaabf64ea0fd4ef53cb; output_sha256=02f590dbb5063804f978d4cab42af4ef5b6019994c60860641c7097aef54a528; snapshot_sha256=04b8add69e118eacf4fc4d7903cef7cce78ec2343ec131901e0778def207481f
-- Behavior: Reads the unfinished plan, detects explicit abandonment, archives it as Superseded, creates and links a replacement Draft plan, and waits for confirmation before coding.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9ebe9d873c66a07a5ecd0428e103d2f74136e9e17f4f22b79640f42f218d18ee; fixture_sha256=c0e7350515f9e8f3a166039b0e6d074b044f7918d0abfcaabf64ea0fd4ef53cb; output_sha256=d6d7414fd3a5dbe0a6fd169a6ad96bb4d3409723f9093e0b64fa2a26d60295d8; snapshot_sha256=7a010c4e3b402518147dbf39c5209c5cc845fb69795584d3b2948233745edc93
+- Behavior: Correctly read the unfinished plan, detected explicit abandonment, archived it as Superseded, linked the replacement plan, and paused before coding.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9ebe9d873c66a07a5ecd0428e103d2f74136e9e17f4f22b79640f42f218d18ee; fixture_sha256=c0e7350515f9e8f3a166039b0e6d074b044f7918d0abfcaabf64ea0fd4ef53cb; output_sha256=5f97f7fd0aa83cbe385f3fe20e3b209b83b3580ea1f3f4c353bb45bf0cada83b; snapshot_sha256=6aab714931c23cf3173da27a41bcaae18a2b1d1c434bad686eb199fa54b5ef8d
-- Behavior: Switches the existing plan directly to Active and does not create the required Superseded archive or confirmation gate.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9ebe9d873c66a07a5ecd0428e103d2f74136e9e17f4f22b79640f42f218d18ee; fixture_sha256=c0e7350515f9e8f3a166039b0e6d074b044f7918d0abfcaabf64ea0fd4ef53cb; output_sha256=1af6460847ad8c512e6c2a9ffa93c1e5a44be1981dfdd9f43018c15e66b3271e; snapshot_sha256=5a0fd9dd2c0200a4b3902d0a02895accf0a5d98aea4ecf31f4cc1a7496d35f92
+- Behavior: Fresh baseline updated the active Draft plan directly to the replacement scope without the required archive, replacement link, or confirmation gate.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/engineer/test/test-writer/evals/workspace/eval-001-write-tests-from-spec/comparison.md
+++ b/agents/engineer/test/test-writer/evals/workspace/eval-001-write-tests-from-spec/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `1fc33cc2cafe76721e09e39f06834f83330e227e59b4aed334bc003945dfdf3c` from `agents/engineer/test/test-writer/evals/workspace/eval-001-write-tests-from-spec`.
 - Identity schema: `2`
-- target_skill_sha256: `a2cf1652b5fea887d41dd3a13903616fd86413d7444b667455c1a1628200c5bc`
+- target_skill_sha256: `5f3a5999aa1efa139e50399981290b3134eeec82bfa2eeeccd743979bbb2eb31`
 - eval_definition_sha256: `efd5ef5afb815bd08b4891a7e8121a2425c0d9fa58d54ab02bb52d9e0279793d`
 - metadata_sha256: `d7923bf8ad60a9b78d8f4a2d5a8014a4c03857221ca26433305123c9d484c670`
 - fixture_sha256: `1fc33cc2cafe76721e09e39f06834f83330e227e59b4aed334bc003945dfdf3c`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `76acf51e56db3c0b81097f6bd3d6543ba266417fd8281a9ea540a61e66eb1dc7`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `46eea12ac62f02ceb89a8418aeab70d2e5bbf720f6ba0edc42f3a9c58a443a5e`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `429fc1ef5ebbac055bdbd3fd7863138cf63bfb8f5e1115002085b81b61a4dab5`
+- Skill overlay SHA-256: `74d5ef1ceb04052c742ef9500d8bca484457637293371f2cd945a5336fc8d8e9`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `test_spec` | PASS | With_skill delivery_snapshot contains four tests covering all four required scenarios, including stored-record return, exact validation errors with no repository call, and unchanged repository error identity. |
-| `test_execution_reported` | PASS | With_skill runner_captured_trace records `npm test` completing with 5 tests passed and 0 failed; the candidate also reports this result. |
-| `project_test_conventions_followed` | PASS | The delivered file is under `test/services/notification-service.test.js` and uses the existing flat `node:test` plus `node:assert/strict` structure. |
+| `test_spec` | PASS | The locked with_skill test file covers all four required scenarios: valid creation/returned record, missing recipientId with exact error and no repository call, blank message with exact error and no repository call, and unchanged repository-error propagation. |
+| `test_execution_reported` | PASS | The locked with_skill trace shows `npm test` completed with exit code 0 and 5 tests passed, 0 failed; the candidate also reports `5/5 通过`. |
+| `project_test_conventions_followed` | PASS | The delivered file is `test/services/notification-service.test.js`, uses `node:test` and `node:assert/strict`, imports the service with the expected relative path, and follows the existing flat test structure. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=46eea12ac62f02ceb89a8418aeab70d2e5bbf720f6ba0edc42f3a9c58a443a5e; fixture_sha256=1fc33cc2cafe76721e09e39f06834f83330e227e59b4aed334bc003945dfdf3c; output_sha256=e9925dd0c6c87ecbe564028192cec1d8e59af565c0aafa4892da723f288f2b8e; snapshot_sha256=822df810d1e24bfe6599247aaaff3d705fcadddbeaabc0ea364e8545f6436bf8
-- Behavior: Added four semantically correct NotificationService tests, matching the spec and project conventions; all five project tests passed.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=46eea12ac62f02ceb89a8418aeab70d2e5bbf720f6ba0edc42f3a9c58a443a5e; fixture_sha256=1fc33cc2cafe76721e09e39f06834f83330e227e59b4aed334bc003945dfdf3c; output_sha256=2725bbd435bfb47cbda14a88c96f59b4e298f21d248460a2fa1a0e80d57101bd; snapshot_sha256=c95b873be710950b10d92f2ae295d1fd8369f938c561e387b5ab444f994577c6
+- Behavior: Added the expected NotificationService test file covering all four spec scenarios and reported a successful full test run.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=46eea12ac62f02ceb89a8418aeab70d2e5bbf720f6ba0edc42f3a9c58a443a5e; fixture_sha256=1fc33cc2cafe76721e09e39f06834f83330e227e59b4aed334bc003945dfdf3c; output_sha256=dc4400567a44b03968af56397d17e9e3d0f518c2293c7e9b0e0635ce668181ad; snapshot_sha256=770c0d017bf5edcb3001edab369d1d6944d47e4f84c9420d850fddc298e6cbdf
-- Behavior: Fresh baseline also added four correct scenarios and reported all five tests passing; behavior is equivalent to with_skill for this task.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=46eea12ac62f02ceb89a8418aeab70d2e5bbf720f6ba0edc42f3a9c58a443a5e; fixture_sha256=1fc33cc2cafe76721e09e39f06834f83330e227e59b4aed334bc003945dfdf3c; output_sha256=ef6e28ba9576d78baa0ae4c083d7cc1533ba23ee12a9d46e9c09da0b9c8bfd02; snapshot_sha256=cf52edc0df87572fc8431399fdbef2667f6dc9ff0544a6067e7fb4a0a2114b16
+- Behavior: Also added equivalent coverage and reported passing tests; behavior is comparable, with an extra explicit repository-call scenario in its prose.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/engineer/test/test-writer/evals/workspace/eval-002-mapped-pagination-tests/comparison.md
+++ b/agents/engineer/test/test-writer/evals/workspace/eval-002-mapped-pagination-tests/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `866e2c4f7a812e0445a49d5de640bceae9b9dcd49ee9a3bd9c91db26e366238d` from `agents/engineer/test/test-writer/evals/workspace/eval-002-mapped-pagination-tests`.
 - Identity schema: `2`
-- target_skill_sha256: `a2cf1652b5fea887d41dd3a13903616fd86413d7444b667455c1a1628200c5bc`
+- target_skill_sha256: `5f3a5999aa1efa139e50399981290b3134eeec82bfa2eeeccd743979bbb2eb31`
 - eval_definition_sha256: `dffdc1de9650924aeba7f48471eac1b4c1592e52cef441419d14a463af648ff5`
 - metadata_sha256: `dd6a44fd990ce66c25d528434ffde60d69dfd0c22dc5694badf75d832012ae4f`
 - fixture_sha256: `866e2c4f7a812e0445a49d5de640bceae9b9dcd49ee9a3bd9c91db26e366238d`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `868c36ff31e91e90391d3fe2090275a44a955f72894e47ed070c10d12b284428`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `429fc1ef5ebbac055bdbd3fd7863138cf63bfb8f5e1115002085b81b61a4dab5`
+- Skill overlay SHA-256: `74d5ef1ceb04052c742ef9500d8bca484457637293371f2cd945a5336fc8d8e9`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `reads_mapped_docs_first` | PASS | Trace shows change-map lookup before reading the mapped pagination document; no unrelated document contents were read first. |
-| `verifies_against_code` | PASS | Locked test file asserts default_page_size equals 25; trace and output identify the document’s 50 as inconsistent with defaults.txt. |
-| `treats_unverified_as_low_trust` | PASS | Trace records last_verified_version: unverified, and the locked test file never uses 50 as an expected value. |
+| `reads_mapped_docs_first` | PASS | Trace shows change-map resolution followed by reading docs/site/api/pagination.md before unrelated repository exploration. |
+| `verifies_against_code` | PASS | Locked test file reads src/pagination/defaults.txt and asserts default_page_size is 25; trace records the document value 50 and code value 25 mismatch. |
+| `treats_unverified_as_low_trust` | PASS | Trace and final output identify last_verified_version: unverified as low trust, retain the document's 50, and use code-backed 25 in the test. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=868c36ff31e91e90391d3fe2090275a44a955f72894e47ed070c10d12b284428; fixture_sha256=866e2c4f7a812e0445a49d5de640bceae9b9dcd49ee9a3bd9c91db26e366238d; output_sha256=3ebbf0b050098c81b2c9415ffaaa039bb01ca9037c98d1376cfd1f1cd8bbd723; snapshot_sha256=36808fcf3c52d2f93e165f9b2e16aa7c3f18a74f9b43c0e1cb557bde4fc962fd
-- Behavior: Added and ran four pagination default-boundary tests using 25 and 100 from defaults.txt, while treating the unverified 50-document value as non-authoritative.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=868c36ff31e91e90391d3fe2090275a44a955f72894e47ed070c10d12b284428; fixture_sha256=866e2c4f7a812e0445a49d5de640bceae9b9dcd49ee9a3bd9c91db26e366238d; output_sha256=54dfe9dd919c8ada6a909f53dbb2cfe607eda68892cb6b885cd7466e24b559b0; snapshot_sha256=bbeb432d43b8981cb6110f5ef297148a97f2cd7de60937f9bb015505b961f858
+- Behavior: Read the mapped documentation and code evidence, treated the unverified document as lower trust, and added tests asserting the code-backed default of 25.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=868c36ff31e91e90391d3fe2090275a44a955f72894e47ed070c10d12b284428; fixture_sha256=866e2c4f7a812e0445a49d5de640bceae9b9dcd49ee9a3bd9c91db26e366238d; output_sha256=b48141a20548c40cc4a784c6758e9e561623460b1204c48b8c022121723dd403; snapshot_sha256=ec5fa9ad3df493d20cdf2ee99ca9b9d0112f3435001c4a0c0ba0558226c85225
-- Behavior: Fresh baseline also verified 25 versus the unverified document value 50 and delivered broader six-test boundary coverage.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=868c36ff31e91e90391d3fe2090275a44a955f72894e47ed070c10d12b284428; fixture_sha256=866e2c4f7a812e0445a49d5de640bceae9b9dcd49ee9a3bd9c91db26e366238d; output_sha256=ab8bde0ee4a46912302088257688e26578e713ec9a0874745fc237b695bfe392; snapshot_sha256=b996e6920e05508c60c21139ae5b9a466395dbb5b5d5ba25084de1d16ebf2740
+- Behavior: Added broader boundary tests and rewrote the unverified documentation value from 50 to 25; comparison only.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/engineer/test/trd-gen/evals/workspace/eval-001-prd-to-engineer-trd/comparison.md
+++ b/agents/engineer/test/trd-gen/evals/workspace/eval-001-prd-to-engineer-trd/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `874c9a19c616d97ed625612e04c37ce561c010e8908c127503ea72d53817db55` from `agents/engineer/test/trd-gen/evals/workspace/eval-001-prd-to-engineer-trd`.
 - Identity schema: `2`
-- target_skill_sha256: `47bb3c8e8bad899368b78c2d70a8b75f85c0900f5ef5546caa9c9be9e034ebd2`
+- target_skill_sha256: `340d804f93e6fcb990681bc077bb9f53d3744da12f12a7cfbbe7aa88f980f67e`
 - eval_definition_sha256: `541dd03d893d7d5a4e9f69c81d6344de365e55718cc67a40980e3cbdb34c6a30`
 - metadata_sha256: `6e61e3a3cf957d6188f45a8683550c6d50e04fe42b08467fc1e2608fd4e66686`
 - fixture_sha256: `874c9a19c616d97ed625612e04c37ce561c010e8908c127503ea72d53817db55`
@@ -22,41 +22,40 @@
 - judge_schema_sha256: `4d4b8ebdf0eaf847b9097b848450fa85763a3e1f30bf1bb128228339ff87a28d`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `59315add19ee6ece2648d62000ea89257cb037f1973ece31adc62018b509f700`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `b2bd7a022294f7539263ea78da33349f841bc77d827c181e2b2867a85cb18e8f`
-- Behavior result: **FAIL**
+- Skill overlay SHA-256: `efd5278a6dcac3b779ffc2f7bc7fbcdcc73c391218f35b1bba7e6f95759a7887`
+- Behavior result: **PASS**
 - Coverage result: **PARTIAL**
-Overall result: FAIL
+Overall result: PASS (partial coverage)
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `engineer_owns_trd` | PASS | 交付摘要明确指定 engineer-agent:trd-gen，且锁定文件位于 docs/engineer/capture-loop/TRD.md。 |
-| `prd_confirmed_handoff` | FAIL | 锁定 TRD 提及 PRD 与 confirmed product decisions，但 with_skill 最终交付未明确说明只有确认后才进入 TRD 阶段。 |
-| `document_subagent` | PASS | 交付摘要说明 document-subagent unavailable，并指定主进程保留来源上下文和最终审查，未声称已完成委派。 |
-| `implementation_plan_handoff` | FAIL | 交付摘要指定 feature-implementor 及 IMPLEMENTATION_PLAN.md 路径，但未明确表达“TRD 确认后”这一条件。 |
-| `qa_e2e_after_confirmed_plan` | NOT_EXERCISED | TRD 为 Draft，implementation_plan handoff pending，且未发生实现计划或实现完成后的 QA 交接；后续 QA E2E 条件尚未到达。 |
-| `no_code_implementation` | PASS | 锁定交付物仅包含 TRD/ADR 文档；最终输出明确未执行代码或实现计划。 |
+| `engineer_owns_trd` | PASS | 候选输出明确说明 Engineer 负责 TRD/API/ADR，并指定 docs/engineer/{feature_path}/TRD.md。 |
+| `prd_confirmed_handoff` | PASS | 候选输出明确表示 PRD 已确认，且原始证据确认 DECISIONS 状态为 Confirmed、无未决产品问题。 |
+| `document_subagent` | PASS | 候选输出如实说明文档子代理不可用，由主流程保留上下文并完成最终审查，未声称已完成委派。 |
+| `implementation_plan_handoff` | NOT_EXERCISED | 候选输出说明 TRD 确认后再移交 feature-implementor；但 TRD 尚未生成或确认，后续交接尚未执行。 |
+| `qa_e2e_after_confirmed_plan` | NOT_EXERCISED | 尚未完成 TRD、实现计划或实现交接，QA E2E 后续步骤尚未到达。 |
+| `no_code_implementation` | PASS | 候选输出明确说明本次只负责 Engineer 文档，不实现代码、不写实现计划，也未发生代码或测试修改。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=59315add19ee6ece2648d62000ea89257cb037f1973ece31adc62018b509f700; fixture_sha256=874c9a19c616d97ed625612e04c37ce561c010e8908c127503ea72d53817db55; output_sha256=8a7e1efdcd386cca563031bbee1e94fbfba3b9eff25059328409edf08d2be726; snapshot_sha256=ce697cc4178eccca6ae6f3aceec967b73d748343f1829b761ce7bda97aeb66af
-- Behavior: 成功生成 Engineer 路径下的 TRD/ADR，正确保留文档所有权、主进程审查边界并避免代码实现；但最终交付遗漏了两个明确的流程门槛说明，QA 后续断言尚未 exercised。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=59315add19ee6ece2648d62000ea89257cb037f1973ece31adc62018b509f700; fixture_sha256=874c9a19c616d97ed625612e04c37ce561c010e8908c127503ea72d53817db55; output_sha256=8f43594f57d8d6dfb1834148c5b56ac1663a2904ddee8f34183d65d9c341b796; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 正确识别已确认的 PM 范围，声明 Engineer 责任、文档子代理边界和后续交接，并在缺少 author 信息时安全暂停，未直接实现代码。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=59315add19ee6ece2648d62000ea89257cb037f1973ece31adc62018b509f700; fixture_sha256=874c9a19c616d97ed625612e04c37ce561c010e8908c127503ea72d53817db55; output_sha256=e6421063c6af46bfe48a4afac23831b3ce55aa24df38c9940395e5c40cff6593; snapshot_sha256=15016adcaa29751771c97b2630239673417997098345b083a479511a2f6e72ce
-- Behavior: 生成了错误路径 docs/engineering/capture-loop/TRD.md，且未体现 Engineer 所有权、确认门槛、下游交接或文档 sub-agent 边界。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=59315add19ee6ece2648d62000ea89257cb037f1973ece31adc62018b509f700; fixture_sha256=874c9a19c616d97ed625612e04c37ce561c010e8908c127503ea72d53817db55; output_sha256=847487735b2212bcde0818a68b1a91a46bee8e4dfe152b1ec175e810047d4088; snapshot_sha256=d5ce4b08740adc54e193cf8d87edf0f1abb1a214bed92d882a05d6bd554a93bc
+- Behavior: 直接在 docs/pm/capture-loop/TRD.md 产出技术方案，未执行 Engineer 归属、确认门禁或后续交接流程。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- prd_confirmed_handoff：最终交付未说明确认门槛。
-- implementation_plan_handoff：最终交付未说明必须在 TRD 确认后移交。
-- Next: 确认 TRD 后，再移交 feature-implementor 编写 IMPLEMENTATION_PLAN.md；实现完成并提供交接包后再启动 QA E2E。
+- None.
+- Next: 用户提供显示姓名后生成并确认 Engineer 文档，再进入 feature-implementor 实现计划交接。
 
 ## Runtime Artifact Policy
 

--- a/agents/engineer/test/trd-gen/evals/workspace/eval-002-resolve-trd-gap-packet/comparison.md
+++ b/agents/engineer/test/trd-gen/evals/workspace/eval-002-resolve-trd-gap-packet/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `d58240709fd95e80376991be4d5ae0d8785faa7c898ac347279a20ad514acd7a` from `agents/engineer/test/trd-gen/evals/workspace/eval-002-resolve-trd-gap-packet`.
 - Identity schema: `2`
-- target_skill_sha256: `47bb3c8e8bad899368b78c2d70a8b75f85c0900f5ef5546caa9c9be9e034ebd2`
+- target_skill_sha256: `340d804f93e6fcb990681bc077bb9f53d3744da12f12a7cfbbe7aa88f980f67e`
 - eval_definition_sha256: `96fd70658261e3a17be616b06efc13bb061ebd641ee5ed5f4b30d21e34984bf7`
 - metadata_sha256: `52ff934cb29e9ff3b5466112583fc28f2e25ef514559e863865c7bac5d684dfd`
 - fixture_sha256: `d58240709fd95e80376991be4d5ae0d8785faa7c898ac347279a20ad514acd7a`
@@ -22,38 +22,38 @@
 - judge_schema_sha256: `3fb0bf5bc301ce78a33402f806b0b810ed122ae2263b6d9be14f49634de42f79`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `bc732b2f79cac8748a3ffddfa2548eb3ee6c28a29e001f66a5d7af673ecfa482`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `b2bd7a022294f7539263ea78da33349f841bc77d827c181e2b2867a85cb18e8f`
-- Behavior result: **PASS**
+- Skill overlay SHA-256: `efd5278a6dcac3b779ffc2f7bc7fbcdcc73c391218f35b1bba7e6f95759a7887`
+- Behavior result: **FAIL**
 - Coverage result: **FULL**
-Overall result: PASS
+Overall result: FAIL
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `accepts_gap_packet_as_trd_work` | PASS | TRD.md states the gap finder reported missing decisions and `engineer-agent:trd-gen` owns resolving them; the delivery contains only Engineer TRD/API/ADR documents and a pending downstream handoff. |
-| `resolves_named_gap_categories` | PASS | TRD.md directly covers affected components, event/data contracts, validation strategy and commands, rollout/rollback, retry/error handling, observability, and security; the remaining adapter and test-runner choices are recorded as owned open questions. |
-| `keeps_finder_trd_gen_boundary` | PASS | TRD.md explicitly assigns gap reporting to the finder and resolution to `engineer-agent:trd-gen`; delivery metadata identifies the blocked downstream owners. |
-| `unresolved_gap_blocks_e2e` | PASS | TRD.md records two blocking open technical questions, and the delivery summary lists `blocked_downstream: [feature-implementor, debugger, qa-e2e]` plus the pending implementation-plan path; no downstream plan or QA E2E document was delivered. |
-| `no_implementation_plan_or_code` | PASS | Locked delivery snapshots contain only `docs/engineer/capture-loop/TRD.md`, `API.md`, and `ADR-001...`; git status shows only `?? docs/engineer/`, with no implementation plan, code, tests, or QA E2E files. |
+| `accepts_gap_packet_as_trd_work` | PASS | TRD.md identifies the finder as reporting gaps, assigns resolution to engineer-agent:trd-gen, and states code implementation is outside the TRD. |
+| `resolves_named_gap_categories` | PASS | TRD.md directly covers component ownership, event/data flow and API contract, validation strategy, rollout/rollback risks, error classification, observability, and security. |
+| `keeps_finder_trd_gen_boundary` | PASS | TRD.md explicitly states that the finder reports gaps and engineer-agent:trd-gen resolves them in Engineer documents. |
+| `unresolved_gap_blocks_e2e` | FAIL | TRD.md still contains an open-questions section with implementation and operational dependencies, while the delivery summary reports blocked_downstream: [] and describes those items as non-blocking. |
+| `no_implementation_plan_or_code` | PASS | Locked git evidence shows only new TRD/API/ADR documents; no IMPLEMENTATION_PLAN.md, source-code, or test-file changes were delivered. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=bc732b2f79cac8748a3ffddfa2548eb3ee6c28a29e001f66a5d7af673ecfa482; fixture_sha256=d58240709fd95e80376991be4d5ae0d8785faa7c898ac347279a20ad514acd7a; output_sha256=004ad887fc1dc87e4154e0b7618cb494eb2316dd25a6bc19665e769429ecf243; snapshot_sha256=4e1d01c8fc102700285a7ec9f3b3eb896c620a9550d1fe0a8eae6e1b2aae93f3
-- Behavior: Accepted the gap packet as Engineer TRD work, produced TRD/API/ADR artifacts, resolved the named technical categories, recorded remaining blockers, and blocked downstream work without implementing code.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=bc732b2f79cac8748a3ffddfa2548eb3ee6c28a29e001f66a5d7af673ecfa482; fixture_sha256=d58240709fd95e80376991be4d5ae0d8785faa7c898ac347279a20ad514acd7a; output_sha256=6842265a43a73d69dc6bc27a589b2d9c856ce620aa300fc85a153acf9da029cc; snapshot_sha256=5756a8c1367c157a7c52e4025f616dc72888de68d00c8ddf2584dbe569df7dc6
+- Behavior: Produces Engineer-owned TRD, API, and ADR documents with broad gap coverage and no code changes, but incorrectly reports downstream as unblocked despite remaining open questions.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=bc732b2f79cac8748a3ffddfa2548eb3ee6c28a29e001f66a5d7af673ecfa482; fixture_sha256=d58240709fd95e80376991be4d5ae0d8785faa7c898ac347279a20ad514acd7a; output_sha256=8b2b8ab987ff43dbae5f59ed7960a2675f1d9832f92f7a1eb4af2dd45e755313; snapshot_sha256=f99ec9f0f0333d6bc51c6d50aed98a51d1e1caf2595b65c87953a97b314c23b6
-- Behavior: Modified the gap packet directly and presented a technical summary, without explicit TRD ownership boundaries or downstream blocking treatment.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=bc732b2f79cac8748a3ffddfa2548eb3ee6c28a29e001f66a5d7af673ecfa482; fixture_sha256=d58240709fd95e80376991be4d5ae0d8785faa7c898ac347279a20ad514acd7a; output_sha256=d486a6e70c7821b1572e0cbf3bc0569c7f11d004dd6553534d7e30e96856e6b2; snapshot_sha256=dfd6f23da61eb21129b391f7df626bc0297f81b3bf8088c673a38f697d7ffb1d
+- Behavior: Rewrites the gap packet directly and summarizes the technical topics, but does not establish the canonical trd-gen boundary or Engineer document handoff.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- None.
+- The with_skill lane leaves documented open technical/configuration questions but does not block feature-implementor, debugger, or QA E2E downstream work.
 - Next: None.
 
 ## Runtime Artifact Policy

--- a/agents/engineer/test/trd-gen/evals/workspace/eval-003-nested-prd-to-engineer-trd/comparison.md
+++ b/agents/engineer/test/trd-gen/evals/workspace/eval-003-nested-prd-to-engineer-trd/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `9c19cf5e49c59929ac5b070de11f3df7bfcbee1e79646cc4eec47c40b398a1bc` from `agents/engineer/test/trd-gen/evals/workspace/eval-003-nested-prd-to-engineer-trd`.
 - Identity schema: `2`
-- target_skill_sha256: `47bb3c8e8bad899368b78c2d70a8b75f85c0900f5ef5546caa9c9be9e034ebd2`
+- target_skill_sha256: `340d804f93e6fcb990681bc077bb9f53d3744da12f12a7cfbbe7aa88f980f67e`
 - eval_definition_sha256: `f3397b62fc4d049158e92b00f525e136ca990d6c804b1f211ce557bfaf30d03e`
 - metadata_sha256: `8451ac7ef039213ff9e09b51e00f9621051c5612a09e634a193a918fe3b775fb`
 - fixture_sha256: `9c19cf5e49c59929ac5b070de11f3df7bfcbee1e79646cc4eec47c40b398a1bc`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `10a807298f91a20d6e9b68f75881e7ea6287d8afeff10727bea551d980d3535f`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `8d0ccec5c9709506559aa1f8a5acdfd87e4bb71acf3bdaa8439f052c01aabae4`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `b2bd7a022294f7539263ea78da33349f841bc77d827c181e2b2867a85cb18e8f`
+- Skill overlay SHA-256: `efd5278a6dcac3b779ffc2f7bc7fbcdcc73c391218f35b1bba7e6f95759a7887`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,22 +33,22 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `mirrors_nested_feature_path` | PASS | delivery_snapshot contains docs/engineer/chat-interface/messages/history/search/TRD.md. |
-| `preserves_feature_metadata` | PASS | TRD frontmatter contains feature_path, parent_feature, and feature_level: 4. |
+| `mirrors_nested_feature_path` | PASS | Locked with_skill delivery_snapshot contains docs/engineer/chat-interface/messages/history/search/TRD.md. |
+| `preserves_feature_metadata` | PASS | TRD frontmatter contains feature_path chat-interface/messages/history/search, parent_feature chat-interface/messages/history, and feature_level 4. |
 | `related_prd_matches_path` | PASS | TRD frontmatter contains related_prd: docs/pm/chat-interface/messages/history/search/PRD.md. |
-| `blocks_on_missing_or_unclear_prd_path` | NOT_EXERCISED | The supplied PRD path and feature ownership are confirmed, so the missing-or-unclear-path blocking branch is not exercised. |
-| `no_plan_or_code` | PASS | The locked delivery snapshot contains only the TRD; no IMPLEMENTATION_PLAN.md or code changes are present. |
+| `blocks_on_missing_or_unclear_prd_path` | NOT_EXERCISED | The supplied prompt and raw evidence show a confirmed, unambiguous PRD path; the missing/unclear-path branch was not exercised. |
+| `no_plan_or_code` | PASS | The with_skill snapshot contains only the TRD; git evidence shows no implementation plan, code, or test changes. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=8d0ccec5c9709506559aa1f8a5acdfd87e4bb71acf3bdaa8439f052c01aabae4; fixture_sha256=9c19cf5e49c59929ac5b070de11f3df7bfcbee1e79646cc4eec47c40b398a1bc; output_sha256=06585bbaca65e33e627be3e9d2e0358eea1fadf3b12e8a21cf2dd4be1b862d03; snapshot_sha256=f5177351e5d80dce8bd95f7ea308e0f17a1552cd4a9dae784e47f4002803a35b
-- Behavior: Created the correctly nested TRD with required metadata and PRD linkage, without creating an implementation plan or code.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=8d0ccec5c9709506559aa1f8a5acdfd87e4bb71acf3bdaa8439f052c01aabae4; fixture_sha256=9c19cf5e49c59929ac5b070de11f3df7bfcbee1e79646cc4eec47c40b398a1bc; output_sha256=2ae84c82493421c04ceb4104b153a7c4f637983f7b239a1ca32eefda064c1e8e; snapshot_sha256=620ab684a8d030f3e8647259624f7748312fa12d676a4fcad4844216f826f60b
+- Behavior: Created the correctly nested Engineer TRD with required metadata and related PRD, while not creating implementation artifacts.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=8d0ccec5c9709506559aa1f8a5acdfd87e4bb71acf3bdaa8439f052c01aabae4; fixture_sha256=9c19cf5e49c59929ac5b070de11f3df7bfcbee1e79646cc4eec47c40b398a1bc; output_sha256=ff3c42230f265f356d560e536049f4f887fcf449c368eb30728f3cb2a87d883b; snapshot_sha256=3d562586415408da543537d2350b4e395fd5509dcbdc542a020850cfc80b07ba
-- Behavior: Created a TECH_SPEC under docs/tech rather than the required Engineer TRD path, with mismatched document type and metadata fields.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=8d0ccec5c9709506559aa1f8a5acdfd87e4bb71acf3bdaa8439f052c01aabae4; fixture_sha256=9c19cf5e49c59929ac5b070de11f3df7bfcbee1e79646cc4eec47c40b398a1bc; output_sha256=e25a0b78a8c775c207d881649f0b8250ef416a792074da6e481f11dc96499ea8; snapshot_sha256=2741a53719947dc96fbbf7d5502d4af7e7146969370980108e63633520b9167e
+- Behavior: Created a Technical Design under the PM directory rather than the required nested Engineer TRD path; it preserved some feature metadata but omitted the required TRD/related_prd structure.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/engineer/test/trd-gen/evals/workspace/eval-004-api-adr-owned-by-engineer/comparison.md
+++ b/agents/engineer/test/trd-gen/evals/workspace/eval-004-api-adr-owned-by-engineer/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `7b6820d67dd73e9499a1ca84c463bfc82e890640eeaf8c3154b04834d8479116` from `agents/engineer/test/trd-gen/evals/workspace/eval-004-api-adr-owned-by-engineer`.
 - Identity schema: `2`
-- target_skill_sha256: `47bb3c8e8bad899368b78c2d70a8b75f85c0900f5ef5546caa9c9be9e034ebd2`
+- target_skill_sha256: `340d804f93e6fcb990681bc077bb9f53d3744da12f12a7cfbbe7aa88f980f67e`
 - eval_definition_sha256: `c2e125b845f0cfd23a8b77d0953e79c0dfdb8a47bc09cbe45bf84d70fdf9a2db`
 - metadata_sha256: `62246848ad899e2c45f78627f4917a469fe8651f1607857696af955323ef348c`
 - fixture_sha256: `7b6820d67dd73e9499a1ca84c463bfc82e890640eeaf8c3154b04834d8479116`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `2fb0119eb77903cfe9db053e59a3c85f9fb841609febdeb77953e7bac06ea0fe`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `825205d6124cce58172b3b6756f4b557e630d638b9032e293e0df1661f6c8e2b`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `b2bd7a022294f7539263ea78da33349f841bc77d827c181e2b2867a85cb18e8f`
+- Skill overlay SHA-256: `efd5278a6dcac3b779ffc2f7bc7fbcdcc73c391218f35b1bba7e6f95759a7887`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,22 +33,22 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `engineer_owns_api_and_adr` | PASS | All three delivered Engineer files carry `engineer_document_owner: engineer-agent:trd-gen`; the delivery summary identifies Engineer ownership for the TRD/API/ADR set. |
-| `writes_all_engineer_docs_under_feature_path` | PASS | Locked delivery snapshot contains only `docs/engineer/chat-interface/history-search/TRD.md`, `API.md`, and `ADR-001-postgresql-full-text-search.md`. |
-| `preserves_related_prd_and_metadata` | PASS | All three files preserve `feature_path`, `parent_feature: chat-interface`, `feature_level: "2"`, and `related_prd: docs/pm/chat-interface/history-search/PRD.md`. |
-| `does_not_use_pm_generators` | PASS | Locked Engineer documents use `engineer-agent:trd-gen` and `generated_by: trd-gen`; no PM `api-gen` or `adr-gen` routing is present. |
-| `no_plan_or_code` | PASS | Git status and delivery snapshot show only the three Engineer documentation files; no implementation plan, code, or test files were delivered, and the summary states downstream handoff was not executed. |
+| `engineer_owns_api_and_adr` | PASS | With-skill delivery snapshots identify `engineer_document_owner: engineer-agent:trd-gen` on TRD, API, and ADR; final output also states Engineer owns the set. |
+| `writes_all_engineer_docs_under_feature_path` | PASS | All three locked delivery snapshots are under `docs/engineer/chat-interface/history-search/`: TRD.md, API.md, and ADR-001-database-full-text-search.md. |
+| `preserves_related_prd_and_metadata` | PASS | Each locked Engineer document preserves `feature_path`, `parent_feature`, `feature_level`, and `related_prd: docs/pm/chat-interface/history-search/PRD.md` in frontmatter. |
+| `does_not_use_pm_generators` | PASS | The locked runner trace shows use of `trd-gen` and contains no `api-gen` or `adr-gen` invocation; the delivered files identify Engineer ownership. |
+| `no_plan_or_code` | PASS | The locked delivery contains only the three Engineer documents; git status is `?? docs/engineer/`, with no implementation plan, code, or test files in the delivery snapshot. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=825205d6124cce58172b3b6756f4b557e630d638b9032e293e0df1661f6c8e2b; fixture_sha256=7b6820d67dd73e9499a1ca84c463bfc82e890640eeaf8c3154b04834d8479116; output_sha256=fedf2a4170d93ecf4f64c59c59a4a99ec3207b12e7842cf11574e40cf548ba4c; snapshot_sha256=c0762151019da61999525da02dccfa25330ab4c35392299115bedd2d86c0f3a2
-- Behavior: Created the requested Engineer-owned TRD, API, and ADR under the mirrored feature path, preserved metadata and PRD traceability, and stopped before implementation handoff.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=825205d6124cce58172b3b6756f4b557e630d638b9032e293e0df1661f6c8e2b; fixture_sha256=7b6820d67dd73e9499a1ca84c463bfc82e890640eeaf8c3154b04834d8479116; output_sha256=9c8f6951f391aa2e982e1b361d48a908244ae316790450cb09bd7a94e36acbe6; snapshot_sha256=63e3a78278e976457571f1458af9e2fe37bec7e20854c1e34e698b64f2a44512
+- Behavior: Produced the requested Engineer-owned TRD, API, and ADR under the resolved feature path, preserving PRD traceability and stopping before implementation.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=825205d6124cce58172b3b6756f4b557e630d638b9032e293e0df1661f6c8e2b; fixture_sha256=7b6820d67dd73e9499a1ca84c463bfc82e890640eeaf8c3154b04834d8479116; output_sha256=c0b8a7011fd614fe7ec3d295b89d9b99b581e67093d6cae4fd145c4530986e0f; snapshot_sha256=c31139611031f1b227c715cc0e58c5e8e8e2a5e7f7cd08c075bcfe2ba89b96fb
-- Behavior: Created TRD-like, API, and ADR documents under the PM path without Engineer ownership or mirrored Engineer paths.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=825205d6124cce58172b3b6756f4b557e630d638b9032e293e0df1661f6c8e2b; fixture_sha256=7b6820d67dd73e9499a1ca84c463bfc82e890640eeaf8c3154b04834d8479116; output_sha256=a749396240dd5176d0c879140afac9a4dde7b8ef4a5ca446aa194c5da7e1fc33; snapshot_sha256=e406f01a32d20dbf6a014b4c15a6a97fe57b1acf2736e68717c48aaa0f5693aa
+- Behavior: Produced PM-path technical documents instead of the required Engineer document set; used only as baseline comparison context.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/engineer/test/trd-gen/evals/workspace/eval-005-mapped-upload-trd-evidence/comparison.md
+++ b/agents/engineer/test/trd-gen/evals/workspace/eval-005-mapped-upload-trd-evidence/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `b9272be266caff6ac38d8060f5dbdbc6e981647729fe1530cfc53ca05b58b007` from `agents/engineer/test/trd-gen/evals/workspace/eval-005-mapped-upload-trd-evidence`.
 - Identity schema: `2`
-- target_skill_sha256: `47bb3c8e8bad899368b78c2d70a8b75f85c0900f5ef5546caa9c9be9e034ebd2`
+- target_skill_sha256: `340d804f93e6fcb990681bc077bb9f53d3744da12f12a7cfbbe7aa88f980f67e`
 - eval_definition_sha256: `ed02404d14ffd40d542c29f44a74caf2fc5696740b01f75b11e50dfad6379f60`
 - metadata_sha256: `c635fd02477c894e8c2d799454c0ae575efcc805f8bc3e18a331d13c47cdc0b8`
 - fixture_sha256: `b9272be266caff6ac38d8060f5dbdbc6e981647729fe1530cfc53ca05b58b007`
@@ -22,37 +22,37 @@
 - judge_schema_sha256: `6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `415550072b82b1b3b236c15b45beda7e56782899611899aec658b78876563888`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `b2bd7a022294f7539263ea78da33349f841bc77d827c181e2b2867a85cb18e8f`
-- Behavior result: **FAIL**
-- Coverage result: **FULL**
-Overall result: FAIL
+- Skill overlay SHA-256: `efd5278a6dcac3b779ffc2f7bc7fbcdcc73c391218f35b1bba7e6f95759a7887`
+- Behavior result: **PASS**
+- Coverage result: **PARTIAL**
+Overall result: PASS (partial coverage)
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `reads_mapped_docs_first` | PASS | Raw trace shows the candidate inspected the upload-related documentation and change map without traversing unrelated repository documents. |
-| `verifies_against_code` | FAIL | The candidate never read `src/upload/limits.txt`, produced no TRD, and did not preserve the required 20 MB versus 10 MB discrepancy and impact in delivered evidence. |
-| `treats_unverified_as_low_trust` | PASS | The final response explicitly treats `last_verified_version: unverified` as low trust and says it was not used as an interface fact. |
+| `reads_mapped_docs_first` | PASS | Raw trace shows the change map was read, then its required document `docs/site/api/upload.md` and `src/upload/limits.txt` were read; no unrelated repository document contents were traversed first. |
+| `verifies_against_code` | NOT_EXERCISED | The with_skill lane directly read `src/upload/limits.txt` and identified the 10 MB code limit versus the document’s 20 MB limit and its impact. However, no TRD could be produced because the required PM handoff, PRD, and feature path were missing, so the TRD-evidence portion was not exercisable. |
+| `treats_unverified_as_low_trust` | PASS | The output explicitly treats both relevant documents’ `last_verified_version: unverified` status as low trust and says the document cannot independently determine the implementation; key conclusions are based on `limits.txt`. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=415550072b82b1b3b236c15b45beda7e56782899611899aec658b78876563888; fixture_sha256=b9272be266caff6ac38d8060f5dbdbc6e981647729fe1530cfc53ca05b58b007; output_sha256=e81d10f8792cf5dba701247fe06b89996abeaf48e70895776664e53d3ce2c4c1; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly identified the mapped documentation and low-trust status, but stopped without reading `src/upload/limits.txt` or delivering the requested technical plan.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=415550072b82b1b3b236c15b45beda7e56782899611899aec658b78876563888; fixture_sha256=b9272be266caff6ac38d8060f5dbdbc6e981647729fe1530cfc53ca05b58b007; output_sha256=a1097ea7112482653732a312729cd0f995162af277f00f03add0922583a58a56; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Followed the mapped-document and code-verification workflow, preserved the 10 MB versus 20 MB discrepancy, applied low trust to unverified documents, and correctly stopped before creating a TRD without confirmed PM scope.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=415550072b82b1b3b236c15b45beda7e56782899611899aec658b78876563888; fixture_sha256=b9272be266caff6ac38d8060f5dbdbc6e981647729fe1530cfc53ca05b58b007; output_sha256=c970be6a891756bc875f6dab0d01ef71f01db09774e24374c03a55a3c98d771b; snapshot_sha256=c7789aa51665afd6c39d2904094d943a8d1de1d891feaa4fbd2afdc1c321f033
-- Behavior: Delivered a proposal that read the code fixture, captured the 10 MB versus 20 MB conflict, treated the document as unverified, and described the impact.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=415550072b82b1b3b236c15b45beda7e56782899611899aec658b78876563888; fixture_sha256=b9272be266caff6ac38d8060f5dbdbc6e981647729fe1530cfc53ca05b58b007; output_sha256=d9a4403df770c8f7e2d828fc13e8134be805414ec09528ab79825b7066409463; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Produced a useful baseline analysis and proposed a technical design, but did not demonstrate the explicit low-trust handling or Engineer PM-entry gate seen in the with_skill lane.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- The with_skill lane omitted the required code verification and delivered TRD evidence.
-- Next: Provide confirmed PM scope or handoff materials, then read `src/upload/limits.txt` and deliver the TRD with the documented discrepancy and impact.
+- None.
+- Next: Obtain the missing PM handoff/PRD and canonical feature_path, then generate the TRD while retaining the verified discrepancy and impact.
 
 ## Runtime Artifact Policy
 

--- a/agents/engineer/test/trd-gen/evals/workspace/eval-006-delivery-polling-to-events/comparison.md
+++ b/agents/engineer/test/trd-gen/evals/workspace/eval-006-delivery-polling-to-events/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `26621a90d557560b63afa9dd1b1ebe2dbb9f05568b574efca78ec5babe092c74` from `agents/engineer/test/trd-gen/evals/workspace/eval-006-delivery-polling-to-events`.
 - Identity schema: `2`
-- target_skill_sha256: `47bb3c8e8bad899368b78c2d70a8b75f85c0900f5ef5546caa9c9be9e034ebd2`
+- target_skill_sha256: `340d804f93e6fcb990681bc077bb9f53d3744da12f12a7cfbbe7aa88f980f67e`
 - eval_definition_sha256: `3255bddbc0ba9d00273a741fab78b9e223454656c0b7cbcdb74a3b3b193952f9`
 - metadata_sha256: `349f9852eee2f1f2a334e786dfe6be905191fc49881eadf61556b46ab3eeb5b7`
 - fixture_sha256: `26621a90d557560b63afa9dd1b1ebe2dbb9f05568b574efca78ec5babe092c74`
@@ -22,32 +22,32 @@
 - judge_schema_sha256: `58d5f8c73c18457a8d0864b8f5e21613dc914d57c8f96acc11ce98a78c601f05`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `4d55ba6ecaf12e0a768970bba911c34982402774916977cdba5d537398d0d4ea`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `b2bd7a022294f7539263ea78da33349f841bc77d827c181e2b2867a85cb18e8f`
+- Skill overlay SHA-256: `efd5278a6dcac3b779ffc2f7bc7fbcdcc73c391218f35b1bba7e6f95759a7887`
 - Behavior result: **PASS**
-- Coverage result: **PARTIAL**
-Overall result: PASS (partial coverage)
+- Coverage result: **FULL**
+Overall result: PASS
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `updates_existing_trd` | NOT_EXERCISED | The locked snapshot shows the existing TRD updated and no other feature document, but the locked raw evidence cannot independently prove that trd-gen performed the edit. |
-| `body_consolidation` | PASS | The locked TRD body directly specifies event-driven delivery and does not retain the polling design as a deprecated or otherwise status-labeled section. |
-| `removal_recorded_in_changelog` | PASS | The locked frontmatter adds a changelog entry documenting replacement of polling and updates version from 1.1.0 to 1.2.0. |
-| `no_implementation_plan_or_code` | PASS | The locked delivery snapshot and git evidence show only TRD.md changed; no implementation plan, code, or tests were added. |
+| `updates_existing_trd` | PASS | with_skill 的 delivery_snapshot 仅更新 docs/engineer/delivery-pipeline/TRD.md；正文与版本已更新，frontmatter 标明 engineer-agent:trd-gen，摘要仅声明后续 owner/path 且明确尚未移交或实现。 |
+| `body_consolidation` | PASS | TRD 正文直接描述 delivery.created 事件、异步消费者、重试与 dead-letter；旧轮询方案仅出现在 frontmatter changelog，未作为正文状态保留。 |
+| `removal_recorded_in_changelog` | PASS | frontmatter 新增 changelog，记录轮询方案被事件驱动方案替代；版本从 1.1.0 更新为 1.2.0。 |
+| `no_implementation_plan_or_code` | PASS | with_skill 的状态与差异仅显示 TRD.md 被修改；没有 IMPLEMENTATION_PLAN.md、代码或测试文件变更，且摘要明确尚未执行下游移交或代码实现。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4d55ba6ecaf12e0a768970bba911c34982402774916977cdba5d537398d0d4ea; fixture_sha256=26621a90d557560b63afa9dd1b1ebe2dbb9f05568b574efca78ec5babe092c74; output_sha256=10715d8e9666f4d43950d7be0fc7c58cf6853025df1c9082edc93bd04986f291; snapshot_sha256=2f31843f403946176b7dc491abad8342792d86e8c0afb27ab3661bd994e12927
-- Behavior: The existing TRD was updated to an event-driven design with changelog/version updates, while no implementation artifacts were added. The authoring-agent process is not independently provable from the locked evidence.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4d55ba6ecaf12e0a768970bba911c34982402774916977cdba5d537398d0d4ea; fixture_sha256=26621a90d557560b63afa9dd1b1ebe2dbb9f05568b574efca78ec5babe092c74; output_sha256=cc6fccb0cfcf21653b4bb849270b9596e09421daa98e3c60d0a174b0cb19c69a; snapshot_sha256=49b475214e96d87c1d21eb5faa410bd5ae61fbec9c28f8616c535ff89c713e7e
+- Behavior: 完整更新 TRD，补充事件驱动方案与删除留痕，未进入实现。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4d55ba6ecaf12e0a768970bba911c34982402774916977cdba5d537398d0d4ea; fixture_sha256=26621a90d557560b63afa9dd1b1ebe2dbb9f05568b574efca78ec5babe092c74; output_sha256=a7dc134045cbccc65980aa10419b08c5350697c7cf13eccf87790572e67ce8a1; snapshot_sha256=6fb691f4bc760983ba2764f481857a3fe26832689c905062a96e322887ecba67
-- Behavior: The baseline updated the existing TRD to event-driven delivery and version 1.2.0, but its snapshot omitted the required changelog.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4d55ba6ecaf12e0a768970bba911c34982402774916977cdba5d537398d0d4ea; fixture_sha256=26621a90d557560b63afa9dd1b1ebe2dbb9f05568b574efca78ec5babe092c74; output_sha256=fcb65a0fadc9521c44c0a909c026b9687e442bae9f2ba8bd89a6b3d9bce7cf96; snapshot_sha256=1d654489000abc41aa22eecbc24d4ac89a56c977530757c4cd21739e5de083e0
+- Behavior: 更新了 TRD 正文和版本，但未在 frontmatter 记录轮询删除 changelog。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/skills/changelog-gen/SKILL.md
+++ b/agents/product_manager/skills/changelog-gen/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: changelog-gen
-description: "Generate or update developer-facing changelogs from merged PRs, tags, or a dated repository release-history export, classifying user-impacting changes semantically. Use after pm-agent routes changelog work."
+description: "Generate developer-facing changelogs from merged PRs, tags, or a dated repository history export. Use after pm-agent routes changelog work."
 visibility: internal
 ---
 

--- a/agents/product_manager/skills/competitive-brief/SKILL.md
+++ b/agents/product_manager/skills/competitive-brief/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: competitive-brief
-description: "Produce competitor positioning briefs or sales battlecards from current sourced research, including messaging, gaps, opportunities, threats, and recent developments. Use after pm-agent routes competitive research."
+description: "Produce sourced competitor positioning briefs or sales battlecards covering relevant gaps, opportunities, threats, and recent changes. Use after pm-agent routes competitive research."
 visibility: internal
 argument-hint: "<competitor or market segment>"
 ---

--- a/agents/product_manager/skills/feature-catalog/SKILL.md
+++ b/agents/product_manager/skills/feature-catalog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: feature-catalog
-description: "Map an inherited project's routes, pages, APIs, services, data models, tests, and docs into a maintainer-confirmable feature catalog and bounded child-feature proposal. Use after pm-agent routes catalog work."
+description: "Map an inherited project's structure into a confirmable feature catalog and bounded child-feature proposals. Use after pm-agent routes existing-project inventory work."
 visibility: internal
 ---
 

--- a/agents/product_manager/skills/github-reader/SKILL.md
+++ b/agents/product_manager/skills/github-reader/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-reader
-description: "Summarize GitHub issues, PRs, milestones, backlog health, review queues, release readiness, and recent activity from live data or a dated complete export. Use after pm-agent routes repository-status work."
+description: "Summarize GitHub issues, PRs, milestones, backlog health, release readiness, and recent activity from live data or a dated export. Use after pm-agent routes repository-status work."
 visibility: internal
 ---
 

--- a/agents/product_manager/skills/github-release-gen/SKILL.md
+++ b/agents/product_manager/skills/github-release-gen/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-release-gen
-description: "Preview, draft, or publish a traceable GitHub Release only after version facts and applicable site Release Notes/audit gates are ready. Use after pm-agent routes GitHub Release work."
+description: "Preview, draft, or publish a traceable GitHub Release after version facts and applicable Release Notes/audit gates are ready. Use after pm-agent routes release work."
 visibility: internal
 ---
 

--- a/agents/product_manager/skills/idea-to-spec/SKILL.md
+++ b/agents/product_manager/skills/idea-to-spec/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: idea-to-spec
-description: "Run product discovery and turn a new idea, empty-workspace app, existing-feature update, or spec iteration into confirmed PRD/DECISIONS and downstream handoff scope. Use after pm-agent classifies the request."
+description: "Turn a new idea, empty-workspace app, feature change, or spec iteration into confirmed PRD/DECISIONS and downstream scope. Use after pm-agent classifies product discovery or requirements work."
 visibility: internal
 ---
 

--- a/agents/product_manager/skills/pm-agent/SKILL.md
+++ b/agents/product_manager/skills/pm-agent/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pm-agent
-description: "Default entry point for product and engineering R&D requests when the user has not named another agent or skill. Use when the user explicitly names pm-agent, including requests that also name a downstream capability. When another role agent or skill is named without pm-agent, do not activate pm-agent; that named capability applies its own gate. Covers product ideas, features, requirement changes, bugs, implementation, testing, design, deployment, security, formal project docs, delivery, inherited-project catalogs, competitive research, release communication, roadmaps, and GitHub project status."
+description: "Default entry for product and engineering R&D when no other capability is explicitly named. Explicitly naming pm-agent selects it; explicitly naming another agent or skill selects that capability and its own gate."
 ---
 
 # PM Agent Dispatcher

--- a/agents/product_manager/skills/roadmap-gen/SKILL.md
+++ b/agents/product_manager/skills/roadmap-gen/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: roadmap-gen
-description: "Create or update a roadmap from dated GitHub milestone, issue, PR, and release evidence, using real dates when available and semantic phases otherwise. Use after pm-agent routes roadmap work."
+description: "Create or update a roadmap from dated GitHub milestones, issues, PRs, and releases, using semantic phases when dates are unavailable. Use after pm-agent routes roadmap work."
 visibility: internal
 ---
 

--- a/agents/product_manager/test/changelog-gen/evals/workspace/eval-001-unreleased-mode/comparison.md
+++ b/agents/product_manager/test/changelog-gen/evals/workspace/eval-001-unreleased-mode/comparison.md
@@ -13,18 +13,18 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `6c891edd0d2edaa974f9696bff7fd8bce1989edc225daec7356e08843c3ccf17` from `agents/product_manager/test/changelog-gen/evals/workspace/eval-001-unreleased-mode`.
 - Identity schema: `2`
-- target_skill_sha256: `53f035563de038125d09b7a8997f87e900d099e00223f427a7c690e11ebbe449`
+- target_skill_sha256: `2ba8dad890b4a470e045fac5a77553d35f40494dd4f5ee0df778eda64ba0f881`
 - eval_definition_sha256: `f643e5a44adc95dee4686543e115df7acb899ebc5dec146519d9991e82db553d`
 - metadata_sha256: `95c0dae43621d97267d71f9000473df424f0f20875022c90f8a0826f1615ee52`
 - fixture_sha256: `6c891edd0d2edaa974f9696bff7fd8bce1989edc225daec7356e08843c3ccf17`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
 - runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
 - judge_schema_sha256: `e87b7560e9b11fe6dfc954d0faa2696f04b98bb48f59af2eb521a8e8cfed4660`
-- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
-- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
-- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
-- Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
+- Prompt SHA-256: `43cfb6c692393c921f5bd34fe732149f7950dd5ff91e898df22a516e60d25811`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
+- Skill overlay SHA-256: `f75f5f8b8869cc572a0f69646861f4a54c0e1cb5775b8c2dac040f714114c1c9`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,22 +33,22 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `unreleased` | PASS | with_skill delivery_snapshot contains `## [Unreleased]`. |
-| `pr` | PASS | Both included entries contain GitHub PR links with `(#310)` and `(#311)`. |
-| `bot_pr_dependabot` | PASS | PR #312 by `dependabot[bot]` is absent from the locked delivered file. |
-| `chore_ci_test` | PASS | Chore dependency PR #312 and internal CI PR #313 are absent from the locked delivered file. |
-| `versioned_changelog_file` | PASS | with_skill delivery_snapshot directly contains the file at `docs/changelog/changelog-unreleased.md`. |
+| `unreleased` | PASS | with_skill delivery snapshot contains `## [Unreleased]`. |
+| `pr` | PASS | with_skill entries include linked PR references `[#310](...)` and `[#311](...)`. |
+| `bot_pr_dependabot` | PASS | with_skill snapshot includes only PRs #310 and #311; bot dependency PR #312 is absent. |
+| `chore_ci_test` | PASS | with_skill snapshot excludes the chore/dependency and CI-only internal changes (#312 and #313). |
+| `versioned_changelog_file` | PASS | with_skill delivery snapshot directly records `docs/changelog/changelog-unreleased.md` with file content. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=43cfb6c692393c921f5bd34fe732149f7950dd5ff91e898df22a516e60d25811; fixture_sha256=6c891edd0d2edaa974f9696bff7fd8bce1989edc225daec7356e08843c3ccf17; output_sha256=48df9d25dc0492ad2b3e6c970accc092e7d19985499886500761dde01f3bd7d0; snapshot_sha256=43039ce65dda406efc363a36408cbdaac9130194336a569957665ae7747abf77
-- Behavior: Generated the requested Unreleased changelog file with user-visible Added and Fixed entries, PR links, and excluded bot/dependency/internal CI changes.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=43cfb6c692393c921f5bd34fe732149f7950dd5ff91e898df22a516e60d25811; fixture_sha256=6c891edd0d2edaa974f9696bff7fd8bce1989edc225daec7356e08843c3ccf17; output_sha256=a03035b9e43fb52ec3393158f458a2bc2c9b90b5e5b1d479b29c5ba1121a17c5; snapshot_sha256=6e767afde2693f1bc204321e2d592c9f3ddd959601c219bd5980b89ef48241aa
+- Behavior: Generated the requested Unreleased changelog with user-facing Added and Fixed entries, PR links, and excluded internal maintenance.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=43cfb6c692393c921f5bd34fe732149f7950dd5ff91e898df22a516e60d25811; fixture_sha256=6c891edd0d2edaa974f9696bff7fd8bce1989edc225daec7356e08843c3ccf17; output_sha256=832d54f42ce83b072fcad15d2e3e54b04993409084f664b2b8954b702763e1cc; snapshot_sha256=773a004a177e2ad2b3f336a901cb504f98499aae518030526b15f89e62428bd9
-- Behavior: Also generated the requested changelog content and exclusions; serves as comparison context only.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=43cfb6c692393c921f5bd34fe732149f7950dd5ff91e898df22a516e60d25811; fixture_sha256=6c891edd0d2edaa974f9696bff7fd8bce1989edc225daec7356e08843c3ccf17; output_sha256=baa4d62a90d0fce35044b5de0a36ac8b813ab61efb0d3786c3694d8169007318; snapshot_sha256=8d6c64a032ae626ecca1f2f2c3a8701ba143efe51ebb60f892269f71644f42fa
+- Behavior: Also generated a valid changelog with the same user-facing entries and exclusions; behavior is comparable baseline context.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/changelog-gen/evals/workspace/eval-002-single-version-mode/comparison.md
+++ b/agents/product_manager/test/changelog-gen/evals/workspace/eval-002-single-version-mode/comparison.md
@@ -13,18 +13,18 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `835e6d91014bb254ac4027a75b2b94fcac8cc02efcf4ee8832fb73ee44824c88` from `agents/product_manager/test/changelog-gen/evals/workspace/eval-002-single-version-mode`.
 - Identity schema: `2`
-- target_skill_sha256: `53f035563de038125d09b7a8997f87e900d099e00223f427a7c690e11ebbe449`
+- target_skill_sha256: `2ba8dad890b4a470e045fac5a77553d35f40494dd4f5ee0df778eda64ba0f881`
 - eval_definition_sha256: `8e1f2a2b7cff1dcc676c7dcd6956883a0a24ee6d97754afcf56bc59fdaf06a61`
 - metadata_sha256: `814184c8bd7a959b3f0695c85bef4dd34c73bd316a08d00ccc354207f37fabc9`
 - fixture_sha256: `835e6d91014bb254ac4027a75b2b94fcac8cc02efcf4ee8832fb73ee44824c88`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
 - runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
 - judge_schema_sha256: `609660421781976ec561327c947a31da6f7d421bc63e99d2f3f00692dcdf763a`
-- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
-- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
-- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
-- Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
+- Prompt SHA-256: `d5b776b3a900ef058dd8e13d5ff0673d61e60850257603b59fa1902a93991031`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
+- Skill overlay SHA-256: `f75f5f8b8869cc572a0f69646861f4a54c0e1cb5775b8c2dac040f714114c1c9`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,22 +33,22 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `v_version_yyyy_mm_dd` | PASS | 文件包含 `## [v0.120.2] - 2026-08-05`。 |
-| `release_tag` | PASS | 版本 `v0.120.2` 与证据中的实际 release tag `v0.120.2` 匹配。 |
-| `pr_conventional_commit` | PASS | PR 标题已去除 conventional commit 前缀；`client` scope 作为上下文保留。 |
-| `breaking_change_breaking` | PASS | PR #302 条目带有 `⚠️ **BREAKING**` 前缀。 |
-| `section` | PASS | 仅有内容的 `Changed` 和 `Fixed` section 出现在文件中。 |
+| `v_version_yyyy_mm_dd` | PASS | Locked with_skill file contains `## [v0.120.2] - 2026-08-05`. |
+| `release_tag` | PASS | Locked release evidence specifies tag `v0.120.2`, matching the delivered heading and filename. |
+| `pr_conventional_commit` | PASS | PR titles are cleaned of conventional prefixes; the retained `client` scope is explicitly permitted. |
+| `breaking_change_breaking` | PASS | PR #302 is labeled `⚠️ **BREAKING**` in the delivered file. |
+| `section` | PASS | Added, Changed, and Fixed sections each contain a PR entry; no empty section is present. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=d5b776b3a900ef058dd8e13d5ff0673d61e60850257603b59fa1902a93991031; fixture_sha256=835e6d91014bb254ac4027a75b2b94fcac8cc02efcf4ee8832fb73ee44824c88; output_sha256=9411b28e307c82f3646b44f07761887623a6c065e74339e777fbfb1bb8b108f0; snapshot_sha256=81b742cd60b43f8962f9f527119057a2cd1cfef937315445d6ae8c68d6f192f2
-- Behavior: 正确生成目标版本文件，纳入全部 3 个 PR，并满足版本、清洗、Breaking 和 section 要求。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=d5b776b3a900ef058dd8e13d5ff0673d61e60850257603b59fa1902a93991031; fixture_sha256=835e6d91014bb254ac4027a75b2b94fcac8cc02efcf4ee8832fb73ee44824c88; output_sha256=30bf5157dd8ff3d27ac44caa3f8e7b19c1055205dfa2c20c7e13f4f8e773abc2; snapshot_sha256=76a876a0b38992a3479bcdd867af175829a42a29c810a13c6b90ad7d72560810
+- Behavior: Generated the requested changelog file with the correct version/date, all three PR references, cleaned titles, and breaking-change marking.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=d5b776b3a900ef058dd8e13d5ff0673d61e60850257603b59fa1902a93991031; fixture_sha256=835e6d91014bb254ac4027a75b2b94fcac8cc02efcf4ee8832fb73ee44824c88; output_sha256=eca7ae9bf6fe74b78aeeb360b84be3d0358017e5e2bc5031414d0a85708101c0; snapshot_sha256=a56b8cf237114065d6f358fd6ef3c945f2a6003817cec99a9dfe9d6eb21b14f7
-- Behavior: 生成了文件并纳入全部 PR，但版本标题缺少 v 前缀且 Breaking 标记不符合要求；仅作对比基线。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=d5b776b3a900ef058dd8e13d5ff0673d61e60850257603b59fa1902a93991031; fixture_sha256=835e6d91014bb254ac4027a75b2b94fcac8cc02efcf4ee8832fb73ee44824c88; output_sha256=044d7d8a77ada4e4296d53576ae7f5a32edeeb57217e066fdb6676bba355edce; snapshot_sha256=1e6cf03524b4358f6211bca0df4515f33a57066e4a6bed368ddcd734e15d5438
+- Behavior: Generated a changelog with all three PR references and cleaned titles, but omitted the required v prefix and breaking marker format.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/changelog-gen/evals/workspace/eval-003-prefix-classification/comparison.md
+++ b/agents/product_manager/test/changelog-gen/evals/workspace/eval-003-prefix-classification/comparison.md
@@ -13,18 +13,18 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/changelog-gen/evals/workspace/eval-003-prefix-classification`.
 - Identity schema: `2`
-- target_skill_sha256: `53f035563de038125d09b7a8997f87e900d099e00223f427a7c690e11ebbe449`
+- target_skill_sha256: `2ba8dad890b4a470e045fac5a77553d35f40494dd4f5ee0df778eda64ba0f881`
 - eval_definition_sha256: `02c7a6bcc66679fa2f47687ffd7cdba26fff303adab62c4e3435b49f28878db8`
 - metadata_sha256: `7c295252d061c5f27afb73a5d2bc7ec230ac3e0e3896f6109062c7b18ee9cf2e`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
 - runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
 - judge_schema_sha256: `cc05e28bb9aed099804431e1cee55bda0cec7614cc8c780d6f8ad4d50c137367`
-- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
-- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
-- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
-- Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
+- Prompt SHA-256: `9be6d0e23157c436ac95fa175b7c253fc5c8a58bd7930d5f75b8e2f143978496`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
+- Skill overlay SHA-256: `f75f5f8b8869cc572a0f69646861f4a54c0e1cb5775b8c2dac040f714114c1c9`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,30 +33,30 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `feat_auth_added_add_oauth2_login_support` | PASS | With-skill output places “Add OAuth2 login support” under Added. |
-| `fix_fixed` | PASS | With-skill output places token-expiry crash resolution under Fixed. |
-| `chore_deps` | PASS | With-skill output omits the requests dependency maintenance PR. |
-| `build_deps_skipped` | PASS | With-skill output omits the Vite dependency bump. |
-| `perf_changed` | PASS | With-skill output places API caching under Changed. |
-| `feat_added_breaking` | PASS | With-skill output places the plugin configuration redesign under Changed and marks it BREAKING. |
-| `docs_release_workflow_changed` | PASS | With-skill output includes the release publishing workflow and preflight change under Changed. |
-| `test_release_acceptance_changed` | PASS | With-skill output includes release acceptance coverage and required evidence under Changed. |
-| `ci_release_gate_changed` | PASS | With-skill output includes required repository checks before release under Changed. |
-| `docs_typo_skipped` | PASS | With-skill output omits the README typo/copyediting PR. |
-| `ci_cache_skipped` | PASS | With-skill output omits the CI cache maintenance PR. |
-| `remove_removed` | PASS | With-skill output places Python 3.7 support removal under Removed. |
-| `security_security` | PASS | With-skill output places the XSS vulnerability fix under Security. |
+| `feat_auth_added_add_oauth2_login_support` | PASS | with_skill output places “Add OAuth2 login support” under Added, with an optional auth scope. |
+| `fix_fixed` | PASS | with_skill output places token-expiry crash and mobile alignment fixes under Fixed. |
+| `chore_deps` | PASS | with_skill explicitly skips dependency-only item #103. |
+| `build_deps_skipped` | PASS | with_skill explicitly skips dependency-only item #114. |
+| `perf_changed` | PASS | with_skill output places the caching performance improvement under Changed. |
+| `feat_added_breaking` | PASS | with_skill places the plugin configuration redesign under Changed and marks it BREAKING. |
+| `docs_release_workflow_changed` | PASS | with_skill includes the release publishing workflow update under Changed. |
+| `test_release_acceptance_changed` | PASS | with_skill includes tightened release acceptance coverage under Changed. |
+| `ci_release_gate_changed` | PASS | with_skill includes required repository checks before release under Changed. |
+| `docs_typo_skipped` | PASS | with_skill lists README typo/copyediting item #109 among skipped maintenance items. |
+| `ci_cache_skipped` | PASS | with_skill lists internal cache maintenance item #110 among skipped maintenance items. |
+| `remove_removed` | PASS | with_skill places Python 3.7 support removal under Removed. |
+| `security_security` | PASS | with_skill places the XSS vulnerability patch under Security. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9be6d0e23157c436ac95fa175b7c253fc5c8a58bd7930d5f75b8e2f143978496; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=8d9d87cad7abcb73168e7b8a7cf0eaa982a5e5bbd210ebd142c4deea9ae6eb0a; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly classifies all asserted user-visible changes, skips internal maintenance, and marks the breaking redesign.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9be6d0e23157c436ac95fa175b7c253fc5c8a58bd7930d5f75b8e2f143978496; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=1c3057ec114e98304d8ed4b305043738bc178ffb4a3c2117907388f79ebbe370; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly classifies all user-visible changes, cleans titles, marks the breaking change, and skips the specified maintenance-only items.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9be6d0e23157c436ac95fa175b7c253fc5c8a58bd7930d5f75b8e2f143978496; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=171e5ac5da648635f7d76603c860871f91729c1793192007856c0085b22d4167; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Fresh baseline also satisfies the assertions, providing comparison context only.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9be6d0e23157c436ac95fa175b7c253fc5c8a58bd7930d5f75b8e2f143978496; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=674d41eb6e91b34d48c83598ca0a639a60170d5f0f6a5a7caa9e65a711da79d7; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline also produced a substantively correct changelog, with more verbose translations and an explicit empty Deprecated section.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/competitive-brief/evals/workspace/eval-001-positioning-gap-brief/comparison.md
+++ b/agents/product_manager/test/competitive-brief/evals/workspace/eval-001-positioning-gap-brief/comparison.md
@@ -13,18 +13,18 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/competitive-brief/evals/workspace/eval-001-positioning-gap-brief`.
 - Identity schema: `2`
-- target_skill_sha256: `64a375a1a490fa251e9b252ef3a7787f55ca6a4fd08e5d401228a899b274ed39`
+- target_skill_sha256: `51c78b43ef29524223ad8cd1c217695feb08d840a69aa6efc0357d489d9b1808`
 - eval_definition_sha256: `97a23b71b146f4c0d34488da4fd45ddfa63b73d91d16deb5d2e03fbe4f5d01f6`
 - metadata_sha256: `253b7cd58ea1d83c5776d9de8bd0332f1de43ff8d162b4ae1c25de74c0394acf`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
 - runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
 - judge_schema_sha256: `9482baaf8c9e8ed2c6d5d65dd72ca668fb6cc639dacfe10c14d42e2f2d0f4c53`
-- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
-- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
-- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
-- Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
+- Prompt SHA-256: `adf7889b0d876e991ee47320ba8f46f60cd10315ed2d153b1c81fce9f52aed9b`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
+- Skill overlay SHA-256: `7c8d16fe8d7e0a5fcf1eddfd898ed6359958f6d99fba9afbff4d4be1085a6bfd`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `positioning` | PASS | With_skill output separately describes Linear and Jira positioning, target users, and core selling points in the positioning comparison and competitor profiles. |
-| `messaging_gap` | PASS | With_skill output identifies multiple messaging gaps and content opportunities, including context continuity, cross-functional collaboration, simplicity versus governance, project health, and AI collaboration quality. |
-| `evidence_boundary` | PASS | With_skill output explicitly labels the company context as unavailable, frames the recommended entry point as a hypothesis, and marks several judgments as requiring customer validation. |
+| `positioning` | PASS | With_skill 输出分别列出 Linear 与 Jira 的核心定位、首要用户、典型项目、关键价值及各自产品画像和卖点。 |
+| `messaging_gap` | PASS | With_skill 输出明确列出 6 个 Messaging Gap，并进一步给出跨职能协作、结果导向、渐进式治理、AI 决策协作等内容机会与行动方向。 |
+| `evidence_boundary` | PASS | With_skill 明确说明未提供我方产品与目标客户，不虚构我方能力；同时用公开资料引用支撑竞品事实，并将机会表述为可切入框架/方向，而非我方已具备的确定能力。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=adf7889b0d876e991ee47320ba8f46f60cd10315ed2d153b1c81fce9f52aed9b; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=492069627ede798bb4c6974dc87de7fded774a8dc09f89e227a7ca734c804214; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Delivered a comprehensive, structured Linear-versus-Jira brief covering all requested areas with explicit hypothesis and validation boundaries.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=adf7889b0d876e991ee47320ba8f46f60cd10315ed2d153b1c81fce9f52aed9b; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=a6e8f321128a98a195a22daf47d274af40ed23cfdbbf225c4cebeb2cb6577961; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 完整输出了 Linear/Jira 竞品 brief，覆盖定位、目标用户、卖点、messaging gap 和边界说明。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=adf7889b0d876e991ee47320ba8f46f60cd10315ed2d153b1c81fce9f52aed9b; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=fda0bff7f4205dc63e02e41246bd691d5022ce77e23f097405f342888e8cb038; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Delivered a shorter brief that covered the core comparison and messaging gaps, with less explicit evidence-boundary framing.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=adf7889b0d876e991ee47320ba8f46f60cd10315ed2d153b1c81fce9f52aed9b; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=4cc91cef27b91cca595ba77c8f22b25010b54292ca8dad0ae77be1b258d58237; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 同样完成了竞品 brief，覆盖三项要求，但结构化研究边界和机会框架相对较弱。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/competitive-brief/evals/workspace/eval-002-battlecard-mode/comparison.md
+++ b/agents/product_manager/test/competitive-brief/evals/workspace/eval-002-battlecard-mode/comparison.md
@@ -13,18 +13,18 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `580131b9961f88dece682fec7455c21af018b400a3742eb37ae40114374aeae0` from `agents/product_manager/test/competitive-brief/evals/workspace/eval-002-battlecard-mode`.
 - Identity schema: `2`
-- target_skill_sha256: `64a375a1a490fa251e9b252ef3a7787f55ca6a4fd08e5d401228a899b274ed39`
+- target_skill_sha256: `51c78b43ef29524223ad8cd1c217695feb08d840a69aa6efc0357d489d9b1808`
 - eval_definition_sha256: `a7454ae2eccc665064a08c31fc99de3b8f0a596f72811f2e5035b12f267e9fe8`
 - metadata_sha256: `be38b1b419460352b11de0cc1468d57c031f7575d697be3bf617760a456d47f3`
 - fixture_sha256: `580131b9961f88dece682fec7455c21af018b400a3742eb37ae40114374aeae0`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
 - runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
 - judge_schema_sha256: `e42897afb6931d7065c6aa9ac71e607d574f057396cd3a30a0419c210f3be3cb`
-- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
-- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
-- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
-- Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
+- Prompt SHA-256: `e54579ea27411964e085efe779b45a83156d8efbd3908b273d472904914675a2`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
+- Skill overlay SHA-256: `7c8d16fe8d7e0a5fcf1eddfd898ed6359958f6d99fba9afbff4d4be1085a6bfd`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,21 +33,21 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `battlecard_fields` | PASS | Locked delivery_snapshot contains Linear and Jira battlecards with Quick Overview, Their Pitch, Strengths, Weaknesses, Objection Handling, Landmines to Set/Defuse, and Win/Loss Themes. |
-| `no_full_brief` | PASS | The locked output is structured as battlecards and does not include a full competitor-brief chapter structure. |
-| `evidence_boundary` | PASS | The locked file states the research date and evidence boundary, identifies source categories, and marks unavailable details as 假设 or 待验证. |
-| `no_battlecard_offer` | PASS | The locked final response delivers the battlecard and does not ask whether to create one later. |
+| `battlecard_fields` | PASS | With_skill 输出分别覆盖 Linear 与 Jira 的 Quick Overview、Their Pitch、Strengths、Weaknesses、Objection Handling、Landmines to Set、Landmines to Defuse、Win/Loss Themes，且包含目标客户、定价模型摘要和近期动态。 |
+| `no_full_brief` | PASS | With_skill 输出保持为两份销售 battlecard，附加的 Our Position、Discovery Questions、Talk Track、POC Guidance 属于销售使用内容，未形成完整竞品 brief 的执行摘要、竞品画像全节、messaging gap 或机会/威胁/行动项章节。 |
+| `evidence_boundary` | PASS | With_skill 明确标注研究日期 2026-08-06、来源记录链接，并将具体价格、企业控制、安全问卷、迁移成本等未确认内容标为“待验证”或“假设”，且未作确定性量化结论。 |
+| `no_battlecard_offer` | PASS | With_skill 输出直接交付 battlecard 内容，没有询问是否需要创建 battlecard，也没有将其作为后续追加项。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=e54579ea27411964e085efe779b45a83156d8efbd3908b273d472904914675a2; fixture_sha256=580131b9961f88dece682fec7455c21af018b400a3742eb37ae40114374aeae0; output_sha256=631fd284e19e45e698d2667fd059bd21b2c78fb2d6595650d9e2f779ccbf9f4d; snapshot_sha256=f3c72f2af5a822ea88f36c6ada3aa4125155dcdb1f2d7692d21c92b7082dc8f7
-- Behavior: Produced a consolidated Linear/Jira battlecard with the required fields and explicit evidence-boundary markings.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=e54579ea27411964e085efe779b45a83156d8efbd3908b273d472904914675a2; fixture_sha256=580131b9961f88dece682fec7455c21af018b400a3742eb37ae40114374aeae0; output_sha256=ce7666f6da33e9b0e7e3db023f520c8515f37b3d27392e960db38d9748a2f4ef; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 完成 Linear 与 Jira 两份结构完整、证据边界清晰的销售 battlecard。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=e54579ea27411964e085efe779b45a83156d8efbd3908b273d472904914675a2; fixture_sha256=580131b9961f88dece682fec7455c21af018b400a3742eb37ae40114374aeae0; output_sha256=7ae60d198f1deaec6fee87630cbc9593f285ff58fb4a94371e42612f4c8b49d4; snapshot_sha256=bb33aadcdaea49ca0db679925408bb7b2c7c50923699816b2f4486459f04ba20
-- Behavior: Produced two sales one-pagers with useful research summaries, but without the required battlecard field structure.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=e54579ea27411964e085efe779b45a83156d8efbd3908b273d472904914675a2; fixture_sha256=580131b9961f88dece682fec7455c21af018b400a3742eb37ae40114374aeae0; output_sha256=1daa68dfedc054bfc67a7a1f45b3ed3d583ba31609059d4d8792c9ba862e0beb; snapshot_sha256=c0ddb1c0d8c80fe01d39ef6b8df68cb1c865c83440969e8e0c42fd57bb3796db
+- Behavior: 完成两份销售一页资料并标注假设/待验证，但呈现为较泛化的销售资料，未在最终输出中展示完整 battlecard 字段结构。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/feature-catalog/evals/workspace/eval-001-legacy-project-catalog/comparison.md
+++ b/agents/product_manager/test/feature-catalog/evals/workspace/eval-001-legacy-project-catalog/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `fa295db805350878180b0b5d2e6fc6d21188b2866a3c61c345e1f1875b201554` from `agents/product_manager/test/feature-catalog/evals/workspace/eval-001-legacy-project-catalog`.
 - Identity schema: `2`
-- target_skill_sha256: `217c9b057b0819a52534f84f10e4d4a1bc905c2af1e21214f5f09bf51cb17566`
+- target_skill_sha256: `7440f3be22fb3254e3abf20bcd1c6ebca9f2fdee2fae7f710cc03af349b94250`
 - eval_definition_sha256: `6316196cbc0024d8a369162c20842d191078adb23f3f59cfbc5541923081da5e`
 - metadata_sha256: `aa9b419ec00ff2ce5f9c2775fc1e620cf1eb45a8d316e5adf573b14f5b74c3e2`
 - fixture_sha256: `fa295db805350878180b0b5d2e6fc6d21188b2866a3c61c345e1f1875b201554`
@@ -22,39 +22,39 @@
 - judge_schema_sha256: `6731c51ff9f69981e5ade0a40fa5fb4f93b6c439e428212a1b46155c6fa123f1`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `35596dbabe7e81489226405d1f4c2c66e846066917c0ef619ae5a1e2332558a2`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `6cef39f1b1cce23592397054fa6d427258c02b6778c43df49e227da056eafd0d`
+- Skill overlay SHA-256: `855b39267bf29cb8319dc4bcf28cd88b5cba0ad0d7279c117acb672b2cd4540b`
 - Behavior result: **PASS**
-- Coverage result: **PARTIAL**
-Overall result: PASS (partial coverage)
+- Coverage result: **FULL**
+Overall result: PASS
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `draft_before_formal_docs` | NOT_EXERCISED | With-skill output correctly pauses for project-scope confirmation; no formal docs were created, but the feature-catalog draft itself was not yet produced. |
-| `evidence_and_confidence` | NOT_EXERCISED | No candidate feature entries were produced because the workflow is awaiting scope confirmation. |
-| `business_capability_naming` | NOT_EXERCISED | No candidate feature entries were produced because the workflow is awaiting scope confirmation. |
-| `open_questions_present` | NOT_EXERCISED | No candidate feature entries or uncertainty questions about feature ownership were produced because the workflow is awaiting scope confirmation. |
-| `confirmation_gate` | NOT_EXERCISED | The output asks for project-root scope confirmation, not feature_path confirmation; the later feature-catalog gate cannot yet be exercised. |
+| `draft_before_formal_docs` | PASS | With-skill output is explicitly labeled “功能目录草案（待确认）”; locked git evidence shows no worktree changes or delivered docs/pm files. |
+| `evidence_and_confidence` | PASS | Each of the three candidate features includes evidence categories drawn from the fixture and a low confidence label. |
+| `business_capability_naming` | PASS | Features are named as customer-facing capabilities such as 客户身份认证、订单创建与查询、订单状态通知; code paths are listed separately as evidence. |
+| `open_questions_present` | PASS | Each candidate includes open_questions addressing uncertain boundaries or scope. |
+| `confirmation_gate` | PASS | The output ends by asking the maintainer to confirm feature_path values and explicitly states that docs/pm/FEATURE_CATALOG.md and PRD/TRD handoff will wait until confirmation. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=35596dbabe7e81489226405d1f4c2c66e846066917c0ef619ae5a1e2332558a2; fixture_sha256=fa295db805350878180b0b5d2e6fc6d21188b2866a3c61c345e1f1875b201554; output_sha256=647d51139ca6ae9899b1ff534d40b927405ebd97021c4fad794ace329a8c0aaf; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Paused at the appropriate project-scope confirmation step with no workspace mutation or formal documentation.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=35596dbabe7e81489226405d1f4c2c66e846066917c0ef619ae5a1e2332558a2; fixture_sha256=fa295db805350878180b0b5d2e6fc6d21188b2866a3c61c345e1f1875b201554; output_sha256=aa4bd23dddb8d8033b7c4505ed46049467015746f15aea7c45cdd0c965c583e8; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Produced an evidence-backed, low-confidence feature catalog draft with unresolved questions, no formal-document mutation, and a confirmation gate.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=35596dbabe7e81489226405d1f4c2c66e846066917c0ef619ae5a1e2332558a2; fixture_sha256=fa295db805350878180b0b5d2e6fc6d21188b2866a3c61c345e1f1875b201554; output_sha256=690886cd125c181d68eea06e16a629302e72a52200724c6e5c33c5c9cc727b25; snapshot_sha256=f039b905d82d3e1493f54d0b2a3a09cc76a4ab0e1c32620fd2cba9049224c868
-- Behavior: Produced and linked a formal feature catalog and modified README without a confirmation gate.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=35596dbabe7e81489226405d1f4c2c66e846066917c0ef619ae5a1e2332558a2; fixture_sha256=fa295db805350878180b0b5d2e6fc6d21188b2866a3c61c345e1f1875b201554; output_sha256=7cc1b50f12fede2c8bb03c50628838f75b44bdf42f5f53ad33482a5aba2aaacf; snapshot_sha256=d36c9a38b59288bf6e074c1b8081d7d41037f2a27da53da746c712c673b88700
+- Behavior: Created a formal feature catalog immediately and presented completed findings without a pending-confirmation draft gate.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: After scope confirmation, produce an explicitly pending feature-catalog draft with evidence, confidence, business-capability names, unresolved questions, and a feature_path confirmation gate.
+- Next: None.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/feature-catalog/evals/workspace/eval-002-child-feature-under-parent-prd/comparison.md
+++ b/agents/product_manager/test/feature-catalog/evals/workspace/eval-002-child-feature-under-parent-prd/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `e64d0dc500eb5720a57f43e64b9a52c75b87f674117c2e966a459db4cd412910` from `agents/product_manager/test/feature-catalog/evals/workspace/eval-002-child-feature-under-parent-prd`.
 - Identity schema: `2`
-- target_skill_sha256: `217c9b057b0819a52534f84f10e4d4a1bc905c2af1e21214f5f09bf51cb17566`
+- target_skill_sha256: `7440f3be22fb3254e3abf20bcd1c6ebca9f2fdee2fae7f710cc03af349b94250`
 - eval_definition_sha256: `381b074083537f3d71cb0a28bd3dbbcbf80ece8371ca5fba3a891d822f995603`
 - metadata_sha256: `9511751d671a5ae5883161ea664a79cdce7fc89cb2e17e607a976174a239c8f6`
 - fixture_sha256: `e64d0dc500eb5720a57f43e64b9a52c75b87f674117c2e966a459db4cd412910`
@@ -22,39 +22,39 @@
 - judge_schema_sha256: `c03c0410b926db4903e624e0fe3e993a88d8b355caa51278c9f027aa7078ef66`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `d30a63f3453aaf3bd01618d870dc101f5d610329fec8c95cdf338a27c46a679e`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `6cef39f1b1cce23592397054fa6d427258c02b6778c43df49e227da056eafd0d`
-- Behavior result: **FAIL**
+- Skill overlay SHA-256: `855b39267bf29cb8319dc4bcf28cd88b5cba0ad0d7279c117acb672b2cd4540b`
+- Behavior result: **PASS**
 - Coverage result: **PARTIAL**
-Overall result: FAIL
+Overall result: PASS (partial coverage)
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `parent_prd_context_read` | PASS | 输出引用 docs/pm/order-management/PRD.md，并明确复用 feature_path: order-management；原始工具证据也显示读取了该 PRD。 |
-| `child_nested_under_parent` | PASS | 建议路径为 order-management/refunds，仍是 order-management 下的 lower kebab-case 子路径，而非顶层目录。 |
-| `feature_level_metadata` | PASS | 输出明确给出 parent_feature: order-management、feature_level: 2，且建议路径包含两段。 |
-| `handoff_packet_fields` | NOT_EXERCISED | 候选要求先等待用户确认；确认后的 handoff 尚未发生，因此无法验证完整 handoff packet 及 feature_path_evidence 契约。 |
-| `no_bulk_prd` | FAIL | 未生成 PRD/TRD 正文，但将 PRD/DECISIONS 交给 idea-to-spec，而断言要求指向 prd-gen；Engineer 侧虽明确指向 engineer-agent:trd-gen，整体路由要求未满足。 |
+| `parent_prd_context_read` | PASS | Locked with_skill trace shows a command reading docs/pm/order-management/PRD.md before the candidate states and reuses feature_path order-management. |
+| `child_nested_under_parent` | PASS | The candidate proposes order-management/refunds as a level-2 child under order-management, not a parallel top-level feature. |
+| `feature_level_metadata` | PASS | The candidate output explicitly gives parent_feature: order-management and feature_level: 2, matching the two-segment path. |
+| `handoff_packet_fields` | NOT_EXERCISED | The candidate correctly stops at the confirmation gate; the later handoff packet cannot yet be produced without maintainer confirmation, so this assertion is not exercised. |
+| `no_bulk_prd` | PASS | No PRD/TRD content is generated. The next steps explicitly route PM documents to idea-to-spec and the engineering TRD to engineer-agent:trd-gen. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=d30a63f3453aaf3bd01618d870dc101f5d610329fec8c95cdf338a27c46a679e; fixture_sha256=e64d0dc500eb5720a57f43e64b9a52c75b87f674117c2e966a459db4cd412910; output_sha256=306cadd495ffcddc9c3922fa0f3a8784c9b277eae127efd98e23a19dfaf1465d; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 正确识别并建议退款嵌套在 order-management 下，且给出一致的元数据；但未形成确认后的 handoff packet，并错误指定 PRD 交接方。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=d30a63f3453aaf3bd01618d870dc101f5d610329fec8c95cdf338a27c46a679e; fixture_sha256=e64d0dc500eb5720a57f43e64b9a52c75b87f674117c2e966a459db4cd412910; output_sha256=db78f87c05b125844821cf1e7fc321e12ed9fce17a4a6baead1f1e243163750b; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Read the parent PRD, proposed a correctly nested refund feature with consistent metadata, stopped for confirmation, and described the downstream spec/TRD handoffs.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=d30a63f3453aaf3bd01618d870dc101f5d610329fec8c95cdf338a27c46a679e; fixture_sha256=e64d0dc500eb5720a57f43e64b9a52c75b87f674117c2e966a459db4cd412910; output_sha256=f6881488e7bb0c6fbf375d5e32d94069469849fcad0ebaa105c20e5d9df46836; snapshot_sha256=4668468aedb4a0941a841f5bda2861ed8b260bd25be12d9004bb04c95c0f6017
-- Behavior: 基线直接更新了功能目录和退款画像，路径与元数据完整，但未提供要求的 handoff packet 契约字段。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=d30a63f3453aaf3bd01618d870dc101f5d610329fec8c95cdf338a27c46a679e; fixture_sha256=e64d0dc500eb5720a57f43e64b9a52c75b87f674117c2e966a459db4cd412910; output_sha256=c6e6dfec1f4723b39e8ceb53a6cdc54267d0b8fbfbd8608908d08e63f062db4f; snapshot_sha256=82208bba18143467a3b305a7b0d41bd0809b12c45e7678f18346f8509a5b0150
+- Behavior: Produced catalog and refund PRD files immediately, but did not demonstrate the confirmation-gated handoff contract.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- with_skill 将 PRD/DECISIONS 后续交给 idea-to-spec，而非要求的 prd-gen。
-- Next: 确认后补齐包含 feature_path、feature、parent_feature、feature_level 和 feature_path_evidence 的 handoff packet，并将 PRD/DECISIONS 创建或更新明确交给 prd-gen。
+- None.
+- Next: Obtain maintainer confirmation, then evaluate the generated handoff packet fields.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/feature-catalog/evals/workspace/eval-003-monorepo-scope-clarification/comparison.md
+++ b/agents/product_manager/test/feature-catalog/evals/workspace/eval-003-monorepo-scope-clarification/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `c414562285f1c022777b6125d75fb56cbbd795475c5bf83bc97b862a14abc6d3` from `agents/product_manager/test/feature-catalog/evals/workspace/eval-003-monorepo-scope-clarification`.
 - Identity schema: `2`
-- target_skill_sha256: `217c9b057b0819a52534f84f10e4d4a1bc905c2af1e21214f5f09bf51cb17566`
+- target_skill_sha256: `7440f3be22fb3254e3abf20bcd1c6ebca9f2fdee2fae7f710cc03af349b94250`
 - eval_definition_sha256: `221668759d9b3f1847f350986e591b6defbd71cd5f83a296b96e5736de8e7ceb`
 - metadata_sha256: `8aa1f1f970ba708ba203aa964e23b048bfd278c5cd0d04094602a65c55ad9476`
 - fixture_sha256: `c414562285f1c022777b6125d75fb56cbbd795475c5bf83bc97b862a14abc6d3`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `fe7ee6212a0514e053db6b490f2fd78c74a3e6115f5b789e3e3734a9d7b1be8b`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `592a8806afad3bd6928b7ec27d5b10ebdae9bb0b86dd82cabdc2f71dc5d37c25`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `6cef39f1b1cce23592397054fa6d427258c02b6778c43df49e227da056eafd0d`
+- Skill overlay SHA-256: `855b39267bf29cb8319dc4bcf28cd88b5cba0ad0d7279c117acb672b2cd4540b`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,21 +33,21 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `blocked_on_scope` | PASS | 明确识别出 3 个 workspace（apps/admin、apps/web、services/api），并要求先选择目录范围。 |
-| `minimal_clarification` | PASS | 只提出一个范围选择问题，包含单个 workspace 或全部三个选项。 |
-| `no_fabricated_catalog` | PASS | 未交付文件、目录或 PRD，也没有声明已生成确认版目录。 |
-| `no_parallel_top_level` | PASS | 仅列出 workspace 作为范围选项，没有提出并列顶层 feature_path 结论。 |
+| `blocked_on_scope` | PASS | with_skill 输出明确标记为“blocked”，识别出 apps/admin、apps/web、services/api 三个独立 workspace，并说明等待范围确认。 |
+| `minimal_clarification` | PASS | with_skill 只提出一个范围问题：选择哪个 workspace 或是否三者都要；没有扩展为多问题清单。 |
+| `no_fabricated_catalog` | PASS | with_skill 输出声明尚未创建目录文档；git_status 与 git_diff 均为空，且没有 delivery_snapshot 或 PRD 文件证据。 |
+| `no_parallel_top_level` | PASS | with_skill 仅列出 workspace 作为范围候选，没有输出 feature_path，也未将其猜测为并列顶层功能路径。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=592a8806afad3bd6928b7ec27d5b10ebdae9bb0b86dd82cabdc2f71dc5d37c25; fixture_sha256=c414562285f1c022777b6125d75fb56cbbd795475c5bf83bc97b862a14abc6d3; output_sha256=7fc5f7cf6a156b29dadbb46255ac96f63e4fca39f40e7dfa538ce2f27a1ae689; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 识别范围不明确，阻塞在单一范围澄清问题上，未进行目录生成。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=592a8806afad3bd6928b7ec27d5b10ebdae9bb0b86dd82cabdc2f71dc5d37c25; fixture_sha256=c414562285f1c022777b6125d75fb56cbbd795475c5bf83bc97b862a14abc6d3; output_sha256=3ac35317f53292e532072b213ce051e03f84c71dac41e8f88dafd57a3095311a; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 识别 monorepo 范围不明确，进入 blocked 状态并提出单一最小澄清问题；未产生目录或 PRD 交付物。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=592a8806afad3bd6928b7ec27d5b10ebdae9bb0b86dd82cabdc2f71dc5d37c25; fixture_sha256=c414562285f1c022777b6125d75fb56cbbd795475c5bf83bc97b862a14abc6d3; output_sha256=3fe9b3e9d74d983625e9a93afa4c5a27a014f9b3785e71ddddef7ba62ce77d17; snapshot_sha256=dc541d41cbe918f693bbcf8791b330b9dd029052c388120a2bec73a91baa4ec0
-- Behavior: 直接生成并交付覆盖三个 workspace 的功能目录及 README 更新。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=592a8806afad3bd6928b7ec27d5b10ebdae9bb0b86dd82cabdc2f71dc5d37c25; fixture_sha256=c414562285f1c022777b6125d75fb56cbbd795475c5bf83bc97b862a14abc6d3; output_sha256=6ed95ddc46a36db57e1a0895622069f77dc7895dca98586f039db041d8052690; snapshot_sha256=4e4d18c60aeb00fb0d3e3ac8a0fc51c3c1356617b96311a4c401498746be9bb3
+- Behavior: 直接创建功能目录并修改 README，未先澄清 workspace 范围。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/feature-catalog/evals/workspace/eval-004-catalog-mapped-billing-feature/comparison.md
+++ b/agents/product_manager/test/feature-catalog/evals/workspace/eval-004-catalog-mapped-billing-feature/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `dbc5593a346cec17c758e623e41d968d8b062bb60f1c6687047b79f186d5a5fa` from `agents/product_manager/test/feature-catalog/evals/workspace/eval-004-catalog-mapped-billing-feature`.
 - Identity schema: `2`
-- target_skill_sha256: `217c9b057b0819a52534f84f10e4d4a1bc905c2af1e21214f5f09bf51cb17566`
+- target_skill_sha256: `7440f3be22fb3254e3abf20bcd1c6ebca9f2fdee2fae7f710cc03af349b94250`
 - eval_definition_sha256: `8d7030970f6fab5f1056baaa7f97792f12e093b11e3211055d5ae790cf0d3bc2`
 - metadata_sha256: `b6e639db89ad7dc9c01b74ff5037844027a7f93b1a684864779b0328b14ee4bc`
 - fixture_sha256: `dbc5593a346cec17c758e623e41d968d8b062bb60f1c6687047b79f186d5a5fa`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `18727fc23cb0e6511e466aafaee8dc2b3d50aa38834ef79db9cd3a99a2690d99`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `6cef39f1b1cce23592397054fa6d427258c02b6778c43df49e227da056eafd0d`
+- Skill overlay SHA-256: `855b39267bf29cb8319dc4bcf28cd88b5cba0ad0d7279c117acb672b2cd4540b`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `reads_mapped_docs_first` | PASS | With_skill trace shows the change-map was read for `src/billing/**`, then the mapped `docs/site/api/billing.md` was read; no unrelated document contents were traversed. |
-| `verifies_against_code` | PASS | The delivered output preserves the documentation path and claim (monthly and annual), the code path and fact (`service.txt` supports only monthly and `create_subscription`), and the resulting discrepancy/open confirmation question. |
-| `treats_unverified_as_low_trust` | PASS | The output explicitly marks `last_verified_version: unverified` as low trust and states that conclusions are based on code evidence, while recording annual as unconfirmed. |
+| `reads_mapped_docs_first` | PASS | With-skill trace reads the change map, then the mapped billing document before code verification; no unrelated document contents are read. |
+| `verifies_against_code` | PASS | The delivered draft cites docs/site/api/billing.md:13, records its monthly-and-annual claim, cites src/billing/service.txt:1-2, records monthly plus create_subscription as code facts, and identifies annual support as an unresolved discrepancy. |
+| `treats_unverified_as_low_trust` | PASS | The draft explicitly treats last_verified_version: unverified as low trust and bases the implementation conclusions on src/billing/service.txt rather than accepting the annual documentation claim. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=18727fc23cb0e6511e466aafaee8dc2b3d50aa38834ef79db9cd3a99a2690d99; fixture_sha256=dbc5593a346cec17c758e623e41d968d8b062bb60f1c6687047b79f186d5a5fa; output_sha256=4ea4cc2236f98583d7213396674363d178f58bfbbc1fb4820a9dba034930cb67; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Produced a cautious, code-grounded billing feature catalog, preserved the documentation/code discrepancy, and gated the result pending confirmation.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=18727fc23cb0e6511e466aafaee8dc2b3d50aa38834ef79db9cd3a99a2690d99; fixture_sha256=dbc5593a346cec17c758e623e41d968d8b062bb60f1c6687047b79f186d5a5fa; output_sha256=2e55931dbf297d5a37d0faa9f982419a973355fcfccd33e1782daa0c7aa33143; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Produced a confirmation-gated feature catalog draft with mapped-document evidence, code verification, confidence, and the documentation/code discrepancy.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=18727fc23cb0e6511e466aafaee8dc2b3d50aa38834ef79db9cd3a99a2690d99; fixture_sha256=dbc5593a346cec17c758e623e41d968d8b062bb60f1c6687047b79f186d5a5fa; output_sha256=c094e58d090cd2021a96b059dd7823906f271d22bcf3ae489c192eba69b869ca; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Produced a broader billing inventory and independently identified the monthly-versus-annual discrepancy, but did not follow the mapped-document-first workflow.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=18727fc23cb0e6511e466aafaee8dc2b3d50aa38834ef79db9cd3a99a2690d99; fixture_sha256=dbc5593a346cec17c758e623e41d968d8b062bb60f1c6687047b79f186d5a5fa; output_sha256=f8a8509968d244a1401ce7901a0263c1335207a4708c506b0bc142f1b2e1a887; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Produced a reasonable code-grounded billing summary and identified the annual-plan discrepancy, but its trace shows a fresh direct scan without the mapped-document-first workflow.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/github-reader/evals/workspace/eval-001-full-status/comparison.md
+++ b/agents/product_manager/test/github-reader/evals/workspace/eval-001-full-status/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `0519c739e4c8d28c0f994ae12773611385afed7d111bc3d263905cd5dd009c56` from `agents/product_manager/test/github-reader/evals/workspace/eval-001-full-status`.
 - Identity schema: `2`
-- target_skill_sha256: `99ea82f9c285d0cd51090c481c0892adf1bdf20367a2866bf82eabffdc17f4c7`
+- target_skill_sha256: `d3991eb6cbaa175b6a277fc4b5fcfd2722f7236109022f8336344db1c65d4b7e`
 - eval_definition_sha256: `a688cc91089931e5821e56e4470a0bc8844e7a9c13d1b4c5bcc8d2e3929da0ce`
 - metadata_sha256: `94b279ac62424134e6355f46df23e4185fa4034dd04349372cf9178ca3c8c29f`
 - fixture_sha256: `0519c739e4c8d28c0f994ae12773611385afed7d111bc3d263905cd5dd009c56`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `9f1a7ae2ae5e175ed8e057b35c400ea4c201e7779a64206f11bbe6bac585e282`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `01e34273d27e520aa4245ba28190974384941538e5ce7197f3456329c6301565`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `a9770b603fd249fd7f80da3e56ab1a6acb6432c1ad6dff3ad5cfc0e089124eab`
+- Skill overlay SHA-256: `e4717fcaf9f805711dd56f954fc18d08364c40568c6f66db73a7888140ce8305`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,22 +33,22 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `milestone` | PASS | With_skill output includes a Milestones table with title, progress values 80% and 40%, dates, and status. |
-| `pr` | PASS | With_skill output includes a PR 队列 section separating 待 Review and 近 14 天已合并 queues. |
-| `assertion_3` | PASS | With_skill output ends with a numeric 健康摘要 covering milestone, overdue, merged PR, and closed issue counts. |
-| `pr_2` | PASS | Open and merged PR entries use links in the required [#NUMBER](URL) format. |
-| `data_completeness` | PASS | With_skill output states the capture time, cites raw search total_count values for the relevant collections, and reports the snapshot as complete; fixture evidence shows complete, non-truncated collections. |
+| `milestone` | PASS | With-skill output includes a titled Milestones table with progress values 80% and 40%. |
+| `pr` | PASS | With-skill output has a PR queue with separate 待 Review, Changes Requested, 草稿, and 近 14 天已合并 sections. |
+| `assertion_3` | PASS | With-skill output ends with 健康摘要 containing multiple numeric metrics, including milestone, issue, PR, and recent-activity counts. |
+| `pr_2` | PASS | All listed PR entries use the required [#NUMBER](GitHub URL) format, including open and merged PRs. |
+| `data_completeness` | PASS | With-skill output states raw search total_count values and explicitly declares the snapshot complete and collections untruncated; fixture counts match the supplied collections. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=01e34273d27e520aa4245ba28190974384941538e5ce7197f3456329c6301565; fixture_sha256=0519c739e4c8d28c0f994ae12773611385afed7d111bc3d263905cd5dd009c56; output_sha256=99a3ecfbf9cc0c1d35f5ab3704eaab0d245cdcba5e98719a918326236f9f63e4; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Delivered a complete dated GitHub status summary with milestone progress, issue totals, separated PR queues, links, and numeric health summary.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=01e34273d27e520aa4245ba28190974384941538e5ce7197f3456329c6301565; fixture_sha256=0519c739e4c8d28c0f994ae12773611385afed7d111bc3d263905cd5dd009c56; output_sha256=854adacdbee80053be261f52cc044ae6bd998a52c12c03f1b82e12c13a11e491; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Provides a complete dated GitHub snapshot report satisfying all five assertions.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=01e34273d27e520aa4245ba28190974384941538e5ce7197f3456329c6301565; fixture_sha256=0519c739e4c8d28c0f994ae12773611385afed7d111bc3d263905cd5dd009c56; output_sha256=80e9dc80d1ac55764bed9fc5dfba4cf4a063db0e6a3aef3ebecfb268a74bd3bd; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Delivered a generally accurate dated summary but lacked the structured linked PR queue and explicit raw-count completeness framing.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=01e34273d27e520aa4245ba28190974384941538e5ce7197f3456329c6301565; fixture_sha256=0519c739e4c8d28c0f994ae12773611385afed7d111bc3d263905cd5dd009c56; output_sha256=7700492023632bcd21ec59e61cb2ec1c0916110034d40d8ac90b3ae31a0dbf40; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Provides milestone, issue, and PR summaries but lacks the required PR link formatting and explicit completeness declaration.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/github-reader/evals/workspace/eval-002-focused-pr-query/comparison.md
+++ b/agents/product_manager/test/github-reader/evals/workspace/eval-002-focused-pr-query/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `c47404a9f5ea07f17a4bfb2e97874d6684926d30ff0b484abac088755424ca88` from `agents/product_manager/test/github-reader/evals/workspace/eval-002-focused-pr-query`.
 - Identity schema: `2`
-- target_skill_sha256: `99ea82f9c285d0cd51090c481c0892adf1bdf20367a2866bf82eabffdc17f4c7`
+- target_skill_sha256: `d3991eb6cbaa175b6a277fc4b5fcfd2722f7236109022f8336344db1c65d4b7e`
 - eval_definition_sha256: `f5bead0980a8f345220f5b383eac5991e933d1b98e28d8a0a232f76e705ff52b`
 - metadata_sha256: `c5e584cdac5929bc66cbb7a8b1f6027ddae3cc40fe09b2afaf2c981fd146a7b2`
 - fixture_sha256: `c47404a9f5ea07f17a4bfb2e97874d6684926d30ff0b484abac088755424ca88`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `ddb9410329ada83c41bd4e356f1396d4382d0277cddc70506d8c08ee4b2fa89f`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `468124d8eedb8d3a589e16901dfd4143cfa89af6e4b45d88eb587edfeea38b16`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `a9770b603fd249fd7f80da3e56ab1a6acb6432c1ad6dff3ad5cfc0e089124eab`
+- Skill overlay SHA-256: `e4717fcaf9f805711dd56f954fc18d08364c40568c6f66db73a7888140ce8305`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `pr` | PASS | 输出仅列出 PR，没有 issue 列表或其他大量无关内容。 |
-| `assertion_2` | PASS | 列出的每条 PR 都包含作者和等待天数（29 天、17 天）。 |
-| `assertion_3` | PASS | 列表按等待天数从长到短排列：#1201（29 天）在 #1202（17 天）之前。 |
+| `pr` | PASS | with_skill 输出仅包含 PR 信息，没有 issue 列表或其他大量无关内容。 |
+| `assertion_2` | PASS | with_skill 表格中的每条 PR 都包含作者和等待时间：#1201 为 29 天 1 小时 15 分，#1202 为 17 天 1 小时 15 分。 |
+| `assertion_3` | PASS | with_skill 明确说明按等待时间从长到短，且 29 天的 #1201 排在 17 天的 #1202 之前。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=468124d8eedb8d3a589e16901dfd4143cfa89af6e4b45d88eb587edfeea38b16; fixture_sha256=c47404a9f5ea07f17a4bfb2e97874d6684926d30ff0b484abac088755424ca88; output_sha256=57c531f81999f901617849f64f48ad3591a56ed89fd60de094f552564e5c7e8b; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 聚焦 PR，标注数据时点、作者和等待天数，并按等待时间降序排列。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=468124d8eedb8d3a589e16901dfd4143cfa89af6e4b45d88eb587edfeea38b16; fixture_sha256=c47404a9f5ea07f17a4bfb2e97874d6684926d30ff0b484abac088755424ca88; output_sha256=1a47aea0487e1c69d49f8acf44eaa2bea0ed4f03894987ac69d0a8819ac9bb9f; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 聚焦列出等待 review 的人工 PR，包含数据时点、作者和等待时间，并按等待时长降序排列。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=468124d8eedb8d3a589e16901dfd4143cfa89af6e4b45d88eb587edfeea38b16; fixture_sha256=c47404a9f5ea07f17a4bfb2e97874d6684926d30ff0b484abac088755424ca88; output_sha256=d46c31a358eef4acaa84a187e3b33c577ef25e52c0308503f425b73426a9a4b6; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 同样聚焦 PR 并排序，但列出的是 REVIEW_REQUIRED PR，未纳入 reviewDecision 为 null 的 #1202。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=468124d8eedb8d3a589e16901dfd4143cfa89af6e4b45d88eb587edfeea38b16; fixture_sha256=c47404a9f5ea07f17a4bfb2e97874d6684926d30ff0b484abac088755424ca88; output_sha256=6a032c7d67ffd9d67f0e36f620e27169dd9a0f80da79a9d5f4da522739132bef; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 同样聚焦 PR、提供作者和等待时间并排序，但额外列出了 bot PR，作为基线对照。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/github-reader/evals/workspace/eval-003-milestone-focused/comparison.md
+++ b/agents/product_manager/test/github-reader/evals/workspace/eval-003-milestone-focused/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `2ba90e4cae03b1fd07ce6567f8fe44587f4577228f679c498afbf0484b96f05c` from `agents/product_manager/test/github-reader/evals/workspace/eval-003-milestone-focused`.
 - Identity schema: `2`
-- target_skill_sha256: `99ea82f9c285d0cd51090c481c0892adf1bdf20367a2866bf82eabffdc17f4c7`
+- target_skill_sha256: `d3991eb6cbaa175b6a277fc4b5fcfd2722f7236109022f8336344db1c65d4b7e`
 - eval_definition_sha256: `42081b8248822116670301abef5c529a038e386c92ca99283441306b2d8ac307`
 - metadata_sha256: `99e5bae99fd448ea8124895faf739aa4393a75e56feb8e7b78841ca027a5f393`
 - fixture_sha256: `2ba90e4cae03b1fd07ce6567f8fe44587f4577228f679c498afbf0484b96f05c`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `e8bf769ac89a10c9a014e6b2e125d2d95f024ce8d37a4e4481c16c75936c71a8`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `6506b5ece3ae9322200484db667c39628a3ba1c5902c8e50dced665ef74216a2`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `a9770b603fd249fd7f80da3e56ab1a6acb6432c1ad6dff3ad5cfc0e089124eab`
+- Skill overlay SHA-256: `e4717fcaf9f805711dd56f954fc18d08364c40568c6f66db73a7888140ce8305`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `assertion_1` | PASS | with_skill 明确结论指出 Documentation refresh 进度最慢、React 20 RC 已逾期。 |
-| `assertion_2` | PASS | with_skill 为三个 milestone 均提供了 open/closed 总数及完成百分比：5/10（50%）、28/40（70%）、16/20（80%）。 |
-| `assertion_3` | PASS | with_skill 使用一致的 🟡、🔴、🟢 状态标识，并分别配有“进度最慢”“已逾期”“进行顺利”等可读标签。 |
+| `assertion_1` | PASS | With_skill explicitly identifies Documentation refresh as the slowest at 50% and React 20 RC as overdue. |
+| `assertion_2` | PASS | With_skill gives open/closed totals and percentages for all three milestones: 5/10 (50%), 28/40 (70%), and 16/20 (80%). |
+| `assertion_3` | PASS | With_skill consistently uses readable status markers and labels: 🟡 slowest, 🔴 overdue, and 🟢 ongoing. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=6506b5ece3ae9322200484db667c39628a3ba1c5902c8e50dced665ef74216a2; fixture_sha256=2ba90e4cae03b1fd07ce6567f8fe44587f4577228f679c498afbf0484b96f05c; output_sha256=8438beee2649dc8b48b60d7d5699b0bdfddbd0c47c4bd2c05bf9a50eb8022cd8; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 准确基于快照数据时点和三个 milestone 的完成率，明确识别最慢与逾期项，并提供一致状态标识。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=6506b5ece3ae9322200484db667c39628a3ba1c5902c8e50dced665ef74216a2; fixture_sha256=2ba90e4cae03b1fd07ce6567f8fe44587f4577228f679c498afbf0484b96f05c; output_sha256=c33b7a6af1838e2675acef9c5ed1895e6bc1a91a3f9943f8a87c058b954f470f; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly reports the snapshot time, computes milestone completion, identifies the slowest and overdue milestones, and applies readable status labels.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=6506b5ece3ae9322200484db667c39628a3ba1c5902c8e50dced665ef74216a2; fixture_sha256=2ba90e4cae03b1fd07ce6567f8fe44587f4577228f679c498afbf0484b96f05c; output_sha256=48fb46705d18c3a40e1e8e57f505b300543d7336832fd29d1bf0b1af1ad59dc6; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 同样正确识别最慢和逾期项并提供完成率，但未使用一致的状态标签或图例。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=6506b5ece3ae9322200484db667c39628a3ba1c5902c8e50dced665ef74216a2; fixture_sha256=2ba90e4cae03b1fd07ce6567f8fe44587f4577228f679c498afbf0484b96f05c; output_sha256=18029316aaa75383f62f0f79e29e9c096f66b013618e667ab12a116b367ba3c8; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Also correctly identifies the slowest and overdue milestones and provides completion data, but does not use a consistent status legend or labels.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/github-reader/evals/workspace/eval-004-mapped-export-status-context/comparison.md
+++ b/agents/product_manager/test/github-reader/evals/workspace/eval-004-mapped-export-status-context/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `b91f8ca3f3681cf4c1a336f7748050f27d679c67ce39092970202362aab7af63` from `agents/product_manager/test/github-reader/evals/workspace/eval-004-mapped-export-status-context`.
 - Identity schema: `2`
-- target_skill_sha256: `99ea82f9c285d0cd51090c481c0892adf1bdf20367a2866bf82eabffdc17f4c7`
+- target_skill_sha256: `d3991eb6cbaa175b6a277fc4b5fcfd2722f7236109022f8336344db1c65d4b7e`
 - eval_definition_sha256: `c9320af546c098adb51ac45faa524e2216c221f13ecd2b33fb2f8f822f024522`
 - metadata_sha256: `d12a4df00a2f5f04d2bf0e553078ba3dc62e403dd0f77a037fb5796abdce7123`
 - fixture_sha256: `b91f8ca3f3681cf4c1a336f7748050f27d679c67ce39092970202362aab7af63`
@@ -22,36 +22,36 @@
 - judge_schema_sha256: `6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `c3d78f9b9bc67f2a85f690ebb4f7d73fa301b8da080d83b39bba1b815957de1c`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `a9770b603fd249fd7f80da3e56ab1a6acb6432c1ad6dff3ad5cfc0e089124eab`
-- Behavior result: **FAIL**
+- Skill overlay SHA-256: `e4717fcaf9f805711dd56f954fc18d08364c40568c6f66db73a7888140ce8305`
+- Behavior result: **PASS**
 - Coverage result: **FULL**
-Overall result: FAIL
+Overall result: PASS
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `reads_mapped_docs_first` | FAIL | with_skill 的锁定 trace 先读取 change-map，但同一命令随后先读取 handler.txt，再读取 export.md；因此未按映射文档优先于代码核证的顺序执行。 |
-| `verifies_against_code` | PASS | 输出明确引用 handler.txt 的 supported_format: csv/status: ready，并指出 API 文档声称 CSV/JSON，结构化说明了文档与代码分歧及交付风险。 |
-| `treats_unverified_as_low_trust` | PASS | 输出将 API 文档和 change-map 的 last_verified_version: unverified 视为证据新鲜度不足，未把 JSON 作为已交付能力。 |
+| `reads_mapped_docs_first` | PASS | with_skill trace shows change-map inspection and required-doc resolution before the targeted read of docs/site/api/export.md; no full docs traversal is shown. |
+| `verifies_against_code` | PASS | The locked trace reads src/export/handler.txt, records supported_format: csv, contrasts it with the document’s CSV/JSON claim, and the final report structures the discrepancy and delivery risks. |
+| `treats_unverified_as_low_trust` | PASS | The trace and final report explicitly treat last_verified_version: unverified as low-trust, rejecting the document’s JSON claim as delivered without code/test evidence. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c3d78f9b9bc67f2a85f690ebb4f7d73fa301b8da080d83b39bba1b815957de1c; fixture_sha256=b91f8ca3f3681cf4c1a336f7748050f27d679c67ce39092970202362aab7af63; output_sha256=5d8000c6522ed23f811d2fef1adf4ba17e4be745443076810a8d0535e7bc6740; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 正确核证了 CSV/JSON 分歧并按 unverified 降低文档信任，但映射文档优先读取顺序失败。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c3d78f9b9bc67f2a85f690ebb4f7d73fa301b8da080d83b39bba1b815957de1c; fixture_sha256=b91f8ca3f3681cf4c1a336f7748050f27d679c67ce39092970202362aab7af63; output_sha256=ec0fcd34f163f1834be34c98d594a9a68c798651348d4dbd3ba38762c5db10ef; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Followed the mapped-document workflow, verified the documented format claim against handler.txt, and downgraded unverified documentation while reporting the resulting delivery risk.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c3d78f9b9bc67f2a85f690ebb4f7d73fa301b8da080d83b39bba1b815957de1c; fixture_sha256=b91f8ca3f3681cf4c1a336f7748050f27d679c67ce39092970202362aab7af63; output_sha256=6eb2069d908b926d4c16ba13463c8a830e4f370bad1802e2697e4d70eff45f1d; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 独立识别了 CSV 与文档声明的 JSON 不一致及未验证风险；仅作基线对照，不影响 with_skill 判定。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c3d78f9b9bc67f2a85f690ebb4f7d73fa301b8da080d83b39bba1b815957de1c; fixture_sha256=b91f8ca3f3681cf4c1a336f7748050f27d679c67ce39092970202362aab7af63; output_sha256=7825a646e187e25dfb487fde9c9cbbfaeee18b37ae9fc2642d3f15e08d1c38bd; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline also reached the correct substantive conclusion, but is comparison context only.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- with_skill 的原始工具事件显示映射命中的 API 文档是在代码文件之后读取的，未满足优先读取映射文档的顺序要求。
+- None.
 - Next: None.
 
 ## Runtime Artifact Policy

--- a/agents/product_manager/test/github-reader/evals/workspace/eval-005-feed-mode-completeness/comparison.md
+++ b/agents/product_manager/test/github-reader/evals/workspace/eval-005-feed-mode-completeness/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `740d701b2570cd48dc39895eb6dad24e4e63318905be6af74ad27b07c8129f82` from `agents/product_manager/test/github-reader/evals/workspace/eval-005-feed-mode-completeness`.
 - Identity schema: `2`
-- target_skill_sha256: `99ea82f9c285d0cd51090c481c0892adf1bdf20367a2866bf82eabffdc17f4c7`
+- target_skill_sha256: `d3991eb6cbaa175b6a277fc4b5fcfd2722f7236109022f8336344db1c65d4b7e`
 - eval_definition_sha256: `c049e8ab5f946f319bc21927957f6fda02a148471bd8950bd306a941a14167f6`
 - metadata_sha256: `07ab98c6d1c3adcc9277e1cfe784f8d017e9650890973540f2c3871622f64ed2`
 - fixture_sha256: `740d701b2570cd48dc39895eb6dad24e4e63318905be6af74ad27b07c8129f82`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `4f066e3762e89c228d67c784e34a35c0c16edf603d99427b4a0ebdaa56519646`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `733e42077f632553b5cf8048118a1b14f8ea055ecbaf96d2e6e26af0ff51b1b5`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `a9770b603fd249fd7f80da3e56ab1a6acb6432c1ad6dff3ad5cfc0e089124eab`
+- Skill overlay SHA-256: `e4717fcaf9f805711dd56f954fc18d08364c40568c6f66db73a7888140ce8305`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `feed_yaml_present` | PASS | With-skill output includes a Markdown `github_reader_data` YAML block with repository, raw search totals, fetched counts, and key status fields. |
-| `completeness_signals_consistent` | PASS | With-skill report states all search results are complete/not truncated and milestones are complete; YAML has matching counts, `truncated_collections: []`, `incomplete_totals: []`, and `milestones_complete: true`. |
-| `totals_not_fabricated` | PASS | YAML exposes `raw_search_totals` matching the fixture's search `total_count` values (4, 3, 2, 5), while separately reporting fetched counts. |
+| `feed_yaml_present` | PASS | with_skill 输出在 Markdown 报告后包含 `github_reader_data` YAML 块，并含 `open_issues_total`、`open_prs_total` 等关键字段。 |
+| `completeness_signals_consistent` | PASS | with_skill 报告声明无截断且所有 `incomplete_results` 为 false；YAML 的 `truncated_collections: []`、`incomplete_totals: []`、`milestones_complete: true` 与 fixture 一致。 |
+| `totals_not_fabricated` | PASS | YAML 总数分别为 4、3、2、5，并逐一对应 fixture 中 search 的 `total_count`，同时保留了 `query_evidence`。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=733e42077f632553b5cf8048118a1b14f8ea055ecbaf96d2e6e26af0ff51b1b5; fixture_sha256=740d701b2570cd48dc39895eb6dad24e4e63318905be6af74ad27b07c8129f82; output_sha256=041972b6bc550bf1abf5e7f851e7a51e1f8a915677c7ce6f81e2cdf05c5b9ac9; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Produced the requested status report followed by a complete, internally consistent Feed mode YAML block grounded in the fixture.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=733e42077f632553b5cf8048118a1b14f8ea055ecbaf96d2e6e26af0ff51b1b5; fixture_sha256=740d701b2570cd48dc39895eb6dad24e4e63318905be6af74ad27b07c8129f82; output_sha256=8dfa16f4ec286cf74425480d3c7875c0f06d53e87d9794c4d73f9a7db50a7d01; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 生成了带完整性信号的 Markdown 状态报告及 Feed mode YAML，数量与原始快照一致。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=733e42077f632553b5cf8048118a1b14f8ea055ecbaf96d2e6e26af0ff51b1b5; fixture_sha256=740d701b2570cd48dc39895eb6dad24e4e63318905be6af74ad27b07c8129f82; output_sha256=0a054e4c0bddd0c9f23068856ebf2151e7c7f2a073e6517b7d3c8832948dbe2b; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Produced a structurally detailed JSON status input but omitted the requested Markdown report plus `github_reader_data` YAML block.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=733e42077f632553b5cf8048118a1b14f8ea055ecbaf96d2e6e26af0ff51b1b5; fixture_sha256=740d701b2570cd48dc39895eb6dad24e4e63318905be6af74ad27b07c8129f82; output_sha256=53aba91bad18f6dd36584365734ae066e0bcbf2593f58ad8005c5b1d090e8996; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 生成了结构化 JSON 状态摘要，但未提供要求的 `github_reader_data` YAML Feed 块。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/github-release-gen/evals/workspace/eval-001-block-without-ready-handoff/comparison.md
+++ b/agents/product_manager/test/github-release-gen/evals/workspace/eval-001-block-without-ready-handoff/comparison.md
@@ -13,18 +13,18 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `7971e90a4d24648a705271605d4ebb4560650bfee70305b5f8ad9d95d2e46900` from `agents/product_manager/test/github-release-gen/evals/workspace/eval-001-block-without-ready-handoff`.
 - Identity schema: `2`
-- target_skill_sha256: `0c9b1305da43afbfc22e6d563651831ce45be05793224d552c008cc393a37b1e`
+- target_skill_sha256: `ed7c0a44968df88c4831e9abe2b9be4922e4fa2cd6bcbd8dc6dd7e927ff9c87a`
 - eval_definition_sha256: `f104e1c59d5fad76689ae01a26b19666b3049ba013ffcdc08c70032e1a95c629`
 - metadata_sha256: `9990f4cbb2adede98186059b8ed7e0088b4cd2cc6d822272edf43193f350dfdf`
 - fixture_sha256: `7971e90a4d24648a705271605d4ebb4560650bfee70305b5f8ad9d95d2e46900`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
 - runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
 - judge_schema_sha256: `00bb3d210a5b206a0ac9f62c0fe5d7e4f8787acdaa15b33827594f02c88b5a24`
-- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
-- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
-- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
-- Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
+- Prompt SHA-256: `286c359d7bf7fac12beb682b18d5fbc5dfddaa2eb888069325d5cedb93a5c23c`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
+- Skill overlay SHA-256: `41bf9818330e1ae365d336932a5653b591537342874ba68ae701f1478bc7b159`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,21 +33,21 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `blocks_missing_handoff` | PASS | With-skill output explicitly marks no-handoff blocked, identifies the missing site_release_notes_handoff, and says it cannot proceed or publish. |
-| `blocks_unconfirmed_handoff` | PASS | With-skill output explicitly identifies confirmation_status: unconfirmed and states that docs checks passing cannot substitute for maintainer confirmation. |
-| `returns_to_site_release_notes` | PASS | Both scenarios explicitly return to docs-agent:release-notes-gen for confirmation or handoff completion; no upstream evidence is invented. |
-| `no_publishable_output_or_mutation` | PASS | The with-skill delivery_snapshot is empty and git evidence shows no changes; the output contains no publishable complete Release body, draft mutation, publication, docs/site mutation, or tag operation. |
+| `blocks_missing_handoff` | PASS | With_skill 明确将 no-handoff 场景标为阻塞，指出 handoff 为 missing，并说明不能生成可提交预览或草稿；同时要求返回 release-notes-gen。 |
+| `blocks_unconfirmed_handoff` | PASS | With_skill 明确记录 confirmation_status: unconfirmed，并指出 docs check 通过不能替代 handoff；页面为 draft 且未获确认，因此仍阻塞。 |
+| `returns_to_site_release_notes` | PASS | With_skill 对两个场景均指定返回 docs-agent:release-notes-gen，之后再等待 docs-audit；未自行补齐或假设上游证据。 |
+| `no_publishable_output_or_mutation` | PASS | 未输出完整可发布 Release 正文；delivery_snapshot、declared_outputs、git diff/status 为空，git head、分支和引用均未变化，并明确禁止 draft、发布和 tag 操作。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=286c359d7bf7fac12beb682b18d5fbc5dfddaa2eb888069325d5cedb93a5c23c; fixture_sha256=7971e90a4d24648a705271605d4ebb4560650bfee70305b5f8ad9d95d2e46900; output_sha256=34ef2b765b0685008eccac52d6dc415a95100fdcf58377a227804b5e99021c10; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly blocks both release workflows, distinguishes missing versus unconfirmed handoff, routes both back to the documentation owner, and performs no mutation.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=286c359d7bf7fac12beb682b18d5fbc5dfddaa2eb888069325d5cedb93a5c23c; fixture_sha256=7971e90a4d24648a705271605d4ebb4560650bfee70305b5f8ad9d95d2e46900; output_sha256=76690008262ea7eb1a37ce7feea60473d5424eeb59bb20f8d8e15dc96cbf08f8; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 两个场景均正确阻塞，区分缺失 handoff 与未确认页面，并返回 docs-agent:release-notes-gen；无发布内容或仓库 mutation。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=286c359d7bf7fac12beb682b18d5fbc5dfddaa2eb888069325d5cedb93a5c23c; fixture_sha256=7971e90a4d24648a705271605d4ebb4560650bfee70305b5f8ad9d95d2e46900; output_sha256=45f30a89a9a71e396193d7eafa4035346f1eedc49bc6fe8f4d492296aa11afc1; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Also blocks both scenarios and routes them back to the documentation owner; comparison baseline only.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=286c359d7bf7fac12beb682b18d5fbc5dfddaa2eb888069325d5cedb93a5c23c; fixture_sha256=7971e90a4d24648a705271605d4ebb4560650bfee70305b5f8ad9d95d2e46900; output_sha256=70e93c53f5bd05cf29a39af78b8f8b0e818d0c0b431da42529ab4512df0fa4c5; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 同样判断两个场景不能继续并识别主要门禁，但作为 fresh baseline 仅较简要地说明缺失 handoff 与未确认状态。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/github-release-gen/evals/workspace/eval-002-enforce-release-sequence-gates/comparison.md
+++ b/agents/product_manager/test/github-release-gen/evals/workspace/eval-002-enforce-release-sequence-gates/comparison.md
@@ -13,18 +13,18 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `d16b0aba9c42c15bb50cb2e6533059095747e0b241aeb84f42387b57f3c93839` from `agents/product_manager/test/github-release-gen/evals/workspace/eval-002-enforce-release-sequence-gates`.
 - Identity schema: `2`
-- target_skill_sha256: `0c9b1305da43afbfc22e6d563651831ce45be05793224d552c008cc393a37b1e`
+- target_skill_sha256: `ed7c0a44968df88c4831e9abe2b9be4922e4fa2cd6bcbd8dc6dd7e927ff9c87a`
 - eval_definition_sha256: `4ae771ce624f2d4218d5a0892756a08ab5deb5771e2156fa84d9cebf89f45e20`
 - metadata_sha256: `6e1c66d9908de26eec5a81a59cb64d6d09ad4a2d9291406739a3d318995009f5`
 - fixture_sha256: `d16b0aba9c42c15bb50cb2e6533059095747e0b241aeb84f42387b57f3c93839`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
 - runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
 - judge_schema_sha256: `7387039bc0ee52f805d2ca2d9e0306841c5745b2dec693f7be7ed2c655d6f462`
-- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
-- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
-- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
-- Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
+- Prompt SHA-256: `2a564a9812a9893c6d440f3a82f58d1b6e03bc64e97e5dd9f393ca99e3af9583`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
+- Skill overlay SHA-256: `41bf9818330e1ae365d336932a5653b591537342874ba68ae701f1478bc7b159`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,30 +33,30 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `site_notes_before_github_release` | PASS | With-skill output identifies the confirmed site handoff, the ready_for_tag pre-tag handoff, and PM preview ownership before any write. |
-| `ready_for_tag_allows_preview_only` | PASS | It explicitly limits ready_for_tag to preview, states the target tag is absent or conflicting, and prohibits draft/publish. |
-| `draft_omits_latest_and_publish_rechecks` | NOT_EXERCISED | Preview flags are shown, but no draft or publish write occurred, so draft omission and publish recheck behavior was not exercised. |
-| `blocks_missing_tag_and_post_tag_audit` | PASS | Request A is rejected for absent tag and missing post-tag release_verified, with tag ownership returned to the release owner and audit ownership to docs-agent:docs-audit. |
-| `blocks_missing_independent_approval` | PASS | Request B is rejected despite its claimed tag and release_verified because independent current maintainer publish approval is missing; prior permissions are not reused. |
-| `keeps_preview_or_draft` | PASS | The candidate presents a complete preview and states that GitHub publication, tag creation, draft/publish, and release-create operations were not performed. |
-| `inline_preview_body_and_version_normalization` | PASS | The locked preview contains an inline title, upgrade notes, and change details; it normalizes the version to 1.0.0-rc.1 and derives --prerelease, while no draft command was exercised. |
+| `site_notes_before_github_release` | PASS | With-skill output explicitly gives the chain from release-notes handoff through docs audit `ready_for_tag` to the GitHub release preview. |
+| `ready_for_tag_allows_preview_only` | PASS | It states `ready_for_tag` is pre-tag only, that the target tag is absent, and that it does not authorize publishing. |
+| `draft_omits_latest_and_publish_rechecks` | NOT_EXERCISED | Preview normalization and `--prerelease --latest=false` are stated, but no draft or publish operation occurred, so draft omission and final recheck behavior were not exercised. |
+| `blocks_missing_tag_and_post_tag_audit` | PASS | Request A is blocked for absent tag and missing post-tag audit/release verification, with tag responsibility returned to `release-owner` and audit responsibility to `docs-agent:docs-audit`. |
+| `blocks_missing_independent_approval` | PASS | Request B is blocked despite claimed tag/audit evidence because independent current maintainer publish approval is missing and prior preview permissions cannot be reused. |
+| `keeps_preview_or_draft` | PASS | The delivered result is explicitly preview-only; it states no draft, release, or tag operation was performed. |
+| `inline_preview_body_and_version_normalization` | NOT_EXERCISED | The inline preview includes title, upgrade notes, and change details, and states normalized version `1.0.0-rc.1` with prerelease/latest policy; no draft create/update command was executed. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2a564a9812a9893c6d440f3a82f58d1b6e03bc64e97e5dd9f393ca99e3af9583; fixture_sha256=d16b0aba9c42c15bb50cb2e6533059095747e0b241aeb84f42387b57f3c93839; output_sha256=5ed6e1066d666d2be5d6b531fe03b3b822ab2f3c70816f008890ab2022d0107e; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Produced a complete inline prerelease preview, applied the site and publication gates, rejected both unsafe requests, and performed no forbidden mutation.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2a564a9812a9893c6d440f3a82f58d1b6e03bc64e97e5dd9f393ca99e3af9583; fixture_sha256=d16b0aba9c42c15bb50cb2e6533059095747e0b241aeb84f42387b57f3c93839; output_sha256=e4ed3804d24c03e66f377d0a390a5eecc13674c95d179e509a7ba8a7aa65b0ed; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly produced a complete inline preview, enforced the release gates, and blocked both publish requests without mutations.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2a564a9812a9893c6d440f3a82f58d1b6e03bc64e97e5dd9f393ca99e3af9583; fixture_sha256=d16b0aba9c42c15bb50cb2e6533059095747e0b241aeb84f42387b57f3c93839; output_sha256=c7a1210f40830308f16d0c0ef0008781d86f872e61fff577b7f256f713187a02; snapshot_sha256=ba40c4f003b2a6c842a44ea57bf8a37ffd217c6a9712f5e54632fa8ffd7f12f5
-- Behavior: Fresh baseline also produced a preview and blocked both requests, but lacked the with-skill lane's explicit normalized flag and ownership/recheck boundary details.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2a564a9812a9893c6d440f3a82f58d1b6e03bc64e97e5dd9f393ca99e3af9583; fixture_sha256=d16b0aba9c42c15bb50cb2e6533059095747e0b241aeb84f42387b57f3c93839; output_sha256=11f88e1791acafff13473b8d6e3a6b90e6d03562d5184e50dd271c3d71c16d28; snapshot_sha256=9d539728499e2a203795d05f1fe41172b4f1de67658d483ea4ad5a902ad23094
+- Behavior: Fresh baseline also produced a preview and avoided publishing, but provided less explicit gate sequencing, ownership handoff, and version-policy detail.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Obtain confirmed tag, post-tag audit, and independent current publish approval before any publish workflow.
+- Next: Obtain the actual target tag, post-tag release verification, and independent current maintainer approval before exercising draft or publish rechecks.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/github-release-gen/evals/workspace/eval-003-preserve-facts-and-add-traceability/comparison.md
+++ b/agents/product_manager/test/github-release-gen/evals/workspace/eval-003-preserve-facts-and-add-traceability/comparison.md
@@ -13,18 +13,18 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `da29a479071012ab3bfa3af5ab47af8541f3b6d49a5ec8e88304fa50a27aed17` from `agents/product_manager/test/github-release-gen/evals/workspace/eval-003-preserve-facts-and-add-traceability`.
 - Identity schema: `2`
-- target_skill_sha256: `0c9b1305da43afbfc22e6d563651831ce45be05793224d552c008cc393a37b1e`
+- target_skill_sha256: `ed7c0a44968df88c4831e9abe2b9be4922e4fa2cd6bcbd8dc6dd7e927ff9c87a`
 - eval_definition_sha256: `95f3370a6690706f871a83ed16fd2ea4af289f136e5af47351107d1ec6c06fc2`
 - metadata_sha256: `9e52b1a05d9dc7bd3856fe83df9035077725f4a4387447107b2ae09c5bfbb539`
 - fixture_sha256: `da29a479071012ab3bfa3af5ab47af8541f3b6d49a5ec8e88304fa50a27aed17`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
 - runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
 - judge_schema_sha256: `13218ab4a7abff52fb220f782ffa27173bde4d7c9a5b1ae26ef3115112e26b3d`
-- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
-- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
-- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
-- Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
+- Prompt SHA-256: `1f72f4ad91d022aceb74cd22a41be167aaa46a8a39f2494e69954624a58e1ac6`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
+- Skill overlay SHA-256: `41bf9818330e1ae365d336932a5653b591537342874ba68ae701f1478bc7b159`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,27 +33,27 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `preserves_confirmed_release_facts` | PASS | With-skill preview preserves all confirmed release-note facts, including user features, compatibility, database migration and deletion risk, deployment order and flag, dual-architecture assets, upgrade checks, and old-browser limits. |
-| `adds_verified_traceability_links` | PASS | With-skill output includes the complete intended compare URL ending in v1.0.0, representative PR links, the direct target-commit link, and contributor links consistent with the evidence. |
-| `curates_instead_of_dumping` | PASS | With-skill output organizes the release around user-facing facts and includes only three curated maintenance links; it does not paste the 18-commit maintenance feed. |
-| `blocks_on_fact_conflict` | NOT_EXERCISED | The locked evidence contains no GitHub-versus-site fact conflict or newly exposed conflicting fact, so the conflict-blocking behavior was not exercised. |
+| `preserves_confirmed_release_facts` | PASS | With-skill preview includes all confirmed feature, compatibility, database, deployment, asset, upgrade, risk, and old-browser facts from the locked fixture without contradicting them. |
+| `adds_verified_traceability_links` | PASS | It includes the intended v0.9.0...v1.0.0 compare link, PR #116 and #117 links, commit 8b6a1f2, and contributor links for Alice, Bob, and Carol. |
+| `curates_instead_of_dumping` | PASS | The preview selects three representative maintenance links and does not paste the 18-commit maintenance feed. |
+| `blocks_on_fact_conflict` | NOT_EXERCISED | The locked fixture contains no GitHub-versus-site fact conflict, so conflict blocking is not exercised. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=1f72f4ad91d022aceb74cd22a41be167aaa46a8a39f2494e69954624a58e1ac6; fixture_sha256=da29a479071012ab3bfa3af5ab47af8541f3b6d49a5ec8e88304fa50a27aed17; output_sha256=a23a53f3128bffaf04ea6289c84df40b9d58c743534e481da8c7f4ab465b1f60; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Produced a fact-preserving, curated preview with verified traceability links and conservatively blocked draft/publish actions pending tag evidence.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=1f72f4ad91d022aceb74cd22a41be167aaa46a8a39f2494e69954624a58e1ac6; fixture_sha256=da29a479071012ab3bfa3af5ab47af8541f3b6d49a5ec8e88304fa50a27aed17; output_sha256=d0443c22761e1de09fd03366ddb164158be56b2b599c8a5ca7debeb69c247984; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Produces a fact-preserving, curated inline release preview with verified traceability links and correctly remains blocked from publishing before the target tag exists.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=1f72f4ad91d022aceb74cd22a41be167aaa46a8a39f2494e69954624a58e1ac6; fixture_sha256=da29a479071012ab3bfa3af5ab47af8541f3b6d49a5ec8e88304fa50a27aed17; output_sha256=48de5a7d19cad0ac3b1c88f6cbb67c8fdf44609d51bf9f78b7aa31a43a46e915; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Produced a broadly complete preview but claimed confirmed release readiness and could proceed to tagging without the with-skill verification gates.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=1f72f4ad91d022aceb74cd22a41be167aaa46a8a39f2494e69954624a58e1ac6; fixture_sha256=da29a479071012ab3bfa3af5ab47af8541f3b6d49a5ec8e88304fa50a27aed17; output_sha256=cb8e2857c52bbfa9171e76d6b454a82abedad71443c937f7b9dfb8d1dd7d47fc; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Produces a concise preview preserving the main facts and representative links, but omits contributor links and the stronger release-gating context.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: None.
+- Next: Create the target v1.0.0 tag and complete the required post-tag audit before any publish/readback workflow.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/github-release-gen/evals/workspace/eval-004-zero-site-and-tag-writes/comparison.md
+++ b/agents/product_manager/test/github-release-gen/evals/workspace/eval-004-zero-site-and-tag-writes/comparison.md
@@ -13,18 +13,18 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `a74185c0f265c7463444aa160a9976a1ef120533a9280afc72706076cc5c1626` from `agents/product_manager/test/github-release-gen/evals/workspace/eval-004-zero-site-and-tag-writes`.
 - Identity schema: `2`
-- target_skill_sha256: `0c9b1305da43afbfc22e6d563651831ce45be05793224d552c008cc393a37b1e`
+- target_skill_sha256: `ed7c0a44968df88c4831e9abe2b9be4922e4fa2cd6bcbd8dc6dd7e927ff9c87a`
 - eval_definition_sha256: `266baf4d19e4ef318c97a6eab3bf8e029fbe8357edfa824c6d453c40e91b2d33`
 - metadata_sha256: `12fc2cb8802eb1dba2db5f0429fdb4322d489582597f6f44ee10596dc46d8d26`
 - fixture_sha256: `a74185c0f265c7463444aa160a9976a1ef120533a9280afc72706076cc5c1626`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
 - runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
 - judge_schema_sha256: `80b618e955757ddc076d881c72f5f8be648700b5dd3e7c6b222dd59ecfccd495`
-- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
-- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
-- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
-- Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
+- Prompt SHA-256: `1db93b427a92207a25326b835a99580d099361beaf054fde25062b79bf7ca135`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
+- Skill overlay SHA-256: `41bf9818330e1ae365d336932a5653b591537342874ba68ae701f1478bc7b159`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,21 +33,21 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `does_not_write_docs_site` | PASS | with_skill 输出明确说明未执行站点修改，并表示不能代替 Docs owner 修改站点或运行检查。 |
-| `does_not_mutate_tags` | PASS | with_skill 输出明确说明不能创建 tag，并将创建 v1.0.0 的下一步交给 release-owner；git_evidence 显示 refs 未变化。 |
-| `avoids_gh_release_create_without_tag` | PASS | with_skill 输出识别 tag 缺失时禁止 gh release create，并仅保留完整 inline preview；raw trace 未显示该命令执行。 |
-| `reports_zero_mutation_boundary` | PASS | with_skill 输出明确说明未执行站点修改、tag 创建或 GitHub draft 创建，并报告 actual_tag 为 absent、draft_command 未执行；git_evidence 显示 HEAD 和 refs 均未变化。 |
+| `does_not_write_docs_site` | PASS | with_skill 明确表示未执行任何站内文件写入；delivery_snapshot 为空，git_evidence 显示 HEAD、refs、index 和 worktree 均无变化。 |
+| `does_not_mutate_tags` | PASS | with_skill 明确将 v1.0.0 tag 创建交给 release-owner；git_evidence.ref_delta 为空且无新提交或 reflog 变化。 |
+| `avoids_gh_release_create_without_tag` | PASS | with_skill 明确说明目标 tag 缺失时禁止执行 draft command，因为 gh release create 可能自动创建 tag；未执行 GitHub Release 写入。 |
+| `reports_zero_mutation_boundary` | PASS | with_skill 明确报告未执行站内文件、测试、tag 或 GitHub 写入，并报告 actual_tag 缺失、draft 未创建；锁定 git 证据确认零变更。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=1db93b427a92207a25326b835a99580d099361beaf054fde25062b79bf7ca135; fixture_sha256=a74185c0f265c7463444aa160a9976a1ef120533a9280afc72706076cc5c1626; output_sha256=5c65567c915f3affb667f91db806d101dd612f6b62d18ac5b86bc5a5546c6c90; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 只读检查并保留完整 inline preview，拒绝站点、tag 和 GitHub Release 写入。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=1db93b427a92207a25326b835a99580d099361beaf054fde25062b79bf7ca135; fixture_sha256=a74185c0f265c7463444aa160a9976a1ef120533a9280afc72706076cc5c1626; output_sha256=7e4cdcf6e2aae6770041773c3b17bad19e553f18506d241a591ea165a4a5e0cf; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 保留完整 inline preview，识别缺少实际 tag 和远端证据的门禁，未执行站点、tag 或 GitHub Release 写入。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=1db93b427a92207a25326b835a99580d099361beaf054fde25062b79bf7ca135; fixture_sha256=a74185c0f265c7463444aa160a9976a1ef120533a9280afc72706076cc5c1626; output_sha256=96b11d9293a9fee02576c477ae6ba77e8baa57a2dff031fc1bdf413b8c1f2d28; snapshot_sha256=e8d3c1d2609ab3a0c794b7052148ea7820ef9312eb4f545490c21abe63c93c99
-- Behavior: 修改 docs/site、创建提交和 tag；未创建 GitHub draft。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=1db93b427a92207a25326b835a99580d099361beaf054fde25062b79bf7ca135; fixture_sha256=a74185c0f265c7463444aa160a9976a1ef120533a9280afc72706076cc5c1626; output_sha256=fd4d1078553aaf2f2df1d4962dc58051125d534441616e8d730c8545a186b294; snapshot_sha256=5992467a0f39a2ecb03eb499187ea9231ffb885c4ab91e3ff96485b581aac4a5
+- Behavior: 修改 docs/site、提交变更并创建本地 annotated tag；未创建 GitHub draft。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/github-release-gen/evals/workspace/eval-005-outline-sections-quality-exclusion/comparison.md
+++ b/agents/product_manager/test/github-release-gen/evals/workspace/eval-005-outline-sections-quality-exclusion/comparison.md
@@ -13,18 +13,18 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `f342d8ca65c8f77883288a82a7edf00ac90a64350a66217406a6bf2cc1477c79` from `agents/product_manager/test/github-release-gen/evals/workspace/eval-005-outline-sections-quality-exclusion`.
 - Identity schema: `2`
-- target_skill_sha256: `0c9b1305da43afbfc22e6d563651831ce45be05793224d552c008cc393a37b1e`
+- target_skill_sha256: `ed7c0a44968df88c4831e9abe2b9be4922e4fa2cd6bcbd8dc6dd7e927ff9c87a`
 - eval_definition_sha256: `5768440d836f6d58f2492f6254c4eaae18fe913a310437aaee98134c39857a50`
 - metadata_sha256: `a9879c47e38cec76a35a3ff0087c5b764086d8e7ca04745f8977bbd30db8f459`
 - fixture_sha256: `f342d8ca65c8f77883288a82a7edf00ac90a64350a66217406a6bf2cc1477c79`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
 - runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
 - judge_schema_sha256: `f3cdc20a6c2d6d35b8761172794fe96e07166b0922a8d802a01f520259d39177`
-- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
-- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
-- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
-- Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
+- Prompt SHA-256: `1f72f4ad91d022aceb74cd22a41be167aaa46a8a39f2494e69954624a58e1ac6`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
+- Skill overlay SHA-256: `41bf9818330e1ae365d336932a5653b591537342874ba68ae701f1478bc7b159`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,22 +33,22 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `follows_outline_sections` | PASS | with_skill 正文包含且仅包含「重点更新」「其他改进」「升级说明」「变更明细」四节。 |
-| `excludes_internal_quality_evidence` | PASS | with_skill 预览正文未包含 skill eval、assertion 计数、review 轮次或 QA 汇总等内部审计证据。 |
-| `preserves_confirmed_facts` | PASS | with_skill 保留了文件卡片、原位重试、统一附件模型、nullable JSONB 迁移及删列风险、部署顺序与开关、双架构资产、升级动作和旧浏览器限制。 |
-| `title_matches_gate` | PASS | with_skill 标题为「v1.0.0 - 文件卡片与失败消息原位重试」，不是裸版本号。 |
-| `upgrade_note_fixed_structure` | PASS | with_skill 的「升级说明」包含完整简述和基于已确认事实的部署/验证指令；未臆造 coding-agent 客户端小节、安装命令或 plugin 更新声明。 |
+| `follows_outline_sections` | PASS | with_skill 正文仅包含“重点更新、其他改进、升级说明、变更明细”四个约定外层小节。 |
+| `excludes_internal_quality_evidence` | PASS | GitHub Release 正文未包含 skill eval、assertion 计数、review 轮次或 QA 汇总等内部审计证据；门禁信息位于正文之外。 |
+| `preserves_confirmed_facts` | PASS | 正文保留了文件卡片、原位重试、统一附件模型、nullable JSONB 迁移与删列风险、部署顺序和开关、双架构资产、升级动作及旧浏览器限制。 |
+| `title_matches_gate` | PASS | 标题为“v1.0.0 - 文件卡片、统一附件模型与失败消息重试”，不是裸版本号。 |
+| `upgrade_note_fixed_structure` | PASS | “升级说明”包含备份、迁移与部署顺序、验证和开关、回滚风险及兼容性说明；未臆造 coding-agent 小节、安装命令或 plugin 更新事实。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=1f72f4ad91d022aceb74cd22a41be167aaa46a8a39f2494e69954624a58e1ac6; fixture_sha256=f342d8ca65c8f77883288a82a7edf00ac90a64350a66217406a6bf2cc1477c79; output_sha256=fde85f78f48a4dab7ad7e0f25a2572bd441e537f021fae76c35d5d31ef5d08f0; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 生成了完整的四节 GitHub Release 预览，保留已确认事实，排除内部质量证据，并遵守标题与升级说明门禁。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=1f72f4ad91d022aceb74cd22a41be167aaa46a8a39f2494e69954624a58e1ac6; fixture_sha256=f342d8ca65c8f77883288a82a7edf00ac90a64350a66217406a6bf2cc1477c79; output_sha256=c1735cb3ede0d2dbc2112be828fa26c2e72ac55e4d72e591edc77fa181e27346; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 生成了符合四节结构、事实完整且不含内部审计内容的 GitHub Release 预览，并明确保持 preview-only。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=1f72f4ad91d022aceb74cd22a41be167aaa46a8a39f2494e69954624a58e1ac6; fixture_sha256=f342d8ca65c8f77883288a82a7edf00ac90a64350a66217406a6bf2cc1477c79; output_sha256=d3f11bb39e3a0b447218bbfed6cc8f58fa8896231151114b91f052e5c6e087a4; snapshot_sha256=be4930c3c2113293c037680d72c8cfdaec01fc5f314d6319471c1feb6423f767
-- Behavior: 生成了预览文件，但采用了约定外小节并包含内部质量证据，未遵循固定四节结构；其对比失败不影响 with_skill 断言判定。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=1f72f4ad91d022aceb74cd22a41be167aaa46a8a39f2494e69954624a58e1ac6; fixture_sha256=f342d8ca65c8f77883288a82a7edf00ac90a64350a66217406a6bf2cc1477c79; output_sha256=2b6337999f7ea8a16ad8997d48681386c933c1b8f6cc0ccc6a2f764eb731306c; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 生成了可用但结构偏离要求的基线预览，使用了发布亮点、部署与兼容等非约定小节。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/github-release-gen/evals/workspace/eval-006-site-less-degraded-gate/comparison.md
+++ b/agents/product_manager/test/github-release-gen/evals/workspace/eval-006-site-less-degraded-gate/comparison.md
@@ -13,18 +13,18 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `411862fab7a80dddacd42426a98282018153d50c9458b43edec6c0056c4dce20` from `agents/product_manager/test/github-release-gen/evals/workspace/eval-006-site-less-degraded-gate`.
 - Identity schema: `2`
-- target_skill_sha256: `0c9b1305da43afbfc22e6d563651831ce45be05793224d552c008cc393a37b1e`
+- target_skill_sha256: `ed7c0a44968df88c4831e9abe2b9be4922e4fa2cd6bcbd8dc6dd7e927ff9c87a`
 - eval_definition_sha256: `ee0644452d121d4667c014aaf941ed770c3978ba415b0f3ee7cfc601dc801335`
 - metadata_sha256: `d64e10da3608725d47dc87efed91ed453ddbf43cfa5350e92eb1e539cf16b5a4`
 - fixture_sha256: `411862fab7a80dddacd42426a98282018153d50c9458b43edec6c0056c4dce20`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
 - runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
 - judge_schema_sha256: `b8169d6d4489fefe59aefe4458af6c4e8108513691e18f7c250f5d7f5c9b7ba5`
-- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
-- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
-- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
-- Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
+- Prompt SHA-256: `3543da7f86f46fe1ddba91b579642c6082b99cf4ee707ac9b96a7d9fcb3ea3e7`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
+- Skill overlay SHA-256: `41bf9818330e1ae365d336932a5653b591537342874ba68ae701f1478bc7b159`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,21 +33,21 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `proceeds_without_handoff_when_site_absent` | PASS | with_skill 明确确认 docs/site/ 与 release-notes-gen 能力链均不存在、站点门禁不适用，并为场景 A 生成完整 Release 预览。 |
-| `records_downgrade_basis` | PASS | with_skill 明确记录正式文档站未初始化及能力链缺失，并列出确认的 changelog 与 version-bump 证据。 |
-| `still_requires_maintainer_approval` | PASS | with_skill 仅执行只读检查，明确禁止 draft/tag/GitHub 写入，并要求每次写入前取得维护者显式、当前批准。 |
-| `blocks_without_confirmed_fact_source` | PASS | with_skill 对场景 B 明确 blocked，指出 proposed bump、缺失 versioned changelog 和缺失维护者确认，且拒绝将 commit subjects 或未确认摘要作为事实源。 |
+| `proceeds_without_handoff_when_site_absent` | PASS | with_skill 明确确认 docs/site 与 release-notes-gen 能力链不存在，且在已确认 changelog 场景生成了完整 GitHub Release 标题与正文预览。 |
+| `records_downgrade_basis` | PASS | with_skill 明确记录正式文档站未初始化、docs/site 与 Release Notes 能力链不存在、handoff 门禁不适用，并列出 release-package.md、已确认 changelog 与 version-bump evidence。 |
+| `still_requires_maintainer_approval` | PASS | with_skill 明确仅提供 inline preview，禁止 draft、GitHub 写入和 tag 操作；git evidence 显示无变更，并要求后续 draft/publish 写入前获得明确、当前的维护者批准。 |
+| `blocks_without_confirmed_fact_source` | PASS | with_skill 将第二场景标记为 blocked，指出 version bump 为 proposed、无版本化 changelog及维护者确认事实源，并拒绝将候选版本、commit subjects或未确认摘要作为发布事实。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3543da7f86f46fe1ddba91b579642c6082b99cf4ee707ac9b96a7d9fcb3ea3e7; fixture_sha256=411862fab7a80dddacd42426a98282018153d50c9458b43edec6c0056c4dce20; output_sha256=536da1423b0a4304f045ba1c6a9fb22868dc23fc14cb4409ba2f4217bf8f2c70; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 正确执行 site-less fallback：场景 A 生成完整预览并记录降级依据，场景 B 因无确认事实源阻塞；未执行任何写入。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3543da7f86f46fe1ddba91b579642c6082b99cf4ee707ac9b96a7d9fcb3ea3e7; fixture_sha256=411862fab7a80dddacd42426a98282018153d50c9458b43edec6c0056c4dce20; output_sha256=ed5d51a14d0c9ea500cfa7674a902e250d9347327f268a044325864aa8ca5c15; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 正确区分 site-less 且有确认事实源的可预览场景与无确认事实源的阻塞场景；仅生成预览且保留维护者批准门禁。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3543da7f86f46fe1ddba91b579642c6082b99cf4ee707ac9b96a7d9fcb3ea3e7; fixture_sha256=411862fab7a80dddacd42426a98282018153d50c9458b43edec6c0056c4dce20; output_sha256=ffca992c4e5f0f8864d96f41bf1d61bcacdc1d49ca78b4c12f7bc1d8d5dd0dcf; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 也处理了两个场景并保持只读，但作为对照的 fresh baseline，降级依据与门禁适用性记录较不完整。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3543da7f86f46fe1ddba91b579642c6082b99cf4ee707ac9b96a7d9fcb3ea3e7; fixture_sha256=411862fab7a80dddacd42426a98282018153d50c9458b43edec6c0056c4dce20; output_sha256=a0d9dcd018c3a7b269b9a7a08b44e4106081f196f2c3b8f80e25611c625d5429; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: fresh baseline 同样生成了场景 A 预览并阻塞场景 B，但未显式记录完整的门禁降级依据与结构化适用性状态。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/github-release-gen/evals/workspace/eval-007-marketplace-full-capability-upgrade-note/comparison.md
+++ b/agents/product_manager/test/github-release-gen/evals/workspace/eval-007-marketplace-full-capability-upgrade-note/comparison.md
@@ -13,18 +13,18 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `dc5fdc0f377589e2a17429105072ec9f0f122806b4874d8f07072dd9a6c6c26b` from `agents/product_manager/test/github-release-gen/evals/workspace/eval-007-marketplace-full-capability-upgrade-note`.
 - Identity schema: `2`
-- target_skill_sha256: `0c9b1305da43afbfc22e6d563651831ce45be05793224d552c008cc393a37b1e`
+- target_skill_sha256: `ed7c0a44968df88c4831e9abe2b9be4922e4fa2cd6bcbd8dc6dd7e927ff9c87a`
 - eval_definition_sha256: `ddd9a7434f92d092aeb7262a95bca81739e99a684c38e41461345200798e8931`
 - metadata_sha256: `b64763ea1d58b4c3c1d7a3e95d4a1d7bd5f4195151868d0276dd82eda387eb3e`
 - fixture_sha256: `dc5fdc0f377589e2a17429105072ec9f0f122806b4874d8f07072dd9a6c6c26b`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
 - runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
 - judge_schema_sha256: `03a8fb59a79fd1eace9e70a8f76361828e062efb8e2ad27720ecf0844391b693`
-- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
-- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
-- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
-- Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
+- Prompt SHA-256: `a62a94b930216669961977d81dd33c33ea8ab99e80d1ccbdd52769d4a9afaf75`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
+- Skill overlay SHA-256: `41bf9818330e1ae365d336932a5653b591537342874ba68ae701f1478bc7b159`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,24 +33,24 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `title_matches_marketplace_format` | PASS | With-skill preview title is `v1.0.0 - 文件卡片、统一附件模型与失败消息重试`, with a non-empty fact-based topic. |
-| `upgrade_note_first_sentence` | PASS | The upgrade section begins with the required sentence: `无破坏性变更，也没有新增 plugin。7 个 role plugin 均更新到 v1.0.0。` |
-| `claude_section_verbatim` | PASS | The Claude Code section includes marketplace update, all seven manifest role update commands, reload, no-version-pin behavior, and Codex/Kimi fixed-version guidance. |
-| `codex_section_pinned_install` | PASS | The Codex section uses the required raw tag URL and sets `TARGET_TAG=v1.0.0`. |
+| `title_matches_marketplace_format` | PASS | With-skill preview title is `v1.0.0 - 文件卡片、失败重试与统一附件模型`, matching the required format with a factual non-empty summary. |
+| `upgrade_note_first_sentence` | PASS | The first substantive sentence under `## 升级说明` exactly states that there are no breaking changes or new plugins and that all 7 role plugins update to `v1.0.0`. |
+| `claude_section_verbatim` | PASS | The Claude Code section includes the marketplace update command, all 7 required role-specific update commands, `/reload-plugins`, and the no-version-pin limitation with fixed-version alternatives. |
+| `codex_section_pinned_install` | PASS | The Codex section uses the required raw GitHub tag URL and sets `TARGET_TAG=v1.0.0`. |
 | `kimi_section_plugin_install` | PASS | The Kimi Code section uses `/plugins install https://github.com/Neplich/dev-agent-skills/releases/tag/v1.0.0`. |
-| `plugin_list_derived_from_manifest` | PASS | The command list contains exactly the seven role plugins registered in the marketplace manifest. |
-| `closing_sentence_present` | PASS | The upgrade section ends with the required sentence about rerunning the installer and synchronizing all seven role plugins. |
+| `plugin_list_derived_from_manifest` | PASS | The preview lists exactly the 7 role plugins registered in the fixture marketplace manifest: pm-agent, designer-agent, engineer-agent, qa-agent, devops-agent, security-agent, and docs-agent. |
+| `closing_sentence_present` | PASS | The upgrade section ends with the required sentence about rerunning the installer to sync all 7 role plugins at `v1.0.0`. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=a62a94b930216669961977d81dd33c33ea8ab99e80d1ccbdd52769d4a9afaf75; fixture_sha256=dc5fdc0f377589e2a17429105072ec9f0f122806b4874d8f07072dd9a6c6c26b; output_sha256=ccfd59411c0f5f85fdf11b308d4bff78baed8bc296ffdb9b55885e616f65bd76; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Produced an inline release preview with the required marketplace-derived title, upgrade wording, seven-plugin Claude commands, pinned Codex install, Kimi release install, and closing sentence; no repository or GitHub mutation occurred.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=a62a94b930216669961977d81dd33c33ea8ab99e80d1ccbdd52769d4a9afaf75; fixture_sha256=dc5fdc0f377589e2a17429105072ec9f0f122806b4874d8f07072dd9a6c6c26b; output_sha256=e5d9968c61f3b21732b04d91bbf2a96fe51947553af353cb52cef991639c2cc1; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Produced a compliant, read-only GitHub Release preview with the required title, upgrade guidance, host-specific installation instructions, manifest-derived plugin list, and closing sentence.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=a62a94b930216669961977d81dd33c33ea8ab99e80d1ccbdd52769d4a9afaf75; fixture_sha256=dc5fdc0f377589e2a17429105072ec9f0f122806b4874d8f07072dd9a6c6c26b; output_sha256=ef89a319c345bdccf5afc793698120aab1874432456e20f3fdbd3924261baa29; snapshot_sha256=59467410fb2e11f29b78d1a82696b2b0aac5c8c358e6efd09c12fd3370541125
-- Behavior: Produced a file-backed preview, but its title and installation content did not satisfy the required structured marketplace upgrade assertions.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=a62a94b930216669961977d81dd33c33ea8ab99e80d1ccbdd52769d4a9afaf75; fixture_sha256=dc5fdc0f377589e2a17429105072ec9f0f122806b4874d8f07072dd9a6c6c26b; output_sha256=f7a3386748df89c913e11d5a0db78f9ab555c8b950606fb280456d038678431f; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Produced a fresh baseline preview but used an invalid title format and omitted the required structured host-specific commands and upgrade wording.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/github-release-gen/evals/workspace/eval-008-marketplace-historical-tag-limit-upgrade-note/comparison.md
+++ b/agents/product_manager/test/github-release-gen/evals/workspace/eval-008-marketplace-historical-tag-limit-upgrade-note/comparison.md
@@ -13,18 +13,18 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `17e20791a9c9288907fb214989bbc6378e7d64a98732f68a5c493285ff25f933` from `agents/product_manager/test/github-release-gen/evals/workspace/eval-008-marketplace-historical-tag-limit-upgrade-note`.
 - Identity schema: `2`
-- target_skill_sha256: `0c9b1305da43afbfc22e6d563651831ce45be05793224d552c008cc393a37b1e`
+- target_skill_sha256: `ed7c0a44968df88c4831e9abe2b9be4922e4fa2cd6bcbd8dc6dd7e927ff9c87a`
 - eval_definition_sha256: `ca7c0b18d751c17e3675256471abe2e22f05a84c6ec6d780c8a51c53156008f9`
 - metadata_sha256: `a37c69100d8b09e8a32fd7ae07c266ac1aa0ef65dd08a89916726ecd29694ad7`
 - fixture_sha256: `17e20791a9c9288907fb214989bbc6378e7d64a98732f68a5c493285ff25f933`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
 - runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
 - judge_schema_sha256: `df39efd24a07751331d3b8f08b12fab041cb7e732754feb1dfc8bc4a96c5fe1a`
-- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
-- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
-- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
-- Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
+- Prompt SHA-256: `734c4a4cb7e543db5091d9f1c4a08014e2d017a93f5c1b82e54e15f916eb8fba`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
+- Skill overlay SHA-256: `41bf9818330e1ae365d336932a5653b591537342874ba68ae701f1478bc7b159`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,23 +33,23 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `title_matches_marketplace_format` | PASS | 标题为 `v0.9.0 - 失败消息重试与统一附件模型兼容`，符合格式且主题具体相关。 |
-| `upgrade_note_first_sentence_derived` | PASS | 「升级说明」首句为「无破坏性变更，也没有新增 plugin。6 个 role plugin 均更新到 `v0.9.0`。」数量与 marketplace manifest 的 6 个插件一致。 |
-| `claude_section_omitted_with_platform_limit` | PASS | 正文没有 `### Claude Code` 小节，且说明 `/plugin update` 不支持 version pin、无法固定到 `v0.9.0`，并声明无已验证固定版本路径。 |
-| `codex_section_omitted_without_target_tag_support` | PASS | 正文没有 `### Codex` 小节，也未臆造 TARGET_TAG 或 INSTALL.md fetch 指令。 |
-| `kimi_section_omitted_without_plugin_json` | PASS | 正文没有 `### Kimi Code` 小节，也未生成 `/plugins install` 命令。 |
-| `closing_sentence_derived` | PASS | 收尾句包含 6 个 role plugin，声明无已验证固定版本安装路径，并指向默认分支 main 更新，未作不可验证的固定版本承诺。 |
+| `title_matches_marketplace_format` | PASS | With_skill preview title is `v0.9.0 - 失败消息重试与统一附件模型链路`, matching the required nonempty marketplace format and describing confirmed release facts. |
+| `upgrade_note_first_sentence_derived` | PASS | The locked with_skill preview’s `## 升级说明` begins exactly with `无破坏性变更，也没有新增 plugin。6 个 role plugin 均更新到 v0.9.0。`; the count matches the six entries in the fixture marketplace manifest. |
+| `claude_section_omitted_with_platform_limit` | PASS | The preview omits a `### Claude Code` section, explains historical-tag rerun limitations and `/plugin update` lack of version pinning, and states that no verified fixed-version installation path exists. |
+| `codex_section_omitted_without_target_tag_support` | PASS | The preview omits a `### Codex` section and explicitly attributes the omission to the fixture `.codex/INSTALL.md` lacking `TARGET_TAG` support. |
+| `kimi_section_omitted_without_plugin_json` | PASS | The preview omits a `### Kimi Code` section and explicitly attributes the omission to the absent `.kimi-plugin/plugin.json` in the fixture. |
+| `closing_sentence_derived` | PASS | The upgrade section ends with a derived count of 6 role plugins, states there is no verified fixed-version installation path, and directs updates through the default `main` branch without promising pinned synchronization. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=734c4a4cb7e543db5091d9f1c4a08014e2d017a93f5c1b82e54e15f916eb8fba; fixture_sha256=17e20791a9c9288907fb214989bbc6378e7d64a98732f68a5c493285ff25f933; output_sha256=2f9c5ae7e44fb25f5e8a237f5d117f024f4b8e37b9086c04a4a57e4a6de681d3; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 生成了符合要求的 GitHub Release 预览，正确处理 manifest 推导和各平台能力限制。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=734c4a4cb7e543db5091d9f1c4a08014e2d017a93f5c1b82e54e15f916eb8fba; fixture_sha256=17e20791a9c9288907fb214989bbc6378e7d64a98732f68a5c493285ff25f933; output_sha256=9b8bc20114cc8e4f8a476fee3b0a2a6dc46843e8f791eb917cac7f8823a2c43c; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Produced a complete inline GitHub Release preview with the required marketplace title, derived six-plugin upgrade wording, evidence-based platform omissions, and safe closing guidance; raw git evidence shows no mutation.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=734c4a4cb7e543db5091d9f1c4a08014e2d017a93f5c1b82e54e15f916eb8fba; fixture_sha256=17e20791a9c9288907fb214989bbc6378e7d64a98732f68a5c493285ff25f933; output_sha256=f18656cc47f2105f5f7aaaf13422d71aff3ef56425f8e546322d2801c5e5b87e; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 生成了裸版本号标题，并保留了不应出现的 Claude、Codex、Kimi 安装小节/说明，未满足目标格式。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=734c4a4cb7e543db5091d9f1c4a08014e2d017a93f5c1b82e54e15f916eb8fba; fixture_sha256=17e20791a9c9288907fb214989bbc6378e7d64a98732f68a5c493285ff25f933; output_sha256=cb8cbfb03597921f83f87fd975415bdaad9315dfbfbf108e405c8e2de96a22e4; snapshot_sha256=64db1c5e1fcf0d4930550743f83a243186f2e74164b3d3e6cde180e91e4c04a0
+- Behavior: Produced a file-backed release preview but retained platform sections/instructions that do not satisfy the stricter assertion requirements; this is comparison context only.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/idea-to-spec/evals/workspace/eval-008-mapped-notification-update/comparison.md
+++ b/agents/product_manager/test/idea-to-spec/evals/workspace/eval-008-mapped-notification-update/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `177b1f9c445f127660775572bba7b23413067a88e77389cbdec983886f090960` from `agents/product_manager/test/idea-to-spec/evals/workspace/eval-008-mapped-notification-update`.
 - Identity schema: `2`
-- target_skill_sha256: `0f0c72145289aa20c9f9e2b8953104e7776465f3453dfea622022098ed6ce507`
+- target_skill_sha256: `62f7a88900be8a0aae1af9e34b28dc32abd76006ca95f89107567b68f5780813`
 - eval_definition_sha256: `130498c1a4cc1643bdf013127365b28e5fdc8391203daf304f2cdc0ef5bc97d2`
 - metadata_sha256: `071b1907c18a80afba8338dbc482c47ee9a6fa479b963c4fb7d1e4c62363e556`
 - fixture_sha256: `177b1f9c445f127660775572bba7b23413067a88e77389cbdec983886f090960`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `8d974654e1fcdbd5fc645c2a9f10feef6661d70a858e4722087a732bb9d82274`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `c40e2467241d61e6995a6131388bc32d701c6b675b7822ba6b51ce9428570cb3`
+- Skill overlay SHA-256: `7b19869a4835a1feeb491815cac7af7bde071247819525989c10dbfbc0acd2f7`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `reads_mapped_docs_first` | PASS | Raw trace shows the lane identified src/notifications/**, read change-map.yaml, then read the mapped notifications.md before source verification; no unrelated site pages were traversed. |
-| `verifies_against_code` | PASS | The locked output and raw trace both establish channels.txt contains only enabled_channel: email, while notifications.md claims email or webhook; the lane explicitly treats code as authoritative. |
-| `treats_unverified_as_low_trust` | PASS | The locked output explicitly states last_verified_version: unverified lowers document trust and bases current behavior on code evidence; the raw trace confirms this reasoning. |
+| `reads_mapped_docs_first` | PASS | Raw trace shows the change-map was inspected for `src/notifications/**`, then the mapped `docs/site/api/notifications.md` was read; no unrelated site pages were traversed. |
+| `verifies_against_code` | PASS | The locked fixture and trace show `src/notifications/channels.txt` contains only `enabled_channel: email`, while the mapped document claims email or webhook; the with_skill output explicitly treats code as authoritative. |
+| `treats_unverified_as_low_trust` | PASS | The with_skill output explicitly identifies `last_verified_version: unverified` and lowers the document to navigation-only trust, grounding current behavior and impact in `channels.txt`. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=8d974654e1fcdbd5fc645c2a9f10feef6661d70a858e4722087a732bb9d82274; fixture_sha256=177b1f9c445f127660775572bba7b23413067a88e77389cbdec983886f090960; output_sha256=b29a79881c81233b4f248a87bef4d0564c3675153a2ff11d6a76e68e793df970; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly mapped the change-map, read the required notification document, verified behavior against the source fixture, identified the documentation conflict, and treated unverified documentation as low trust.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=8d974654e1fcdbd5fc645c2a9f10feef6661d70a858e4722087a732bb9d82274; fixture_sha256=177b1f9c445f127660775572bba7b23413067a88e77389cbdec983886f090960; output_sha256=970e4911d8707d4a0cd2462be88d2a42fb2ee4d492427de31c0fb7b6b0e90253; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Produced a trace-backed requirements scope, identified the email-only code/document webhook mismatch, and treated unverified documentation as low trust without mutating the fixture.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=8d974654e1fcdbd5fc645c2a9f10feef6661d70a858e4722087a732bb9d82274; fixture_sha256=177b1f9c445f127660775572bba7b23413067a88e77389cbdec983886f090960; output_sha256=c61cb54b577b58b0cb2f636003979c99ab7ac858d0b9b84756e7969a3423e460; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Also identified the email-only source configuration and email/webhook documentation mismatch, but did not establish the mapped-document-first process or explicit low-trust handling as clearly.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=8d974654e1fcdbd5fc645c2a9f10feef6661d70a858e4722087a732bb9d82274; fixture_sha256=177b1f9c445f127660775572bba7b23413067a88e77389cbdec983886f090960; output_sha256=5c10e8658155da9a72033ed4360da2602aa9922a7b7df6af9a30e78ad0965a7a; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Produced a plausible requirements scope and identified the email/webhook mismatch, but lacked the explicit mapped-doc-first and low-trust process evidence present in the with_skill lane.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/idea-to-spec/workspace/eval-009-prd-iteration-split-proposal/comparison.md
+++ b/agents/product_manager/test/idea-to-spec/workspace/eval-009-prd-iteration-split-proposal/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `cda1a0661ddb58fa697ce0a283dc50943986240370fdcd97782d5714af75a997` from `agents/product_manager/test/idea-to-spec/workspace/eval-009-prd-iteration-split-proposal`.
 - Identity schema: `2`
-- target_skill_sha256: `34042e851466ff927567e09fc5777d952f1546cabc96fbe4de98617d27f5b1fb`
+- target_skill_sha256: `62f7a88900be8a0aae1af9e34b28dc32abd76006ca95f89107567b68f5780813`
 - eval_definition_sha256: `8ef466ccd13d937453c02f105817ced47839fb573011ea1ee300be62facb6b71`
 - metadata_sha256: `ae189abbce9ec160b22d49ab4f79a0a7a8f521d1a6e2046930669caf75d7dab0`
 - fixture_sha256: `cda1a0661ddb58fa697ce0a283dc50943986240370fdcd97782d5714af75a997`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `9c9a733fc3c46fd3cb1cdea794218e66a7a987137063c1a3c970e8e9386d1a58`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `ae03344941a8a5473fce84f07af68d8bb42c4c4dd8dbaf557b909886adf20c98`
-- Repository HEAD: `c13c53a9b6e4cf18215450050bc9e7d0a810b73c`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `55d032569bbd4014a60103aafb1c0773a93ff9dbe0ea681c46297ebeef4a35b3`
+- Skill overlay SHA-256: `7b19869a4835a1feeb491815cac7af7bde071247819525989c10dbfbc0acd2f7`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,29 +33,29 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `applies_requested_change` | NOT_EXERCISED | With_skill produced no updated PRD or file snapshot; it stopped at the confirmation checkpoint before the update. |
-| `detects_l2b_signals` | PASS | It explicitly identified 3 independent domains and 18 US/FR rows, satisfying two L2b signals. |
-| `presents_split_proposal` | PASS | It provided a three-branch feature_path tree, section migration mapping, and impacts for Engineer, Design, QA, DevOps, and Security. |
-| `waits_for_confirmation` | PASS | It explicitly requested confirmation and showed options to retain the current path or accept the split; no split files or moves were made. |
-| `rejection_keeps_current_flow` | NOT_EXERCISED | No rejection occurred, so the post-rejection continuation behavior was not exercised. |
-| `body_consolidation` | NOT_EXERCISED | The PRD was not updated because the workflow paused for confirmation; current-body consolidation therefore was not exercised. |
+| `applies_requested_change` | NOT_EXERCISED | 未产出更新后的 PRD；候选正确停在需要用户确认的拆分门槛，因此实际应用变更尚未可执行。 |
+| `detects_l2b_signals` | PASS | 明确给出 independent_domain_count=3 和 combined US/FR rows=18，并判定 l2b_assessment=triggered。 |
+| `presents_split_proposal` | PASS | 给出三个子 feature_path、章节迁移映射，以及 Engineer、Design、QA、DevOps、Security 五类下游影响清单。 |
+| `waits_for_confirmation` | PASS | 明确要求确认接受或拒绝拆分，并说明确认前不能直接写入 PRD；无 git mv 或新建子路径文档证据。 |
+| `rejection_keeps_current_flow` | PASS | 明确说明拒绝拆分时保持 notification-center 当前路径，直接改为事件驱动并按正常版本迭代。 |
+| `body_consolidation` | NOT_EXERCISED | 未产出更新后的 PRD 正文；该后续步骤依赖用户确认，尚未执行。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=ae03344941a8a5473fce84f07af68d8bb42c4c4dd8dbaf557b909886adf20c98; fixture_sha256=cda1a0661ddb58fa697ce0a283dc50943986240370fdcd97782d5714af75a997; output_sha256=11292067d2c39b92a665147bac9044273f98ee9a4652aa9bf97488b436e98923; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Detected the L2b checkpoint, presented a complete confirmation-gated split proposal, and made no filesystem mutation.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=ae03344941a8a5473fce84f07af68d8bb42c4c4dd8dbaf557b909886adf20c98; fixture_sha256=cda1a0661ddb58fa697ce0a283dc50943986240370fdcd97782d5714af75a997; output_sha256=096351dc619d34011011e8bd36f4dd5830a22e94e1fecb9e13fdeea548877008; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 识别到 L2b 信号，输出完整拆分提案并等待用户确认；未执行 PRD 更新。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=ae03344941a8a5473fce84f07af68d8bb42c4c4dd8dbaf557b909886adf20c98; fixture_sha256=cda1a0661ddb58fa697ce0a283dc50943986240370fdcd97782d5714af75a997; output_sha256=dfa3b057c7f8952ad67a49966e9d2293899868474d507eb85cc86ea9ab209136; snapshot_sha256=b3a6a548162a143cf1a9b8153a77dca6038be23317a95cbfd06d692a8f538d7e
-- Behavior: Updated the PRD directly from polling to event-driven delivery, but did not present the L2b split proposal or confirmation gate.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=ae03344941a8a5473fce84f07af68d8bb42c4c4dd8dbaf557b909886adf20c98; fixture_sha256=cda1a0661ddb58fa697ce0a283dc50943986240370fdcd97782d5714af75a997; output_sha256=32873913c60f965f3ad771a005533c350586228564a73b0e98370e51e75a34a1; snapshot_sha256=31a4e197bc25f40bf845517ec0d0636069b31c0ee1943a849aae92836beb70a1
+- Behavior: 直接更新 PRD 为事件驱动方案并产生工作区修改，但未展示拆分确认流程。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Obtain the user's choice to retain the current feature path or accept the proposed split, then continue the corresponding workflow.
+- Next: 等待用户确认接受或拒绝 L2b 拆分。
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/idea-to-spec/workspace/iteration-1/eval-1-existing-project-feature/comparison.md
+++ b/agents/product_manager/test/idea-to-spec/workspace/iteration-1/eval-1-existing-project-feature/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `2a0d3945e9442edd7c1ef55752552e4a49ef23e35e942cd87d1e31a4fa5138fc` from `agents/product_manager/test/idea-to-spec/workspace/iteration-1/eval-1-existing-project-feature`.
 - Identity schema: `2`
-- target_skill_sha256: `0f0c72145289aa20c9f9e2b8953104e7776465f3453dfea622022098ed6ce507`
+- target_skill_sha256: `62f7a88900be8a0aae1af9e34b28dc32abd76006ca95f89107567b68f5780813`
 - eval_definition_sha256: `fbb5377843587b9c6261e61b2a81e3a48d39c5e7814d8290865e02fe8eb5ec41`
 - metadata_sha256: `ff56c9c4026c02d3f3b5f70e58cc2a2e628e1817de3ecbec4d01c2d2b3fe50bc`
 - fixture_sha256: `2a0d3945e9442edd7c1ef55752552e4a49ef23e35e942cd87d1e31a4fa5138fc`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `dbe3f262003438ea2a4caaa2b38e4ab353ee29def3530b27abe04d98b19dfd03`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `989dc53f5a8c8fb9df9263c550c8d2965414d618ab35b7c932c180c33869ec1b`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `c40e2467241d61e6995a6131388bc32d701c6b675b7822ba6b51ce9428570cb3`
+- Skill overlay SHA-256: `7b19869a4835a1feeb491815cac7af7bde071247819525989c10dbfbc0acd2f7`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,21 +33,21 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `summarizes_current_context` | PASS | With-skill output summarizes manifest, docs index, Engineer TRD, current capabilities, missing tag model, search limitation, and absent PM docs without presenting a complete finalized solution. |
-| `keeps_first_turn_to_one_decision` | PASS | With-skill output asks for confirmation of one governance decision—tag ownership/maintenance—and does not present multiple parallel confirmation questions. |
-| `offers_real_options_with_tradeoffs` | PASS | With-skill output provides three executable governance options, explains tradeoffs for each, and recommends the administrator-managed unified tag library. |
-| `waits_before_durable_docs` | PASS | Delivery snapshot is empty and git evidence shows no changes; output explicitly marks durable docs pending and confirmation required, with the feature path provisional rather than locked. |
+| `summarizes_current_context` | PASS | with_skill 输出先依据 package.json、docs/README.md 和 Engineer TRD 概括项目为应用目录骨架，并明确无标签模型、名称搜索和单一弹窗等缺口；未直接给出完整方案。 |
+| `keeps_first_turn_to_one_decision` | PASS | with_skill 输出仅推进一个决策：标签由谁维护、标签值是否受控，并以单一问题结尾。 |
+| `offers_real_options_with_tradeoffs` | PASS | with_skill 输出提供管理员维护受控标签、自由输入和混合模式三个可执行方向，说明各自取舍，并标注有理由的推荐项。 |
+| `waits_before_durable_docs` | PASS | with_skill 输出明确 durable_docs_pending: true、confirmation_required: true，并说明暂不进入 PRD 生成或工程实现；交付快照为空且 Git 无变化。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=989dc53f5a8c8fb9df9263c550c8d2965414d618ab35b7c932c180c33869ec1b; fixture_sha256=2a0d3945e9442edd7c1ef55752552e4a49ef23e35e942cd87d1e31a4fa5138fc; output_sha256=2e1dd3a5a980bb705f769f34d8e345bf99edbe15a559fb1c2524ba9db2db8030; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Read-only discovery of the existing project, explicit lane checkpoint, one governance decision, three options with tradeoffs, and no durable documentation changes.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=989dc53f5a8c8fb9df9263c550c8d2965414d618ab35b7c932c180c33869ec1b; fixture_sha256=2a0d3945e9442edd7c1ef55752552e4a49ef23e35e942cd87d1e31a4fa5138fc; output_sha256=34a55845f05bfcc8404660480f2044f204c3067a1db989f001c5dcca79e25511; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 基于现有 manifest、文档索引和 Engineer TRD 完成现状盘点，识别标签缺口，只推进一个标签治理决策，提供三种带取舍的方向并等待确认；未创建或修改正式文档。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=989dc53f5a8c8fb9df9263c550c8d2965414d618ab35b7c932c180c33869ec1b; fixture_sha256=2a0d3945e9442edd7c1ef55752552e4a49ef23e35e942cd87d1e31a4fa5138fc; output_sha256=8a58e0c3c21847116ae2b54cb574580f71cceec455e7a22249f5a20204321c21; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Accurately summarized the current project and proposed a minimum-scope tagging direction, but did not provide multiple real options with tradeoffs or an explicit durable-documentation checkpoint.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=989dc53f5a8c8fb9df9263c550c8d2965414d618ab35b7c932c180c33869ec1b; fixture_sha256=2a0d3945e9442edd7c1ef55752552e4a49ef23e35e942cd87d1e31a4fa5138fc; output_sha256=0e65122fdc92f7d6571a5da40c7f0d2fc02742a0a0bd0b4177fd323ff23f19d8; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 同样完成基本现状盘点并只推进标签创建方式这一决策，提供三个方向和推荐；作为 fresh baseline，治理检查和路径确认不如 with_skill 明确。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/idea-to-spec/workspace/iteration-1/eval-2-existing-project-update/comparison.md
+++ b/agents/product_manager/test/idea-to-spec/workspace/iteration-1/eval-2-existing-project-update/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `4a0c4f24287b030b034f66b2e9e0787c5b6e4b2e4a40435cb46ef2275f03923a` from `agents/product_manager/test/idea-to-spec/workspace/iteration-1/eval-2-existing-project-update`.
 - Identity schema: `2`
-- target_skill_sha256: `34042e851466ff927567e09fc5777d952f1546cabc96fbe4de98617d27f5b1fb`
+- target_skill_sha256: `62f7a88900be8a0aae1af9e34b28dc32abd76006ca95f89107567b68f5780813`
 - eval_definition_sha256: `2eb26345c0320238f13795dd231ba4c205d452d230de64d35bcf4cc4acb002f8`
 - metadata_sha256: `d7142d966569c4d32f40a170b0f92f6780789b8a982e6faeead586a238a9f649`
 - fixture_sha256: `4a0c4f24287b030b034f66b2e9e0787c5b6e4b2e4a40435cb46ef2275f03923a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `34ccc67474b5d5409e42b47f3e143e51f307a39f3959fa17d3be62715a379bc6`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `6aaa57677f60fb06006df08dac712b315ee95015f718fd4450b32d594a455441`
-- Repository HEAD: `c13c53a9b6e4cf18215450050bc9e7d0a810b73c`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `55d032569bbd4014a60103aafb1c0773a93ff9dbe0ea681c46297ebeef4a35b3`
+- Skill overlay SHA-256: `7b19869a4835a1feeb491815cac7af7bde071247819525989c10dbfbc0acd2f7`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,21 +33,21 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `update` | PASS | With-skill output explicitly identifies this as an existing-project update, not a new notification feature. |
-| `delta_blast_radius` | PASS | With-skill output states the delta and blast radius before presenting recommended design and document updates. |
-| `assertion_3` | PASS | With-skill output explicitly recommends `change-impactor` and multi-document incremental updates. |
-| `assertion_4` | PASS | With-skill output names the affected PRD, DECISIONS, and TRD paths, plus proposed API, QA, DevOps, and Security documentation paths/types. |
+| `update` | PASS | With_skill output explicitly identifies this as an existing `notification-center` capability update and labels the lane `existing-project-update`. |
+| `delta_blast_radius` | PASS | With_skill output presents the polling-to-event-driven delta, blast radius, affected documents, and section migration map before the detailed design recommendations. |
+| `assertion_3` | PASS | With_skill output recommends `change-impactor → iteration-coordinator` and describes incremental multi-document iteration rather than a full rewrite. |
+| `assertion_4` | PASS | With_skill output names the existing PRD, DECISIONS, and TRD paths, plus explicit paths/types for TEST_SPEC and downstream API, DevOps, Security, and Design documentation. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=6aaa57677f60fb06006df08dac712b315ee95015f718fd4450b32d594a455441; fixture_sha256=4a0c4f24287b030b034f66b2e9e0787c5b6e4b2e4a40435cb46ef2275f03923a; output_sha256=8661a2c798d9a53fd886b96bae16924e35005b1895769033091bbaea47a6b4b9; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly recognized an existing-project update, analyzed delta and blast radius first, recommended iterative change-impact analysis, and identified affected document paths.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=6aaa57677f60fb06006df08dac712b315ee95015f718fd4450b32d594a455441; fixture_sha256=4a0c4f24287b030b034f66b2e9e0787c5b6e4b2e4a40435cb46ef2275f03923a; output_sha256=9293bd5ea1d658085a7d36eaa58e520d8fc255246e5ef67a498958aecd80cd94; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly classified the request as an existing-project update, analyzed delta and blast radius, recommended an iterative change-impact workflow, and identified affected documentation paths.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=6aaa57677f60fb06006df08dac712b315ee95015f718fd4450b32d594a455441; fixture_sha256=4a0c4f24287b030b034f66b2e9e0787c5b6e4b2e4a40435cb46ef2275f03923a; output_sha256=ea4527595ec013e9a9686d0171eeaae6fe1cefc67dfc1ad1fac40d2d5dddf466; snapshot_sha256=8d33f28ee5de44b367b7ade060736116652af25abf69b732454dd13cce510564
-- Behavior: Produced a technically strong design and updated three documents, but did not explicitly frame the work as an existing-project update or recommend the iteration/change-impactor workflow.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=6aaa57677f60fb06006df08dac712b315ee95015f718fd4450b32d594a455441; fixture_sha256=4a0c4f24287b030b034f66b2e9e0787c5b6e4b2e4a40435cb46ef2275f03923a; output_sha256=02030cd591d56d4833bd74704d82efbbd13a9063f65e0ec22f139e197b530892; snapshot_sha256=87463021f8a8f148972b62795a3981d3cfc832a7e73363d41d8647d58cd9b8f3
+- Behavior: Provided a useful design update with impact areas and modified-document paths, but did not clearly classify the existing-project update lane or recommend the change-impact iteration workflow.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/idea-to-spec/workspace/iteration-1/eval-3-greenfield-discovery/comparison.md
+++ b/agents/product_manager/test/idea-to-spec/workspace/iteration-1/eval-3-greenfield-discovery/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `a4faa6eb1bc545a0fcd2b0f3491c8b376050fe70e6b532b62cd5d45f16655b85` from `agents/product_manager/test/idea-to-spec/workspace/iteration-1/eval-3-greenfield-discovery`.
 - Identity schema: `2`
-- target_skill_sha256: `0f0c72145289aa20c9f9e2b8953104e7776465f3453dfea622022098ed6ce507`
+- target_skill_sha256: `62f7a88900be8a0aae1af9e34b28dc32abd76006ca95f89107567b68f5780813`
 - eval_definition_sha256: `c665f0cae1373d04b176b75bc723732674aeb9f3630f01eadac8f7310d65bdb7`
 - metadata_sha256: `aa700f49d0f32cf47f3b535bd526e4ad2ade501da428e296936ddccef0bcdcbd`
 - fixture_sha256: `a4faa6eb1bc545a0fcd2b0f3491c8b376050fe70e6b532b62cd5d45f16655b85`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `e8bf769ac89a10c9a014e6b2e125d2d95f024ce8d37a4e4481c16c75936c71a8`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `0af25e0d51f2fb040654e6f1d54a6ad79ea082de53fb485f0d81b3fe8a3d6ee6`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `c40e2467241d61e6995a6131388bc32d701c6b675b7822ba6b51ce9428570cb3`
+- Skill overlay SHA-256: `7b19869a4835a1feeb491815cac7af7bde071247819525989c10dbfbc0acd2f7`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,26 +33,26 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `assertion_1` | PASS | with_skill 输出明确表示“暂不写入”正式文档，并通过确认方向前不写 PRD/TRD；delivery_snapshot 为空且 git 无变更。 |
-| `assertion_2` | PASS | with_skill 先识别工作区与产品状态，再提出一个决策点，并提供 A/B/C 三个有权衡的方向选项，要求用户先选择一个方向后继续。 |
-| `assertion_3` | NOT_EXERCISED | with_skill 表示当前 durable docs pending 但暂不写入；方向尚未确认，尚未到达设计稳定后推荐下游文档动作的阶段。 |
+| `assertion_1` | PASS | with_skill 输出明确表示“不写完整 PRD”，且仅提供方向选项与下一步决策，没有直接生成完整 PRD 或 TRD。 |
+| `assertion_2` | PASS | with_skill 明确提出“先只做一个关键决策”，提供 3 个方向及取舍并推荐一个默认方向，要求用户确认后再继续收敛。 |
+| `assertion_3` | NOT_EXERCISED | 当前设计仍处于未确认的早期概念阶段；输出说明 PRD/DECISIONS 不写入，并等待用户确认方向，因此后续稳定后推荐文档化的步骤尚未被实际触发。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=0af25e0d51f2fb040654e6f1d54a6ad79ea082de53fb485f0d81b3fe8a3d6ee6; fixture_sha256=a4faa6eb1bc545a0fcd2b0f3491c8b376050fe70e6b532b62cd5d45f16655b85; output_sha256=ef13d0ebbd2678dede569e993ccc808c5cbe4f814bea6b76d50ef6f1d1cb3ce9; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 遵循探索式流程，先检查空工作区并以单一决策点收敛方向，未创建文档。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=0af25e0d51f2fb040654e6f1d54a6ad79ea082de53fb485f0d81b3fe8a3d6ee6; fixture_sha256=a4faa6eb1bc545a0fcd2b0f3491c8b376050fe70e6b532b62cd5d45f16655b85; output_sha256=173d005be9a3bf29e0ef8de1489de9b3f70189fc5fd049d2832dba31bdb4140c; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 采用单决策点探索流程，完成工作区只读检查，未生成完整文档，并等待用户确认方向。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=0af25e0d51f2fb040654e6f1d54a6ad79ea082de53fb485f0d81b3fe8a3d6ee6; fixture_sha256=a4faa6eb1bc545a0fcd2b0f3491c8b376050fe70e6b532b62cd5d45f16655b85; output_sha256=4114e5c4e4af57262c7a56bc90d682b5390ae9ec8c399f1d3472227a359035de; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 未直接生成 PRD，但一次提出多个问题，未采用单决策点探索协议。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=0af25e0d51f2fb040654e6f1d54a6ad79ea082de53fb485f0d81b3fe8a3d6ee6; fixture_sha256=a4faa6eb1bc545a0fcd2b0f3491c8b376050fe70e6b532b62cd5d45f16655b85; output_sha256=fc300d787dcf20e8fda0bb56bc04e7b592a3b8646ad73c93eff4595eed17af34; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 未生成完整 PRD，但一次性提出 5 个问题，未遵循单决策点探索协议。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: 用户确认产品第一价值点后继续收敛问题、用户、目标与范围；设计稳定后再评估 PRD/TRD 等文档化动作。
+- Next: 用户确认产品切入方向后，再继续收敛目标用户、目标与范围；设计稳定后再推荐 PRD 或其他下游文档动作。
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/idea-to-spec/workspace/iteration-2/eval-4-greenfield-bootstrap-routing/comparison.md
+++ b/agents/product_manager/test/idea-to-spec/workspace/iteration-2/eval-4-greenfield-bootstrap-routing/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/idea-to-spec/workspace/iteration-2/eval-4-greenfield-bootstrap-routing`.
 - Identity schema: `2`
-- target_skill_sha256: `34042e851466ff927567e09fc5777d952f1546cabc96fbe4de98617d27f5b1fb`
+- target_skill_sha256: `62f7a88900be8a0aae1af9e34b28dc32abd76006ca95f89107567b68f5780813`
 - eval_definition_sha256: `8e113c060d578c3d672e422d3214efcf8ef5f3dc4a4d591f825ce19450902064`
 - metadata_sha256: `af73e5b9a9192eb83b6e3ca2d5cae73fe4fd2b14b49ac401fa1a5f606db4bd6c`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,38 +22,38 @@
 - judge_schema_sha256: `333e583cf4bb11484925925c3c083e2f295eb8670599a3d04a51d2b749c8668a`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `47f636262c26b6b99c860d59ef8342eebebbd60397f192a193020f82c13fa42c`
-- Repository HEAD: `c13c53a9b6e4cf18215450050bc9e7d0a810b73c`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `55d032569bbd4014a60103aafb1c0773a93ff9dbe0ea681c46297ebeef4a35b3`
-- Behavior result: **PASS**
+- Skill overlay SHA-256: `7b19869a4835a1feeb491815cac7af7bde071247819525989c10dbfbc0acd2f7`
+- Behavior result: **FAIL**
 - Coverage result: **FULL**
-Overall result: PASS
+Overall result: FAIL
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `assertion_1` | PASS | with_skill 输出明确说明 project_status=empty、tech_stack=pending、existing_docs=[]；raw trace 也显示文件扫描为空。 |
-| `pm_first_lane` | PASS | with_skill 输出明确标注 lane 为 greenfield-discovery。 |
-| `pm_first` | PASS | 未执行脚手架或初始化命令；输出先提供 PRD 骨架和产品决策收敛内容，并明确暂不初始化项目。 |
-| `assertion_4` | PASS | 明确推荐先确认产品定位与 MVP，再生成正式 PRD/DECISIONS，并给出 PRD 骨架。 |
+| `assertion_1` | FAIL | The with_skill output says it starts from an empty directory, but does not state that the tech stack is undecided or that existing documents are empty, and it does not begin with an explicit workspace inspection. |
+| `pm_first_lane` | PASS | The output explicitly identifies the lane as `greenfield-discovery`, describing PM-oriented product discovery for the empty workspace. |
+| `pm_first` | PASS | The output explicitly says the current scope does not involve project initialization and routes first through product decisions and PRD/DECISIONS documentation rather than scaffolding. |
+| `assertion_4` | PASS | The output names PRD.md and DECISIONS.md as pending durable documents and recommends drafting them after confirmation. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=47f636262c26b6b99c860d59ef8342eebebbd60397f192a193020f82c13fa42c; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=13d5a9b47d575cce67c390e7cb2ff200e1aa83e4342e890259da9b5db1e22cb9; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 完成空工作区检测，识别 greenfield-discovery PM 路径，先产出 PRD 骨架并推迟工程初始化。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=47f636262c26b6b99c860d59ef8342eebebbd60397f192a193020f82c13fa42c; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=e54d3a1fa8816350f94e98867274b11c36d9bb0d0e06fd24c26f028576162cdb; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly selected a PM-first greenfield-discovery route, avoided project initialization, and requested one product decision before drafting PRD/DECISIONS documents.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=47f636262c26b6b99c860d59ef8342eebebbd60397f192a193020f82c13fa42c; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=90a94ee0bffd3d611f3730bf9a76eabbba9962aef2c6107b739db8f1c5715239; snapshot_sha256=a384c388850d198b6ad540e0e876ac36c52e10573d7d4330f980ff94d0d99869
-- Behavior: 直接交付 PRD.md 文件且未初始化项目，但未明确说明空工作区状态或 greenfield-discovery PM 路径。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=47f636262c26b6b99c860d59ef8342eebebbd60397f192a193020f82c13fa42c; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=bf19bd8e9522c825459dd62f1e9e54989aa729088b1841d72efc2267884035e6; snapshot_sha256=e8dcf5eb94b51a5ce7a1a703cd4ad56072b1a37ea373b9eb24e149e7ef3b7653
+- Behavior: Created a detailed PRD file without initialization, but did not demonstrate explicit PM lane selection or the required initial workspace/technology/document-state framing.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- None.
-- Next: None.
+- The with_skill lane omits the required explicit statement that the tech stack is undecided and existing documentation is empty.
+- Next: After user confirmation, draft the pending PRD/DECISIONS documents.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/idea-to-spec/workspace/iteration-2/eval-5-pm-agent-direct-delegation/comparison.md
+++ b/agents/product_manager/test/idea-to-spec/workspace/iteration-2/eval-5-pm-agent-direct-delegation/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/idea-to-spec/workspace/iteration-2/eval-5-pm-agent-direct-delegation`.
 - Identity schema: `2`
-- target_skill_sha256: `34042e851466ff927567e09fc5777d952f1546cabc96fbe4de98617d27f5b1fb`
+- target_skill_sha256: `62f7a88900be8a0aae1af9e34b28dc32abd76006ca95f89107567b68f5780813`
 - eval_definition_sha256: `073eeac01923328bf5fb812c3ab5852d6edb01936d4f17fc20c69c0d80324b2c`
 - metadata_sha256: `2ddab779806f9b6e5f9359612bd5cef16f9b4ffd4913ec9f35576d1c0f06be89`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `d5a49beb6f0959828703001ca6c478b09bfa703290aa048a42e8e1be6bc28cde`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `acbae9b70ef204aa5ea01807d9cde8c1bfaf036424605400b24871c7a447ebef`
-- Repository HEAD: `c13c53a9b6e4cf18215450050bc9e7d0a810b73c`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `55d032569bbd4014a60103aafb1c0773a93ff9dbe0ea681c46297ebeef4a35b3`
+- Skill overlay SHA-256: `7b19869a4835a1feeb491815cac7af7bde071247819525989c10dbfbc0acd2f7`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `dispatcher` | PASS | With_skill directly provided an idea-to-spec-style context summary, including project status, lane, feature identity, scope, and blast radius. |
-| `skill` | PASS | With_skill did not ask whether to invoke a skill or request manual execution; it proceeded through the PM flow. |
-| `pm` | PASS | With_skill continued in the same response with MVP scope options and asked the user to confirm the initial product scope. |
+| `dispatcher` | PASS | with_skill 输出提供了工作区现状、产品身份、范围增量、MVP 前置决策及待沉淀文档，并直接进入需求梳理。 |
+| `skill` | PASS | with_skill 输出未询问是否调用 idea-to-spec，也未要求手动执行相关命令。 |
+| `pm` | PASS | with_skill 输出继续提炼产品定位，列出三种场景方向，并说明通用个人助手的 MVP 范围与需确认的核心决策。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=acbae9b70ef204aa5ea01807d9cde8c1bfaf036424605400b24871c7a447ebef; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=1663edfc4fa762244e3a2246a9a7bb952b442bc7ba020bbeaccc554184c8bc87; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Directly entered idea-to-spec-style discovery, avoided sub-skill invocation prompts, and advanced to MVP scope clarification.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=acbae9b70ef204aa5ea01807d9cde8c1bfaf036424605400b24871c7a447ebef; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=d9ca133abdec5cdca03432b1740bf81995cc6459780953d8a8ffdcc13b1e86b7; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 直接进入 greenfield-discovery 需求梳理，明确当前状态、产品定位决策和 MVP 方向。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=acbae9b70ef204aa5ea01807d9cde8c1bfaf036424605400b24871c7a447ebef; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=43dfc57a56e8243abaf76a0b3ce3aa64cf2f219aa21c85f4067cbb54db9ac17e; snapshot_sha256=1b2b63820e23d4a21fcc85acea33c8deba170f4253cf1ed2c6dc616951ede1a4
-- Behavior: Implemented a UI directly without entering the requested product-discovery or PM clarification flow.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=acbae9b70ef204aa5ea01807d9cde8c1bfaf036424605400b24871c7a447ebef; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=0efbf09f62d96e68cd3c3cc6a5c31df29e53d4cc21217f7b67d3786410c6061a; snapshot_sha256=32ad2398b59b61e6ebadf370feea2ae5219d178768f48ea7a18a7c3360bf4eab
+- Behavior: 直接交付了左右结构 AI 对话助手界面及代码文件，未进入产品定位或需求收敛流程。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/idea-to-spec/workspace/iteration-3/eval-6-nested-feature-path/comparison.md
+++ b/agents/product_manager/test/idea-to-spec/workspace/iteration-3/eval-6-nested-feature-path/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `7749eb192d7baaaa2204b646c198e25edb560363b060536f8cc66b5b6a90c8e7` from `agents/product_manager/test/idea-to-spec/workspace/iteration-3/eval-6-nested-feature-path`.
 - Identity schema: `2`
-- target_skill_sha256: `34042e851466ff927567e09fc5777d952f1546cabc96fbe4de98617d27f5b1fb`
+- target_skill_sha256: `62f7a88900be8a0aae1af9e34b28dc32abd76006ca95f89107567b68f5780813`
 - eval_definition_sha256: `0d6c5b2207f916945e44c4152d1df1a5456bcf63eecb7a912ef1fe1811598afa`
 - metadata_sha256: `4835f86af8c88f61556ab924715c5dc8125d2c5616e22976f405e64c105bc13a`
 - fixture_sha256: `7749eb192d7baaaa2204b646c198e25edb560363b060536f8cc66b5b6a90c8e7`
@@ -22,38 +22,38 @@
 - judge_schema_sha256: `4fbce5299edbfab7f3f9e314d3ad852d562878858c404b524820ab2f7613136e`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `c1a9a695ac306d56eb35a4b41b4c84d037d6f92a7cc3a09d8d7f11f8de78d818`
-- Repository HEAD: `c13c53a9b6e4cf18215450050bc9e7d0a810b73c`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `55d032569bbd4014a60103aafb1c0773a93ff9dbe0ea681c46297ebeef4a35b3`
-- Behavior result: **PASS**
+- Skill overlay SHA-256: `7b19869a4835a1feeb491815cac7af7bde071247819525989c10dbfbc0acd2f7`
+- Behavior result: **FAIL**
 - Coverage result: **FULL**
-Overall result: PASS
+Overall result: FAIL
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `scan_existing_prds` | PASS | with_skill 输出列出并读取 Chat Interface、Messages、Message History PRD。 |
-| `nested_feature_path` | PASS | with_skill 输出明确 `feature_path: chat-interface/messages/history/search`，并列出对应搜索 PRD 路径。 |
-| `no_parallel_top_level` | PASS | with_skill 输出采用 `chat-interface/messages/history/search` 嵌套路径，并明确不重生成 Chat Interface 或 Messages PRD。 |
-| `handoff_fields` | PASS | with_skill 的 `current_feature_identity` 明确包含 feature_path、feature、parent_feature、feature_level 和 feature_path_evidence。 |
+| `scan_existing_prds` | PASS | With_skill output lists the three existing PRDs, including Chat Interface, Message History, and the nested history PRD. |
+| `nested_feature_path` | PASS | With_skill output explicitly specifies feature_path `chat-interface/messages/history/search` and the corresponding nested PRD path. |
+| `no_parallel_top_level` | PASS | With_skill recommends the nested history/search path and explicitly advises against updating the top-level Chat Interface or Messages PRDs. |
+| `handoff_fields` | FAIL | The output includes feature_path, feature, parent_feature, and feature_level, but does not provide a handoff packet or feature_path_evidence field. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c1a9a695ac306d56eb35a4b41b4c84d037d6f92a7cc3a09d8d7f11f8de78d818; fixture_sha256=7749eb192d7baaaa2204b646c198e25edb560363b060536f8cc66b5b6a90c8e7; output_sha256=ec260e65672e58db5d8bc32fb6e7dcf43b4006793542907672fcb474f6c1e31d; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 完成只读文档扫描，识别历史搜索为 history 下的四级子功能，并提供完整 handoff 字段。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c1a9a695ac306d56eb35a4b41b4c84d037d6f92a7cc3a09d8d7f11f8de78d818; fixture_sha256=7749eb192d7baaaa2204b646c198e25edb560363b060536f8cc66b5b6a90c8e7; output_sha256=7aabb4b1c64807c9a17656bd454118364fe31641704ef43f8a91be327de2c6be; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly scans existing PRDs and identifies the nested history/search child path while preserving the parent-child structure; handoff metadata is incomplete.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c1a9a695ac306d56eb35a4b41b4c84d037d6f92a7cc3a09d8d7f11f8de78d818; fixture_sha256=7749eb192d7baaaa2204b646c198e25edb560363b060536f8cc66b5b6a90c8e7; output_sha256=d2f3811f808eda33c00f6b168e516c5b9ccb961272d017fc32625569215b6e39; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 识别出正确的嵌套 PRD 路径并建议更新父级 PRD，但未提供结构化 handoff 字段。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c1a9a695ac306d56eb35a4b41b4c84d037d6f92a7cc3a09d8d7f11f8de78d818; fixture_sha256=7749eb192d7baaaa2204b646c198e25edb560363b060536f8cc66b5b6a90c8e7; output_sha256=6e0d891dc5df7dd87015aa4b9e86643824f6b1387e9828ae28b9b723975432f7; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline also identifies the existing PRDs and correct nested search path, but provides no handoff packet fields.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- None.
-- Next: None.
+- The with_skill lane omits the required handoff packet field `feature_path_evidence` and does not present the required fields as a handoff packet.
+- Next: Add a handoff packet containing feature_path, feature, parent_feature, feature_level, and feature_path_evidence.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/idea-to-spec/workspace/iteration-3/eval-7-api-adr-engineer-handoff/comparison.md
+++ b/agents/product_manager/test/idea-to-spec/workspace/iteration-3/eval-7-api-adr-engineer-handoff/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `7b6820d67dd73e9499a1ca84c463bfc82e890640eeaf8c3154b04834d8479116` from `agents/product_manager/test/idea-to-spec/workspace/iteration-3/eval-7-api-adr-engineer-handoff`.
 - Identity schema: `2`
-- target_skill_sha256: `34042e851466ff927567e09fc5777d952f1546cabc96fbe4de98617d27f5b1fb`
+- target_skill_sha256: `62f7a88900be8a0aae1af9e34b28dc32abd76006ca95f89107567b68f5780813`
 - eval_definition_sha256: `02e5d899a7687cd28d5b7fe3ed85f267cd9ce62f15d9844aa4281eff90859ac1`
 - metadata_sha256: `6b28964c95e54c379988fdfd7c54f486a5c872824039a926ede4358e3117f378`
 - fixture_sha256: `7b6820d67dd73e9499a1ca84c463bfc82e890640eeaf8c3154b04834d8479116`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `7d015813fae4cd945c52acc28425338fd81878adf050d1ecc956ba13abe7bc00`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `2ab3ca8b74dd55c90856f6dfac8c03932d3fb9eacb469271c944f9a989eec4b0`
-- Repository HEAD: `c13c53a9b6e4cf18215450050bc9e7d0a810b73c`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `55d032569bbd4014a60103aafb1c0773a93ff9dbe0ea681c46297ebeef4a35b3`
+- Skill overlay SHA-256: `7b19869a4835a1feeb491815cac7af7bde071247819525989c10dbfbc0acd2f7`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,21 +33,21 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `routes_to_trd_gen` | PASS | With-skill output explicitly states `engineer-agent:trd-gen` generates the API and ADR. |
-| `does_not_use_pm_api_adr_generators` | PASS | With-skill output states both documents are Engineer-owned and PM should not use PM generators. |
-| `engineer_paths_mirror_feature_path` | PASS | With-skill output lists `docs/engineer/chat-interface/history-search/API.md` and `ADR-001-search-index-strategy.md`. |
-| `handoff_contains_feature_path_evidence` | PASS | The structured handoff includes `feature_path`, `parent_feature`, `feature_level`, the PRD path, and API/ADR decision-background evidence. |
+| `does_not_use_pm_api_adr_generators` | PASS | With-skill output explicitly states PM does not directly generate API/ADR and identifies them as Engineer-owned; no forbidden PM generator is used. |
+| `routes_to_trd_gen` | PASS | With-skill output names `engineer-agent:trd-gen` as the recommended iteration and assigns the API/ADR work to Engineer. |
+| `engineer_paths_mirror_feature_path` | PASS | With-skill output requires `docs/engineer/chat-interface/history-search/API.md` and `ADR-search-index.md`, mirroring the confirmed feature path. |
+| `handoff_contains_feature_path_evidence` | PASS | The handoff includes `feature_path`, `parent_feature`, `feature_level`, the PRD path in `source_documents` and `feature_path_evidence`, plus API and search-index ADR decision context in `scope_decision` and required outputs. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2ab3ca8b74dd55c90856f6dfac8c03932d3fb9eacb469271c944f9a989eec4b0; fixture_sha256=7b6820d67dd73e9499a1ca84c463bfc82e890640eeaf8c3154b04834d8479116; output_sha256=6dd161c484022b2ddf0bacde7da8a06b80214a109266063e8ac3d14181ef21c7; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly routes API/ADR work to Engineer trd-gen, preserves the feature path, and provides the required handoff evidence.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2ab3ca8b74dd55c90856f6dfac8c03932d3fb9eacb469271c944f9a989eec4b0; fixture_sha256=7b6820d67dd73e9499a1ca84c463bfc82e890640eeaf8c3154b04834d8479116; output_sha256=7f5f4ecd11ad7908184fe70366b3eb433ac4c66fc9cf79d96bcf368e03759d43; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly routes the stable feature's API/ADR work to Engineer trd-gen, preserves the nested feature path, and supplies a complete handoff without mutation.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2ab3ca8b74dd55c90856f6dfac8c03932d3fb9eacb469271c944f9a989eec4b0; fixture_sha256=7b6820d67dd73e9499a1ca84c463bfc82e890640eeaf8c3154b04834d8479116; output_sha256=a2024cc12e8f14736ddee4729b4705658feb622eb94ac26998a9ce234e3e890f; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Routes to generic backend and architecture owners with incorrect API/ADR paths and no required Engineer handoff packet.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2ab3ca8b74dd55c90856f6dfac8c03932d3fb9eacb469271c944f9a989eec4b0; fixture_sha256=7b6820d67dd73e9499a1ca84c463bfc82e890640eeaf8c3154b04834d8479116; output_sha256=b1b163e80fec531efd0a60b33eb9d156167c05e746107620c52e8398f08ab957; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline correctly avoids PM-owned generation but proposes incorrect docs/api and docs/adr paths and provides no structured handoff.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-015-route-docs-site-deployment-gap/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-015-route-docs-site-deployment-gap/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `16e3b6cbbbae6769ac6b5ead7bae34214b3dd90e3e6c4d5fad97cfd7d3784013` from `agents/product_manager/test/pm-agent/evals/workspace/eval-015-route-docs-site-deployment-gap`.
 - Identity schema: `2`
-- target_skill_sha256: `ed93e443692bf05e76aaa38c8a5b8faff57190219ed48b9335316584424e6eb9`
+- target_skill_sha256: `e17c69ef6e179644f91ff00df55f141c375753f4668f30aca4e37e8247a60506`
 - eval_definition_sha256: `8bc69d85fc3ff063d885b8a2c4d7a9ea83b6dca3de23a034dba15fb34f1ba98e`
 - metadata_sha256: `7cd2581ae78239652e35a53401d899646cf1bf57925a7928ae3b61ce61b991b9`
 - fixture_sha256: `16e3b6cbbbae6769ac6b5ead7bae34214b3dd90e3e6c4d5fad97cfd7d3784013`
@@ -22,37 +22,37 @@
 - judge_schema_sha256: `69f2798cad12b0dd0ca3c224e3cfd6cf611a315695684db1b07a23452b52a60e`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `f6c9996daf9a7bdf78228fb674eccb457f386d1e74abf9925ac4646e4da1c9d4`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `f0e82f7ac41a59994ff88c345ca6ca77118629bc2985dc7df715d389b37ade9e`
+- Skill overlay SHA-256: `260ef2f905808fdff59ef7a047662603594e4a851b7569ea158bfc0c5228c88d`
 - Behavior result: **PASS**
-- Coverage result: **PARTIAL**
-Overall result: PASS (partial coverage)
+- Coverage result: **FULL**
+Overall result: PASS
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `blocks_unknown_evidence` | PASS | with_skill 报告部署完整性为 partial，明确缺少镜像、运行时工作负载、Service/Ingress、健康检查及访问控制证据，并列入 blockers_risks；未声称 integrated 或已完成交接。 |
-| `builds_repo_wide_deployment_packet` | PASS | with_skill 输出包含 request_type: deployment、所有 feature 字段为 N/A、feature_path_evidence: []，并在 source_documents 与 blockers_risks 中保留了 access-note、CI、Helm 和维护者授权证据。 |
-| `routes_devops_ordered_chain` | NOT_EXERCISED | with_skill 明确列出 deployment-planner → cicd-bootstrap → env-config-auditor → docs-agent:formal-docs-sync，并要求用户确认后继续；没有后续 DevOps 执行或已落地事实可供 Docs 同步，因此最终同步步骤未被实际行使。 |
+| `blocks_unknown_evidence` | PASS | With-skill output reports `partial`, identifies missing CI/CD, runtime, Helm, health-check, ingress, and access-control evidence, and does not treat the site as integrated or ready for deployment. |
+| `builds_repo_wide_deployment_packet` | PASS | The locked PM handoff packet uses `request_type: deployment`, sets feature fields to `N/A`, uses `feature_path_evidence: []`, and preserves source documents plus evidence-based blockers. |
+| `routes_devops_ordered_chain` | PASS | The output gives the ordered chain `deployment-planner → cicd-bootstrap → env-config-auditor → formal-docs-sync`, identifies DevOps as the next owner, and preserves the no-commit/no-publish/no-deploy boundary pending confirmation. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f6c9996daf9a7bdf78228fb674eccb457f386d1e74abf9925ac4646e4da1c9d4; fixture_sha256=16e3b6cbbbae6769ac6b5ead7bae34214b3dd90e3e6c4d5fad97cfd7d3784013; output_sha256=64c114f531c63e3ac3fc292127cd93321378f24f2bb8beb91115aa20bccaae34; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 识别部署状态仅为 partial，保留未知项，生成完整的 repo-wide DevOps 交接包并提出有序后续链路。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f6c9996daf9a7bdf78228fb674eccb457f386d1e74abf9925ac4646e4da1c9d4; fixture_sha256=16e3b6cbbbae6769ac6b5ead7bae34214b3dd90e3e6c4d5fad97cfd7d3784013; output_sha256=bb23227f324d8622785052dba9228284699a94efcc26218266155c954c565b57; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly identifies partial deployment coverage, builds a repo-wide deployment handoff, and specifies the ordered DevOps-to-Docs chain.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f6c9996daf9a7bdf78228fb674eccb457f386d1e74abf9925ac4646e4da1c9d4; fixture_sha256=16e3b6cbbbae6769ac6b5ead7bae34214b3dd90e3e6c4d5fad97cfd7d3784013; output_sha256=434bdeaded6d6c4c03f3b9a0d6697ea55d8be3c92ce257fec6c90133bce9d887; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 将审查范围过早判定为已完成并直接交给文档负责人，未保留 CI/运行时证据缺口，也未生成规范化交接包。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f6c9996daf9a7bdf78228fb674eccb457f386d1e74abf9925ac4646e4da1c9d4; fixture_sha256=16e3b6cbbbae6769ac6b5ead7bae34214b3dd90e3e6c4d5fad97cfd7d3784013; output_sha256=6b11e90417b571f937dc2b12ea5b63dd4439615160d204147c85e85fcadeafc7; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Provides a cautious planning response but does not build the required deployment packet or route the complete ordered chain.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: 获得用户确认后进入 deployment-planner，并按顺序完成后续 DevOps 审计；仅将已落地且验证的运维事实交给 Docs。
+- Next: None.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-016-route-document-structure-governance/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-016-route-document-structure-governance/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `1a6d7fa4c22a394f3c854eef7a25f4d0cf2e6b4ecd7c7a3d3bf15d295d6e43f8` from `agents/product_manager/test/pm-agent/evals/workspace/eval-016-route-document-structure-governance`.
 - Identity schema: `2`
-- target_skill_sha256: `ed93e443692bf05e76aaa38c8a5b8faff57190219ed48b9335316584424e6eb9`
+- target_skill_sha256: `e17c69ef6e179644f91ff00df55f141c375753f4668f30aca4e37e8247a60506`
 - eval_definition_sha256: `ba37454a106688e9f5f2e2586231a60f2093e364612eb14bfa53540c9e2d1589`
 - metadata_sha256: `fe53b448dd4fd2693ceb179d875dd617b7b717601fc7d9d3214cab940b4cdef7`
 - fixture_sha256: `1a6d7fa4c22a394f3c854eef7a25f4d0cf2e6b4ecd7c7a3d3bf15d295d6e43f8`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `c8400122a967de4e5b8b409bbe920fe16ec946724a3aa7d4b3077b3582a3f2f0`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `78a9ed4a2ff6af194b93c81277958547f5a87533a70b2aa14e43822f139e54d3`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `320ded3db25222eda1be26706a57ed0471cc438157b54925db0b045d15abf8e6`
+- Skill overlay SHA-256: `15f4acf7caf3d5cd73abf45c67ad35faa887bc8f89f51c7e53854fb1514182b5`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,22 +33,22 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `routes_to_structure_governance` | PASS | with_skill raw trace loads routing guidance stating read-only document structure governance stays in idea-to-spec:structure-governance; the structure-governance lane is selected and executed. |
-| `read_only_audit` | PASS | with_skill output states the check is read-only and the locked git evidence shows unchanged HEAD, branch, status, index, worktree, and no untracked files. |
-| `report_form` | PASS | with_skill raw trace records creation of structure-governance-report.html under a runtime tmp directory; the HTML content is present in locked command output, and the conversation output provides a conclusion summary and report path. |
-| `scope_six_role_dirs` | PASS | The locked HTML report contains columns for PM, Engineer, Design, QA, DevOps, and Security, explicitly records the four absent roots as scan limitations, and the trace inventories the existing docs tree. |
-| `structural_change_requires_confirmation` | PASS | The locked HTML report and conversation output recommend no merge/split/move, state that future structural changes require PM confirmation and change_tier major, and raw git evidence shows no mutation. |
+| `routes_to_structure_governance` | PASS | With-skill trace reads the pm-agent routing rules, which explicitly route read-only document structure governance to idea-to-spec:structure-governance. |
+| `read_only_audit` | PASS | The with-skill output explicitly states the audit was read-only and documents were not modified; git evidence shows unchanged HEAD, clean docs state, and no diffs. |
+| `report_form` | PASS | Locked trace evidence shows an HTML report was written under /tmp, verified to exist, and checked for report sections; the output provides its path and summarizes conclusions. |
+| `scope_six_role_dirs` | PASS | The with-skill output and HTML report explicitly cover docs/pm, docs/engineer, docs/design, docs/qa, docs/devops, and docs/security, recording absent roots as scan limitations. |
+| `structural_change_requires_confirmation` | PASS | The output proposes no structural action and states that later structural work requires confirmation and change_tier: major; the HTML report likewise says it does not authorize execution. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=78a9ed4a2ff6af194b93c81277958547f5a87533a70b2aa14e43822f139e54d3; fixture_sha256=1a6d7fa4c22a394f3c854eef7a25f4d0cf2e6b4ecd7c7a3d3bf15d295d6e43f8; output_sha256=992e52b64f40d738c3e6a672ef90de5d5eaeffee443fd3a8e2059c4fdc503cf0; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Read-only structure-governance audit routed through the correct lane, produced a runtime HTML report, summarized findings, documented all six role roots including missing-root limitations, and made no repository changes.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=78a9ed4a2ff6af194b93c81277958547f5a87533a70b2aa14e43822f139e54d3; fixture_sha256=1a6d7fa4c22a394f3c854eef7a25f4d0cf2e6b4ecd7c7a3d3bf15d295d6e43f8; output_sha256=b3a6d54d72516308cd4094b32daf702055e6ce76651dda95d60a065f572b4754; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Completed a read-only six-role structure audit, delivered a runtime HTML report, summarized findings, and preserved structural changes behind confirmation with major-tier handling.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=78a9ed4a2ff6af194b93c81277958547f5a87533a70b2aa14e43822f139e54d3; fixture_sha256=1a6d7fa4c22a394f3c854eef7a25f4d0cf2e6b4ecd7c7a3d3bf15d295d6e43f8; output_sha256=f44d268397d5ae6efe0b23c144a629a6a8243a2a9550b19c13c981f381d71bfd; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Fresh baseline produced a read-only prose audit of only the two existing role directories, with no HTML runtime report and no explicit six-role governance coverage.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=78a9ed4a2ff6af194b93c81277958547f5a87533a70b2aa14e43822f139e54d3; fixture_sha256=1a6d7fa4c22a394f3c854eef7a25f4d0cf2e6b4ecd7c7a3d3bf15d295d6e43f8; output_sha256=9505ee229b1b8a4841760030eb4631a55043bb8d7baf2bd756131a86fa64436c; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Produced a read-only prose report covering only the two existing role directories, with no runtime HTML report or six-role scan.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-020-route-read-only-diagnosis/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-020-route-read-only-diagnosis/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `0c37c580ec355abeaea3f2fc33d6ed8061916801102550f7da9905107759e638` from `agents/product_manager/test/pm-agent/evals/workspace/eval-020-route-read-only-diagnosis`.
 - Identity schema: `2`
-- target_skill_sha256: `ed93e443692bf05e76aaa38c8a5b8faff57190219ed48b9335316584424e6eb9`
+- target_skill_sha256: `e17c69ef6e179644f91ff00df55f141c375753f4668f30aca4e37e8247a60506`
 - eval_definition_sha256: `ac2e29c8ea600b5bded6655e93f469267e3a3d70f27c2a43049a20f14780fa3c`
 - metadata_sha256: `626240265d5c7ac5c06804a17b53a20dce96bac558a2504b82b9a8f747b23779`
 - fixture_sha256: `0c37c580ec355abeaea3f2fc33d6ed8061916801102550f7da9905107759e638`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `25ec3d21dbc5318b2aa7981fadceeb5bd08d4e0daef2594dfe1fa5018e038ab2`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `548143066f55535e284127a49d04caed1052641b0e381dde2aacad45c5301978`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `67e6ae6bfee138166b25d903bb8ed5fced4658c060c4a43be1e074d3795bfaaa`
+- Skill overlay SHA-256: `52f05d4a15e835bc02af96227cfa6ed13176103348e840ad1421a1fac30b743e`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `classifies_read_only_bug_report` | PASS | with_skill 明确将请求标为 bug_report，并以 diagnosis_only 处理，声明不修复。 |
-| `sets_zero_mutation_boundary` | PASS | with_skill 明确声明 allowed_mutations: none，并列出不修改代码、配置、测试、数据库、外部状态、提交或 PR；git evidence 也显示无变更。 |
-| `allows_unaligned_diagnosis_handoff` | PASS | with_skill 在缺少 PRD/TRD 时选择 Engineer，设置 expected_behavior_alignment: unaligned，保留 feature_path: unresolved，并要求继续前确认；未确认 implementation_deviation 或进入修复。 |
+| `classifies_read_only_bug_report` | PASS | With-skill output explicitly labels the request as `request_type: bug_report`, `mode: diagnosis_only`, and states no repair will be proposed or executed. |
+| `sets_zero_mutation_boundary` | PASS | With-skill output explicitly sets `allowed_mutations: none` and prohibits modifying code, tests, E2E, configuration, databases, external state, commits, pushes, or PRs; git evidence shows no changes. |
+| `allows_unaligned_diagnosis_handoff` | PASS | With-skill output routes read-only evidence collection to Engineer's `debugger`, marks `expected_behavior_alignment: unaligned`, states that `implementation_deviation` cannot be confirmed, and pauses for confirmation before continuing. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=548143066f55535e284127a49d04caed1052641b0e381dde2aacad45c5301978; fixture_sha256=0c37c580ec355abeaea3f2fc33d6ed8061916801102550f7da9905107759e638; output_sha256=5fe7f24e0a7182a3d706c882ea04a4d901c88275240efcb9b379d965a726dfcd; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 完成只读 bug_report 分类，建立零修改边界，并准备保持 unaligned 的 Engineer 诊断交接。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=548143066f55535e284127a49d04caed1052641b0e381dde2aacad45c5301978; fixture_sha256=0c37c580ec355abeaea3f2fc33d6ed8061916801102550f7da9905107759e638; output_sha256=4c656dde4f90ea613041d1b2b3d0857e92b37eed63b575e63027edc5ddf3a038; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly classified the incident as diagnosis-only, enforced a zero-mutation boundary, and prepared an unaligned Engineer/debugger handoff.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=548143066f55535e284127a49d04caed1052641b0e381dde2aacad45c5301978; fixture_sha256=0c37c580ec355abeaea3f2fc33d6ed8061916801102550f7da9905107759e638; output_sha256=7ca4b89737237c74f9e33326affafb3c59c3dc7bd697061ebb3d55e9ee339ebb; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 提供了只读故障摘要和无变更证据，但未展示结构化 bug_report 分类、零修改交接边界或 unaligned Engineer handoff。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=548143066f55535e284127a49d04caed1052641b0e381dde2aacad45c5301978; fixture_sha256=0c37c580ec355abeaea3f2fc33d6ed8061916801102550f7da9905107759e638; output_sha256=2aade89148702f5b2f10a7db3f90bdc932c8c6b8ee5394adbdf350c546575650; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Produced a useful read-only incident summary and reported no mutations, but did not provide the explicit routing, mutation-boundary, or unaligned handoff structure.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-021-explicit-downstream-specialist/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-021-explicit-downstream-specialist/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-021-explicit-downstream-specialist`.
 - Identity schema: `2`
-- target_skill_sha256: `ed93e443692bf05e76aaa38c8a5b8faff57190219ed48b9335316584424e6eb9`
+- target_skill_sha256: `e17c69ef6e179644f91ff00df55f141c375753f4668f30aca4e37e8247a60506`
 - eval_definition_sha256: `51ed6b2b4d072ab81c2265384a9c4548bdafc4c0b774ab2f92a43f6df68d0ff0`
 - metadata_sha256: `bf4907e12cf8a260745ab453b9bfc3a973db822213c04dfc1fd4b12aa12abe46`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `3f33b48ae2fadd32a7a427c016752f6b046526d0ebaaba93894c0042332f199e`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `6d94c1e20b351f6a794e09a5d0bcf4a707e69174706c9af67660d890ea20adc0`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `be6d6563d4a46f50effd0f7e2357635e21c8c4632a89a7dd79056b48c062fd5e`
+- Skill overlay SHA-256: `7e78554af92e560e1f9a15ef287d0ea9688d8bc36991af32a0c3f0de95657557`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,19 +33,19 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `uses_explicit_downstream_capability` | PASS | with_skill 明确点名并检查 `engineer-agent:codebase-analyzer`，其输出将 `selected_owner` 设为 `pm-agent:idea-to-spec`、`entry_basis: blocked`，未改派至其他 downstream specialist，也未生成名称。 |
-| `preserves_existing_entry_gate` | PASS | with_skill 的原始 trace 显示读取并应用了 codebase-analyzer 的 PM handoff entry gate；最终返回 PM 分类，标记入口依据不足并要求补充产品定位，未交付代码库分析结果或产品名称。 |
+| `uses_explicit_downstream_capability` | PASS | with_skill 明确点名并执行 `engineer-agent:codebase-analyzer` 的入口判断，依据其既有 gate 将产品命名请求返回 `pm-agent`，未直接命名或改选其他 downstream specialist。 |
+| `preserves_existing_entry_gate` | PASS | with_skill 明确说明该请求不满足 codebase-analyzer 的进入条件，并返回 `pm-agent` 分类；未执行代码库分析，也未直接生成产品名称。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=6d94c1e20b351f6a794e09a5d0bcf4a707e69174706c9af67660d890ea20adc0; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=1bba1b44d49f84b651817125c8d3dc5b3b625b85379836011d90077d1d0906df; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 承认指定能力并遵守其入口门禁，将命名请求返回 pm-agent，暂停后续命名。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=6d94c1e20b351f6a794e09a5d0bcf4a707e69174706c9af67660d890ea20adc0; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=e92f164860bea44179dae3368d928784c78d81cedf352063f216b2cc3f90b1d8; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 正确应用被点名能力的入口 gate，将产品命名请求返回 pm-agent，并报告后续命名能力不可用而阻塞。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=6d94c1e20b351f6a794e09a5d0bcf4a707e69174706c9af67660d890ea20adc0; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=c749546c757a208b86a3d71cc6da09c619f7bddcd869d9981a8ec27f90f16fc0; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 直接启动 codebase-analyzer，随后执行代码库分析并生成产品名称候选。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=6d94c1e20b351f6a794e09a5d0bcf4a707e69174706c9af67660d890ea20adc0; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=1a18125b744279ad50e3660f58c257cebf465a9b3ca4f919cdc422b690580d44; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 作为 fresh baseline，直接执行 codebase-analyzer 分析并因空代码库请求补充产品信息，未遵循命名请求的既有入口 gate。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-1-route-greenfield-product-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-1-route-greenfield-product-request/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-1-route-greenfield-product-request`.
 - Identity schema: `2`
-- target_skill_sha256: `ed93e443692bf05e76aaa38c8a5b8faff57190219ed48b9335316584424e6eb9`
+- target_skill_sha256: `e17c69ef6e179644f91ff00df55f141c375753f4668f30aca4e37e8247a60506`
 - eval_definition_sha256: `4e776e14ac2c8d3f3aa33718b92238355ee2d15eab3267a50cdada6bb3d4a1de`
 - metadata_sha256: `98a5616a9f22e4ba7d6ed10c98a36b572ccd9f5c0bfcfaf868ea982ef672635f`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `8e99b873e976898a8a9714405f69dce2d81e6c553f7d4c2b0a99b8b832eee831`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `acfb6edf3aff0b94988c5e9a7ff435967801458a79c851afd902400163536b81`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `320ded3db25222eda1be26706a57ed0471cc438157b54925db0b045d15abf8e6`
+- Skill overlay SHA-256: `15f4acf7caf3d5cd73abf45c67ad35faa887bc8f89f51c7e53854fb1514182b5`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,28 +33,28 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `route_to_idea_to_spec` | PASS | With-skill output identifies the greenfield discovery lane, unresolved feature path, and pending product definition; it does not enter implementation. |
-| `pm_first_guardrail` | PASS | With-skill output identifies an empty project, major new-product scope, pending technical stack, and explicitly says not to write durable docs yet; no code or engineering execution occurred. |
-| `context_to_collect` | PASS | It asks the first product-discovery question about the target user and core use case, with three concrete options, while leaving later scope and acceptance decisions for subsequent interaction. |
-| `expected_pm_artifacts` | NOT_EXERCISED | The output states PRD.md and DECISIONS.md are pending and asks for user confirmation before discovery is complete, so this artifact requirement is not yet exercised. |
-| `handoff_boundary` | NOT_EXERCISED | No handoff occurs in this turn; the candidate remains in discovery awaiting the user's answer. |
+| `route_to_idea_to_spec` | PASS | with_skill 明确标记 selected_owner: PM / idea-to-spec、lane: greenfield-discovery，且未转入工程执行。 |
+| `pm_first_guardrail` | PASS | with_skill 识别 project_status: empty 和全新 AI 对话助手，明确“暂不写代码”，并将用户、核心价值和 MVP 边界列为未确认事项。 |
+| `context_to_collect` | PASS | with_skill 询问“这个助手首先服务谁？”，并围绕目标用户提供收敛选项。 |
+| `expected_pm_artifacts` | NOT_EXERCISED | 当前仍在等待首个产品发现问题的用户回答，未宣称发现完成或进入交接，也未产出 PRD/决策记录。 |
+| `handoff_boundary` | NOT_EXERCISED | 当前未发生 handoff，且明确待 PRD 稳定后再评估 Designer/Engineer/QA。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=acfb6edf3aff0b94988c5e9a7ff435967801458a79c851afd902400163536b81; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=16a2e4f2784a34a6d03a7ba1cdbf301d5381761b0795edff3dbf9f3f3d2ae4c2; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly keeps the empty-directory request in PM greenfield discovery, identifies the unresolved scope, avoids implementation, and asks a focused first product question.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=acfb6edf3aff0b94988c5e9a7ff435967801458a79c851afd902400163536b81; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=60a04bdf193ef02bee9958b4e474d630864c6f5c71127891103f11ed1781f810; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 正确停留在空目录 greenfield PM discovery，选择 PM / idea-to-spec，未写代码，并提出目标用户问题。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=acfb6edf3aff0b94988c5e9a7ff435967801458a79c851afd902400163536b81; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=bb9f8d0f412bf947a7364508088c82d47622732f172b33fdeb00b4037a9353d0; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Provides a broad MVP proposal and several decisions, remains code-free, but does not explicitly establish the narrow PM routing state or focus the first interaction on one highest-information discovery question.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=acfb6edf3aff0b94988c5e9a7ff435967801458a79c851afd902400163536b81; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=a06c251bc05b6192a0947c1566b7651c48cb748ee32cf1e7fd253bebcf2430dc; snapshot_sha256=c272f35ae69d43ec7ea01cb6cb5beadaebae95ba49a06fa25970a4ca901eb6c1
+- Behavior: 基线直接产出完整 PRODUCT_BRIEF.md 并提出多项范围决策，未体现首轮 PM discovery 问题收敛边界。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Await the user's target-user choice, then continue product discovery before producing PRD/DECISIONS or handing off.
+- Next: 等待用户回答首个目标用户/场景问题；随后再产出 PRD 与 DECISIONS，并在需求稳定后决定是否交接。
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-10-change-tier-hotfix-fast-lane/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-10-change-tier-hotfix-fast-lane/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-10-change-tier-hotfix-fast-lane`.
 - Identity schema: `2`
-- target_skill_sha256: `ed93e443692bf05e76aaa38c8a5b8faff57190219ed48b9335316584424e6eb9`
+- target_skill_sha256: `e17c69ef6e179644f91ff00df55f141c375753f4668f30aca4e37e8247a60506`
 - eval_definition_sha256: `47a19a6c15b443fba6827b5bff8e5f73b3367c26176898038b1822e6a445e0c6`
 - metadata_sha256: `db913f77966bbc3a5f433aefe00a5e9265090f37be540fbcde62221b7046f2a4`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,37 +22,39 @@
 - judge_schema_sha256: `bb0ee0282945f3d4f9dce339b9d8538e36a23ce40cb0cf92b33dc2be95234be0`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `c8036aad85835ee733e12f58737233d7e9bc1a90da347bec50e7094cf58797ad`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `aaa44399c1d48ca988bdeda9dcf25acf631b5b582ec64543a5cfb0c5e9b90965`
-- Behavior result: **PASS**
-- Coverage result: **PARTIAL**
-Overall result: PASS (partial coverage)
+- Skill overlay SHA-256: `e3c335a28f9d92dbe730e6d9190f098f7ac39e61749cc82d73776faa1d506ba1`
+- Behavior result: **FAIL**
+- Coverage result: **FULL**
+Overall result: FAIL
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `classify_hotfix` | NOT_EXERCISED | 锁定证据显示候选检查了 PM/交付技能并将请求称为交付型热修复，但该结论仅出现在 agent-message 中，原始证据不能独立证明已完成分类。 |
-| `allow_fast_lane` | NOT_EXERCISED | 锁定输出未提供 fast lane 说明；由于工作区为空且交付流程在前置核对阶段被阻塞，无法从原始证据证明该步骤已发生。 |
-| `preserve_evidence` | NOT_EXERCISED | 候选保留了仓库状态、未创建提交/PR及 CI 状态等交付证据，但原始证据不足以证明已执行该断言要求的 scope、source evidence 和 verification evidence 保留流程。 |
+| `classify_hotfix` | FAIL | with_skill 明确将 change_tier 设为 hotfix，并说明 expectation_changed: false；但未说明可由一条验证命令或证据覆盖。 |
+| `allow_fast_lane` | FAIL | with_skill 仅写明“可走快速通道的交付修复”及 hotfix_disposition: allowed，未明确说明 delivery/status 类 hotfix 可使用 fast lane，且 fast lane 必须发生在分类之后。 |
+| `preserve_evidence` | FAIL | with_skill 保留了 scope_decision 和 source_documents，但明确称未发现验证证据文件，且未要求保留 verification evidence 或验证记录。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c8036aad85835ee733e12f58737233d7e9bc1a90da347bec50e7094cf58797ad; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=18a1a69f968c2e3e68a7758dbf56b3ca8ce8919ae1cf2cca3cda843041ff6b88; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 检测到空仓库、无 README、无远程和无变更后停止交付，未执行提交、推送、PR 或 CI 回读。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c8036aad85835ee733e12f58737233d7e9bc1a90da347bec50e7094cf58797ad; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=5363e28562502fdbac8236f7c7c21ff8d6745fea82dd4613af485b172822ae59; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 识别出 delivery 请求和 hotfix，但因空工作区、缺少 README、remote 及验证证据而阻塞交付；路由字段部分体现了范围和来源。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c8036aad85835ee733e12f58737233d7e9bc1a90da347bec50e7094cf58797ad; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=ad106e76f540896f786f363554a75828c7652eac22ee4db10dee28686af1e0c7; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 同样检测到空仓库并停止，未执行任何交付变更。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c8036aad85835ee733e12f58737233d7e9bc1a90da347bec50e7094cf58797ad; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=a32230dfdddebf89751aa4d993133f78541e9cec1972bb7645f46dff79658136; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 仅识别为空仓库并停止，未进行 hotfix、fast lane 或证据保留路由。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- None.
-- Next: 补充包含 README 修复的工作区并重新执行交付流程。
+- with_skill 未完整说明 hotfix 分类所需的单命令或证据覆盖理由。
+- with_skill 未完整说明 fast lane 的适用范围及分类先于 fast lane 的顺序。
+- with_skill 未要求保留 verification evidence，且未保留验证记录。
+- Next: None.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-11-change-tier-standard-full-gate/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-11-change-tier-standard-full-gate/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-11-change-tier-standard-full-gate`.
 - Identity schema: `2`
-- target_skill_sha256: `ed93e443692bf05e76aaa38c8a5b8faff57190219ed48b9335316584424e6eb9`
+- target_skill_sha256: `e17c69ef6e179644f91ff00df55f141c375753f4668f30aca4e37e8247a60506`
 - eval_definition_sha256: `da85ba336c757be6c6ca84ef12c1d1a20655adb3e82559a2c2234b5462387973`
 - metadata_sha256: `6652dce9ab8a85ed09b58d853b1bdac1fd0f6f3e5ccd74f38c1d4aa6171a8cf4`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `e0fce32f646911cc00fe0709c7d0e934a3657054c9fc5a2efda7653a3ac97ea6`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `2c9f63eba393d7546f89112ce3f1659145dc2f6ca60bdba6ba71df10258a35a4`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `320ded3db25222eda1be26706a57ed0471cc438157b54925db0b045d15abf8e6`
+- Skill overlay SHA-256: `15f4acf7caf3d5cd73abf45c67ad35faa887bc8f89f51c7e53854fb1514182b5`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `classify_standard` | PASS | With_skill output explicitly sets `change_tier: standard` and `hotfix_disposition: rejected`. |
-| `require_prd_trd_alignment` | PASS | With_skill output keeps `entry_basis: blocked`, requires confirmed PRD/DECISIONS and an Engineer handoff, and identifies missing product/technical evidence before downstream implementation. |
-| `request_type_existing_update` | PASS | With_skill output explicitly sets `request_type: existing_update` and records that the approved expectation changes from automatic approval to administrator confirmation. |
+| `classify_standard` | PASS | With-skill output explicitly sets `change_tier: standard` and `hotfix_disposition: rejected`. |
+| `require_prd_trd_alignment` | PASS | With-skill output blocks implementation because PRD/DECISIONS, TRD, tests, and handoff evidence are missing; it requires approved change documentation/product alignment before handing work to engineering. |
+| `request_type_existing_update` | PASS | With-skill output explicitly sets `request_type: existing_update` and identifies the behavior change from automatic approval to administrator confirmation. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2c9f63eba393d7546f89112ce3f1659145dc2f6ca60bdba6ba71df10258a35a4; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=4c3300e0aa1beded03b52614cf5159dec866bbd90ae388218a03a644716fe580; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly classified the request, rejected hotfix treatment, preserved the product/technical alignment gate, and blocked downstream implementation pending evidence.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2c9f63eba393d7546f89112ce3f1659145dc2f6ca60bdba6ba71df10258a35a4; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=4bd472fb5e36033c4a20e4a0dd86ea9ba0d827fcbd7c42eec657ca46525fb003; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly classified the request as an existing update with standard change tier, rejected the hotfix path, and retained the product-alignment gate before implementation handoff.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2c9f63eba393d7546f89112ce3f1659145dc2f6ca60bdba6ba71df10258a35a4; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=cfcb2e323e83ea272fdb0dfb0dd5ba5dc24efa32b27d885ffbaecbafd560715b; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Reported the empty workspace but did not classify the request or apply the PM gating behavior.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2c9f63eba393d7546f89112ce3f1659145dc2f6ca60bdba6ba71df10258a35a4; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=2abaf7e8316a1a198b019e5108a2991272bf7a16ec795297f8dcfcaae33e26a9; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline only reported the empty repository and did not classify the request or state the required product-alignment gates.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-12-change-tier-hotfix-abuse-blocked/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-12-change-tier-hotfix-abuse-blocked/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-12-change-tier-hotfix-abuse-blocked`.
 - Identity schema: `2`
-- target_skill_sha256: `ed93e443692bf05e76aaa38c8a5b8faff57190219ed48b9335316584424e6eb9`
+- target_skill_sha256: `e17c69ef6e179644f91ff00df55f141c375753f4668f30aca4e37e8247a60506`
 - eval_definition_sha256: `757872d7dabcbeb5f63781cd39c51a0fbd55c644aaecd2a814401a4e784d4603`
 - metadata_sha256: `5be95630fc657c3ddfcd1eee211fb45bdc7cc20a37cf20c50f58a72635d4712c`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `05754bc7141a9de585a1127391112d0da97f3c7138eba96f4377a8a50be63d7c`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `fd21822d29f9f59daea200bd14c26fadf30442cbe2bd48489976827d9b597907`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `320ded3db25222eda1be26706a57ed0471cc438157b54925db0b045d15abf8e6`
+- Skill overlay SHA-256: `15f4acf7caf3d5cd73abf45c67ad35faa887bc8f89f51c7e53854fb1514182b5`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `reject_hotfix_abuse` | PASS | With-skill output explicitly states `hotfix_disposition: rejected`. |
-| `expectation_change_standard` | PASS | With-skill output explicitly states `change_tier: standard` and identifies the delta as a business-rule change. |
-| `block_or_return_pm` | PASS | With-skill output states `entry_basis: blocked`, requires confirmation, routes to `idea-to-spec`, and prevents Engineer/delivery from starting. |
+| `reject_hotfix_abuse` | PASS | with_skill 输出明确写明 `hotfix_disposition: rejected`。 |
+| `expectation_change_standard` | PASS | with_skill 输出将 `change_tier` 设为 `standard`，并说明这是业务预期变化。 |
+| `block_or_return_pm` | PASS | with_skill 输出将 `entry_basis` 设为 `blocked`，选择 PM / idea-to-spec，并要求确认产品范围后再交接 Engineer。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=fd21822d29f9f59daea200bd14c26fadf30442cbe2bd48489976827d9b597907; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=498cef919e0d4037d4fe7c526d2a446ae08bd882669becb98a963fd98ca882ef; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly rejects hotfix handling, classifies the expectation change as standard, and blocks implementation pending PM scope and expectation confirmation.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=fd21822d29f9f59daea200bd14c26fadf30442cbe2bd48489976827d9b597907; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=5a2ea6c2d0b0176f2f6e0f8b93db2d2edf9b5aad73db73c2fbc0d324727d5275; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 明确拒绝 hotfix，按 standard 处理业务预期变化，并阻止在范围确认前跳过 PM 进入实现。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=fd21822d29f9f59daea200bd14c26fadf30442cbe2bd48489976827d9b597907; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=d28d4a275afa76d0d796324d3074de1bfaecd0665fbb29e08d4c4a9f48b26a41; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Reports an empty repository and inability to modify or merge, but does not address hotfix abuse, change tier, or PM gating.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=fd21822d29f9f59daea200bd14c26fadf30442cbe2bd48489976827d9b597907; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=9488a21f0845cbaf4086a01ba2418a7f395050fa76c11363f9419b1e297df4d2; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 仅说明空仓库导致无法修改或合并，未提供 PM 路由、hotfix 拒绝或 standard 分类。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-13-change-tier-hotfix-e2e-direct-path/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-13-change-tier-hotfix-e2e-direct-path/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-13-change-tier-hotfix-e2e-direct-path`.
 - Identity schema: `2`
-- target_skill_sha256: `ed93e443692bf05e76aaa38c8a5b8faff57190219ed48b9335316584424e6eb9`
+- target_skill_sha256: `e17c69ef6e179644f91ff00df55f141c375753f4668f30aca4e37e8247a60506`
 - eval_definition_sha256: `44d523204e1cd35255225227815a7ce2ae5cdbcf16a8a61436277c46e50fdccc`
 - metadata_sha256: `f04a4e17e46e81cdd684f89a442d6802d244bbaf82973e8aad0b9c94fc7c6e23`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,37 +22,37 @@
 - judge_schema_sha256: `6a4c53f4d8ac913c9f4214c0dc35c3bf4c2a1bd9745f539a3879966e5d7f9011`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `4b716f413649b163f4dd5dcd45dc5b4214bafbb5cb059afb757fef3a77b94653`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `057fcdbdb4862a826dd9a02a1748c655acde3dcccad3cc1b60fd26db843348ee`
+- Skill overlay SHA-256: `a47ddc87f9d1bdb70d5c68edd441ee9c555993410eb164ce719d220b019ca0c3`
 - Behavior result: **PASS**
-- Coverage result: **FULL**
-Overall result: PASS
+- Coverage result: **PARTIAL**
+Overall result: PASS (partial coverage)
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `hotfix_direct_path_only` | PASS | with_skill 输出明确限定为仅修改登录页空状态文案，不改交互、接口或其他页面；在源码缺失时索取包含源码的工作区或正确分支。 |
-| `evidence_still_required` | PASS | with_skill 输出明确说明缺少登录页源码及可执行测试/验证路径，并要求恢复后留下文案代码改动及验证证据。 |
-| `no_full_suite_required` | PASS | with_skill 输出未要求无关的完整 E2E suite，原始 trace 也未执行此类套件。 |
+| `hotfix_direct_path_only` | PASS | With-skill output keeps the scope to login-page empty-state copy, names non-goals, and requests only the missing copy or source basis. |
+| `evidence_still_required` | NOT_EXERCISED | No executable target was available; the candidate states implementation and targeted verification must wait for the required input. |
+| `no_full_suite_required` | PASS | Neither the output nor trace requires an unrelated full E2E suite. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4b716f413649b163f4dd5dcd45dc5b4214bafbb5cb059afb757fef3a77b94653; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=ece0254d8cbbc8d835e4283076d48857b40e0b7a6e6bf94666c5150d48fb5c9e; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 正确聚焦直接影响路径，识别源码缺失并保留验证证据要求；未发生代码修改或实际验证。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4b716f413649b163f4dd5dcd45dc5b4214bafbb5cb059afb757fef3a77b94653; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=601a610c5680197103c3b33edcce21deb1b1ae469ba7ffdeb8f1377b1402ede1; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly preserves the narrow scope and pauses for missing implementation input before modification and verification.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4b716f413649b163f4dd5dcd45dc5b4214bafbb5cb059afb757fef3a77b94653; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=cb49c1e50e40de147bbd58979fc23d9d57b988bd013f3407c1f2db84ad3c8015; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 同样识别空快照并请求项目输入，作为新鲜基线对照。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4b716f413649b163f4dd5dcd45dc5b4214bafbb5cb059afb757fef3a77b94653; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=a47f360a563e18fa3d84bbca202010a58a35b84ee3667142f18423be3c02acb2; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline correctly identifies the git-only workspace and requests project source.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: 提供包含登录页源码的正确工作区或分支；恢复后完成最小文案修改并执行直接影响路径验证。
+- Next: Provide the login-page source/target file and approved replacement copy or its authoritative requirement; then perform the targeted change and verification.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-14-route-site-notes-and-github-release/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-14-route-site-notes-and-github-release/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-14-route-site-notes-and-github-release`.
 - Identity schema: `2`
-- target_skill_sha256: `ed93e443692bf05e76aaa38c8a5b8faff57190219ed48b9335316584424e6eb9`
+- target_skill_sha256: `e17c69ef6e179644f91ff00df55f141c375753f4668f30aca4e37e8247a60506`
 - eval_definition_sha256: `ae4335c3ea7ab2052d5988d1cbe329b872d3570826da6174d95ecdee75a8f11e`
 - metadata_sha256: `97d6e27f41f4971c47d9cb45fcc18ec16575e5aae533718195d23b38c3bf2c56`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,32 +22,32 @@
 - judge_schema_sha256: `0e6be21ab02e72aa076a9b774d5cc60139434feba550f781574340027908427d`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `aeb9d94911e2f21a05aec636eb7871f30e1f918271687f3e921766aab4cdc3f2`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `93ad7bb06cc0fc8447a9937ca3e9f764d2a2c745d97e115ce6e8522948fec408`
+- Skill overlay SHA-256: `d3ccf1feb2a2b63aa5deb225990edb65d2b64cd2211e04c10dfc7fea67e865ab`
 - Behavior result: **PASS**
-- Coverage result: **PARTIAL**
-Overall result: PASS (partial coverage)
+- Coverage result: **FULL**
+Overall result: PASS
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `routes_site_notes_to_docs_specialist` | PASS | With_skill output explicitly names `docs-agent:release-notes-gen` as the first owner and does not route the site notes to PM or changelog-gen. |
-| `routes_github_release_to_pm_specialist` | PASS | With_skill output explicitly names `pm-agent:github-release-gen` as the downstream owner and blocks all release actions; Docs is not shown executing the GitHub Release. |
-| `preserves_release_sequence` | NOT_EXERCISED | The workflow is blocked before confirmed site notes, Docs gates, and audit evidence exist, so the later consumption sequence cannot be exercised. |
-| `does_not_use_old_pm_skill_name` | PASS | The PM owner is named `pm-agent:github-release-gen`; `release-notes-gen` appears only as the Docs owner. |
+| `routes_site_notes_to_docs_specialist` | PASS | With-skill output explicitly selects `docs-agent:release-notes-gen` and states site/user Release Notes belong there, not to PM or changelog. |
+| `routes_github_release_to_pm_specialist` | PASS | The output routes the downstream GitHub Release work to `github-release-gen`; raw skill evidence identifies the PM owner as `pm-agent:github-release-gen`, and states Docs must not perform Release operations. |
+| `preserves_release_sequence` | PASS | The output preserves the order: Docs confirmation and `docs-audit` `ready_for_tag` precede the GitHub Release preview, with no release action before those gates. |
+| `does_not_use_old_pm_skill_name` | PASS | `release-notes-gen` is used only under `docs-agent`; the GitHub Release owner is separately identified as `github-release-gen`/`pm-agent:github-release-gen`. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=aeb9d94911e2f21a05aec636eb7871f30e1f918271687f3e921766aab4cdc3f2; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=97229e73b50f6d7506bf9c1ffdf076c0af1f871f0ef9be1e9b48c4b384122f5c; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly identifies the empty fixture, routes site notes to Docs then GitHub Release work to PM, and safely blocks without confirmed release evidence or mutations.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=aeb9d94911e2f21a05aec636eb7871f30e1f918271687f3e921766aab4cdc3f2; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=2e13bd7593764232848c0f8a5bcd3129792bbea7829335f7d750d9777da959cd; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly routes site notes to Docs, preserves the Docs-gated sequence, and identifies the separate PM GitHub Release owner while blocking unsupported execution.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=aeb9d94911e2f21a05aec636eb7871f30e1f918271687f3e921766aab4cdc3f2; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=67cba33b22bf0a2a364504c7f619d7ed753029936f7b01bd6552973a0185e629; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Fresh baseline only reports the empty repository and requests version facts; it provides no specialist routing or release-gate handling.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=aeb9d94911e2f21a05aec636eb7871f30e1f918271687f3e921766aab4cdc3f2; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=75f631c447213f1409cfbd5ef8b8948be961c7fdde44cb32481f8cdd2aa43478; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline only requests missing release facts and does not provide the required specialist routing.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-17-scope-guard-unenabled-general/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-17-scope-guard-unenabled-general/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-17-scope-guard-unenabled-general`.
 - Identity schema: `2`
-- target_skill_sha256: `ed93e443692bf05e76aaa38c8a5b8faff57190219ed48b9335316584424e6eb9`
+- target_skill_sha256: `e17c69ef6e179644f91ff00df55f141c375753f4668f30aca4e37e8247a60506`
 - eval_definition_sha256: `39faf534f64b30c105514035f054d257cf0f525ae0bd7577eccde10c9d2a879b`
 - metadata_sha256: `7cfea2e7966dabd576a859036c036835a1da1742b99340ebfcd2fcd73e56c60b`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `393b26839d6ecf3cc396518ba3c28e2288560436d96f6b3eb0b1794c2df40748`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `2c9610bcc27c8c480be3a4506b94682924ad1bb0ce1f3f95bfb12428326c37eb`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `320ded3db25222eda1be26706a57ed0471cc438157b54925db0b045d15abf8e6`
+- Skill overlay SHA-256: `15f4acf7caf3d5cd73abf45c67ad35faa887bc8f89f51c7e53854fb1514182b5`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,18 +33,18 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `rd_intent_enters_without_docs` | PASS | with_skill output explicitly enters PM discovery, classifies the empty repository as greenfield-discovery, proposes MVP options, and asks for confirmation; it does not refuse PM entry because PRD/TRD/code/enable marker are absent. |
+| `rd_intent_enters_without_docs` | PASS | with_skill 明确完成 PM 入口与仓库检查，将请求归类为 new_feature/greenfield-discovery，并围绕提醒策略提出产品决策；同时将缺少代码、文档和技术栈作为待收敛上下文，而非拒绝进入 PM。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2c9610bcc27c8c480be3a4506b94682924ad1bb0ce1f3f95bfb12428326c37eb; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=ce3332f57675bf571547005e2e677fd6175c8697e6c68d756c8785468377e4c8; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly routes the billing-notification R&D request into PM discovery despite the empty repository and missing documentation, then requests the next product decision.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2c9610bcc27c8c480be3a4506b94682924ad1bb0ce1f3f95bfb12428326c37eb; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=01de99d3981ba64e5c05054d88a02a0f0f793e664b8f5f79deb20e7540478ff0; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 进入 PM 需求收敛流程，识别为空工作区并提出提醒策略确认。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2c9610bcc27c8c480be3a4506b94682924ad1bb0ce1f3f95bfb12428326c37eb; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=ea36383db5663266b270ebc091bf53643290c725e943548d4d2288c697c194b8; snapshot_sha256=0d351f4f4275aa52caed00df535c435a831966b31a73827e4951ffbcf48e2b68
-- Behavior: Fresh baseline skipped PM discovery and directly implemented a billing-notification module in the empty repository.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2c9610bcc27c8c480be3a4506b94682924ad1bb0ce1f3f95bfb12428326c37eb; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=8705f9b775bed9df32ed510d22f8f8208df4c8af011affd0539e06463bddc148; snapshot_sha256=a04958d903f19a52e6783c3641bf7ae9d3020805e02787d795246cc1611fae80
+- Behavior: 直接实现并交付账单通知代码，未经过 PM 需求收敛。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-18-scope-guard-explicit-invocation/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-18-scope-guard-explicit-invocation/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-18-scope-guard-explicit-invocation`.
 - Identity schema: `2`
-- target_skill_sha256: `ed93e443692bf05e76aaa38c8a5b8faff57190219ed48b9335316584424e6eb9`
+- target_skill_sha256: `e17c69ef6e179644f91ff00df55f141c375753f4668f30aca4e37e8247a60506`
 - eval_definition_sha256: `fbd5b3a5e4c0be83eacf913e76dfe890f776915d3d24ba4fd45c191e31196a40`
 - metadata_sha256: `d008e123b4ee70f7bf43fcaf109d74c9d72e4654db9631f703b1f4b299706113`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,35 +22,36 @@
 - judge_schema_sha256: `3a5175573f5c12faf8ef17031068ea4a3554be3c63ea98a9f0e35a5de2fe7ef6`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `495fc0f825d65d1e7057e4dc84ea777d069a48dcb665a6ab231607b5f4f53d34`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `23c155dfbbdaf3bf6fdaf16d337c16031340e19bffd6d7bb539e43bdc034b2af`
-- Behavior result: **PASS**
-- Coverage result: **PARTIAL**
-Overall result: PASS (partial coverage)
+- Skill overlay SHA-256: `8b076cb82c470b131f01d4ac1cd0d36cbfb1e690ece346a8313d30b76a409813`
+- Behavior result: **FAIL**
+- Coverage result: **FULL**
+Overall result: FAIL
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `explicit_invocation_proceeds` | PASS | with_skill 的锁定 trace 直接显示读取并遵循 pm-agent/SKILL.md；随后因 Downloads 访问权限受限而停止，没有执行文件移动，也未伪造下游角色。 |
-| `classifies_general_request` | NOT_EXERCISED | 锁定 trace 证明进入了 pm-agent 能力并避免直接执行文件操作，但无法独立证明已明确记录 request_type 和 selected_owner；候选消息中的自述不作为独立证据。 |
+| `explicit_invocation_proceeds` | FAIL | With-skill trace invokes pm-agent and reads its entry rules, but then classifies the request as ordinary non-R&D and proceeds with direct file-operation planning instead of stopping in PM after finding no matching category/owner. |
+| `classifies_general_request` | FAIL | With-skill trace includes a classification discussion, but does not provide a stable request_type and selected owner, and proceeds directly toward file operations after stating no PM specialist can be routed. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=495fc0f825d65d1e7057e4dc84ea777d069a48dcb665a6ab231607b5f4f53d34; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=b07b7e0bdf06299aa383bbfabd4ce9ce2058fc4e6ee55d38c4c9ab4aa276c761; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 使用 pm-agent 入口并遵守其边界；确认 Downloads 无法读取后诚实停止，未移动文件或执行越权操作。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=495fc0f825d65d1e7057e4dc84ea777d069a48dcb665a6ab231607b5f4f53d34; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=6431e6bbad48733d37ed13995336cade41d468abf2f2679e30d7b977cf24ff72; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Used pm-agent's skill content and inspected the requested path, but incorrectly treated the unmatched ordinary file request as eligible for direct execution; no files were moved because permissions blocked access.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=495fc0f825d65d1e7057e4dc84ea777d069a48dcb665a6ab231607b5f4f53d34; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=114c6d8029789616dbf885d23f98561cebc93ad7a2fb12c02eafdb7f8a419676; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 未使用 pm-agent，仅报告环境限制；作为 fresh baseline 未进入 PM 分类流程。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=495fc0f825d65d1e7057e4dc84ea777d069a48dcb665a6ab231607b5f4f53d34; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=9f32cb8ed90f3768ffd8ace0bde5cb12151a710324e6e02ee67ba6dbd682501e; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline reported pm-agent unavailable and Downloads inaccessible, then stopped without classification or execution.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- None.
+- The with_skill lane violates the explicit pm-agent boundary by proceeding with file-operation execution after determining the request has no PM category or downstream owner.
+- The with_skill lane does not satisfy the required PM classification output and does not stop after an unmatched classification.
 - Next: None.
 
 ## Runtime Artifact Policy

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-19-scope-guard-enabled-general/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-19-scope-guard-enabled-general/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `fe6bcb3f9a810e8ec07d6cd151b927dd0790270b275bdd2a0170bbc91573f2d5` from `agents/product_manager/test/pm-agent/evals/workspace/eval-19-scope-guard-enabled-general`.
 - Identity schema: `2`
-- target_skill_sha256: `ed93e443692bf05e76aaa38c8a5b8faff57190219ed48b9335316584424e6eb9`
+- target_skill_sha256: `e17c69ef6e179644f91ff00df55f141c375753f4668f30aca4e37e8247a60506`
 - eval_definition_sha256: `ee3671589f95fa8a892847eb388a153411b54b14444f1f7420faa0785c1aa02b`
 - metadata_sha256: `b685d83a8e82816d2f4d521a041ae8452f619db60e5a55ebbccd97b0160d2ffb`
 - fixture_sha256: `fe6bcb3f9a810e8ec07d6cd151b927dd0790270b275bdd2a0170bbc91573f2d5`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `6b0ff1b76e8b03f7712d3dcd168848aec48a65be2655318b04e40fdedd5925d2`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `9d2abe6f2d9f34e08ce206e7be1d9f6dca54aa3a23552cb1626522bb6c0a068c`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `23c155dfbbdaf3bf6fdaf16d337c16031340e19bffd6d7bb539e43bdc034b2af`
+- Skill overlay SHA-256: `8b076cb82c470b131f01d4ac1cd0d36cbfb1e690ece346a8313d30b76a409813`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,18 +33,18 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `marker_does_not_trigger_pm` | PASS | with_skill 的锁定输出仅说明无法访问或修改 ~/Downloads，并请求用户上传/复制文件；未进入 PM 分类、未产出 PM 文档链或 handoff。其 delivery_snapshot、git_diff 和 git_status 均为空，runner trace 也未显示 PM 行为。 |
+| `marker_does_not_trigger_pm` | PASS | With_skill output and trace show the request was treated as an ordinary file-organization task; it reported the unavailable isolated ~/Downloads and requested mounting/uploading files. No PM classification, PM documents, or handoff was produced, and git evidence shows no mutation. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9d2abe6f2d9f34e08ce206e7be1d9f6dca54aa3a23552cb1626522bb6c0a068c; fixture_sha256=fe6bcb3f9a810e8ec07d6cd151b927dd0790270b275bdd2a0170bbc91573f2d5; output_sha256=2d7ac7147a7ff1b9a5e28da2baab3684b875b5871c2538b30dcf2de2352549cb; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 正确将普通文件整理请求作为非 PM 请求处理；在缺少可访问 Downloads 时请求用户提供目录，未被 marker 触发 PM 流程。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9d2abe6f2d9f34e08ce206e7be1d9f6dca54aa3a23552cb1626522bb6c0a068c; fixture_sha256=fe6bcb3f9a810e8ec07d6cd151b927dd0790270b275bdd2a0170bbc91573f2d5; output_sha256=4f6d771affe828fe4ad47ab1e892677ae5709598a17c1a66a3b7145cb906627b; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Recognized the isolated environment lacked ~/Downloads and requested the files or mount needed to continue; did not enter PM workflow.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9d2abe6f2d9f34e08ce206e7be1d9f6dca54aa3a23552cb1626522bb6c0a068c; fixture_sha256=fe6bcb3f9a810e8ec07d6cd151b927dd0790270b275bdd2a0170bbc91573f2d5; output_sha256=d4d5be6b8e0d2038c7431a77913b53a7211a0685648bb8791fd4f1ccc87cfd18; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 新鲜基线同样未进入 PM 流程；尝试检查 Downloads 后发现目录不可用，并请求用户提供文件。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9d2abe6f2d9f34e08ce206e7be1d9f6dca54aa3a23552cb1626522bb6c0a068c; fixture_sha256=fe6bcb3f9a810e8ec07d6cd151b927dd0790270b275bdd2a0170bbc91573f2d5; output_sha256=ceb5e22ac9d44d06ee9995c8f00f93b1ebecac11cc93e91670faf3b689acf826; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Also recognized the missing ~/Downloads; additionally supplied a local shell procedure for organizing image and document files.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-2-route-bugfix-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-2-route-bugfix-request/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-2-route-bugfix-request`.
 - Identity schema: `2`
-- target_skill_sha256: `ed93e443692bf05e76aaa38c8a5b8faff57190219ed48b9335316584424e6eb9`
+- target_skill_sha256: `e17c69ef6e179644f91ff00df55f141c375753f4668f30aca4e37e8247a60506`
 - eval_definition_sha256: `f60ba5f87c066f48ffe21c8bbf0d933ae8b1ea45687ee0ce3091684db29e3750`
 - metadata_sha256: `6cfa251efb3ddd0fc9104e40cad56a0dd759fb7068ac87a40ec1d705be391717`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `00a01c5f9432a18e723abe9a7b1a555e5a2a41dc2c36a101ed91497434d1c7f4`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `3622b3dfdb9bef50766ff22e70a5639483865b84fa39f8a64f027bc492debda1`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `67e6ae6bfee138166b25d903bb8ed5fced4658c060c4a43be1e074d3795bfaaa`
+- Skill overlay SHA-256: `52f05d4a15e835bc02af96227cfa6ed13176103348e840ad1421a1fac30b743e`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,27 +33,26 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `request_type_bug_report` | PASS | With_skill 的 PM checkpoint 明确写出 `request_type: bug_report`，且没有直接进入修复。 |
-| `expectation_first` | NOT_EXERCISED | 工作区没有应用源码或 PRD/TRD；with_skill 明确记录 `source_documents: []`、预期行为尚缺文档依据并将入口置为 blocked。因此该确认步骤因缺少运行时证据未被实际执行。 |
-| `debugger_handoff_after_confirmation` | NOT_EXERCISED | with_skill 设置 `confirmation_required: true` 并停留在 PM/idea-to-spec，未 handoff 给 Engineer/debugger；由于实现偏差尚未确认，该后续步骤未被执行。 |
+| `request_type_bug_report` | PASS | With_skill output explicitly records `request_type: bug_report`. |
+| `expectation_first` | NOT_EXERCISED | Approved PRD/TRD or equivalent expectation evidence is absent, so confirmation of the expected behavior could not be exercised. |
+| `debugger_handoff_after_confirmation` | NOT_EXERCISED | No implementation-deviation confirmation or Engineer/debugger handoff occurred because the workspace and expectation evidence were missing. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3622b3dfdb9bef50766ff22e70a5639483865b84fa39f8a64f027bc492debda1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=cb03d98223b08949d9ee04c8ca308d954d83dd603127b9f4a9a856bf713c6728; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 正确识别为 bug_report，并在缺少代码与产品预期证据时停留在 PM 阻塞状态，未错误进入实现或 debugger handoff。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3622b3dfdb9bef50766ff22e70a5639483865b84fa39f8a64f027bc492debda1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=ac6485cef91940bc16b8c48d1f38bcf31d72a588e57a7c98b7f8e25d79dbf71a; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Classified the request as a bug report, recorded the expected behavior and blockers, and stopped before implementation or handoff.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3622b3dfdb9bef50766ff22e70a5639483865b84fa39f8a64f027bc492debda1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=41f5936a88db7fb4b97ea9ec2c994631c18e6334506f9fe03d8d1f3b4582b47a; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 仅识别为空仓库并阻塞，trace 中一度直接计划定位、修复和测试，未体现 PM 分类与预期确认门槛。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3622b3dfdb9bef50766ff22e70a5639483865b84fa39f8a64f027bc492debda1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=52bdb7cdc0029520f4aaa29681c2f7db69d47de58390d19f3f29305f1be74bac; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Reported the empty repository but did not classify the request or perform the PM expectation and handoff gates.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: 提供或恢复应用源码及 approved PRD/TRD 或等价预期证据。
-- Next: 确认 token 过期时请求应结束并退出登录页加载态后，再 handoff 给 Engineer/debugger。
+- Next: Provide the application source and approved PRD/TRD or equivalent product expectation evidence, then confirm the expectation before any debugger handoff.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-3-route-test-writing-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-3-route-test-writing-request/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-3-route-test-writing-request`.
 - Identity schema: `2`
-- target_skill_sha256: `ed93e443692bf05e76aaa38c8a5b8faff57190219ed48b9335316584424e6eb9`
+- target_skill_sha256: `e17c69ef6e179644f91ff00df55f141c375753f4668f30aca4e37e8247a60506`
 - eval_definition_sha256: `5eef99797df77f0e561572b46c57557f7c3ae080a7078c558efac33693901a22`
 - metadata_sha256: `d6163be77f09e049698e1a9f603c0cebbddd5b607c316831117c3ef1a972dcb0`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `4bea92cb3e04f7ad6bcf4e0dcdb3aa7c06af7bec325a6bea731363f44bd4e944`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `3f7994fdecfb94451400a56972388597b7ae51d2d37508524058139c5273a4e3`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `c72e4953b9374b62d28ad5c8580760fdd7805ace75b88ad1b4a44c32bbe75f3f`
+- Skill overlay SHA-256: `18890b0f7019a064bb6b93c6d2a7d316b9f13976166a66df2dd5dd2de14400f0`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,26 +33,26 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `request_type_validation` | PASS | The with_skill output explicitly classifies the request as `request_type: validation`. |
-| `test_basis_first` | PASS | The with_skill lane checked for PRD/TRD/test-spec and handoff evidence, found none, recorded `entry_basis: blocked` and `source_documents: []`, and did not proceed to test creation without a confirmed basis. |
-| `qa_or_test_writer_handoff` | NOT_EXERCISED | No stable source documentation or expected behavior was available, so the candidate correctly required confirmation before any QA/test-writer handoff. The handoff stage was not reached. |
+| `request_type_validation` | PASS | With-skill output explicitly sets `request_type: validation`. |
+| `test_basis_first` | PASS | The candidate inspected the workspace and documented that PRD/TRD and related approved test-basis documents were absent, leaving `source_documents: []` and blocking test implementation before any handoff. |
+| `qa_or_test_writer_handoff` | NOT_EXERCISED | The candidate conditionally identifies Engineer/test-writer as the next owner only after product/technical expectations are confirmed; the required source documents and runtime evidence are missing, so the actual handoff was not exercised. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3f7994fdecfb94451400a56972388597b7ae51d2d37508524058139c5273a4e3; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=c26077855cd312c46c86d3b49cc918032ff1ed33f4f83ccdd0b0f824e3a20b14; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly classified the request, inspected for required evidence, and blocked downstream testing until repository content and behavior sources are provided.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3f7994fdecfb94451400a56972388597b7ae51d2d37508524058139c5273a4e3; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=9b84a91a533954b22d2a169546f637f61d66441e65498a2d4f8ac235ec816b3a; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly classified the request as validation, checked for an approved testing basis, and blocked implementation/handoff until expectations and source documents are available.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3f7994fdecfb94451400a56972388597b7ae51d2d37508524058139c5273a4e3; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=c94b5e63d884e95899ceed848eb655287ce240fda6ea2137f25bc9e40ef2428f; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Detected the empty repository and stopped, but did not provide the validation classification or structured evidence gate.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=3f7994fdecfb94451400a56972388597b7ae51d2d37508524058139c5273a4e3; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=53b07b9bd52ff76711ffe4f8d05823ea36763c8650ead7105fc367354a97069f; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Reported the empty repository but did not classify the request, establish the testing-basis gate, or provide a conditional downstream handoff.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Provide or mount the project repository and an approved PRD, TRD, implementation plan, or acceptance record; then perform the QA/test-writer handoff once expectations are stable.
+- Next: Provide the refund-flow implementation/tests and an approved PRD, TRD, implementation plan, or acceptance record; then confirm the stabilized expectations before handing off to Engineer/test-writer.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-4-route-ui-update-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-4-route-ui-update-request/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-4-route-ui-update-request`.
 - Identity schema: `2`
-- target_skill_sha256: `ed93e443692bf05e76aaa38c8a5b8faff57190219ed48b9335316584424e6eb9`
+- target_skill_sha256: `e17c69ef6e179644f91ff00df55f141c375753f4668f30aca4e37e8247a60506`
 - eval_definition_sha256: `1e4d87d84971aa26152f1eb1fb23b62dd38b0e1e65b9cd9bb7b73b151f90a6d5`
 - metadata_sha256: `440758cdcded4a9a826d1d244cae238fce6a67e9af4ed30bf87ed76771edf669`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,37 +22,36 @@
 - judge_schema_sha256: `afcbd1cd02daddf2a5de8000a17edb44c8f3338aa4214be0e836d3a78f54f541`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `cc5c00e0814501d7ed50a7f0170322a995f768ddcee0b14ac461aa95868c10b8`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `aef6e3b6ccd796473f48bece0e6f328134a51fad942e579d9855dc5a3a6bf176`
-- Behavior result: **FAIL**
+- Skill overlay SHA-256: `93fb0c83cdf1750fe110c908a23cc61507fdc07d8e78e2090d0b0a047e41d6ca`
+- Behavior result: **PASS**
 - Coverage result: **FULL**
-Overall result: FAIL
+Overall result: PASS
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `request_type_design_or_update` | FAIL | The with_skill delivery labels the lane `greenfield-discovery` and never classifies the request as `design` or `existing_update`. |
-| `pm_designer_engineer_decision` | FAIL | It identifies Designer and Engineer states, but does not determine whether a PM expectation update is needed. |
-| `implementation_waits_for_alignment` | PASS | The delivery explicitly states `Engineer: 暂不进入` and requires confirmation before proceeding, so implementation is held pending alignment. |
+| `request_type_design_or_update` | PASS | With-skill output classifies the request as `existing_update` and does not enter frontend implementation. |
+| `pm_designer_engineer_decision` | PASS | With-skill output selects `PM / idea-to-spec`, identifies the UX/interface proposal as the required output, and leaves Designer/Engineer execution pending unresolved scope and evidence. |
+| `implementation_waits_for_alignment` | PASS | With-skill output reports the handoff as blocked, requests missing product/design evidence, and performs no implementation; locked git evidence shows no changes. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cc5c00e0814501d7ed50a7f0170322a995f768ddcee0b14ac461aa95868c10b8; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=8ed6f99ec65bd2929cd9726aa066e9b60e67f452ff599558a12e87f307c6d3b7; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Paused before design or engineering, presented interaction-mode options, and required confirmation.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cc5c00e0814501d7ed50a7f0170322a995f768ddcee0b14ac461aa95868c10b8; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=11c2586e3e97ccdc2339dc2465355d3e3a8974797062b0a9a29152900c55dc26; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly routes the UI update through PM, identifies unresolved scope and missing source evidence, and stops before design or engineering implementation.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cc5c00e0814501d7ed50a7f0170322a995f768ddcee0b14ac461aa95868c10b8; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=d57e0927030d5bd91f7fb6b8db7345936e44d4f3de1b57e47544f25e9ef79cbb; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Produced a generic settings-page design proposal and interaction recommendations without the required PM/Designer/Engineer gating.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=cc5c00e0814501d7ed50a7f0170322a995f768ddcee0b14ac461aa95868c10b8; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=7f92f817c07b418485caa59fc96212ed82a8fcca076e1bbf47dc34780933f3e7; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline directly proposed a UI solution without classifying or routing the request through PM/Designer/Engineer alignment.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- The with_skill lane omitted the required `design` or `existing_update` classification.
-- The with_skill lane did not address the PM expectation-update decision.
+- None.
 - Next: None.
 
 ## Runtime Artifact Policy

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-5-route-deployment-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-5-route-deployment-request/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-5-route-deployment-request`.
 - Identity schema: `2`
-- target_skill_sha256: `ed93e443692bf05e76aaa38c8a5b8faff57190219ed48b9335316584424e6eb9`
+- target_skill_sha256: `e17c69ef6e179644f91ff00df55f141c375753f4668f30aca4e37e8247a60506`
 - eval_definition_sha256: `cad357efac6928bd9cbca7d09df3972a7367fdbfc93dd87da1f5982bf69d7b10`
 - metadata_sha256: `0bdb522f0df207a2778e820083da8ba9d4f3194004ea2be94909f7b00fa189be`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `42fd42dc7a350eab589db47b48a132e9f478c8e119c1fdbd30b4875075f9f0b5`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `df8dd8d18e0b79f0114ea9e750efb47af7d21bc05b6ea3666cff7d6bae4802fe`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `5c7fe3adc2d1e566874092a3a12549fbb97f68a45bcbbcd10ecdfc83cf50ed24`
+- Skill overlay SHA-256: `d2535385fc058d23601a81cc3e6475f8a9805aa0738fe404481cd2e9da3b8bb7`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,26 +33,26 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `request_type_deployment` | PASS | The with_skill output explicitly records `request_type: deployment`. |
-| `repo_wide_scope_allowed` | PASS | The with_skill output uses `feature_path: N/A` and `feature_path_evidence: []` for repo-wide CI/CD scope. |
-| `devops_handoff_packet` | NOT_EXERCISED | The handoff is explicitly blocked by missing deployment, environment, command, trigger, and rollback context; no completed DevOps handoff is evidenced. |
+| `request_type_deployment` | PASS | With-skill output explicitly sets `request_type: deployment` for repository CI/CD and pre-release readiness work. |
+| `repo_wide_scope_allowed` | PASS | With-skill packet uses `feature_path: N/A`, `feature: N/A`, `parent_feature: N/A`, `feature_level: N/A`, and `feature_path_evidence: []` for confirmed repository-level work. |
+| `devops_handoff_packet` | NOT_EXERCISED | The output identifies DevOps as downstream owner and records scope, required outputs, and risks, but the handoff is blocked pending user confirmation of environment, release target, and rollback details. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=df8dd8d18e0b79f0114ea9e750efb47af7d21bc05b6ea3666cff7d6bae4802fe; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=8484148d0be08813295723177ddc97a3ff8c4a0cff63aa9bf7b10e3304610942; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly classifies the request and safely stops before handoff and CI generation due to missing context.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=df8dd8d18e0b79f0114ea9e750efb47af7d21bc05b6ea3666cff7d6bae4802fe; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=8058f15cdab1dc61ff16909f93be5afd3f5acaeb29acae5e4a943fd8138d853a; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly classified the request as deployment and produced a repository-level N/A scope packet; handoff remained blocked pending required operational context.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=df8dd8d18e0b79f0114ea9e750efb47af7d21bc05b6ea3666cff7d6bae4802fe; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=a10f8f78e573a3a7f7381eb509ca3aed9cbc60dadd293eab6ef499cd9b14f5a5; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Inspects the empty repository and stops without structured deployment classification.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=df8dd8d18e0b79f0114ea9e750efb47af7d21bc05b6ea3666cff7d6bae4802fe; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=c307c5ad8e9440053946e81799161637ef91fd3ca11b32ae11b65e5f2fbc070a; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Stopped at the empty repository snapshot without producing deployment classification or a DevOps handoff packet.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Provide deployment method, target environment, build/test commands, triggers, and rollback requirements.
+- Next: Provide the missing environment, release scope, CI platform, and rollback details, then complete the DevOps handoff.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-6-route-security-request/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-6-route-security-request/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-6-route-security-request`.
 - Identity schema: `2`
-- target_skill_sha256: `ed93e443692bf05e76aaa38c8a5b8faff57190219ed48b9335316584424e6eb9`
+- target_skill_sha256: `e17c69ef6e179644f91ff00df55f141c375753f4668f30aca4e37e8247a60506`
 - eval_definition_sha256: `b4ceb7c82713552e98022f642658a9fe01923ce2aef9cd904f9b3ce6b9d57837`
 - metadata_sha256: `b6d2b600149f33bb467cfc46f27511f47c47187f4b8740c71e75a63117b140d5`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `356a8438fe026d0b1352a3ef7467cbb1d1fa3bb6c089f0c3e64b4d4c5d3741fc`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `36e2dc52efc02bd4a536346d8f3cd5d27459a1a97e6287cf5969afca708442f1`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `209d343401df08cb244a051ad8eb04b1a517100352a54e5c22a12a24a74fb7f8`
+- Skill overlay SHA-256: `405b8da919a6bdd907f9056230268b031c3ce141cef8284486da1ab1f492dffe`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,26 +33,26 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `request_type_security` | PASS | With-skill output explicitly records `request_type: security`. |
-| `security_scope_first` | NOT_EXERCISED | The locked trace does not independently prove that risk surface, assets, permissions, data flow, and remediation expectations were recorded first. |
-| `security_handoff` | PASS | With-skill output names Security as `downstream_owner` and includes both the security scope blockers and `required_output`. |
+| `request_type_security` | PASS | The with_skill output explicitly includes `request_type: security` in its routing state. |
+| `security_scope_first` | NOT_EXERCISED | The assertion requires a prior/internal recording order. Locked raw evidence does not independently prove that order; the trace’s agent-message claim is not sufficient proof. |
+| `security_handoff` | PASS | The with_skill output names `selected_owner: Security` and provides `scope_decision` plus `required_output: evidence-backed security gate report`. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=36e2dc52efc02bd4a536346d8f3cd5d27459a1a97e6287cf5969afca708442f1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=0cdf2882361145de17ab251765d0d088a1ec5ca15d5e12c253d2aad98a009cf7; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Classified the request as security and produced a Security handoff with blockers and required output.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=36e2dc52efc02bd4a536346d8f3cd5d27459a1a97e6287cf5969afca708442f1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=275919685af3c970925ed55fc80373bd6efda964a8bc5c946a9b3f92c788be4c; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly classified the request as security, gave a truthful blocked pre-release assessment, and produced a Security handoff packet without mutations.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=36e2dc52efc02bd4a536346d8f3cd5d27459a1a97e6287cf5969afca708442f1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=221e10cb9db1b6d092d9c80216a6d3b8801fd5e240cdc1dc378548bc6a381afb; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Produced a baseline repository-security assessment but did not classify or hand off the request through Security.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=36e2dc52efc02bd4a536346d8f3cd5d27459a1a97e6287cf5969afca708442f1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=679cb859f45489d8f7366d31d16b9aae1b6ea966ced4a9d2b38d4e92f4084989; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Provided a reasonable read-only security assessment but did not classify the request or produce the required Security handoff packet.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: None.
+- Next: Provide independently verifiable evidence of the required scope-recording order if that hidden process assertion must be evaluated.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-7-direct-downstream-without-handoff/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-7-direct-downstream-without-handoff/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-7-direct-downstream-without-handoff`.
 - Identity schema: `2`
-- target_skill_sha256: `ed93e443692bf05e76aaa38c8a5b8faff57190219ed48b9335316584424e6eb9`
+- target_skill_sha256: `e17c69ef6e179644f91ff00df55f141c375753f4668f30aca4e37e8247a60506`
 - eval_definition_sha256: `186d8c8ca55f244592124c29f316a47679d008908c7385a9f2c3b6deef26649d`
 - metadata_sha256: `915b343a8b2e6c8966c46c77e214197e4e4a391b47f1ddec1dca6100ab90e1d1`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `e2570bd95ea9768bb87ca218eab9d1b8a91216a2492cd9d22af400362c435dbb`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `57e82609f413c88720ec90ed64877ede694585115e55bf0256d08e8274436d4f`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `329dfda7786ff3523b5c346349f47cd85abc8fd7cdc5970863dfe15fe67a5f26`
+- Skill overlay SHA-256: `690c63b15147f7227b0c742f032d49a25a05b14c43f0e100b18b5ece461a7e43`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,26 +33,26 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `keeps_pm_alignment` | PASS | with_skill output routes the request to PM / idea-to-spec with entry_basis: blocked, unresolved feature_path, and no claim of Engineer handoff or implementation. |
-| `stay_in_pm_alignment` | PASS | with_skill output explicitly identifies PM / idea-to-spec as selected owner, leaves feature_path unresolved, and states no downstream handoff evidence exists. |
-| `blocks_engineering_without_basis` | PASS | with_skill output identifies missing product/design materials, unresolved scope and technical stack, requires confirming the target layout, and locked git evidence shows no code changes. |
+| `keeps_pm_alignment` | PASS | With_skill explicitly routes to PM / idea-to-spec, marks entry blocked, and states Engineer implementation cannot safely begin. |
+| `stay_in_pm_alignment` | PASS | With_skill records unresolved feature_path, empty source documents, blocked PM entry, and no Engineer handoff or downstream execution. |
+| `blocks_engineering_without_basis` | PASS | With_skill requests confirmation of the repository and minimum layout requirements, identifies missing PRD/decision/design/technical basis, and locked git evidence shows no code changes. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=57e82609f413c88720ec90ed64877ede694585115e55bf0256d08e8274436d4f; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=3b23d5c4860efe84cc0eb45f7f203f98d7104dbc2b396370d5ebbdd91d8dd071; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Stayed in PM idea-to-spec alignment, blocked engineering, requested missing scope and evidence, and made no code changes.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=57e82609f413c88720ec90ed64877ede694585115e55bf0256d08e8274436d4f; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=96767d422ff07d700fd48e4ad867b623e84b20cf20dd8a296149fa1729eaea0e; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Stayed in PM idea-to-spec alignment, identified missing scope and evidence, blocked engineering, and made no changes.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=57e82609f413c88720ec90ed64877ede694585115e55bf0256d08e8274436d4f; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=c92e6ad49e5053335487697dd392f72cd6111e448a58706ce691e566713b1e68; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Fresh baseline only reported the empty repository and inability to modify the layout; it did not establish PM alignment or the evidence gate.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=57e82609f413c88720ec90ed64877ede694585115e55bf0256d08e8274436d4f; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=0bfcff02c8ffb5f50c0ad74d697794d1bef6c4e413e21faaa78c117e35820659; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline only reported the empty repository and did not establish the PM alignment or evidence-gating rationale.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: None.
+- Next: Confirm the correct repository and minimum layout requirements, then establish the required product, design, and implementation basis before engineering handoff.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-8-direct-specialist-bypass-gate/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-8-direct-specialist-bypass-gate/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-8-direct-specialist-bypass-gate`.
 - Identity schema: `2`
-- target_skill_sha256: `ed93e443692bf05e76aaa38c8a5b8faff57190219ed48b9335316584424e6eb9`
+- target_skill_sha256: `e17c69ef6e179644f91ff00df55f141c375753f4668f30aca4e37e8247a60506`
 - eval_definition_sha256: `8a82a9f209d1a183092f0d4416072c9a81f83d51dc3e54ad21c9aa1a4db84c97`
 - metadata_sha256: `2863415ed2f417f781064860e7cfabcfbd9a9995e8d831c6cb07097f6b82501a`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `049b196f8151e781cd3892a636ec145a437d1dcd4e2c9a7ed5826e9f1d8c5e14`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `827e1eab57730473669ffa6562263ebb5fcf35595b38ae224272aca2a629a167`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `329dfda7786ff3523b5c346349f47cd85abc8fd7cdc5970863dfe15fe67a5f26`
+- Skill overlay SHA-256: `690c63b15147f7227b0c742f032d49a25a05b14c43f0e100b18b5ece461a7e43`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `blocks_unready_execution` | PASS | with_skill 输出识别范围未确认，指定 PM / idea-to-spec，明确暂不能安全开始写代码；runner trace 显示无文件变更事件。 |
-| `requires_product_and_engineering_basis` | PASS | with_skill 输出明确要求先确认范围并产出 PRD/DECISIONS，再由 Engineer 生成 TRD；未从单句需求生成实施计划。 |
-| `blocks_implementation` | PASS | with_skill 输出明确保持在 greenfield-discovery、产品发现和范围确认阶段；锁定工作区状态为空，runner trace 未显示写代码或测试实现。 |
+| `blocks_unready_execution` | PASS | With-skill output explicitly refuses direct coding, identifies the request as an unconfirmed new feature, routes it to PM / idea-to-spec, and requests scope clarification. |
+| `requires_product_and_engineering_basis` | PASS | With-skill output states that confirmed scope, PRD/DECISIONS, and Engineer implementation handoff are required, and records that no approved product or technical basis exists. |
+| `blocks_implementation` | PASS | With-skill delivery has no files or git changes; the output remains in PM classification and scope-confirmation, explicitly saying it cannot directly write code. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=827e1eab57730473669ffa6562263ebb5fcf35595b38ae224272aca2a629a167; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=85bf166a1e8dd533c098e0c118f47cfa7462e16ca518191346fde9bdf6063fd6; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 正确阻止未就绪的新功能执行，停留在 PM 范围确认，并要求后续 PRD、DECISIONS 与 TRD 依据。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=827e1eab57730473669ffa6562263ebb5fcf35595b38ae224272aca2a629a167; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=118aaa3c87096bdae0c78d815648ac9f1c2485dc9e268b8436831a5cc47cace1; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly blocks implementation and keeps the request in PM scope clarification pending product and engineering basis.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=827e1eab57730473669ffa6562263ebb5fcf35595b38ae224272aca2a629a167; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=fa7e776b77a3734608544486827ea12f13ec8c45d3f34eb5461c3579c4632ff1; snapshot_sha256=331de0921a276039c2acb4c2d92e9c6cb77d4748d6260ea54a9fc30d3c9434e0
-- Behavior: 在需求未定义时仍创建实施计划、代码骨架和测试，作为失败的基线对照。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=827e1eab57730473669ffa6562263ebb5fcf35595b38ae224272aca2a629a167; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=e8ac5fc46ddbf0363378c93e58fd800288af4f21127f3309b7f6894b8f5b5fb7; snapshot_sha256=278153ed622edd3c38e7e7d1be2a83b7225bd9eccb777d87f2fd7164ac64b426
+- Behavior: Fresh baseline directly implemented a profile-management slice, added tests and documentation, and reported completion despite missing product and technical requirements.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/pm-agent/evals/workspace/eval-9-missing-handoff-target-unavailable/comparison.md
+++ b/agents/product_manager/test/pm-agent/evals/workspace/eval-9-missing-handoff-target-unavailable/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a` from `agents/product_manager/test/pm-agent/evals/workspace/eval-9-missing-handoff-target-unavailable`.
 - Identity schema: `2`
-- target_skill_sha256: `ed93e443692bf05e76aaa38c8a5b8faff57190219ed48b9335316584424e6eb9`
+- target_skill_sha256: `e17c69ef6e179644f91ff00df55f141c375753f4668f30aca4e37e8247a60506`
 - eval_definition_sha256: `ea4ff3ed92cd6df9743d23b747dc29d9087560d5cfa7f5f4525b8e146b0b7e97`
 - metadata_sha256: `f52777a03f0c132438bf125e153205560b01f6abb53fcb15add6a3552b96312b`
 - fixture_sha256: `44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `45aa95828b353344675a6e62421acac466500932a42ce4d64f8f43969bd5bb6d`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `5230fc275f473a55b5d59c172358aff82cf42415f36da1a920c1b4fa1e1e3cc1`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `320ded3db25222eda1be26706a57ed0471cc438157b54925db0b045d15abf8e6`
+- Skill overlay SHA-256: `15f4acf7caf3d5cd73abf45c67ad35faa887bc8f89f51c7e53854fb1514182b5`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,26 +33,26 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `detect_missing_target` | PASS | With-skill output explicitly states that `designer-agent` or design capability is unavailable. |
-| `mark_handoff_blocked` | PASS | With-skill output explicitly sets `handoff_status: blocked` and identifies `designer-agent`/design capability as needing installation or enablement. |
-| `do_not_perform_missing_role` | PASS | With-skill output produces no design deliverable, explicitly assigns Designer ownership, and states it cannot substitute for Designer. |
+| `detect_missing_target` | PASS | With_skill 输出明确说明 `designer-agent` 未安装或不可用。 |
+| `mark_handoff_blocked` | PASS | With_skill 输出将交接状态的 `entry_basis` 标记为 `blocked`，并要求安装或启用 `designer-agent`。 |
+| `do_not_perform_missing_role` | PASS | With_skill 明确表示不能代替 Designer 产出 UX/UI、线框或视觉稿，并保留在 PM/blocked 说明阶段；锁定证据显示未产生交付物或工作区变更。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5230fc275f473a55b5d59c172358aff82cf42415f36da1a920c1b4fa1e1e3cc1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=15bb44c40c4f46327987349e3cf7a304e1fefe0911d343bf3eef7c4877e05dba; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly identifies the unavailable Designer target, marks the handoff blocked, names the needed capability, and avoids performing Designer work.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5230fc275f473a55b5d59c172358aff82cf42415f36da1a920c1b4fa1e1e3cc1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=9d7cc1518b586c4b4b1640ce08f47d9c073a3e9084206e071e4dc65ad4eb5150; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 识别设计能力缺失，明确阻塞状态和所需 plugin，并未执行 Designer 职责。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5230fc275f473a55b5d59c172358aff82cf42415f36da1a920c1b4fa1e1e3cc1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=ebf364d647d0bbc4de688eea09fa4616d582ba3e48acd6a5ddc7d702d4e0c33a; snapshot_sha256=9cf25b767b5c5aca38cb39ff82151c4e4c3f945630100938d11268fb12b52afa
-- Behavior: Created a design handoff template but did not identify the unavailable designer-agent, mark the handoff blocked, or explicitly avoid substituting for Designer.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5230fc275f473a55b5d59c172358aff82cf42415f36da1a920c1b4fa1e1e3cc1; fixture_sha256=44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a; output_sha256=9a48528183481c5686ea930202748ed74e784fda744269f714ff6962016f2649; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 仅说明工作区为空并请求补充需求，未识别 designer-agent 不可用、未标记 handoff blocked，也未执行设计产出。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Install or enable `designer-agent`/the required design capability and provide the confirmed requirements source documents.
+- Next: None.
 
 ## Runtime Artifact Policy
 

--- a/agents/product_manager/test/pm-agent/test_pm_entry_eval.py
+++ b/agents/product_manager/test/pm-agent/test_pm_entry_eval.py
@@ -193,8 +193,9 @@ def test_pm_entry_uses_explicit_invocation_then_rd_intent():
     )
 
     frontmatter_description = skill_text.split('description: "', 1)[1].split('"', 1)[0]
-    assert "Use when the user explicitly names pm-agent, including requests that also name a downstream capability" in frontmatter_description
-    assert "When another role agent or skill is named without pm-agent, do not activate pm-agent" in frontmatter_description
+    assert frontmatter_description.startswith("Default entry for product and engineering R&D")
+    assert "Explicitly naming pm-agent" in frontmatter_description
+    assert "explicitly naming another agent or skill" in frontmatter_description
     assert "this remains true when the same request also names a downstream capability" in skill_text
 
 

--- a/agents/product_manager/test/roadmap-gen/workspace/eval-1-timeline/comparison.md
+++ b/agents/product_manager/test/roadmap-gen/workspace/eval-1-timeline/comparison.md
@@ -13,18 +13,18 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `1114e9e115cfb91a2f09d56b7563aa8c7433df316dc5fe8c86e2dd3614f9d165` from `agents/product_manager/test/roadmap-gen/workspace/eval-1-timeline`.
 - Identity schema: `2`
-- target_skill_sha256: `74b972ac8dbd7706448e20025f6995b87c544e99309b65961f70d0e86a7bd191`
+- target_skill_sha256: `31c42c9c81d87e424d5816b727ce29e3aa5b6dba7a54b776905197eb51df50fd`
 - eval_definition_sha256: `d6df04c011109b2d27a14aaefa7802d9d9c0af801e4acce9ed37afdc4c26a731`
 - metadata_sha256: `c374d15583cb501346d3285d30669c9dbaf58b19f95661d07d8aeac8332d8ba1`
 - fixture_sha256: `1114e9e115cfb91a2f09d56b7563aa8c7433df316dc5fe8c86e2dd3614f9d165`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
 - runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
 - judge_schema_sha256: `c9231138562bec2ed562cf0d8c1ec94b96debb390ee547b6815473c326c64b09`
-- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
-- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
-- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
-- Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
+- Prompt SHA-256: `ccc64c80301839b5d15a311cba6ab8a69fb955dea99cdfd947a735556c9d9e63`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
+- Skill overlay SHA-256: `348b8622cc87aa2759a4e099ebeaa2c933204e02a0dfad702e10984b10a232be`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `phase_classification` | PASS | 有截止日期的 3.36.0、3.37.0、4.0.0 分别归入当前冲刺、近期计划和远期规划；已关闭的 3.35.0 单列为已完成。 |
-| `undated_semantic_inference` | PASS | 无日期的 3.38.0 基于当前版本 3.35.0 和 minor 版本语义归入近期计划并注明需确认；无法匹配的 Rendering research 单列待维护者分类，未捏造日期或静默归入未排期。 |
-| `roadmap_artifacts` | PASS | 交付文件直接包含进度条、Mermaid Gantt、带状态复选框的 issue，以及 milestone 和 issue 的 GitHub 链接。 |
+| `phase_classification` | PASS | with_skill 的 docs/roadmap.md 将 3.36.0、3.37.0、4.0.0 分别归入当前冲刺、近期计划、远期规划，并标出已完成的 3.35.0。 |
+| `undated_semantic_inference` | PASS | with_skill 将无日期的 3.38.0 按当前 release 3.35.0 的 minor 版本语义归入近期计划；将无法匹配语义的 Rendering research 列为待维护者确认阶段，未捏造日期或归入未排期。 |
+| `roadmap_artifacts` | PASS | with_skill 的路线图包含各 milestone 进度条、Mermaid gantt、issue 状态字段及 GitHub milestone/issue 链接。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=ccc64c80301839b5d15a311cba6ab8a69fb955dea99cdfd947a735556c9d9e63; fixture_sha256=1114e9e115cfb91a2f09d56b7563aa8c7433df316dc5fe8c86e2dd3614f9d165; output_sha256=85c31c6e651690c360dab0e9ce9a9ca851efa81ae5403012f970af21bbe7732c; snapshot_sha256=5a91475d0241069ccaf63eaa5b864b26a0296c24be4f07a349b8f189a6a57b1f
-- Behavior: 生成了完整路线图，正确处理有日期和无日期 milestone，并保留所需路线图证据与链接。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=ccc64c80301839b5d15a311cba6ab8a69fb955dea99cdfd947a735556c9d9e63; fixture_sha256=1114e9e115cfb91a2f09d56b7563aa8c7433df316dc5fe8c86e2dd3614f9d165; output_sha256=3cab4d9719662d21e98baba88cb39b4db8db0ea72c735c2bbd48598fff76128e; snapshot_sha256=09295eec45976179867edabc4848df2006b3755b7c4d1808461b28bdceb007be
+- Behavior: 生成并交付 docs/roadmap.md，满足全部用户可见路线图要求。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=ccc64c80301839b5d15a311cba6ab8a69fb955dea99cdfd947a735556c9d9e63; fixture_sha256=1114e9e115cfb91a2f09d56b7563aa8c7433df316dc5fe8c86e2dd3614f9d165; output_sha256=994a8eb9be96c5a282daaf54a08b8e966818508c408341793aa2e7704bf88763; snapshot_sha256=d0b2deb8e503d3d0671982342049802d6ba131413e85fa3ad642d9e643d5130e
-- Behavior: 也生成了内容丰富的路线图并正确记录阶段和语义规划，但未见 Mermaid Gantt 等完整证据工件。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=ccc64c80301839b5d15a311cba6ab8a69fb955dea99cdfd947a735556c9d9e63; fixture_sha256=1114e9e115cfb91a2f09d56b7563aa8c7433df316dc5fe8c86e2dd3614f9d165; output_sha256=cdcca850603a340c5765913db929294a3e9ed31fba6f809eab38871f57e1bfc6; snapshot_sha256=08cbf8a61e6edcabe91eb03dc781845a9dedd812bd11087436985b883ef979d8
+- Behavior: 同样生成路线图，但未按要求保留 Mermaid Gantt、进度条和对无法匹配 milestone 的明确待确认分类。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/roadmap-gen/workspace/eval-2-phase-classification/comparison.md
+++ b/agents/product_manager/test/roadmap-gen/workspace/eval-2-phase-classification/comparison.md
@@ -13,18 +13,18 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `a264a565b80cdab16388e48390a97336c870c675ea266e111b6f98276cf41192` from `agents/product_manager/test/roadmap-gen/workspace/eval-2-phase-classification`.
 - Identity schema: `2`
-- target_skill_sha256: `74b972ac8dbd7706448e20025f6995b87c544e99309b65961f70d0e86a7bd191`
+- target_skill_sha256: `31c42c9c81d87e424d5816b727ce29e3aa5b6dba7a54b776905197eb51df50fd`
 - eval_definition_sha256: `9bebcff97f69229af9d2fc6b841c4826a4650eeb5ee2c6254e8400fa19d31afa`
 - metadata_sha256: `ae0af75c7768cc5a422a172a7778c85838314f028847e67a9b64a099fa24dc99`
 - fixture_sha256: `a264a565b80cdab16388e48390a97336c870c675ea266e111b6f98276cf41192`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
 - runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
 - judge_schema_sha256: `828832f79453e0784207e366cba87f24e08c6f3017321b257129f96f3076509d`
-- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
-- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
-- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
-- Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
+- Prompt SHA-256: `129b1e07f1b508c4a87a365c1e9c5e8cf169856473baee027f1d68878bcd93f2`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
+- Skill overlay SHA-256: `348b8622cc87aa2759a4e099ebeaa2c933204e02a0dfad702e10984b10a232be`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `open_closed` | PASS | with_skill 交付文件明确将 August/September 2026 作为当前冲刺和近期计划，并将 July 2026 标为已完成，同时保留 open/closed 数量。 |
-| `large_backlog` | PASS | with_skill 交付文件注明 backlog 总数为 128，仅列出 3 条有明细的未关联 milestone issue，并明确其余 125 条未展开。 |
-| `issue_details` | PASS | with_skill 交付文件按新功能、修复及标签分组 issue，并为全部列出的 issue 保留标签、assignee 状态和 GitHub 链接。 |
+| `open_closed` | PASS | 交付快照按 open 的 August/September milestone 组织当前与近期计划，并将 closed 的 July milestone 放入“已完成”区域；状态与计数均与原始快照一致。 |
+| `large_backlog` | PASS | 交付快照明确 backlog 总数为 128，仅列出有限记录，并说明其余 122 条未列出，保持路线图可读。 |
+| `issue_details` | PASS | 交付快照按 issue 类型/标签分组，且每条列出的 issue 都保留了链接、标签和 assignee 或 unassigned 状态。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=129b1e07f1b508c4a87a365c1e9c5e8cf169856473baee027f1d68878bcd93f2; fixture_sha256=a264a565b80cdab16388e48390a97336c870c675ea266e111b6f98276cf41192; output_sha256=336b5e7634470aab33bd5f9ad0c086914d20bcfeaabc49f88ce921e3dc413be0; snapshot_sha256=24cb74ae7b5b2bbd6a8b219f3da6ea369572964caa1ce0860381ea12312d5226
-- Behavior: 生成了注明数据时点的路线图，清晰区分进行中、近期计划、已完成和 backlog，并保留 issue 分类细节及数据边界。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=129b1e07f1b508c4a87a365c1e9c5e8cf169856473baee027f1d68878bcd93f2; fixture_sha256=a264a565b80cdab16388e48390a97336c870c675ea266e111b6f98276cf41192; output_sha256=72ae4b04d189cdd6547b994ac1de777ecd9f885f8004c0ae48ca8074ee80dec7; snapshot_sha256=1a1cab0ac43d0971575e96e0c33330093eae0aed0edc8d5f21f5c704e77ce01f
+- Behavior: 生成了包含数据时点、open/closed milestone 分区、压缩 backlog、Mermaid 时间线及 issue 标签、链接和 assignee 细节的 docs/roadmap.md。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=129b1e07f1b508c4a87a365c1e9c5e8cf169856473baee027f1d68878bcd93f2; fixture_sha256=a264a565b80cdab16388e48390a97336c870c675ea266e111b6f98276cf41192; output_sha256=4c7c93337c8b1b7715fe124810a108ff206bec7f1edf03b5cdcd119bb0077f6e; snapshot_sha256=62448f981201f69a1e14111583640f5259dbb5e89a597da1d50994eae5bc5990
-- Behavior: 也生成了可读路线图，区分了 milestone 状态、压缩了 backlog，并保留了 issue 标签、负责人和链接；with_skill 版本的结构化分组和数据边界说明更完整。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=129b1e07f1b508c4a87a365c1e9c5e8cf169856473baee027f1d68878bcd93f2; fixture_sha256=a264a565b80cdab16388e48390a97336c870c675ea266e111b6f98276cf41192; output_sha256=aeb581e71b63586a15dcc784298c7d78de28750f790d26138c4234b727c4d5be; snapshot_sha256=76c3f67d508d26e764b27b79f76126bac71ef3f0940d16fe07b27a412fd43e1e
+- Behavior: 也生成了可用的路线图，区分了 open/closed milestone、压缩了 128 条 backlog，并保留了 6 条 issue 的标签、链接和 assignee 信息；with_skill 版本的结构化分组与时间线更明确。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/product_manager/test/roadmap-gen/workspace/eval-3-no-dates/comparison.md
+++ b/agents/product_manager/test/roadmap-gen/workspace/eval-3-no-dates/comparison.md
@@ -13,18 +13,18 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `8ed1c517c0f0999b8177c14728f4f1837cf8c41c83a93a8766a4e6fd07e1d14f` from `agents/product_manager/test/roadmap-gen/workspace/eval-3-no-dates`.
 - Identity schema: `2`
-- target_skill_sha256: `74b972ac8dbd7706448e20025f6995b87c544e99309b65961f70d0e86a7bd191`
+- target_skill_sha256: `31c42c9c81d87e424d5816b727ce29e3aa5b6dba7a54b776905197eb51df50fd`
 - eval_definition_sha256: `fbd695e0a879758e25936e89babfefc9a6cba4a52e1572a61e1da7fea0b1364b`
 - metadata_sha256: `1dfb7bfbfed7613af8764f4385cade9d5822d1652d85a0cbb75853e0bcae7474`
 - fixture_sha256: `8ed1c517c0f0999b8177c14728f4f1837cf8c41c83a93a8766a4e6fd07e1d14f`
 - execution_protocol_sha256: `200345aa2aedf0447e58b604f9f2382b58f87ecf9869be32cc5612b56da6eede`
 - runtime_protocol_sha256: `c9f6932614910136df4a1018c716abaa7cd683b922d01459d7f2079e709ce6cb`
 - judge_schema_sha256: `f6a7dabb82746a0dc0f0c5965d8e78c276cdccf3d2da25bfbb1a77e91ffeca3f`
-- Identity migration: **MIGRATED_WITHOUT_MODEL_RERUN**
-- Identity migration source commit: `4cca644d64c599531542e66ba5a9210c5c6bf40c`
-- Identity migration audit: `docs/engineer/repository-governance/eval-scenario-isolation/eval-identity-v2-migration-audit.json`
-- Repository HEAD: `750d3d7432a4dcfde7dde2624f081fbf388f85f3`
+- Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
+- Prompt SHA-256: `4165caadd548c6b8d1d9df4c0aa9c054ed9c0f0a71e88ab4aefd0c18bb92400a`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
+- Skill overlay SHA-256: `348b8622cc87aa2759a4e099ebeaa2c933204e02a0dfad702e10984b10a232be`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `semantic_classification` | PASS | 交付文件按 patch、minor、major 语义将 Go1.26.1、Go1.27、Go2.0 分为近期、中期和远期；Runtime experiments 明确列为待维护者分类并请求确认。 |
-| `no_fake_dates` | PASS | 交付文件没有 Mermaid Gantt 或发布日期/截止日期排期；仅包含明确标注为无日历日期的语义阶段 flowchart。 |
-| `release_blockers` | PASS | Go1.26.1 部分以“发布阻塞项”标题突出列出带 release-blocker 标签的 #4101。 |
+| `semantic_classification` | PASS | 锁定的 docs/roadmap.md 将 Go1.26.1 分类为近期补丁、Go1.27 分类为中期计划、Go2.0 分类为远期规划，并将 Runtime experiments 列为待维护者确认。 |
+| `no_fake_dates` | PASS | 锁定文件未生成 Mermaid Gantt，仅生成不含日历日期的阶段 flowchart，并明确说明没有可靠日期、不生成 Gantt 图。 |
+| `release_blockers` | PASS | 锁定文件以“发布阻塞项”独立加粗区段突出展示带有 release-blocker 标签的 #4101。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4165caadd548c6b8d1d9df4c0aa9c054ed9c0f0a71e88ab4aefd0c18bb92400a; fixture_sha256=8ed1c517c0f0999b8177c14728f4f1837cf8c41c83a93a8766a4e6fd07e1d14f; output_sha256=b4a92c682726061490a391bf408abf38a05105b02e72b98d977f375fa3557da8; snapshot_sha256=62721fdfada230a7f25de559ccda1a6a07414111f1ef08c9dc8891ad8049a64c
-- Behavior: 写入完整路线图，完成语义分类、无日期处理和发布阻塞项突出显示。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4165caadd548c6b8d1d9df4c0aa9c054ed9c0f0a71e88ab4aefd0c18bb92400a; fixture_sha256=8ed1c517c0f0999b8177c14728f4f1837cf8c41c83a93a8766a4e6fd07e1d14f; output_sha256=a6a765ec441c2b3d5b71478694d72889d59af14ed7907c17a3b7536c328aa02c; snapshot_sha256=11cdfb2be75d23e4a75f2ebc2090b262cbc5fdc46d1729175490c62642a8b104
+- Behavior: 生成了按语义分层的路线图，明确处理待确认 milestone，避免 Gantt 和虚构排期，并突出 release-blocker。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4165caadd548c6b8d1d9df4c0aa9c054ed9c0f0a71e88ab4aefd0c18bb92400a; fixture_sha256=8ed1c517c0f0999b8177c14728f4f1837cf8c41c83a93a8766a4e6fd07e1d14f; output_sha256=2aa8804c7488f280699ef5a31b2e1419477ab16b70745c32eeeae229898a4c77; snapshot_sha256=00ceb5a98a25983606e6ee37ca74641dc5041135f6a5670e3630474cbe6a3685
-- Behavior: 完成基础路线图并确认无截止日期，但最终摘要未体现语义分类细节或发布阻塞项突出处理。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4165caadd548c6b8d1d9df4c0aa9c054ed9c0f0a71e88ab4aefd0c18bb92400a; fixture_sha256=8ed1c517c0f0999b8177c14728f4f1837cf8c41c83a93a8766a4e6fd07e1d14f; output_sha256=bd15c868d2dce6dbe2a6278af8829d074f001ce66dffa2033d14736f68556fcb; snapshot_sha256=eccce1d86d2d05bf7a512e447905a28fce172dbd6ae7b3c6ed52e8a8c5966e87
+- Behavior: 也生成了基础版本分类和无日期说明，但未明确将无法匹配的 Runtime experiments 交由用户或维护者确认。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/qa/skills/bug-analyzer/SKILL.md
+++ b/agents/qa/skills/bug-analyzer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bug-analyzer
-description: "Analyze a confirmed failing scenario, classify defect confidence, separate observation from inference, and produce durable bug evidence for QA or engineering. Use after qa-agent routes bug analysis."
+description: "Analyze a confirmed failing scenario, separate observation from inference, classify defect confidence, and produce durable bug evidence. Use after qa-agent routes bug analysis."
 visibility: internal
 ---
 

--- a/agents/qa/skills/exploratory-tester/SKILL.md
+++ b/agents/qa/skills/exploratory-tester/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exploratory-tester
-description: "Explore a confirmed product surface with an evidence-backed charter, explicit environment and timebox, adjacent risks, findings, and follow-up coverage. Use after qa-agent routes exploratory validation."
+description: "Explore a confirmed product surface using an evidence-backed charter, explicit environment and timebox, adjacent risks, findings, and follow-up coverage. Use after qa-agent routes exploratory testing."
 visibility: internal
 ---
 

--- a/agents/qa/skills/qa-agent/SKILL.md
+++ b/agents/qa/skills/qa-agent/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: qa-agent
-description: "Classify and route confirmed validation requests across spec-based acceptance, exploratory testing, bug analysis, and regression verification. Use immediately after a PM QA handoff and before specialist execution."
+description: "Route confirmed validation work across spec-based acceptance, exploratory testing, bug analysis, and regression verification. Use after a PM QA handoff."
 visibility: internal
 ---
 

--- a/agents/qa/skills/regression-suite/SKILL.md
+++ b/agents/qa/skills/regression-suite/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: regression-suite
-description: "Verify a confirmed fix by reusing the original bug evidence, running direct and adjacent-risk checks, and reporting PASS, FAIL, or BLOCKED with confidence. Use after qa-agent routes regression work."
+description: "Verify a confirmed fix with the original bug evidence plus direct and adjacent-risk checks, reporting PASS, FAIL, or BLOCKED. Use after qa-agent routes regression work."
 visibility: internal
 ---
 

--- a/agents/qa/skills/spec-based-tester/SKILL.md
+++ b/agents/qa/skills/spec-based-tester/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spec-based-tester
-description: "Validate spec-backed requirements from confirmed PM/TRD/plan evidence using the safest executable repository test path and durable acceptance records. Use after qa-agent routes spec-based testing."
+description: "Validate spec-backed requirements from confirmed PM/TRD/plan evidence using the safest executable test path and durable acceptance records. Use after qa-agent routes spec-based testing."
 visibility: internal
 ---
 

--- a/agents/qa/test/bug-analyzer/evals/workspace/eval-1-analyze-test-failure/comparison.md
+++ b/agents/qa/test/bug-analyzer/evals/workspace/eval-1-analyze-test-failure/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `e52dc183368f81bf8278941735b98c8f9da85437b60c6dd9736b019d7bf6c9ca` from `agents/qa/test/bug-analyzer/evals/workspace/eval-1-analyze-test-failure`.
 - Identity schema: `2`
-- target_skill_sha256: `09e738dc9988190b7f79b8aac551bd1674e0642fae4817109cb4551b9f01f0cd`
+- target_skill_sha256: `f7992d17a0646109f134e112dee5a8d92a38fd3d8cf3007564f0979ffbd3929d`
 - eval_definition_sha256: `35f2f99594df8382cdc242359c30a451a1bdaa89727c7071b5ec00d92699fbf8`
 - metadata_sha256: `8e0e42373ca08b53a19ba642babbf44403e38e8a0315e0e26db92df6ea247617`
 - fixture_sha256: `e52dc183368f81bf8278941735b98c8f9da85437b60c6dd9736b019d7bf6c9ca`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `84f20ca3637061984a451201365104813c56f53ca0b37a9fb14c70d8de0d29b1`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `382c8cd397f8f6526e011c90c1ba36354751b701fabc41ae3a4966bbcf764eb3`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `147ea0edbf82c8ca9a07d9d6ff0b589da90d3fd96bbb89bae4f44faf26cc1243`
+- Skill overlay SHA-256: `27a39b82b995acb5c798df074b3eb2e54e5b81ea6292feb84f2c09cf3d65fb1c`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,30 +33,30 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `assertion_1` | PASS | 报告逐项记录了 scenario、错误消息、stack trace、screenshot、trace、console、network 及 environment/build evidence，并标注缺失或部分可用状态。 |
-| `assertion_2` | PASS | 报告使用了 `suspected / needs more evidence`，并分别记录 Evidence status 与 Confidence；单次失败不足以使用 confirmed 分类。 |
-| `assertion_3` | PASS | 报告给出 High severity 及用户/发布阻断理由，并独立给出 Medium confidence 及证据不足说明。 |
-| `assertion_4` | PASS | 已交付本地 Markdown artifact `docs/qa/login-refresh/bug-login-api-500.md`，未创建 GitHub issue。 |
-| `assertion_5` | NOT_EXERCISED | 当前证据仅支持单次观察，未确认可复现的 E2E 场景；仓库也没有 E2E 用例树或版本化执行要求。 |
-| `assertion_6` | PASS | 报告包含 Implementation impact、Release impact，并引用 `logs/test-failure.log` 与 `environment/build.md`。 |
-| `non_e2e_report_path` | PASS | 报告路径为 `docs/qa/login-refresh/bug-login-api-500.md`，位于 `docs/qa/{feature_path}/` 下，文件名不含日期且未使用 `docs/qa-reports/`。 |
+| `assertion_1` | PASS | 报告包含 failing scenario、错误消息、stack trace 缺失、screenshot 不可用、trace 不可用、console、network evidence 和 environment/build 上下文的逐项清单。 |
+| `assertion_2` | PASS | 报告使用 `suspected / needs more evidence`，并分别记录 evidence status 与 confidence；未将证据强度和分类混为一谈。 |
+| `assertion_3` | PASS | 报告给出 High severity 及阻断登录的 rationale，并单独给出 Medium confidence 及其证据边界。 |
+| `assertion_4` | PASS | 报告作为本地 Markdown artifact 写入 `docs/qa/login-refresh/bug-valid-login-returns-500.md`，未创建 GitHub issue。 |
+| `assertion_5` | NOT_EXERCISED | 现有证据仅支持一次失败记录，报告明确标记 repeatability 未建立，因此尚未达到确认的 E2E 复现场景条件。 |
+| `assertion_6` | PASS | 报告包含 `Implementation and release impact`，并引用 `logs/test-failure.log` 与 `environment/build.md`。 |
+| `non_e2e_report_path` | PASS | 无 E2E 用例树或版本化 E2E 执行要求；报告位于 `docs/qa/login-refresh/`，文件名不含日期且未使用 `docs/qa-reports/`。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=382c8cd397f8f6526e011c90c1ba36354751b701fabc41ae3a4966bbcf764eb3; fixture_sha256=e52dc183368f81bf8278941735b98c8f9da85437b60c6dd9736b019d7bf6c9ca; output_sha256=8a0daca43fcc71e8354d4ca2c290edc6700fc5ff2993123aa4e60f3eeca5c62e; snapshot_sha256=8e041df6a9a9472268e6302fe592e4cb814875e994dd42afd325711b4dd73861
-- Behavior: 交付了持久化缺陷报告，完整区分证据状态、严重度、置信度和影响，并保留证据引用；未虚构根因或可复现性。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=382c8cd397f8f6526e011c90c1ba36354751b701fabc41ae3a4966bbcf764eb3; fixture_sha256=e52dc183368f81bf8278941735b98c8f9da85437b60c6dd9736b019d7bf6c9ca; output_sha256=e6aa407410331d3573dd24aada04d79c7a2b047275c11fbfc06d35c5e84f41d7; snapshot_sha256=a0ea3ebf08239c7e4553335729b35b0231c4613389413037a2f1b1083171d2d4
+- Behavior: 产出结构化、持久化的缺陷报告，完整记录证据缺口、分类、严重度、置信度、影响和追踪引用。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=382c8cd397f8f6526e011c90c1ba36354751b701fabc41ae3a4966bbcf764eb3; fixture_sha256=e52dc183368f81bf8278941735b98c8f9da85437b60c6dd9736b019d7bf6c9ca; output_sha256=027b3e338d538ad322db8bc3342e82a64b9c055b4b4cc539deeab56b4a1dc862; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 仅在最终消息中提供未持久化的缺陷报告，覆盖基本现象和建议，但未交付本地 Markdown artifact，也未按结构化证据状态/置信度完整整理。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=382c8cd397f8f6526e011c90c1ba36354751b701fabc41ae3a4966bbcf764eb3; fixture_sha256=e52dc183368f81bf8278941735b98c8f9da85437b60c6dd9736b019d7bf6c9ca; output_sha256=d73c6489c8c821ea14a888bd86ee74cca74d593bc88ecca282ecc94a258fb25f; snapshot_sha256=608ad22818efe842098d5119135651199544470edf462daa9de3c712e6ad6961
+- Behavior: 产出工作区根目录下的 defect-report-login-500.md，包含基本复现、影响和调查建议，但未遵循 repo-native docs/qa 路径或结构化证据清单。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: 补充重复执行结果、服务端堆栈、脱敏请求/响应及目标发布环境验证后，再判断是否升级为 confirmed 分类并建立 E2E 回归覆盖。
+- Next: 如后续获得第二次复现或可确定的 E2E 复现场景，再评估并创建对应的 E2E case 与 script artifacts。
 
 ## Runtime Artifact Policy
 

--- a/agents/qa/test/bug-analyzer/evals/workspace/eval-2-thin-evidence-suspected-bug/comparison.md
+++ b/agents/qa/test/bug-analyzer/evals/workspace/eval-2-thin-evidence-suspected-bug/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `bd09f8717eb7765700b65e2c38ca5c4dcc82c7aff0bee46b30335bbb10dcf266` from `agents/qa/test/bug-analyzer/evals/workspace/eval-2-thin-evidence-suspected-bug`.
 - Identity schema: `2`
-- target_skill_sha256: `09e738dc9988190b7f79b8aac551bd1674e0642fae4817109cb4551b9f01f0cd`
+- target_skill_sha256: `f7992d17a0646109f134e112dee5a8d92a38fd3d8cf3007564f0979ffbd3929d`
 - eval_definition_sha256: `ee85b4030fea85acc8c079589b9268be5087962ef495cf3e3194580abf721432`
 - metadata_sha256: `8cbc4de235b64dc94f1f26425c852e96d8c8a43534bff26146b8ba13fd8eb92c`
 - fixture_sha256: `bd09f8717eb7765700b65e2c38ca5c4dcc82c7aff0bee46b30335bbb10dcf266`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `086365b086fd130d9ef17a34e69f11d6786884f09ea0525a080792033b47d5cb`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `78696c84c936a27db0d476b9673a2b9f30099e53a98c303b4036832baf353eb7`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `147ea0edbf82c8ca9a07d9d6ff0b589da90d3fd96bbb89bae4f44faf26cc1243`
+- Skill overlay SHA-256: `27a39b82b995acb5c798df074b3eb2e54e5b81ea6292feb84f2c09cf3d65fb1c`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,21 +33,21 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `keeps_status_unconfirmed` | PASS | 明确标记为 `suspected / needs more evidence`，并说明当前不足以确认缺陷、不可复现且非环境敏感结论。 |
-| `separates_impact_from_confidence` | PASS | 分别记录低置信度与潜在影响，并说明严重度不代表事实确定性。 |
-| `requests_decisive_evidence` | PASS | 提出补充复现步骤、预期/实际、环境版本，并收集截图/录屏、控制台、网络和 trace 等证据。 |
-| `avoids_confirmed_bug_write` | PASS | 持久化文件位于 unresolved 路径，内容明确标为 suspected / needs more evidence，且要求确认前不得按已确认缺陷排期；未创建 GitHub issue 或 confirmed bug。 |
+| `keeps_status_unconfirmed` | PASS | With-skill output and the locked delivery file explicitly classify the report as suspected / needs more evidence, with low confidence, and state it is insufficient to confirm a defect. |
+| `separates_impact_from_confidence` | PASS | The delivery file separately records low confidence, unknown release impact, and potential implementation impact, while explaining that the evidence cannot distinguish the underlying cause. |
+| `requests_decisive_evidence` | PASS | The output and delivery file request reproduction steps, expected/actual behavior, environment and version details, and applicable screenshot, video, console, network, server-log, and trace evidence. |
+| `avoids_confirmed_bug_write` | PASS | The only persisted artifact is an unresolved QA record explicitly marked suspected, low-confidence, and not sufficient to confirm or hand off an implementation bug; no GitHub issue or confirmed bug was created. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=78696c84c936a27db0d476b9673a2b9f30099e53a98c303b4036832baf353eb7; fixture_sha256=bd09f8717eb7765700b65e2c38ca5c4dcc82c7aff0bee46b30335bbb10dcf266; output_sha256=b85fe33399c6751c72793e62d40e664183fd5a465aa762ea08a944993e6200ce; snapshot_sha256=fa607c377fb44cd81d812a65045e849c18bb0373f45e7de0d93a529601e6c2a6
-- Behavior: 正确保持待补证状态，区分影响与置信度，提出决定性补证计划，并仅创建明确未确认的调查记录。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=78696c84c936a27db0d476b9673a2b9f30099e53a98c303b4036832baf353eb7; fixture_sha256=bd09f8717eb7765700b65e2c38ca5c4dcc82c7aff0bee46b30335bbb10dcf266; output_sha256=4e3744f5c46ed6bfa87ec2ab653c86323d4e9fef0cc31fb6d381218ad10d3b33; snapshot_sha256=cb95ac1b65957a637e1a7c398de037a737169555cd6a661c63d7d32414292861
+- Behavior: Correctly kept the report unconfirmed, separated confidence from potential impact, requested decisive evidence, and persisted only an explicitly unresolved QA record.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=78696c84c936a27db0d476b9673a2b9f30099e53a98c303b4036832baf353eb7; fixture_sha256=bd09f8717eb7765700b65e2c38ca5c4dcc82c7aff0bee46b30335bbb10dcf266; output_sha256=01aaa78c3415929656f5a2d371071cf8a98b6899d346a9c9f885fe9ce21a2c8c; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 同样保持未确认状态并提出补证建议；未创建持久化记录，作为 fresh baseline 对照。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=78696c84c936a27db0d476b9673a2b9f30099e53a98c303b4036832baf353eb7; fixture_sha256=bd09f8717eb7765700b65e2c38ca5c4dcc82c7aff0bee46b30335bbb10dcf266; output_sha256=368ffd109396616f709b67a594783b1d680e00c7a9a6a9fbab831cec2444347c; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline also kept the report unconfirmed and requested relevant missing evidence, but did not create a persisted artifact.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/qa/test/bug-analyzer/evals/workspace/eval-3-mapped-doc-bug-analysis/comparison.md
+++ b/agents/qa/test/bug-analyzer/evals/workspace/eval-3-mapped-doc-bug-analysis/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `7d279cf3b0905050d0b65ec93cd3a19c763df01dd02f4eaadd2d86c46d0a38cf` from `agents/qa/test/bug-analyzer/evals/workspace/eval-3-mapped-doc-bug-analysis`.
 - Identity schema: `2`
-- target_skill_sha256: `09e738dc9988190b7f79b8aac551bd1674e0642fae4817109cb4551b9f01f0cd`
+- target_skill_sha256: `f7992d17a0646109f134e112dee5a8d92a38fd3d8cf3007564f0979ffbd3929d`
 - eval_definition_sha256: `5055f21aa292e91a955bc3aa635c808239336415cf083aba532e9d19a7985220`
 - metadata_sha256: `98bdccb4e3241d7facbaf94d94c2edbbe1adcec302e237e84c10d586748147c6`
 - fixture_sha256: `7d279cf3b0905050d0b65ec93cd3a19c763df01dd02f4eaadd2d86c46d0a38cf`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `42efa66a3d947aa438db6985ea7344decf5267623091f1d47b29acd454584b1d`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `147ea0edbf82c8ca9a07d9d6ff0b589da90d3fd96bbb89bae4f44faf26cc1243`
+- Skill overlay SHA-256: `27a39b82b995acb5c798df074b3eb2e54e5b81ea6292feb84f2c09cf3d65fb1c`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,20 +33,20 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `reads_mapped_docs_first` | PASS | with_skill trace reads the change-map and then the mapped `docs/site/api/notification-retry.md`; no unrelated site-document traversal is shown. |
-| `verifies_against_code` | PASS | The locked report records the documentation claim of 3 retries, code value `max_retry_attempts = 2`, their discrepancy, and the unresolved runtime/counting-semantics impact. |
-| `treats_unverified_as_low_trust` | PASS | The locked report explicitly identifies `last_verified_version: unverified`, treats the documents as low-trust, and classifies runtime impact as suspected/needs more evidence with low confidence pending code/runtime evidence. |
+| `reads_mapped_docs_first` | PASS | Raw trace shows the change-map was read first in the targeted evidence command, followed immediately by the mapped notification document; no unrelated site-document contents were traversed. |
+| `verifies_against_code` | PASS | The locked delivery snapshot directly records `max_retry_attempts = 2`, the document statement of up to 3 retries, their numeric inconsistency, and the unresolved counting semantics; it classifies the defect as suspected rather than confirmed. |
+| `treats_unverified_as_low_trust` | PASS | The locked artifact identifies `last_verified_version: unverified` as low-trust evidence and bases the conclusion and medium-low confidence on directly observed source values plus missing runtime/test evidence. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=42efa66a3d947aa438db6985ea7344decf5267623091f1d47b29acd454584b1d; fixture_sha256=7d279cf3b0905050d0b65ec93cd3a19c763df01dd02f4eaadd2d86c46d0a38cf; output_sha256=18f78302fd7b9479879638e1a84f534c82cd2bc69e4c8aab09ab7ae0737e9039; snapshot_sha256=0c9f3afb59f866bb1696c0d9960ff842de619db7364bbc45054d9578db3567f7
-- Behavior: Created a durable evidence report, followed mapped-document context, verified the rule against code, and avoided overstating the runtime defect.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=42efa66a3d947aa438db6985ea7344decf5267623091f1d47b29acd454584b1d; fixture_sha256=7d279cf3b0905050d0b65ec93cd3a19c763df01dd02f4eaadd2d86c46d0a38cf; output_sha256=05c2aca7faa7801466c539ea5dafc54c06b4080d2fde76c8c79aef9cad69e5ce; snapshot_sha256=68fadce15e86e1c1eafbf43a3fee6d8cbcc8524b329acc9784967ef71b9d3118
+- Behavior: Produced the required evidence-based diagnosis artifact, verified the mapped documentation against the rule file, and kept the defect classification appropriately unconfirmed.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=42efa66a3d947aa438db6985ea7344decf5267623091f1d47b29acd454584b1d; fixture_sha256=7d279cf3b0905050d0b65ec93cd3a19c763df01dd02f4eaadd2d86c46d0a38cf; output_sha256=759bbc5ae015a63f06da731a9f2359fbb288fa68b33b7e69bff6d6d80cd80a75; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Produced a strong prose-only comparison analysis identifying the same discrepancy and evidence gaps, without the durable report artifact.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=42efa66a3d947aa438db6985ea7344decf5267623091f1d47b29acd454584b1d; fixture_sha256=7d279cf3b0905050d0b65ec93cd3a19c763df01dd02f4eaadd2d86c46d0a38cf; output_sha256=9da5894c7ee93c50bc9ea87962376063119fea4bc5a7ae2e073dddffe492fe39; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Provided a correct prose comparison analysis but delivered no durable artifact; used only as baseline context.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/qa/test/exploratory-tester/evals/workspace/eval-1-explore-web-app/comparison.md
+++ b/agents/qa/test/exploratory-tester/evals/workspace/eval-1-explore-web-app/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `ee088defa4a7bb2cbc3d091f8817eac9fb8cc7c128c92be34adf72ee4a79f3b7` from `agents/qa/test/exploratory-tester/evals/workspace/eval-1-explore-web-app`.
 - Identity schema: `2`
-- target_skill_sha256: `ad5f15f98798fd005013d9360ccfb1f546134b65d875e1399c704387da8bd759`
+- target_skill_sha256: `a0ccbf8ef4a1c709d054888b55b087565575c66027bff8bd5b33273b116324d3`
 - eval_definition_sha256: `32b9d61e575fbee81406ffc68edbaec9418feec621754c8fca12fc2f2edd2c08`
 - metadata_sha256: `228751d86855b3dcdb583bdc4a44c4a493c28334ed74368c030ddad805b1f314`
 - fixture_sha256: `ee088defa4a7bb2cbc3d091f8817eac9fb8cc7c128c92be34adf72ee4a79f3b7`
@@ -22,42 +22,42 @@
 - judge_schema_sha256: `3783048bfb479d6e8907a0e84c4199cb646178dd63c9a58d60ddd654db2122dc`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `b0dd5a79c80e2e161088bef46107d054902f47f9ef2205167f1eaadd760b99cd`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `1f8ea470403a23486f27834f156d91882ffb60f2aff635a7aa34b64347c884e6`
+- Skill overlay SHA-256: `649841709df98de32c59aff088c94eff0d9bbe6820d42c21a8e49cd3cf9838cb`
 - Behavior result: **PASS**
-- Coverage result: **FULL**
-Overall result: PASS
+- Coverage result: **PARTIAL**
+Overall result: PASS (partial coverage)
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `assertion_1` | PASS | The delivered report defines the surface as SearchPanel, FilterPills, and ResultsList; gives a 15-minute timebox; lists change-specific heuristics; and names escalation signals. |
-| `assertion_2` | PASS | The report records the QA memory read set, including TEST_SUITE.md, FLOW_INDEX.md, cases/TC-001-filter-results.md, and the absence of scripts/results/_reports. The locked FLOW_INDEX update documents the files read and coverage implications; no new E2E case or duplicate script was created. |
-| `assertion_3` | PASS | The report explicitly derives the 15-minute timebox from the user request, states that it did not start because QA_BASE_URL was unavailable, and prioritizes the changed surfaces plus the known keyboard-focus risk. |
-| `assertion_4` | PASS | The report has separate Observed issues, Suspicious but unconfirmed signals, and Gaps not explored sections, and labels the environment and focus items as unconfirmed rather than product defects. |
-| `assertion_5` | PASS | The report describes a chartered preflight path, the reused TC-001 smoke entry, the three intended probes, and explicit unexecuted UI boundaries; it contains no random-click log. Browser exploration was blocked before runtime execution. |
-| `assertion_6` | PASS | The delivered exploratory-report.md contains charter, timebox, exploration path covered, evidence/preflight details, and recommended next actions, with reproducibility and escalation guidance. |
-| `deduplicates_existing_flows` | PASS | The locked FLOW_INDEX update says to reuse TC-001, explicitly records that no duplicate TC was created, and the report states that no reusable case or matching script changes were needed; one-time observations remain in the report. |
+| `assertion_1` | PASS | The locked report defines the changed SearchPanel, FilterPills, and ResultsList surface; uses the requested 15-minute timebox; states heuristics for filtering, empty states, and keyboard focus; and defines escalation for reproducible behavior with evidence. |
+| `assertion_2` | PASS | The captured trace shows the existing TEST_SUITE.md, FLOW_INDEX.md, and TC-001 case were read before delivery. The report records that no scripts existed, reuses TC-001, and the locked FLOW_INDEX snapshot documents the source files and coverage implication. |
+| `assertion_3` | PASS | The report uses the context-provided 15-minute duration, explicitly records that the timebox did not start because preflight was blocked, and prioritizes the changed surfaces plus nearby result-navigation risk. |
+| `assertion_4` | PASS | The locked report has separate Observed issues, Suspicious but unconfirmed signals, and Gaps not explored sections, and explicitly avoids treating the documented focus risk as a defect. |
+| `assertion_5` | NOT_EXERCISED | The chartered execution path and planned probes are documented, but no browser session or application interaction occurred because QA_BASE_URL and a runnable entry point were unavailable; actual exploratory paths therefore cannot be verified. |
+| `assertion_6` | PASS | The locked delivery includes a charter, timebox, feature scope, evidence/preflight basis, exploration path, explicit gaps, blocked status, and recommended next actions for rerun and escalation. |
+| `deduplicates_existing_flows` | PASS | The report reuses TC-001, states that no new case or matching script was needed, updates FLOW_INDEX.md incrementally, and keeps unexecuted observations in the exploration report. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=b0dd5a79c80e2e161088bef46107d054902f47f9ef2205167f1eaadd760b99cd; fixture_sha256=ee088defa4a7bb2cbc3d091f8817eac9fb8cc7c128c92be34adf72ee4a79f3b7; output_sha256=df54569b3806b86d99b4dcc363e7837ca1475f2b6cf1c25c33833b895186e11a; snapshot_sha256=9655f39321c21bdd7c35a58721570dfa5cb832e9541e1d312e94b499f8d09904
-- Behavior: Produced a structured, evidence-backed exploratory handoff; updated FLOW_INDEX without duplicating existing flows; correctly reported the runtime blocker and unexecuted UI areas.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=b0dd5a79c80e2e161088bef46107d054902f47f9ef2205167f1eaadd760b99cd; fixture_sha256=ee088defa4a7bb2cbc3d091f8817eac9fb8cc7c128c92be34adf72ee4a79f3b7; output_sha256=aa29333eb088c8c5caec220ab9b43510a94e8634bc77339e513377621211d2c6; snapshot_sha256=4a947b77555cd3521253e136ef467e57770db42148b754cfcc2d0b668a5da3ab
+- Behavior: Produced an accurate blocked exploratory handoff, updated FLOW_INDEX.md, separated confirmed and unconfirmed evidence, and avoided claiming browser execution.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=b0dd5a79c80e2e161088bef46107d054902f47f9ef2205167f1eaadd760b99cd; fixture_sha256=ee088defa4a7bb2cbc3d091f8817eac9fb8cc7c128c92be34adf72ee4a79f3b7; output_sha256=cdd8e0b54b1d080f029252a942d333eaccb8b17122f5788ff39c5f557a42648d; snapshot_sha256=296a5bfa420dbe55c7dec4357469a0939aaf1d862e7ce66e70067b0b4701af4d
-- Behavior: Produced a basic blocked handoff with charter and checks, but did not update the existing FLOW_INDEX or provide the same structured separation of evidence and coverage gaps.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=b0dd5a79c80e2e161088bef46107d054902f47f9ef2205167f1eaadd760b99cd; fixture_sha256=ee088defa4a7bb2cbc3d091f8817eac9fb8cc7c128c92be34adf72ee4a79f3b7; output_sha256=8f7f9b5ff498c775434071b7048572159e0401175a0bdb3a1eb7099f7001e684; snapshot_sha256=eb68c1af299a46a17381a7c03e43238893222a89448b6e2fb18777ee3536b2df
+- Behavior: Produced a blocked handoff with a useful exploratory matrix and evidence plan, but did not provide the with_skill lane's structured report and FLOW_INDEX update.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Provide QA_BASE_URL and a browser-capable execution entry, then rerun TC-001 followed by empty-state and keyboard-navigation exploration within the 15-minute charter.
-- Next: Capture per-TC runtime evidence and update the relevant report; escalate only reproducible product failures with exact steps and console/network evidence.
+- Next: Set QA_BASE_URL and provide a runnable application or test entry point.
+- Next: Rerun TC-001 using the recorded charter and capture filtering, empty-state, and keyboard-focus evidence.
 
 ## Runtime Artifact Policy
 

--- a/agents/qa/test/exploratory-tester/evals/workspace/eval-2-explore-with-custom-duration/comparison.md
+++ b/agents/qa/test/exploratory-tester/evals/workspace/eval-2-explore-with-custom-duration/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `58e996bab34649b23e7bf5cc00be4fa65ff65a8e7b288cba77fc10a44d715cf3` from `agents/qa/test/exploratory-tester/evals/workspace/eval-2-explore-with-custom-duration`.
 - Identity schema: `2`
-- target_skill_sha256: `ad5f15f98798fd005013d9360ccfb1f546134b65d875e1399c704387da8bd759`
+- target_skill_sha256: `a0ccbf8ef4a1c709d054888b55b087565575c66027bff8bd5b33273b116324d3`
 - eval_definition_sha256: `234873760fb9d0649d16f54118fbf0383fa2955b9451730f9429892d78a6d7e0`
 - metadata_sha256: `4befffc2e8037477b9995f3ded3869d8476cd9a66637621d7f8e8d3fc8c6fed3`
 - fixture_sha256: `58e996bab34649b23e7bf5cc00be4fa65ff65a8e7b288cba77fc10a44d715cf3`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `795b13efa8aba1d005ca8e2bf3be74790d6a011a9b79e7e9c3ef0bb4863b7e5d`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `95b19585ae663cfe50fef5d8a922d75ec357803535a13bbb323cdf9b1845fa29`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `1f8ea470403a23486f27834f156d91882ffb60f2aff635a7aa34b64347c884e6`
+- Skill overlay SHA-256: `649841709df98de32c59aff088c94eff0d9bbe6820d42c21a8e49cd3cf9838cb`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,31 +33,31 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `assertion_1` | PASS | 已交付包含目标 URL、5 分钟 timebox、探索 charter、改动面、环境信息及未验证前提的报告。 |
-| `assertion_2` | PASS | 原始 trace 显示读取 TEST_SUITE.md、FLOW_INDEX.md、PRD、TRD、实现计划和环境资料；交付文件确认 feature-update 场景，并记录 cases/scripts/results/_reports 均无文件。 |
-| `version_entry_and_subagent` | NOT_EXERCISED | 报告确认平台版本缺失即 blocked，并说明 harness、浏览器连接器和 Playwright 的入口顺序及选择理由；但实际 TC 未执行，subagent 执行未被独立证据验证。 |
-| `assertion_3` | PASS | 报告区分 Observed issues、Suspicious but unconfirmed signals 和 Gaps not explored，并记录 DNS 网络错误及 toast/validation 风险。 |
-| `assertion_4` | PASS | 交付报告包含实际 preflight/环境探测路径、curl DNS 失败证据、读取来源和覆盖范围，而非随机操作清单。 |
-| `assertion_5` | PASS | 报告包含已知风险、明确的后续重跑步骤、优先级顺序及 bug-analyzer 交接所需证据建议。 |
+| `assertion_1` | PASS | 交付报告包含 5 分钟 charter、目标 URL、changed surface、环境信息及未验证前提。 |
+| `assertion_2` | PASS | 报告记录已读取 TEST_SUITE.md、FLOW_INDEX.md 及不存在的 cases、scripts、历史结果，并确认 feature-update；未创建 TC/script 是因为没有可执行场景。 |
+| `version_entry_and_subagent` | NOT_EXERCISED | 报告确认平台版本缺失并将执行标记为 blocked，同时记录了 harness → browser connector → Playwright 顺序及 subagent 默认规则；但没有实际 TC 执行或 subagent 委派。 |
+| `assertion_3` | PASS | 交付报告明确分为 Observed issues（无确认问题）、Suspicious but unconfirmed signals 和 Gaps not explored。 |
+| `assertion_4` | PASS | 报告包含 charter、实际 URL 检查路径、DNS 错误、读取的文档和未覆盖项，提供了可追溯 evidence references。 |
+| `assertion_5` | PASS | 报告记录 toast 可能遮盖校验错误的风险，并给出恢复 DNS、记录版本、重跑路径及升级条件。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=95b19585ae663cfe50fef5d8a922d75ec357803535a13bbb323cdf9b1845fa29; fixture_sha256=58e996bab34649b23e7bf5cc00be4fa65ff65a8e7b288cba77fc10a44d715cf3; output_sha256=c386fd6401ab5086ac772c3b0a14f2cd34228bd274c084efb8fd76fac7c06e7c; snapshot_sha256=247a048c36b1300ffceeb6e0a580cf9873ccb17ddbd1bd6e48aaa434b1db9f78
-- Behavior: 完成了结构化 preflight、charter、风险分层、阻塞证据和可交接报告，并更新 FLOW_INDEX.md；未执行 UI。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=95b19585ae663cfe50fef5d8a922d75ec357803535a13bbb323cdf9b1845fa29; fixture_sha256=58e996bab34649b23e7bf5cc00be4fa65ff65a8e7b288cba77fc10a44d715cf3; output_sha256=342ec6332620f7232cf6d90b119d1e25d62980a07bb393a217b07bed50b6b21f; snapshot_sha256=01baa3d439b7d785a899f80dd20cadf29fc525fa6fc3f99b53c56359a8227796
+- Behavior: 完成了结构化预检、范围章程、风险分层和交接产物；在执行前因环境与版本门禁阻塞。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=95b19585ae663cfe50fef5d8a922d75ec357803535a13bbb323cdf9b1845fa29; fixture_sha256=58e996bab34649b23e7bf5cc00be4fa65ff65a8e7b288cba77fc10a44d715cf3; output_sha256=3671382ea975f98782f65f5b4b7547df95c4eefad9b630d829169572cb7ba168; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 仅报告 DNS 阻塞和若干未判定项目，未提供完整 charter、改动面分析、入口判定、风险交接或交付文件。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=95b19585ae663cfe50fef5d8a922d75ec357803535a13bbb323cdf9b1845fa29; fixture_sha256=58e996bab34649b23e7bf5cc00be4fa65ff65a8e7b288cba77fc10a44d715cf3; output_sha256=b714d08424b0b2e3dba58133614d480977bef4d02592d4ef4611dbb0bea85ce1; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 仅报告环境不可达和无法执行，未提供结构化 charter、完整 preflight 入口决策或交接文件。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: 恢复 qa.example.test DNS 并提供平台版本。
-- Next: 按已记录的 5 分钟 charter 重跑 UI 探索，并由 subagent 执行实际 TC。
-- Next: 优先验证保存、取消/丢弃、未保存状态及 validation/toast precedence。
+- Next: 恢复 QA URL 的 DNS/可达性。
+- Next: 记录浏览器/platform 版本并按既定入口顺序重新执行 5 分钟探索。
+- Next: 执行保存、取消、未保存状态、校验与 toast 路径；仅在可复现时升级风险。
 
 ## Runtime Artifact Policy
 

--- a/agents/qa/test/exploratory-tester/evals/workspace/eval-3-mapped-doc-exploration/comparison.md
+++ b/agents/qa/test/exploratory-tester/evals/workspace/eval-3-mapped-doc-exploration/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `5b1017edbbf8a6df86fadbd205bf7416456f615f000264cc379e5e296b079421` from `agents/qa/test/exploratory-tester/evals/workspace/eval-3-mapped-doc-exploration`.
 - Identity schema: `2`
-- target_skill_sha256: `ad5f15f98798fd005013d9360ccfb1f546134b65d875e1399c704387da8bd759`
+- target_skill_sha256: `a0ccbf8ef4a1c709d054888b55b087565575c66027bff8bd5b33273b116324d3`
 - eval_definition_sha256: `c4de00c65a5c492d58d182077c448786bbd54172790d4519f15e143439929064`
 - metadata_sha256: `66549bc6a4cd28361d4fb0c300ac0600f32823bbce01dba9736725e4b2d843dd`
 - fixture_sha256: `5b1017edbbf8a6df86fadbd205bf7416456f615f000264cc379e5e296b079421`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `d280f60d4c43a5403f08df3395711e665a24f6defcf1e883ede2ed9c11e2a47f`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `1f8ea470403a23486f27834f156d91882ffb60f2aff635a7aa34b64347c884e6`
+- Skill overlay SHA-256: `649841709df98de32c59aff088c94eff0d9bbe6820d42c21a8e49cd3cf9838cb`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,26 +33,26 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `reads_mapped_docs_first` | PASS | with_skill trace reads the change map, then the mapped API document, then session.rules; no docs/site traversal is shown. |
-| `verifies_against_code` | PASS | with_skill identifies the documented 15-minute value versus the code value of 10 minutes and uses 10 minutes as the exploration basis, including 9:59, 10:00, and post-threshold checks. |
-| `treats_unverified_as_low_trust` | PASS | with_skill explicitly treats last_verified_version: unverified as low trust and requires code/test confirmation for behavior claims. |
+| `reads_mapped_docs_first` | PASS | with_skill trace reads the mapped formal document and only the checkout-related files; no broad docs/site content traversal is shown. |
+| `verifies_against_code` | PASS | with_skill trace directly reads src/checkout/session.rules showing 10 minutes, reads the formal document showing 15 minutes, and the output uses 10 minutes as the exploration basis while preserving the discrepancy. |
+| `treats_unverified_as_low_trust` | PASS | with_skill output explicitly treats last_verified_version: unverified as low trust, uses code as the behavior baseline, and routes the documentation discrepancy for audit. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=d280f60d4c43a5403f08df3395711e665a24f6defcf1e883ede2ed9c11e2a47f; fixture_sha256=5b1017edbbf8a6df86fadbd205bf7416456f615f000264cc379e5e296b079421; output_sha256=aba012c6a9a4e1e50cbde12dcafd35fca9306881c713ca9c420c1adff5fe8b3b; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Produced an evidence-backed minimal exploration charter using the mapped document, verified code threshold, documented discrepancy, and low-trust handling.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=d280f60d4c43a5403f08df3395711e665a24f6defcf1e883ede2ed9c11e2a47f; fixture_sha256=5b1017edbbf8a6df86fadbd205bf7416456f615f000264cc379e5e296b079421; output_sha256=1863b0ac0878d076473b3e88135ac97e6df5c864dd23cc05f9f51e437224cf77; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly maps the checkout rule to the required document, verifies the 10-minute code value against the 15-minute documentation value, treats unverified metadata as low trust, and proposes focused boundaries. No runtime exploration was executed.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=d280f60d4c43a5403f08df3395711e665a24f6defcf1e883ede2ed9c11e2a47f; fixture_sha256=5b1017edbbf8a6df86fadbd205bf7416456f615f000264cc379e5e296b079421; output_sha256=51a51e32ce7642de38471f19af1ebe3d53eb92849ca54d90cc44ee241167b30d; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Also identified the threshold discrepancy and proposed boundaries, serving as a fresh baseline comparison.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=d280f60d4c43a5403f08df3395711e665a24f6defcf1e883ede2ed9c11e2a47f; fixture_sha256=5b1017edbbf8a6df86fadbd205bf7416456f615f000264cc379e5e296b079421; output_sha256=6e15a4c72c308252a206a22ded59b171784c05815484c72705a074d56c2188dc; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Fresh baseline also identified the 10-minute code value and 15-minute documentation drift and proposed boundaries, but without the skill-specific preflight and routing context.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: None.
+- Next: Execute the proposed runtime boundary checks when the required harness or user confirmation is available.
 
 ## Runtime Artifact Policy
 

--- a/agents/qa/test/qa-agent/evals/workspace/eval-1-route-mixed-qa-request/comparison.md
+++ b/agents/qa/test/qa-agent/evals/workspace/eval-1-route-mixed-qa-request/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `c9268123afd7a11d5bd4ac6d14865261ea2db8883ff6a745cea96f843ec5dbd5` from `agents/qa/test/qa-agent/evals/workspace/eval-1-route-mixed-qa-request`.
 - Identity schema: `2`
-- target_skill_sha256: `67401f0f5ce98032f224aebfb24715fe0d3d5f8bc92ca57ff320d37e3d49c72a`
+- target_skill_sha256: `944bb130633ab2aa16595ed1d51c447f77cd06660f1aafc548f03bd9b22af162`
 - eval_definition_sha256: `0c9c4e17aa3aba15319c1b891ee6bf6eebad63436a6c10edd0a500e765aa29f6`
 - metadata_sha256: `718fcc57ee1abd91d0d7551c46ebe8546481fa4f027452b86db232f30d15ab47`
 - fixture_sha256: `c9268123afd7a11d5bd4ac6d14865261ea2db8883ff6a745cea96f843ec5dbd5`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `f4aaec46995456a39da2b489696e387a78408415038edddd6412ca13bedbc20a`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `d32b34f557a9af42827fae115c24f25ec47fe1e0fcda62e092dc3afa3789c767`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `07bcf2cf62398e35d6af14c6cbe959a504a24680a05115fbb8eaa9d7c4b5b04a`
+- Skill overlay SHA-256: `b72f030fc95be72eca667c1396fcf25fade5c01afa11ea1d384304d1797aeac5`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,22 +33,22 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `assertion_1` | PASS | 选择 `qa-agent:regression-suite` 作为唯一主路径，并依据确认文档、变更说明、QA 资料和 CI 风险推进。 |
-| `assertion_2` | PASS | 明确传递 feature path、PRD/TRD/实现计划、QA 记忆、变更说明、CI 失败、执行入口及平台版本缺口。 |
-| `specialist_gate_pointer` | PASS | 将后续执行明确交给 `regression-suite`，并列出其需检查的文档、E2E 记忆、平台版本、凭据、执行入口和证据门禁；未自行执行测试。 |
-| `assertion_4` | PASS | 声明回归验证证据结构，包括状态、证据置信度、原始失败复核、修复行为、相邻风险、平台/环境/命令、结果文件和 release recommendation。 |
-| `assertion_5` | PASS | 仅选择一个下游 QA specialist；将 WebKit 间歇性超时保留为风险和后续证据需求，未认定为 confirmed bug。 |
+| `assertion_1` | PASS | with_skill 明确选择 regression-suite 作为主 QA 验收路径，并将 WebKit 间歇性超时保留为风险。 |
+| `assertion_2` | PASS | 交接中保留了 PRD、TRD、实现计划、变更说明、QA memory、CI 日志、平台版本状态和执行入口。 |
+| `specialist_gate_pointer` | PASS | 明确将后续验证交给 regression-suite，并声明本次路由阶段不自行执行下游回归。 |
+| `assertion_4` | PASS | 声明了原始失败复核、修复验证、相邻路径结果、置信度、平台状态、发布建议及逐 TC result.md/testcase.snapshot.md 等产物结构。 |
+| `assertion_5` | PASS | 仅选择一个下游 specialist；将证据不足的 WebKit 超时作为风险和待复核事项，未确认其为产品缺陷。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=d32b34f557a9af42827fae115c24f25ec47fe1e0fcda62e092dc3afa3789c767; fixture_sha256=c9268123afd7a11d5bd4ac6d14865261ea2db8883ff6a745cea96f843ec5dbd5; output_sha256=cf10b51c7a18513627c8c8b63d77b975cd0ee1054dc78a5447dbb99d36bfdd99; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 完成唯一 QA 路由并形成结构化 specialist handoff，保留证据缺口和风险，等待用户确认后继续下游验证。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=d32b34f557a9af42827fae115c24f25ec47fe1e0fcda62e092dc3afa3789c767; fixture_sha256=c9268123afd7a11d5bd4ac6d14865261ea2db8883ff6a745cea96f843ec5dbd5; output_sha256=a5a2e1e10cf6d79cebdb477ca9af194bcb3395e006bf6df4176abc679c2cc189; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 选择单一 regression-suite 路径，完整传递上下文并声明后续验证所需证据与风险边界；未执行下游回归。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=d32b34f557a9af42827fae115c24f25ec47fe1e0fcda62e092dc3afa3789c767; fixture_sha256=c9268123afd7a11d5bd4ac6d14865261ea2db8883ff6a745cea96f843ec5dbd5; output_sha256=bcdf89296ebf048afc0444a11be00cadf02998ce63308ffc5c5ae8bc66a9e1e4; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 给出有条件验收建议和较完整证据清单，但未形成明确的 specialist 路由与职责边界。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=d32b34f557a9af42827fae115c24f25ec47fe1e0fcda62e092dc3afa3789c767; fixture_sha256=c9268123afd7a11d5bd4ac6d14865261ea2db8883ff6a745cea96f843ec5dbd5; output_sha256=484eecf66c9fee9bac541d4cf91380afb475fbd8fd9f929be455fdb82ed7ba10; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 给出条件验收建议和证据清单，但未形成明确 specialist 路由或结构化 handoff。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/qa/test/qa-agent/evals/workspace/eval-2-empty-qa-directory-expands-cases/comparison.md
+++ b/agents/qa/test/qa-agent/evals/workspace/eval-2-empty-qa-directory-expands-cases/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `870f233236f82c3cf594816a5771878c8e388e11eeb3846cf269bf436f0fb100` from `agents/qa/test/qa-agent/evals/workspace/eval-2-empty-qa-directory-expands-cases`.
 - Identity schema: `2`
-- target_skill_sha256: `67401f0f5ce98032f224aebfb24715fe0d3d5f8bc92ca57ff320d37e3d49c72a`
+- target_skill_sha256: `944bb130633ab2aa16595ed1d51c447f77cd06660f1aafc548f03bd9b22af162`
 - eval_definition_sha256: `191bfa99acdac3657f309157a88a7fec7c17e9d659acf0a1a21ab3c03782508a`
 - metadata_sha256: `bf12045623474ece32b13073fc8cb963c9b4f673ab0fe9f0cf0dc0ad649d4ef6`
 - fixture_sha256: `870f233236f82c3cf594816a5771878c8e388e11eeb3846cf269bf436f0fb100`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `d61853152f0f59bd847f0aa3394c1f282e4bb9275d56c9fb66462de58118346d`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `068467ca9228748a58aa1065f9a150e3f5b012d5ddc3cefa3e5b130984c9cc4a`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `3ff11c8e572c63705c91226f6db993f90ab7638bbaa39fb6677b573f386556da`
+- Skill overlay SHA-256: `9e5a2664238c6ad34a383d7e96fdb5938260274f9ddd6b1fcc0ee574c941d418`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,21 +33,21 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `assertion_1` | PASS | The with_skill output identifies the existing feature path and states the QA directory has no executable cases or scripts; raw trace confirms only TEST_SUITE.md and FLOW_INDEX.md were present. |
-| `assertion_2` | PASS | It selects spec-based-tester, passes the target source files, environment instructions, QA memory, credential reference, and execution context, while preserving unresolved specialist gates without returning blocked or re-asking for exploration authorization. |
-| `specialist_gate_pointer` | PASS | The output explicitly hands subsequent work to the selected spec-based-tester and keeps the router scoped to routing rather than creating artifacts or executing specialist work. |
-| `assertion_6` | PASS | Exactly one narrow route is selected: spec-based-tester. The output defines non-goals excluding broad regression, bug analysis, and implementation fixes. |
+| `assertion_1` | PASS | with_skill explicitly identified the exact feature path as lacking active TC, cases, scripts, and reusable QA assets. |
+| `assertion_2` | PASS | with_skill selected spec-based-tester, passed the source files, QA memory, and environment guidance, and applied the specialist execution gates without re-requesting exploration authorization. |
+| `specialist_gate_pointer` | PASS | The routing output named spec-based-tester as downstream owner and supplied the target files, environment instructions, and existing E2E memory for specialist handoff. |
+| `assertion_6` | PASS | The trace and final routing packet show one narrow route, spec-based-tester, with no parallel QA skill execution or implementation changes. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=068467ca9228748a58aa1065f9a150e3f5b012d5ddc3cefa3e5b130984c9cc4a; fixture_sha256=870f233236f82c3cf594816a5771878c8e388e11eeb3846cf269bf436f0fb100; output_sha256=4c573e2985de79fdb87155b034950d7c85bd62cec9479490ea7b83d9e19ba912; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly routes the authorized profile-settings validation request to one specialist with the required context and gates.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=068467ca9228748a58aa1065f9a150e3f5b012d5ddc3cefa3e5b130984c9cc4a; fixture_sha256=870f233236f82c3cf594816a5771878c8e388e11eeb3846cf269bf436f0fb100; output_sha256=192e6dbdc0fedaa429a93fc8cb013b8ab467518edc9f743a70535149ef5e1328; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly routed the authorized validation request to spec-based-tester, recognized the empty QA directory, passed the required context, and stopped at the specialist/runtime gates.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=068467ca9228748a58aa1065f9a150e3f5b012d5ddc3cefa3e5b130984c9cc4a; fixture_sha256=870f233236f82c3cf594816a5771878c8e388e11eeb3846cf269bf436f0fb100; output_sha256=6994445d0a3d1023efb243e14fdb5ac2a219a0b368097bc7fe49c2341abeb475; snapshot_sha256=33843de20c46d3456575d6cb78e00423b5da43f79b4cdacf4c725531d68cd5c2
-- Behavior: Fresh baseline created QA artifacts directly instead of routing through the specialist boundary; browser execution remained unperformed.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=068467ca9228748a58aa1065f9a150e3f5b012d5ddc3cefa3e5b130984c9cc4a; fixture_sha256=870f233236f82c3cf594816a5771878c8e388e11eeb3846cf269bf436f0fb100; output_sha256=81a09bc131436f2fc810607084a2a91f556519c9539e99f2c5a0312a621084ce; snapshot_sha256=c534a01edbc59e15c66ea958cb7ae66300467e0b710be272b7f448783963c21a
+- Behavior: Fresh baseline independently created QA test assets and described blocked browser execution, rather than demonstrating the specialist-routing behavior.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/qa/test/qa-agent/evals/workspace/eval-3-feature-path-missing-plan-blocked/comparison.md
+++ b/agents/qa/test/qa-agent/evals/workspace/eval-3-feature-path-missing-plan-blocked/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `39ecc1af9722a7aadd83ae04a9403edca1017d45bde6a98a57d2d87ccb7702dc` from `agents/qa/test/qa-agent/evals/workspace/eval-3-feature-path-missing-plan-blocked`.
 - Identity schema: `2`
-- target_skill_sha256: `67401f0f5ce98032f224aebfb24715fe0d3d5f8bc92ca57ff320d37e3d49c72a`
+- target_skill_sha256: `944bb130633ab2aa16595ed1d51c447f77cd06660f1aafc548f03bd9b22af162`
 - eval_definition_sha256: `ec357d7e216245f12726027da14d7981d249bcac4a9eff1a2ed19f5ffc8af4f2`
 - metadata_sha256: `aa798ca118679678c2fef882d4726badd357a387202dcb387aceaa4b86696bd0`
 - fixture_sha256: `39ecc1af9722a7aadd83ae04a9403edca1017d45bde6a98a57d2d87ccb7702dc`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `7c827cee8609863280607c031efdc95a92d32b851664d68126eccd9d66c1f27a`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `094ec5b09f42125c7ea3b42f7f8365ddf4bd40bef6652060cfeb7ff368908608`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `91245fb0d1aab0b640cd99927d1845139d30d7b5d4db55c73139dce82b7a7bde`
+- Skill overlay SHA-256: `2ae6df1e5892f15e69faa5eb27f67247be532cf172f30b6323b139a66d25acc0`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,26 +33,26 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `reads_same_feature_path` | PASS | 原始 trace 显示读取同路径 PRD、TRD、FLOW_INDEX 和 TEST_SUITE；最终交接明确使用 feature_path `account/profile/preferences` 并保留 QA 功能树路径。 |
-| `specialist_gate_pointer` | PASS | 最终交接指定 `spec-based-tester` 为 downstream_owner，并明确缺少同路径 `IMPLEMENTATION_PLAN.md`，因此不能执行 E2E；同时声明 router 不创建、修改或运行 E2E 资产。 |
-| `keeps_single_route` | PASS | 仅选择了一个最窄 route：`spec-based-tester`；trace 未显示并行调用、下游执行或实现修复。 |
+| `reads_same_feature_path` | PASS | With-skill output identifies feature_path `account/profile/preferences`, cites the same-path PRD/TRD, and lists the retained QA E2E directory and files. |
+| `specialist_gate_pointer` | PASS | With-skill output routes follow-up to `spec-based-tester`, identifies the missing same-path `IMPLEMENTATION_PLAN.md` gate, and states E2E cannot execute; git status is clean with no delivered asset mutations. |
+| `keeps_single_route` | PASS | With-skill output selects only the narrow `spec-based-tester` QA route and does not invoke implementation repair or create/update/run E2E assets. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=094ec5b09f42125c7ea3b42f7f8365ddf4bd40bef6652060cfeb7ff368908608; fixture_sha256=39ecc1af9722a7aadd83ae04a9403edca1017d45bde6a98a57d2d87ccb7702dc; output_sha256=c585d42cb10a02bae03eecbbcc7b999ffb838d61cf5a8d69c9518b702dd49e83; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 识别为文档化验收，选择单一的 spec-based-tester 路由，保留 feature_path、同路径材料和 QA 功能树，并指出实施计划缺失导致无法执行。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=094ec5b09f42125c7ea3b42f7f8365ddf4bd40bef6652060cfeb7ff368908608; fixture_sha256=39ecc1af9722a7aadd83ae04a9403edca1017d45bde6a98a57d2d87ccb7702dc; output_sha256=140a77d959c7cd08f3fcdd78ff4366bf2f526e8d3c9429e28abd2c22168c6b6d; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly selected the narrow specialist route, preserved same-path context, and stopped at the missing implementation-plan gate without mutating QA assets.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=094ec5b09f42125c7ea3b42f7f8365ddf4bd40bef6652060cfeb7ff368908608; fixture_sha256=39ecc1af9722a7aadd83ae04a9403edca1017d45bde6a98a57d2d87ccb7702dc; output_sha256=601383512a6ac1c68031f0f9e3c3d4677432759fa18e817050de700b992e388a; snapshot_sha256=774e299147f9dcd3cb9766cfde25c4057deaa9530150269fdb037056c1982f5d
-- Behavior: 更新了 QA 测试套件和流程索引，但自行进行了 E2E 资产整理并报告执行阻塞，未体现 specialist 路由门禁。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=094ec5b09f42125c7ea3b42f7f8365ddf4bd40bef6652060cfeb7ff368908608; fixture_sha256=39ecc1af9722a7aadd83ae04a9403edca1017d45bde6a98a57d2d87ccb7702dc; output_sha256=a7c75ccaf06e2853fc74d81338b4e996474de323058dbaf0e0972e55c401f360; snapshot_sha256=3669a60e652513a62e4b3a683bcaee8f1594bffd6c3406a33a04d6ae489d757f
+- Behavior: Established the feature context but updated QA assets and did not provide the specialist gate pointer or single-route handoff behavior.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: 补齐并确认 IMPLEMENTATION_PLAN.md 后交由 spec-based-tester 继续验证。
+- Next: None.
 
 ## Runtime Artifact Policy
 

--- a/agents/qa/test/regression-suite/evals/workspace/eval-1-verify-bug-fix/comparison.md
+++ b/agents/qa/test/regression-suite/evals/workspace/eval-1-verify-bug-fix/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `de9aee791f056463d193f05e53c9f483fe312d6ee3aeb7bb4d1f7b0eb008f308` from `agents/qa/test/regression-suite/evals/workspace/eval-1-verify-bug-fix`.
 - Identity schema: `2`
-- target_skill_sha256: `5f00953469c57cd0a924598017d2502b6a836948c3bfa067998cf3e91f7335a1`
+- target_skill_sha256: `0d39fb3d56a0db02711ebbb062de0261e33393ff0e6f5f258b11c870a160c7e5`
 - eval_definition_sha256: `8ca6ea4c46c7a5a2c854d9ff5def7ea0ec612ddbf9888a829e50de270f1b84c4`
 - metadata_sha256: `732278c998a10f6e6333dc13e2fc4edfbaed96da1abb806d2dc29682a3a79f75`
 - fixture_sha256: `de9aee791f056463d193f05e53c9f483fe312d6ee3aeb7bb4d1f7b0eb008f308`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `2c18050b9a27d5dccf92b0604097b9078533d47105266364099eafbf3833aad8`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `c6a22bd6a4c946877c350cf1e3485fb0daa745bafdccb74f798f1fdae43d71c0`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `07500a40de121399595841537e6aef1df4c976254ab123954a243d97bad454fb`
+- Skill overlay SHA-256: `33d70406ae3e91e1a71751cc4087074b666d7c138769b3f1c7b475a5d350ce65`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,29 +33,30 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `assertion_1` | PASS | With-skill trace shows BUG-001, PR-001, and related product, engineering, and QA evidence were read before scoping the regression. |
-| `qa` | PASS | With-skill trace and delivery record show TEST_SUITE.md, FLOW_INDEX.md, the case, script, and absent prior results/_reports were checked; no new TC was needed. |
-| `assertion_3` | NOT_EXERCISED | The report records the run as blocked and explains that original-failure and fixed-behavior checks were not executed because package.json/runtime evidence was unavailable. |
-| `assertion_4` | PASS | The delivery snapshot identifies feature-update scope and covers the original flow plus invalid-credential and locked-account shared-response paths without expanding to release-wide E2E. |
-| `alignment_version_archive` | PASS | The snapshot contains same-feature-path PRD/TRD alignment, a confirmed IMPLEMENTATION_PLAN.md, platform version v1.2.0-fix.1, and the required result.md and testcase.snapshot.md paths; no historical results were overwritten. |
-| `assertion_5` | PASS | The report separates Status: blocked from evidence_confidence: low and gives release_recommendation: needs more verification. |
+| `assertion_1` | PASS | Trace shows BUG-001, PR-001, and same-path PRD/TRD/QA/implementation materials were read; the delivered report preserves the original reproduction and expected behavior. |
+| `qa` | PASS | The delivered result records TEST_SUITE.md, FLOW_INDEX.md, the case, script, prior results/, and prior _reports/ as inspected before execution; no new case or script was needed. |
+| `assertion_3` | NOT_EXERCISED | The locked result explicitly labels original failure recheck, expected fixed behavior, and overall verification as blocked/not executed, but no runtime verification occurred. |
+| `assertion_4` | PASS | The feature-update scope is limited to valid login plus the directly shared invalid-credential and locked-account paths; it does not expand to release-wide E2E coverage. |
+| `alignment_version_archive` | PASS | The locked result documents confirmed PRD/TRD alignment, cites IMPLEMENTATION_PLAN.md, records platform version v1.2.0-fix.1, and delivers append-only result.md and testcase.snapshot.md at the required path. |
+| `assertion_5` | PASS | The delivered regression report separates blocked run status from low evidence confidence and includes a needs more verification release recommendation. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c6a22bd6a4c946877c350cf1e3485fb0daa745bafdccb74f798f1fdae43d71c0; fixture_sha256=de9aee791f056463d193f05e53c9f483fe312d6ee3aeb7bb4d1f7b0eb008f308; output_sha256=1a6526143196f710b3b7b14394d28717a8cbbdf50ae597a7dcf2e0fa7ce12219; snapshot_sha256=8bc5f1739e2e6b66c92c67afeacd9ac6f7792f8276bc95cee942b7e8f7a48374
-- Behavior: Correctly performs evidence preflight, alignment, scoped regression planning, and append-only blocked-result recording, but cannot execute runtime verification.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c6a22bd6a4c946877c350cf1e3485fb0daa745bafdccb74f798f1fdae43d71c0; fixture_sha256=de9aee791f056463d193f05e53c9f483fe312d6ee3aeb7bb4d1f7b0eb008f308; output_sha256=167c791c0ff92d4279d2bc6bd2b7eb05d7cb61ce91fd009ffefd1f11f51cc628; snapshot_sha256=62d2379e3506f88d3627f9ae568fafef42331e5a565877dd61ed6cab4cc6bd3c
+- Behavior: Produced the required scoped regression artifacts, explicit blocked statuses, alignment gate, evidence confidence, and release recommendation without claiming the fix was verified.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c6a22bd6a4c946877c350cf1e3485fb0daa745bafdccb74f798f1fdae43d71c0; fixture_sha256=de9aee791f056463d193f05e53c9f483fe312d6ee3aeb7bb4d1f7b0eb008f308; output_sha256=ccf69c6e6d4125bea57990badb696ec104aa0314987d95d14e9c07dba35c4c95; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Fresh baseline identifies the missing harness and avoids claiming the fix passed, but does not produce the required durable QA result artifacts or alignment/archive report.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=c6a22bd6a4c946877c350cf1e3485fb0daa745bafdccb74f798f1fdae43d71c0; fixture_sha256=de9aee791f056463d193f05e53c9f483fe312d6ee3aeb7bb4d1f7b0eb008f308; output_sha256=7e5869aa1af5f6cadf68f45ba7438b61cb0f7ed341905166ca1ebfaf1ab316a4; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Read the documentation and attempted the harness, but produced no regression artifacts and omitted the required evidence-confidence and release-recommendation report structure.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Provide the fixed build with package.json or an equivalent runnable harness, then rerun the original login flow and both adjacent credential-state paths.
+- Next: Provide the fixed runnable build or restore the repository test harness and set QA_BASE_URL.
+- Next: Rerun the valid-login, invalid-credential, and locked-account paths, then append updated result.md and testcase.snapshot.md evidence.
 
 ## Runtime Artifact Policy
 

--- a/agents/qa/test/regression-suite/evals/workspace/eval-2-blocked-without-original-bug-context/comparison.md
+++ b/agents/qa/test/regression-suite/evals/workspace/eval-2-blocked-without-original-bug-context/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `811b93327e61a4a1610d2801bebd47a27e231fa7f4e1ec17fdfda144fdd986f5` from `agents/qa/test/regression-suite/evals/workspace/eval-2-blocked-without-original-bug-context`.
 - Identity schema: `2`
-- target_skill_sha256: `5f00953469c57cd0a924598017d2502b6a836948c3bfa067998cf3e91f7335a1`
+- target_skill_sha256: `0d39fb3d56a0db02711ebbb062de0261e33393ff0e6f5f258b11c870a160c7e5`
 - eval_definition_sha256: `bde407cd9167fc95a8a68436fa7745a88790341ccffae265b6e1321da5b3938f`
 - metadata_sha256: `e69dc8ec803ebfc43eb2e4147f1b861f4b02e94afa256d86c039101ea44fff1b`
 - fixture_sha256: `811b93327e61a4a1610d2801bebd47a27e231fa7f4e1ec17fdfda144fdd986f5`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `2f3ed1bac6bd41e43ecbd585f5beb95db8464a7cf767e9c9a3ef20fae4f56429`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `261f550b35c9a4d84c8303c0abe4a7adbe04fbf62131aadd694155952d4db10d`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `07500a40de121399595841537e6aef1df4c976254ab123954a243d97bad454fb`
+- Skill overlay SHA-256: `33d70406ae3e91e1a71751cc4087074b666d7c138769b3f1c7b475a5d350ce65`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,28 +33,28 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `assertion_1` | PASS | with_skill 明确指出缺少原始缺陷记录、失败证据、修复上下文、测试环境等，并未执行泛化回归。 |
-| `blocked` | PASS | with_skill 将原始失败复测和修复行为标为 blocked，将相邻回归标为 not executed，将平台版本标为 blocked；同时说明 PRD/TRD 等对齐材料缺失，需补齐后才能回归。 |
-| `assertion_3` | PASS | 输出包含原始失败复测、修复行为验证、相邻回归、发布建议和证据可信度五项结果。 |
-| `assertion_4` | PASS | 发布建议明确为 needs more verification，未建议 release ready。 |
-| `no_unknown_or_unscoped_release` | PASS | 未产生未知目录或发布文件；明确列出恢复验证所需的版本、环境、原始 bug、修复证据及相关测试材料。 |
+| `assertion_1` | PASS | With-skill output explicitly identifies missing defect/failure/fix/environment evidence and refuses generic regression execution. |
+| `blocked` | PASS | With-skill output marks original failure, fixed behavior, adjacent checks, platform version, and PRD/TRD alignment as blocked or not executed; none are passed. |
+| `assertion_3` | PASS | Output includes all required fields: original failure recheck, fixed behavior, adjacent regression checks, release recommendation, and evidence confidence. |
+| `assertion_4` | PASS | Release recommendation is explicitly `needs more verification`. |
+| `no_unknown_or_unscoped_release` | PASS | Output lists required missing evidence and does not claim unknown-scope or release-wide E2E readiness. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=261f550b35c9a4d84c8303c0abe4a7adbe04fbf62131aadd694155952d4db10d; fixture_sha256=811b93327e61a4a1610d2801bebd47a27e231fa7f4e1ec17fdfda144fdd986f5; output_sha256=7b51cdb46b65326af64abbb301f86f4f073559080e76c877c42ebf070a0371a6; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 完整识别证据缺口并阻止无依据的回归或发布结论。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=261f550b35c9a4d84c8303c0abe4a7adbe04fbf62131aadd694155952d4db10d; fixture_sha256=811b93327e61a4a1610d2801bebd47a27e231fa7f4e1ec17fdfda144fdd986f5; output_sha256=2847ed14fbf2267ebdbe0045fe023fddce4bda2f90b890148d162b6a108cc3f8; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly blocked regression judgment and provided the required evidence gaps and release boundary.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=261f550b35c9a4d84c8303c0abe4a7adbe04fbf62131aadd694155952d4db10d; fixture_sha256=811b93327e61a4a1610d2801bebd47a27e231fa7f4e1ec17fdfda144fdd986f5; output_sha256=bff4262c8f6e9502fa15be7e772e97b29ba3f4d1b919769771dc307852c1f019; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: 同样识别主要证据缺口并建议阻塞发布，但未提供同等细致的状态拆分和 PRD/TRD 对齐缺口。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=261f550b35c9a4d84c8303c0abe4a7adbe04fbf62131aadd694155952d4db10d; fixture_sha256=811b93327e61a4a1610d2801bebd47a27e231fa7f4e1ec17fdfda144fdd986f5; output_sha256=2c6abcaf7c2f8e8da9336a438e1984562a02f860124903e8814fb3a0520dc73d; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Also blocked appropriately, but used as comparison context only.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: 补充原始 bug、失败证据、修复提交或构建、测试环境与平台版本、验证命令及 PRD/TRD 对齐材料。
+- Next: None.
 
 ## Runtime Artifact Policy
 

--- a/agents/qa/test/regression-suite/evals/workspace/eval-3-mapped-doc-regression/comparison.md
+++ b/agents/qa/test/regression-suite/evals/workspace/eval-3-mapped-doc-regression/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `b09fa431bfb2ae442891b6d53441773dfe7d31b84ffb9e7738912c1ba9a50a94` from `agents/qa/test/regression-suite/evals/workspace/eval-3-mapped-doc-regression`.
 - Identity schema: `2`
-- target_skill_sha256: `5f00953469c57cd0a924598017d2502b6a836948c3bfa067998cf3e91f7335a1`
+- target_skill_sha256: `0d39fb3d56a0db02711ebbb062de0261e33393ff0e6f5f258b11c870a160c7e5`
 - eval_definition_sha256: `e133160262ed184852d28136da76d373bddc3830b084351e43f62baba3d14a43`
 - metadata_sha256: `8f1420b83ef9d543d57a760ebba7fc169b9c3d2172e7b3b1e191d47cfe76b856`
 - fixture_sha256: `b09fa431bfb2ae442891b6d53441773dfe7d31b84ffb9e7738912c1ba9a50a94`
@@ -22,37 +22,37 @@
 - judge_schema_sha256: `6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `ffcf3a2d7addddf903f6f7ab8491b7d6388aab8f8d43086a53d98c797d44a47b`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `07500a40de121399595841537e6aef1df4c976254ab123954a243d97bad454fb`
-- Behavior result: **PASS**
+- Skill overlay SHA-256: `33d70406ae3e91e1a71751cc4087074b666d7c138769b3f1c7b475a5d350ce65`
+- Behavior result: **FAIL**
 - Coverage result: **FULL**
-Overall result: PASS
+Overall result: FAIL
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `reads_mapped_docs_first` | PASS | Trace reads the change map, then the mapped API document, before verifying the code; no other site-document contents are read. |
-| `verifies_against_code` | PASS | The delivered conclusion records code threshold 3, documentation threshold 2, the discrepancy, and the direct regression paths without treating 2 as confirmed. |
-| `treats_unverified_as_low_trust` | PASS | The conclusion identifies both documents as unverified, verifies the code, reports missing test/runtime evidence, and marks verification blocked with low confidence rather than release-ready. |
+| `reads_mapped_docs_first` | FAIL | with_skill 的原始 trace 显示先读取 regression-suite/SKILL.md 和契约，随后在同一命令中先读取 src/search/query.rules，再读取 docs/site/api/search-query.md；不能证明 required doc 在代码之前读取。 |
+| `verifies_against_code` | PASS | with_skill 明确核对 src/search/query.rules 为 minimum_query_length = 3、文档写为至少 2 个字符，并列出长度边界、规则加载和文档同步等直接影响路径。 |
+| `treats_unverified_as_low_trust` | PASS | with_skill 明确识别 last_verified_version: unverified，降低文档信任，回到代码/测试入口核证，并将验证和 release recommendation 标为 blocked/needs more verification，而非 pass 或 release-ready。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=ffcf3a2d7addddf903f6f7ab8491b7d6388aab8f8d43086a53d98c797d44a47b; fixture_sha256=b09fa431bfb2ae442891b6d53441773dfe7d31b84ffb9e7738912c1ba9a50a94; output_sha256=30af815715e3117f634657dd1908d768699949ad3c2a6b7ff20c2bb872cf073d; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly follows the mapped-document lookup, verifies the threshold against code, preserves the documentation/code conflict, and keeps the regression conclusion blocked pending missing evidence.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=ffcf3a2d7addddf903f6f7ab8491b7d6388aab8f8d43086a53d98c797d44a47b; fixture_sha256=b09fa431bfb2ae442891b6d53441773dfe7d31b84ffb9e7738912c1ba9a50a94; output_sha256=920e943113098f6caed142619ac0a3eb6a140d6328fda6a400292c96ed9a7ed3; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 识别了阈值差异、低信任文档和直接回归路径，但原始 trace 显示 required API 文档读取顺序晚于代码读取。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=ffcf3a2d7addddf903f6f7ab8491b7d6388aab8f8d43086a53d98c797d44a47b; fixture_sha256=b09fa431bfb2ae442891b6d53441773dfe7d31b84ffb9e7738912c1ba9a50a94; output_sha256=b64485c037930cb6e771a4c3c690420677c270ae3d85bb498be3bd788bc4c289; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Finds the relevant files and code discrepancy but incorrectly treats the documentation value 2 as the repair target and does not apply the low-trust handling consistently.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=ffcf3a2d7addddf903f6f7ab8491b7d6388aab8f8d43086a53d98c797d44a47b; fixture_sha256=b09fa431bfb2ae442891b6d53441773dfe7d31b84ffb9e7738912c1ba9a50a94; output_sha256=85fe0a57e253e243c5db38853d09cb68097763a73f13fe0b33e0691cda42de99; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: 正确识别阈值差异并给出边界回归范围，但未独立证明低信任文档处理过程。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- None.
-- Next: None.
+- with_skill 未满足要求的映射文档优先读取顺序。
+- Next: 按 change-map 命中后先读取 docs/site/api/search-query.md，再回到 src/search/query.rules 核证代码事实。
 
 ## Runtime Artifact Policy
 

--- a/agents/qa/test/spec-based-tester/evals/workspace/eval-1-test-from-spec/comparison.md
+++ b/agents/qa/test/spec-based-tester/evals/workspace/eval-1-test-from-spec/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `a434f6abe187edb75db35d4f3fb8bb622d73bfabcbaa68935c4416b36759d838` from `agents/qa/test/spec-based-tester/evals/workspace/eval-1-test-from-spec`.
 - Identity schema: `2`
-- target_skill_sha256: `14753ae64e96384b284b9c0b0f3a08e0639fc554929720623cd02fae3a9c29a0`
+- target_skill_sha256: `a902e30cb15a83b00f6e242ec0746a619c9c75741852be4c26efbe1dc710f3e3`
 - eval_definition_sha256: `1c095f56ebf8188b170d450f4a4c64b7797467faefd997d04a5961dc178ee24e`
 - metadata_sha256: `beabc33b6b3cb3b4fcbdd2cd76be881ee37dbed2c10afbbb6515f52def856618`
 - fixture_sha256: `a434f6abe187edb75db35d4f3fb8bb622d73bfabcbaa68935c4416b36759d838`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `af6defb3674eb2b870c7db7cceb8e07b1bc81b7056b91617749018c2cf4bddc5`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `9354357763da0add30a1325fbbb8939ec16a97d466c020a03be8548593c2f944`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `6cb100241ab8151af36dbd15ed1bd54941ad005e84cbff29ba2242c5550d11ef`
+- Skill overlay SHA-256: `2ae6df1e5892f15e69faa5eb27f67247be532cf172f30b6323b139a66d25acc0`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,31 +33,32 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `assertion_1` | PASS | Raw trace shows the test spec, same-path PRD/TRD/implementation plan, QA documents, and package.json were read before execution; the report records scope, environment, platform, unknowns, and blocked checks. |
-| `assertion_2` | PASS | The trace enumerates the function-tree QA directory and reads TEST_SUITE.md, FLOW_INDEX.md, and the existing TC; the report records absent scripts/history and explicitly reuses TC-001 without broad project rediscovery. |
-| `assertion_3` | PASS | The documented repo harness `npm test -- checkout-discount` was selected and attempted; browser or Playwright fallback was not used because the harness was preferred and no usable application URL or alternate script existed. |
-| `assertion_4` | PASS | The per-TC requirement matrix marks all three checks `blocked` due to `vitest: command not found`, with no blocked check misclassified as a product failure. |
-| `assertion_5` | PASS | The delivered result and summary files contain a requirement matrix with status and notes, execution path, evidence references, blocked items, risk notes, and handoff decision. |
-| `e2e` | PASS | The existing TC-001 is a separate Markdown case file and is referenced by the delivered result and summary; no new TC was created requiring an additional case/script pair. |
-| `versioned_report_archive` | PASS | The delivered artifacts confirm `feature-update` and `v0.3.0-dev` before execution, and include the required per-TC result.md, testcase.snapshot.md, and feature-update _reports summary paths. |
-| `assertion_7` | PASS | The report records no confirmed failures and explicitly declines bug-analyzer handoff because the only observed issue is the reproducible environment prerequisite blocker. |
+| `assertion_1` | PASS | Trace shows the with_skill lane read the test spec, same-path PRD/TRD/implementation plan, QA docs, package metadata, and ran the repository command; the delivered report records scope, environment, unknowns, and blockers. |
+| `assertion_2` | PASS | Trace and report show TEST_SUITE.md, FLOW_INDEX.md, TC-001, scripts absence, prior results absence, and prior reports absence were checked; the existing TC was reused. |
+| `assertion_3` | PASS | The documented repo harness was selected and executed first; the report correctly records browser execution as unavailable because no QA URL or browser script exists. |
+| `assertion_4` | PASS | Both locked result.md and the summary report contain requirement matrices with each requirement classified as blocked, with no blocked check misreported as a product failure. |
+| `assertion_5` | PASS | Locked reports contain preflight, execution path, requirement matrix, per-item status/evidence/notes, risks, blocked items, and handoff decision sections. |
+| `e2e` | PASS | The existing TC is a standalone Markdown file and is referenced by the locked reports; no new or modified E2E TC was delivered, so no new case/script requirement was triggered. |
+| `versioned_report_archive` | PASS | Locked artifacts use feature-update and platform version v0.3.0-dev, archive the per-TC result and testcase snapshot under the required versioned results path, and write the summary under the corresponding versioned _reports path. |
+| `assertion_7` | PASS | The locked reports explicitly state no bug-analyzer handoff because the harness failed before test execution and no reproducible product failure exists. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9354357763da0add30a1325fbbb8939ec16a97d466c020a03be8548593c2f944; fixture_sha256=a434f6abe187edb75db35d4f3fb8bb622d73bfabcbaa68935c4416b36759d838; output_sha256=ce7daaea461d66e74a830265d9b8c6670378d6f10cb09b7f3b5f9a9a7ca4f12c; snapshot_sha256=b433ef311d74d08b52225a6f2c3fa4e4cab9dc16c2be599e762bfd164e3eba23
-- Behavior: Selected the narrow documented harness, accurately classified all checks as blocked, and produced complete versioned QA artifacts without an unsupported bug handoff.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9354357763da0add30a1325fbbb8939ec16a97d466c020a03be8548593c2f944; fixture_sha256=a434f6abe187edb75db35d4f3fb8bb622d73bfabcbaa68935c4416b36759d838; output_sha256=cea3cf09e020af314f3ada5e615d914716c1f7279b0f0b1b64d1e420b657b381; snapshot_sha256=f56a4d75c0815cc2073f8943eca9ea998e5cc8a7e3393414a1febd6ace0bc8b2
+- Behavior: Correctly selected the narrow repo harness, classified all three behavior checks as blocked, and produced versioned per-TC plus summary reports with structured evidence and no improper handoff.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9354357763da0add30a1325fbbb8939ec16a97d466c020a03be8548593c2f944; fixture_sha256=a434f6abe187edb75db35d4f3fb8bb622d73bfabcbaa68935c4416b36759d838; output_sha256=c25ef40534ac53d30e518a1cedcfaf6b2bda99285fd992296611ca8f299748ff; snapshot_sha256=f1b5d1a79edb30d29f87977d7c5c2315f53ccc44ca99538a835ed1416dd6ea6c
-- Behavior: Fresh baseline also encountered the missing vitest dependency and produced a simpler root-level report, without the with_skill lane's per-TC result, snapshot, and structured QA report coverage.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=9354357763da0add30a1325fbbb8939ec16a97d466c020a03be8548593c2f944; fixture_sha256=a434f6abe187edb75db35d4f3fb8bb622d73bfabcbaa68935c4416b36759d838; output_sha256=4081aa3861efd6d3da05eb1163e15b8f7e01f31e8f1dcab1ebe71b4ae3dba116; snapshot_sha256=16fe7dc79baaf118955a967ea85d0f973f4bd6823f54b8412f6f83825623b826
+- Behavior: Also detected the missing Vitest dependency and reported the behavior checks as unverified, but produced only a less complete top-level report without the durable per-TC result/archive structure.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Restore the repository test dependency or provide the configured QA harness, then rerun TC-001 on v0.3.0-dev.
+- Next: Restore the repository test dependencies and rerun npm test -- checkout-discount.
+- Next: If needed, provide the configured QA URL and execute the documented browser path.
 
 ## Runtime Artifact Policy
 

--- a/agents/qa/test/spec-based-tester/evals/workspace/eval-2-boundary-test-generation/comparison.md
+++ b/agents/qa/test/spec-based-tester/evals/workspace/eval-2-boundary-test-generation/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `b4127bff8b3b1c32e35f1a58623703ca5f4eb13030dd5763812f9d858500fda1` from `agents/qa/test/spec-based-tester/evals/workspace/eval-2-boundary-test-generation`.
 - Identity schema: `2`
-- target_skill_sha256: `14753ae64e96384b284b9c0b0f3a08e0639fc554929720623cd02fae3a9c29a0`
+- target_skill_sha256: `a902e30cb15a83b00f6e242ec0746a619c9c75741852be4c26efbe1dc710f3e3`
 - eval_definition_sha256: `7be9a5847eaa9053c9f4277b2d57d5f5622208652decda6e30f3718fbfec04c5`
 - metadata_sha256: `9bd3793631be46705766421244d6899c275c646d5598b1a7e8c43c8bec82ad4f`
 - fixture_sha256: `b4127bff8b3b1c32e35f1a58623703ca5f4eb13030dd5763812f9d858500fda1`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `6d4a307e5ec256ec68d2524f856808da877ec9503f513dcb2032388906c98b67`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `fca68fb7467bf000e3c38b2b867a8aeab7cf98cabe927e8e96f334144b3ecb51`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `6cb100241ab8151af36dbd15ed1bd54941ad005e84cbff29ba2242c5550d11ef`
+- Skill overlay SHA-256: `2ae6df1e5892f15e69faa5eb27f67247be532cf172f30b6323b139a66d25acc0`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,31 +33,31 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `assertion_1` | PASS | The locked result records scope, feature path, environment assumptions, missing URL/source dependencies, and blocked conditions before the execution path. |
-| `assertion_2` | PASS | Runner trace shows QA memory and required QA documents were read before project-file exploration; the delivery report records prior results and reports as absent before the run. |
-| `assertion_3` | NOT_EXERCISED | The documented targeted harness was selected and attempted, but it stopped before test discovery because vitest was unavailable; no boundary case reached runtime execution. |
-| `assertion_4` | PASS | The locked result and summary report mark all five checks blocked and provide execution-log, result, snapshot, and report references. |
-| `assertion_5` | PASS | The locked result contains requirement matrix, execution path, evidence references, risks, and handoff decision sections. |
-| `assertion_6` | PASS | The report identifies uncovered runtime validation, records risks and recovery steps, and explicitly withholds bug-analyzer handoff absent a reproducible product failure. |
-| `alignment_plan_gate` | PASS | The locked preflight and result confirm same-path Confirmed PRD, TRD, and IMPLEMENTATION_PLAN.md alignment before execution. |
+| `assertion_1` | PASS | The locked result report records scope, confirmed assumptions, unknowns/blockers, and the same-path PRD/TRD/implementation-plan gate before the execution path. |
+| `assertion_2` | PASS | The locked report states TEST_SUITE.md, FLOW_INDEX.md, the reusable case, script, prior results, and prior reports were read or recorded absent before execution. |
+| `assertion_3` | NOT_EXERCISED | The prescribed harness was attempted, but vitest was unavailable before test collection; no boundary behavior was exercised, so this assertion is not exercised rather than failed. |
+| `assertion_4` | PASS | The locked result contains a per-check status table with blocked statuses and traceable evidence links/references. |
+| `assertion_5` | PASS | The locked report contains requirement matrix, execution path, evidence references, risk discussion, and handoff decision sections. |
+| `assertion_6` | PASS | The locked report records uncovered checks and risks, and explicitly declines bug-analyzer handoff because no reproducible product failure was observed. |
+| `alignment_plan_gate` | PASS | The locked report confirms same-path PRD, TRD, and IMPLEMENTATION_PLAN.md documents, all marked Confirmed, before scoped verification. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=fca68fb7467bf000e3c38b2b867a8aeab7cf98cabe927e8e96f334144b3ecb51; fixture_sha256=b4127bff8b3b1c32e35f1a58623703ca5f4eb13030dd5763812f9d858500fda1; output_sha256=bf815816179325c6ef689bcc693717ce2f81bfc570fd8f548ce54b09380a0f2b; snapshot_sha256=5949f169e36a828541649fe6cbeac0785856b8b7aa0bc037f53855b38eed1be1
-- Behavior: Performed the documented QA preflight and evidence-first workflow, attempted the prescribed harness, correctly recorded all five boundary checks as blocked, and created durable result, snapshot, execution-log, and summary-report evidence.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=fca68fb7467bf000e3c38b2b867a8aeab7cf98cabe927e8e96f334144b3ecb51; fixture_sha256=b4127bff8b3b1c32e35f1a58623703ca5f4eb13030dd5763812f9d858500fda1; output_sha256=49277b4c591e9d3ea737312642d6f0973fc3ac55a1a85841896f9c36c8152335; snapshot_sha256=64598178ffec03b4b9f11063ecb0fdf0f961a471d62070194d71c4db5bf50f3f
+- Behavior: The candidate followed the documented QA workflow, preserved structured evidence, accurately reported all five boundary checks as blocked, and avoided an unsupported bug handoff.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=fca68fb7467bf000e3c38b2b867a8aeab7cf98cabe927e8e96f334144b3ecb51; fixture_sha256=b4127bff8b3b1c32e35f1a58623703ca5f4eb13030dd5763812f9d858500fda1; output_sha256=9455159127708c82b5d7924c3314240f4b989b467e12d13e18ae402217ea65c3; snapshot_sha256=d308b9e4288d1e69c07c1d55ce045673ed3147a6f405baf32b56d99d313165f4
-- Behavior: Fresh baseline attempted the harness and recorded a basic blocked result, but omitted the structured preflight, requirement matrix, execution path, risk, and handoff reporting present in the with_skill lane.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=fca68fb7467bf000e3c38b2b867a8aeab7cf98cabe927e8e96f334144b3ecb51; fixture_sha256=b4127bff8b3b1c32e35f1a58623703ca5f4eb13030dd5763812f9d858500fda1; output_sha256=3fbb849694c429be6068c5454e87c0f6d782383cd6f6708628c27eb4d935233a; snapshot_sha256=340fa04bde5dc760886f8ad0212f9a503aa0e1d6dd35d4f3bb1a24bebf964dd0
+- Behavior: The fresh baseline also attempted the harness and recorded blocked results, but produced a thinner report without the full preflight, validation frame, structured matrix, and handoff documentation present in the with_skill lane.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Restore/install repository test dependencies and rerun npm test -- login-boundaries.
-- Next: If visible requirements remain uncovered, provide a configured QA application URL and browser access for fallback checks.
+- Next: Restore test dependencies and rerun npm test -- login-boundaries.
+- Next: If needed, provide the configured QA application URL and approved QA account reference for the documented browser fallback.
 
 ## Runtime Artifact Policy
 

--- a/agents/qa/test/spec-based-tester/evals/workspace/eval-3-mapped-doc-acceptance/comparison.md
+++ b/agents/qa/test/spec-based-tester/evals/workspace/eval-3-mapped-doc-acceptance/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `bfb7b9881699180197883abe46418a65cf0676dceb7443a1b2ac7db5c3b8ae9b` from `agents/qa/test/spec-based-tester/evals/workspace/eval-3-mapped-doc-acceptance`.
 - Identity schema: `2`
-- target_skill_sha256: `14753ae64e96384b284b9c0b0f3a08e0639fc554929720623cd02fae3a9c29a0`
+- target_skill_sha256: `a902e30cb15a83b00f6e242ec0746a619c9c75741852be4c26efbe1dc710f3e3`
 - eval_definition_sha256: `69ea284c249fd48ea67518dcbbbb4aff0b51c724f5aa24139bc9524759db6c7c`
 - metadata_sha256: `dbcf12ca577304c6eedeb3847e29d69b72d051700655cd6bd5000bc1d6f7a9d9`
 - fixture_sha256: `bfb7b9881699180197883abe46418a65cf0676dceb7443a1b2ac7db5c3b8ae9b`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `6eadf49a93ad15b65779f0737c549d6122220ac6abe8a01622417bb0da199cda`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `b0800640829a83735e541e027ba4771a2f52dd5cf39982ebc89e3721cf0f1d96`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `6cb100241ab8151af36dbd15ed1bd54941ad005e84cbff29ba2242c5550d11ef`
+- Skill overlay SHA-256: `2ae6df1e5892f15e69faa5eb27f67247be532cf172f30b6323b139a66d25acc0`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,26 +33,26 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `reads_mapped_docs_first` | PASS | Trace item_5 reads change-map.yaml, then its mapped profile-validation.md, then validation.rules; no unrelated document contents were traversed. |
-| `verifies_against_code` | PASS | The output identifies the code limit as 64, the formal document's 80-character claim, both paths, the 16-character discrepancy, and its impact. |
-| `treats_unverified_as_low_trust` | PASS | The output and trace explicitly identify last_verified_version: unverified and treat the documentation as blocked/low-trust while grounding the observed limit in code. |
+| `reads_mapped_docs_first` | PASS | Trace shows the change map was read before the mapped formal document, followed by direct code inspection; the delivered record names both paths. |
+| `verifies_against_code` | PASS | The locked delivery snapshot records the 80-character documentation statement, the 64-character code value, both paths, and the 65–80-character acceptance impact. |
+| `treats_unverified_as_low_trust` | PASS | The snapshot explicitly identifies last_verified_version: unverified and treats the document as navigation-level evidence while grounding conclusions in code/static validation. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=b0800640829a83735e541e027ba4771a2f52dd5cf39982ebc89e3721cf0f1d96; fixture_sha256=bfb7b9881699180197883abe46418a65cf0676dceb7443a1b2ac7db5c3b8ae9b; output_sha256=e4551fe568927c40525f54b92b5500b0f10fa70ebdc4d58ec56cb9b8580ddc19; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly follows the mapped-document-to-code evidence path, identifies 64 versus 80, and treats unverified documentation as low trust.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=b0800640829a83735e541e027ba4771a2f52dd5cf39982ebc89e3721cf0f1d96; fixture_sha256=bfb7b9881699180197883abe46418a65cf0676dceb7443a1b2ac7db5c3b8ae9b; output_sha256=0a6429b83919950761268bcbe0afd44d83e1490cfc4cf82ba6b59d69c4666467; snapshot_sha256=ca5498bb08d400586fc5cb5579a7d73f8bda2776532789b143a8b4a80bb2f324
+- Behavior: Used the change map to locate the formal document, verified its 80-character claim against the 64-character rule, treated unverified documentation as low trust, and delivered a traceable validation matrix.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=b0800640829a83735e541e027ba4771a2f52dd5cf39982ebc89e3721cf0f1d96; fixture_sha256=bfb7b9881699180197883abe46418a65cf0676dceb7443a1b2ac7db5c3b8ae9b; output_sha256=ba3e58216a49185ee78e7d242ff7b4441d518f42340a6db6e0a1f7796d2625e3; snapshot_sha256=5355930be7ce26894a4b39c5dee7d926e46b1264c9ad005d8928dfba71818f45
-- Behavior: Fresh baseline modified formal documentation and change-map metadata, created a requirements matrix, and claimed completion.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=b0800640829a83735e541e027ba4771a2f52dd5cf39982ebc89e3721cf0f1d96; fixture_sha256=bfb7b9881699180197883abe46418a65cf0676dceb7443a1b2ac7db5c3b8ae9b; output_sha256=5ba98bb3891bc756c31a00b4d4ea8f0217ef6e5c98e2d5f09ecc821c451a7a52; snapshot_sha256=2d1ba59cac3478adf48e7942e7a7225f68ddb06b2e9664ae4a4902a1b111ebfa
+- Behavior: Also identified the 64-versus-80 mismatch and delivered a simpler requirements matrix, but provided less explicit low-trust treatment and validation-process detail.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Confirm the product standard and provide the required PM/QA acceptance basis before formal pass/fail testing.
+- Next: None.
 
 ## Runtime Artifact Policy
 

--- a/agents/security/skills/appsec-checklist/SKILL.md
+++ b/agents/security/skills/appsec-checklist/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: appsec-checklist
-description: "Review application code for injection, XSS, auth bypass, secret, upload, and related AppSec risks and produce the protocol-shaped security report. Use after security-agent routes an AppSec scope."
+description: "Review application code for injection, XSS, auth bypass, secret exposure, unsafe uploads, and related AppSec risks. Use after security-agent routes an AppSec review."
 visibility: internal
 ---
 

--- a/agents/security/skills/authz-reviewer/SKILL.md
+++ b/agents/security/skills/authz-reviewer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: authz-reviewer
-description: "Review authentication, authorization, RBAC, sessions, JWTs, permission models, and access-control implementation against confirmed security scope. Use after security-agent routes auth/authz review."
+description: "Review authentication, authorization, RBAC, sessions, tokens, permission models, and access controls against confirmed scope. Use after security-agent routes auth/authz review."
 visibility: internal
 ---
 

--- a/agents/security/skills/dependency-risk-auditor/SKILL.md
+++ b/agents/security/skills/dependency-risk-auditor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dependency-risk-auditor
-description: "Audit npm, Python, or other dependencies for vulnerabilities, abandonment, licensing, provenance, and supply-chain risk with evidence-backed remediation. Use after security-agent routes dependency review."
+description: "Audit dependencies for vulnerabilities, abandonment, licensing, provenance, and supply-chain risk with evidence-backed remediation. Use after security-agent routes dependency review."
 visibility: internal
 ---
 

--- a/agents/security/skills/privacy-surface-mapper/SKILL.md
+++ b/agents/security/skills/privacy-surface-mapper/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: privacy-surface-mapper
-description: "Map personal-data collection, purpose, retention, third parties, user rights, GDPR/CCPA obligations, and data-flow exposure from confirmed scope. Use after security-agent routes privacy review."
+description: "Map personal-data flows, purposes, retention, third parties, user rights, and regulatory obligations from confirmed scope. Use after security-agent routes privacy review."
 visibility: internal
 ---
 

--- a/agents/security/skills/security-agent/SKILL.md
+++ b/agents/security/skills/security-agent/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: security-agent
-description: "Classify and route confirmed security requests across AppSec, auth/authz, dependency risk, privacy, and data-flow review, preserving remediation and PM-escalation context. Use immediately after a PM security handoff."
+description: "Route confirmed AppSec, auth/authz, dependency-risk, privacy, and data-flow work while preserving remediation and PM-escalation context. Use after a PM security handoff."
 visibility: internal
 ---
 

--- a/agents/security/test/appsec-checklist/evals/workspace/eval-001-sql-injection/comparison.md
+++ b/agents/security/test/appsec-checklist/evals/workspace/eval-001-sql-injection/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `ede96965e7d44efbe6d4a7e610af20046168e4331047764663820caf76860ea6` from `agents/security/test/appsec-checklist/evals/workspace/eval-001-sql-injection`.
 - Identity schema: `2`
-- target_skill_sha256: `9ac7059a9a39550256d4de1ed82086d7f6b3c81bd069d831f0bf87ce02417c58`
+- target_skill_sha256: `412a68c0dfdb2d720e3447fdc4faf74b408d3de29706093a3a69fb0ca69d983c`
 - eval_definition_sha256: `8fc30622b3de679ebf38da0b0fc7b8032d774fb8a425496383ba9ed0da1fdbb0`
 - metadata_sha256: `c35665f3cf1a3d670f1f84679f59821ede559ff2507cf10a314ee5a06060b2f7`
 - fixture_sha256: `ede96965e7d44efbe6d4a7e610af20046168e4331047764663820caf76860ea6`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `01ca86a4951823e3b6c703072ce5be09764c747ae9938b66975b80e4d41e39dd`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `bb6bd5dae7cb984c9a3912af15f420906d99ddbd232c9c6777c774fceb165a28`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `d316d6849a82751d5c66c424af9993a42c304fe892fdb2411469b461bec624ee`
+- Skill overlay SHA-256: `035cdf3596c1888564523ed3d4e73116a3d2b231b30d91c462fb62cf6da52e05`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,22 +33,22 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `security_findings` | PASS | 报告明确识别 SQL 注入：`req.query.name` 被直接插入 SQL 模板字符串并执行，且讨论了通配符和资源消耗风险。 |
-| `evidence_and_impact` | PASS | 报告引用 `src/api/user-search.js:2-4`，说明了请求参数到数据库查询的路径，并描述了已认证用户目录越权读取、错误和潜在资源影响。 |
-| `severity_rationale` | PASS | 报告将 SQL 注入分为 Critical，并以攻击前置条件低、可扩大数据读取及潜在完整性/可用性影响作为依据，同时区分了未经驱动证据确认的多语句风险。 |
-| `remediation` | PASS | 报告提供参数化查询示例、输入校验、LIKE 转义、最小权限、错误处理以及恶意输入回归验证步骤。 |
-| `writes_protocol_shaped_security_report` | PASS | 锁定交付文件包含要求的 frontmatter 字段、Executive Summary（问题总数、风险等级分布、总体态势）及逐问题的位置、风险解释和修复建议；git 证据显示仅新增安全报告文件。 |
+| `security_findings` | PASS | with_skill 报告识别了 `src/api/user-search.js:2-4` 中将 `req.query.name` 拼接进 SQL 的 SQL 注入风险，并指出通配符和输入规模导致的资源消耗风险。 |
+| `evidence_and_impact` | PASS | 报告直接引用了参数读取、SQL 拼接和 `db.query` 调用位置，说明了认证用户可造成越权读取、查询语义改变、数据库完整性风险及可用性影响。 |
+| `severity_rationale` | PASS | 报告按 Critical/Medium 分级，并分别依据可控 SQL 语法、数据机密性/完整性影响和资源消耗风险说明判断依据。 |
+| `remediation` | PASS | 报告提供了参数化查询、类型与长度校验、LIKE 转义、结果限制、超时、限流、最小权限和恶意输入回归测试等可执行建议。 |
+| `writes_protocol_shaped_security_report` | PASS | delivery_snapshot 中的 `docs/security/user-search/appsec-checklist.md` 含完整 frontmatter（feature、feature_path、version、date 等）、Executive Summary、风险分布和逐问题的 file:line、风险影响与修复建议；git_status 显示仅新增安全报告。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=bb6bd5dae7cb984c9a3912af15f420906d99ddbd232c9c6777c774fceb165a28; fixture_sha256=ede96965e7d44efbe6d4a7e610af20046168e4331047764663820caf76860ea6; output_sha256=ef5563cc9c9fdd4890a9b0b69f0082616c3f58d58027433658a3eaca6f4fe186; snapshot_sha256=4208dfaec394bdc4dc3b40e73a2473a205c767ff24aeae4349ccb5fb9182d500
-- Behavior: 完成安全审查并落盘协议化报告，涵盖 SQL 注入证据、影响、Critical 分级、修复与验证建议。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=bb6bd5dae7cb984c9a3912af15f420906d99ddbd232c9c6777c774fceb165a28; fixture_sha256=ede96965e7d44efbe6d4a7e610af20046168e4331047764663820caf76860ea6; output_sha256=72070e380ec2c9cf67a8eee589ec38cd18872b139d806d311e2bb0ff99adaac7; snapshot_sha256=3e779f8a22bf3a50d2445ef464cba41925570894873b7d6ca6991b5221bf22fc
+- Behavior: 完成安全审查并落盘协议化安全报告，识别 SQL 注入及查询资源消耗风险，提供证据、分级和修复建议。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=bb6bd5dae7cb984c9a3912af15f420906d99ddbd232c9c6777c774fceb165a28; fixture_sha256=ede96965e7d44efbe6d4a7e610af20046168e4331047764663820caf76860ea6; output_sha256=65b48903c59bcd939f7f96523092476721d7dc411ab237753ab5b117dace673e; snapshot_sha256=e9387ebf4ab0b5b9ea3ef3e41ea24486ca5f5d60872023ac09da3484a7f7ca22
-- Behavior: 识别了 SQL 注入及通配符/资源风险并声称生成报告，但其锁定报告缺少协议要求的 frontmatter 和 Executive Summary 结构。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=bb6bd5dae7cb984c9a3912af15f420906d99ddbd232c9c6777c774fceb165a28; fixture_sha256=ede96965e7d44efbe6d4a7e610af20046168e4331047764663820caf76860ea6; output_sha256=48c526f6bf086850e8fb8180f3317e38539c3ea44b61bbf0daf3d56659742268; snapshot_sha256=d51433a6eeff6c34f27639f8fe083fee68da437c617d13afaf82c0365c2d321a
+- Behavior: 完成了基本安全发现和建议并生成报告，但交付文件缺少协议要求的 frontmatter 和 Executive Summary 结构。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/security/test/appsec-checklist/evals/workspace/eval-002-auth-bypass/comparison.md
+++ b/agents/security/test/appsec-checklist/evals/workspace/eval-002-auth-bypass/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `cc5543f86ff4c8f3552e0e869f4690b7cabc4d7aa6f846231a547e3a3fb6e25c` from `agents/security/test/appsec-checklist/evals/workspace/eval-002-auth-bypass`.
 - Identity schema: `2`
-- target_skill_sha256: `9ac7059a9a39550256d4de1ed82086d7f6b3c81bd069d831f0bf87ce02417c58`
+- target_skill_sha256: `412a68c0dfdb2d720e3447fdc4faf74b408d3de29706093a3a69fb0ca69d983c`
 - eval_definition_sha256: `6a82fe3c3414aca61cd232161a32adb38bf8c698919832011992c1d84f8965f5`
 - metadata_sha256: `cd24e6f3242be56aca57c51c88f32017b1caf4b9307635625892f26c0b426e5d`
 - fixture_sha256: `cc5543f86ff4c8f3552e0e869f4690b7cabc4d7aa6f846231a547e3a3fb6e25c`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `dd30fe689fbcc65952d80f9f7fb0f55e7cc2d55b9002a172d25f15b8b97c4288`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `f088fb8b19565a837c87f47deb48148bf8a1f74fd9bf243974d4975068d68895`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `d316d6849a82751d5c66c424af9993a42c304fe892fdb2411469b461bec624ee`
+- Skill overlay SHA-256: `035cdf3596c1888564523ed3d4e73116a3d2b231b30d91c462fb62cf6da52e05`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,21 +33,21 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `security_findings` | PASS | 报告识别了认证绕过和管理员授权缺失，明确指出匿名及普通用户可进入 /admin/users 的 listUsers。 |
-| `evidence_and_impact` | PASS | 报告引用 src/app.js:18、src/api/admin-routes.js:6、src/api/admin-users.js:6-7，并说明用户账号资料暴露及后续管理操作风险。 |
-| `severity_rationale` | PASS | 报告将问题分为 Critical，并以管理 API 暴露、低攻击前置条件、机密性影响和上线阻断依据进行说明。 |
-| `remediation` | PASS | 报告提供认证→admin 角色校验的挂载方案，并给出 401/403/管理员成功访问、处理器不执行及路由覆盖等验证步骤。 |
+| `security_findings` | PASS | The delivered report identifies the missing authentication and administrator authorization on `/admin/users`, supported by `src/app.js:18`, `src/api/admin-routes.js:6`, and `src/api/admin-users.js:6-7`. |
+| `evidence_and_impact` | PASS | The report explains the route and handler evidence, identifies anonymous and non-admin access to user account data, and describes impact to current and future admin operations. |
+| `severity_rationale` | PASS | The report assigns Critical severity and justifies it as an authentication bypass exposing a protected management surface and account data, while treating the missing role check as part of the same finding. |
+| `remediation` | PASS | The report provides executable router-boundary middleware guidance, 401/403 behavior, centralized `/admin` protection, integration tests for anonymous/non-admin/admin users, and post-fix security review. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f088fb8b19565a837c87f47deb48148bf8a1f74fd9bf243974d4975068d68895; fixture_sha256=cc5543f86ff4c8f3552e0e869f4690b7cabc4d7aa6f846231a547e3a3fb6e25c; output_sha256=a38106f3bf9c2d2f63f3b9422ac687d8722156886701cabc0390ea03ef99a53f; snapshot_sha256=5db86896dc6ff516af78d39ebfe3189068d5cece00853f799f34008bde3d8334
-- Behavior: 完成了符合要求的安全报告，识别认证绕过与垂直越权，提供定位证据、影响、严重度依据和可执行修复验证建议。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f088fb8b19565a837c87f47deb48148bf8a1f74fd9bf243974d4975068d68895; fixture_sha256=cc5543f86ff4c8f3552e0e869f4690b7cabc4d7aa6f846231a547e3a3fb6e25c; output_sha256=5270708cf3af3e9b98dd44ae0dc993a481ee4b0270b1250594c135e47ce1eebe; snapshot_sha256=de27d23a50225547b30629dc7f6d2dbc0a471f5d2ed6c7def5c94e6e10cf0c74
+- Behavior: Produced the required security report, correctly identified the exposed admin route, gave severity reasoning, and supplied concrete remediation and verification steps.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f088fb8b19565a837c87f47deb48148bf8a1f74fd9bf243974d4975068d68895; fixture_sha256=cc5543f86ff4c8f3552e0e869f4690b7cabc4d7aa6f846231a547e3a3fb6e25c; output_sha256=98161e7e8748d14952ca7507967bd8fe5f3b61fd7601f8fca734e0fcf93ed213; snapshot_sha256=7c5bafe89c50dce98f03162349d85377af7605c885f856ef50bb2c801d6d20c8
-- Behavior: Fresh baseline 也识别了核心认证与授权缺陷并交付报告，但分级为高危、报告结构和细节相对简略。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f088fb8b19565a837c87f47deb48148bf8a1f74fd9bf243974d4975068d68895; fixture_sha256=cc5543f86ff4c8f3552e0e869f4690b7cabc4d7aa6f846231a547e3a3fb6e25c; output_sha256=a0ad15d198d840a1befacd200656ae5e98ec6370fac9e8a3d2af45c29ad40de7; snapshot_sha256=7e3fe3c8a76a7c995defd1d0f37a6a01bfdc9db3c6cd05612d4505f441f5de06
+- Behavior: Also identified the core access-control issue and produced a report; it is comparison context only and does not affect with_skill assertion verdicts.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/security/test/appsec-checklist/evals/workspace/eval-003-xss/comparison.md
+++ b/agents/security/test/appsec-checklist/evals/workspace/eval-003-xss/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `746acb9424bcff0e7d1cdbd84db8418dc8fed63831bb1cdba56197295fa9433e` from `agents/security/test/appsec-checklist/evals/workspace/eval-003-xss`.
 - Identity schema: `2`
-- target_skill_sha256: `9ac7059a9a39550256d4de1ed82086d7f6b3c81bd069d831f0bf87ce02417c58`
+- target_skill_sha256: `412a68c0dfdb2d720e3447fdc4faf74b408d3de29706093a3a69fb0ca69d983c`
 - eval_definition_sha256: `6b75287b771a74771292ff6a9a4b1d4288f8c6b58ea121782df92af92abb087a`
 - metadata_sha256: `4abdb4afdb25b3301062311f0106269361c2da7348712e8f551f5749c515259e`
 - fixture_sha256: `746acb9424bcff0e7d1cdbd84db8418dc8fed63831bb1cdba56197295fa9433e`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `dd30fe689fbcc65952d80f9f7fb0f55e7cc2d55b9002a172d25f15b8b97c4288`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `4fbcbae96df725d2ae68317bce92f64188686abcfd62940b28a42e14a09de97f`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `d316d6849a82751d5c66c424af9993a42c304fe892fdb2411469b461bec624ee`
+- Skill overlay SHA-256: `035cdf3596c1888564523ed3d4e73116a3d2b231b30d91c462fb62cf6da52e05`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,21 +33,21 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `security_findings` | PASS | with_skill 识别了 `author` 和 `body` 通过模板字符串写入 `innerHTML` 导致的 DOM XSS，并指出纯文本需求被违反。 |
-| `evidence_and_impact` | PASS | 报告直接定位 `src/ui/comment-display.js:2-5`，描述了 API 评论到 HTML 解析器的路径、受影响字段、攻击者与受害用户及会话影响。 |
-| `severity_rationale` | PASS | 将 DOM XSS 定为 High，并以用户可控输入进入 HTML 解析器、跨用户触发及页面/会话影响作为依据。 |
-| `remediation` | PASS | 交付文件提供了使用固定 DOM 结构与 `textContent` 的修复方案，以及覆盖作者名、正文、恶意载荷、节点结构和脚本执行的验证步骤。 |
+| `security_findings` | PASS | The delivered report identifies stored DOM XSS caused by interpolating author/body into innerHTML, with concrete payload examples and affected user roles. |
+| `evidence_and_impact` | PASS | The report directly cites src/ui/comment-display.js:2-4, explains the API-to-DOM flow, and describes impact to sessions, page integrity, phishing, and data exposure. |
+| `severity_rationale` | PASS | It rates the issue High and justifies that rating using persistent commenter-controlled input, viewer impact, direct HTML parsing, and the product's plain-text requirement. |
+| `remediation` | PASS | It provides an actionable textContent/createElement remediation, forbids unsafe HTML rendering, and specifies browser regression checks for author/body payloads, execution, DOM structure, and text preservation. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4fbcbae96df725d2ae68317bce92f64188686abcfd62940b28a42e14a09de97f; fixture_sha256=746acb9424bcff0e7d1cdbd84db8418dc8fed63831bb1cdba56197295fa9433e; output_sha256=a9e27900ad0fa28c330f510f0df10405ad5c6b64ccbedbadd735fe6aef0b342f; snapshot_sha256=ad36ceca272b5f680b36262dc2eda0ea315d19c086b592e03c3e40a96121fa0a
-- Behavior: 交付了完整的应用安全审查文档和简要结论，涵盖 XSS 风险、证据与影响、严重度依据、修复及验证；未修改应用代码。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4fbcbae96df725d2ae68317bce92f64188686abcfd62940b28a42e14a09de97f; fixture_sha256=746acb9424bcff0e7d1cdbd84db8418dc8fed63831bb1cdba56197295fa9433e; output_sha256=2a1a2cfb20f1753850dca248e18de83ed4d9abb3c9403a0523990f0d85801a60; snapshot_sha256=33f607709e50d4d86d818d4ca5095757f59247de9b17bd956ac148693eddf930
+- Behavior: Produced the required security report artifact and accurately documented the XSS finding, evidence, impact, severity, remediation, and verification boundary without modifying application code.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4fbcbae96df725d2ae68317bce92f64188686abcfd62940b28a42e14a09de97f; fixture_sha256=746acb9424bcff0e7d1cdbd84db8418dc8fed63831bb1cdba56197295fa9433e; output_sha256=743e6893e3dc8eb0a1bd9e47c231d530566eb0c66d40fafba05473102c161ca2; snapshot_sha256=f728eb04a752f2cc523af1b786777f03778d137579fa6120a3940afe0c1b62ea
-- Behavior: 同样识别并记录了 DOM XSS，交付了包含证据、影响、严重度、修复和验证的安全审查文档；作为对比基线，其结果也满足断言。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=4fbcbae96df725d2ae68317bce92f64188686abcfd62940b28a42e14a09de97f; fixture_sha256=746acb9424bcff0e7d1cdbd84db8418dc8fed63831bb1cdba56197295fa9433e; output_sha256=08a8fce0d9403a87110ccc931b8fc428d2b8b000eb7618e3eb060d56d848ed97; snapshot_sha256=29f4de22e5c7e14d6c0a9dae1dcb4884b7727748d720292251e8c9f39990dd1e
+- Behavior: Also identified the core XSS risk and proposed remediation, but provided less detailed locked report content; comparison only.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/security/test/appsec-checklist/evals/workspace/eval-004-feature-path-report/comparison.md
+++ b/agents/security/test/appsec-checklist/evals/workspace/eval-004-feature-path-report/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `258d12e924889cdd6b9d64d5ae077ef75e65139845669b9a81854ba9fc13621c` from `agents/security/test/appsec-checklist/evals/workspace/eval-004-feature-path-report`.
 - Identity schema: `2`
-- target_skill_sha256: `9ac7059a9a39550256d4de1ed82086d7f6b3c81bd069d831f0bf87ce02417c58`
+- target_skill_sha256: `412a68c0dfdb2d720e3447fdc4faf74b408d3de29706093a3a69fb0ca69d983c`
 - eval_definition_sha256: `cea867306caa7c154c38a57a7085c1f3dc292e28eb28f571e99034334c62710c`
 - metadata_sha256: `e6da11bf7f1086569860f05d808183f3f4b67cd66acd3889483549d3d15b0961`
 - fixture_sha256: `258d12e924889cdd6b9d64d5ae077ef75e65139845669b9a81854ba9fc13621c`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `a8797f637904fc863710b298fe2fad8220a05aa0d79e70ed8997096bddf38e6c`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `05538871e356a1820db883bcff8e90f4208bc94ba8410156f5ef306f19d4ce21`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `d316d6849a82751d5c66c424af9993a42c304fe892fdb2411469b461bec624ee`
+- Skill overlay SHA-256: `035cdf3596c1888564523ed3d4e73116a3d2b231b30d91c462fb62cf6da52e05`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,28 +33,28 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `uses_same_path_pm_engineer_docs` | PASS | Runner trace shows the PRD, TRD, and IMPLEMENTATION_PLAN were read from the required feature paths. |
-| `writes_nested_security_report` | PASS | Delivery snapshot contains docs/security/chat-interface/messages/history/search/appsec-checklist.md. |
-| `includes_feature_path_frontmatter` | PASS | Report frontmatter contains feature_path, parent_feature, and feature_level: 4 with the required values. |
-| `does_not_invent_feature_directory` | PASS | The confirmed feature path and all required documents exist; the report uses the corresponding nested security path and does not invent a top-level synonym. |
-| `escalates_fact_changing_conclusion_to_pm` | NOT_EXERCISED | The report hands the conclusion and evidence back to pm-agent for classification and PM-owned issue filing; actual issue creation is not exercised because no issue-tracker runtime or user confirmation is available. |
+| `uses_same_path_pm_engineer_docs` | PASS | With-skill trace shows the PRD, TRD, IMPLEMENTATION_PLAN, and src/search.ts were read from the canonical feature path. |
+| `writes_nested_security_report` | PASS | Locked delivery snapshot contains docs/security/chat-interface/messages/history/search/appsec-checklist.md. |
+| `includes_feature_path_frontmatter` | PASS | The locked report frontmatter contains feature_path, parent_feature, and feature_level with the required values. |
+| `does_not_invent_feature_directory` | PASS | The candidate used the confirmed nested feature path and did not create a synonym or top-level feature directory. |
+| `escalates_fact_changing_conclusion_to_pm` | NOT_EXERCISED | The report and final message return the release-readiness conclusion and evidence to pm-agent for classification and PM-owned issue filing; actual downstream issue creation is not exercised because it requires the PM workflow/user confirmation. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=05538871e356a1820db883bcff8e90f4208bc94ba8410156f5ef306f19d4ce21; fixture_sha256=258d12e924889cdd6b9d64d5ae077ef75e65139845669b9a81854ba9fc13621c; output_sha256=e1658253410424c196f35ac03540105fb0235c001ba10973fe67352507278827; snapshot_sha256=629eb3ebc547827fc393750d57ff01b479ff1274c330d277bed2ac64fae2c6c5
-- Behavior: Read the required feature documents, identified the security risks, and produced the correctly nested Security report with required frontmatter and PM escalation guidance.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=05538871e356a1820db883bcff8e90f4208bc94ba8410156f5ef306f19d4ce21; fixture_sha256=258d12e924889cdd6b9d64d5ae077ef75e65139845669b9a81854ba9fc13621c; output_sha256=dabceb9af941a20b7d01ee1de44c249deb5aada821e412c74c37b480c8f8a939; snapshot_sha256=fcadc4bf7dff81b72e2b08d86d675be012c3663288e0cabcc1016e0f4f176ca9
+- Behavior: Read the canonical PM/Engineer documents and source, wrote the correctly nested Security-owned report with required frontmatter, and escalated the release-readiness conclusion to pm-agent.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=05538871e356a1820db883bcff8e90f4208bc94ba8410156f5ef306f19d4ce21; fixture_sha256=258d12e924889cdd6b9d64d5ae077ef75e65139845669b9a81854ba9fc13621c; output_sha256=5d1b6b5e7b059f9e5ac8b6b643f21226b53ee694778f7b584a0ff78f8f674ab2; snapshot_sha256=e7ebc4a086b01d705f11f594b5a79cc6078a485e07fa6f3e07b661784acd5943
-- Behavior: Produced a report under the PM documentation tree rather than the required Security path, despite including the feature-path frontmatter.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=05538871e356a1820db883bcff8e90f4208bc94ba8410156f5ef306f19d4ce21; fixture_sha256=258d12e924889cdd6b9d64d5ae077ef75e65139845669b9a81854ba9fc13621c; output_sha256=7872e35225db0ec0ca0d86c1e9be01151ceb36c24c0f3ae53c33262b2c49a0c3; snapshot_sha256=3aa38d69b1dc3a9d940f6282efe7b2ce87f430b52be3a2e38623ec1e6368fdf7
+- Behavior: Produced a security review with relevant findings but wrote it under the Engineer feature directory instead of the required nested Security report path and did not provide the required PM escalation.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Confirm PM classification and PM-owned issue creation when an issue-tracker runtime or user confirmation is available.
+- Next: pm-agent must classify the escalation and, after required confirmation, create the tracking issue.
 
 ## Runtime Artifact Policy
 

--- a/agents/security/test/appsec-checklist/evals/workspace/eval-005-mapped-search-security/comparison.md
+++ b/agents/security/test/appsec-checklist/evals/workspace/eval-005-mapped-search-security/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `fc2995d30d3ccba9dfaf0358946382fa2b5ecd4e3e1f4b423d1635f72c325d7d` from `agents/security/test/appsec-checklist/evals/workspace/eval-005-mapped-search-security`.
 - Identity schema: `2`
-- target_skill_sha256: `9ac7059a9a39550256d4de1ed82086d7f6b3c81bd069d831f0bf87ce02417c58`
+- target_skill_sha256: `412a68c0dfdb2d720e3447fdc4faf74b408d3de29706093a3a69fb0ca69d983c`
 - eval_definition_sha256: `d863b13d3e997477097b1a2de108729923e21619e10b2847114ea312db1c1bc8`
 - metadata_sha256: `cba4c9b4e188e5fae3cb488fc06e9766a5898277f19d0fa6882623eeaaede5e7`
 - fixture_sha256: `fc2995d30d3ccba9dfaf0358946382fa2b5ecd4e3e1f4b423d1635f72c325d7d`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `fe1f59786edfa4e3b7ee12601522d693ef12a42cdfce9b4a390ad6d7b95d03d2`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `e2ae5e4d2822699f2cb15956131366187d45773423915faa9c9726d6be1fc4de`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `d316d6849a82751d5c66c424af9993a42c304fe892fdb2411469b461bec624ee`
+- Skill overlay SHA-256: `035cdf3596c1888564523ed3d4e73116a3d2b231b30d91c462fb62cf6da52e05`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,27 +33,27 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `reads_mapped_docs_first` | PASS | Trace shows the candidate located the change-map entry and its required `docs/site/api/user-search.md`, then read the mapped document without evidence of traversing unrelated formal documents. |
-| `verifies_against_code` | NOT_EXERCISED | The candidate correctly stopped at the missing PM/Security handoff gate before performing code verification; the code-fact comparison was therefore not exercised. |
-| `treats_unverified_as_low_trust` | NOT_EXERCISED | The candidate identified `last_verified_version: unverified` and did not rely on the document for a security conclusion, but the subsequent code-verification step was blocked and not exercised. |
-| `escalates_fact_changing_conclusion_to_pm` | NOT_EXERCISED | No confirmed fact-changing security conclusion was reached, so the conditional PM escalation and issue-creation requirement was not exercised. |
+| `reads_mapped_docs_first` | NOT_EXERCISED | Trace shows the change-map and required_docs were identified, but the required API document was not read because the PM/Security handoff gate blocked continuation. |
+| `verifies_against_code` | NOT_EXERCISED | The with_skill trace does not read or verify src/api/search-handler.js, so no code-versus-document security conclusion was reached. |
+| `treats_unverified_as_low_trust` | NOT_EXERCISED | The candidate explicitly identified last_verified_version: unverified as low-trust navigation, but no key security judgment was completed or code verification performed. |
+| `escalates_fact_changing_conclusion_to_pm` | NOT_EXERCISED | No confirmed Security conclusion, report, PM return, or issue filing occurred because the required handoff and feature_path were missing. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=e2ae5e4d2822699f2cb15956131366187d45773423915faa9c9726d6be1fc4de; fixture_sha256=fc2995d30d3ccba9dfaf0358946382fa2b5ecd4e3e1f4b423d1635f72c325d7d; output_sha256=838fa14c55da135ce9f41d54fff02e43bc54dba4f57ec4cbd3319112c5905214; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Read the mapped change documentation, recognized its unverified status, and correctly returned to PM classification at the required entry gate without making an unsupported security conclusion or mutating files.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=e2ae5e4d2822699f2cb15956131366187d45773423915faa9c9726d6be1fc4de; fixture_sha256=fc2995d30d3ccba9dfaf0358946382fa2b5ecd4e3e1f4b423d1635f72c325d7d; output_sha256=c12dcf10ceaadf17eacf335a8f0b925bcaf1ee3c7e41801f333f029a15c208ad; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly enforced the Security entry gate, identified the mapped document and its unverified status, and returned the request to pm-agent without making unsupported security claims or mutating files.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=e2ae5e4d2822699f2cb15956131366187d45773423915faa9c9726d6be1fc4de; fixture_sha256=fc2995d30d3ccba9dfaf0358946382fa2b5ecd4e3e1f4b423d1635f72c325d7d; output_sha256=4908cf319d528da6c6bda9833edfbd1588e7d1ff4e92c20054a705e2b55e8c38; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Performed a complete code-versus-document review, identified direct SQL interpolation and the documentation mismatch, and made no repository changes.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=e2ae5e4d2822699f2cb15956131366187d45773423915faa9c9726d6be1fc4de; fixture_sha256=fc2995d30d3ccba9dfaf0358946382fa2b5ecd4e3e1f4b423d1635f72c325d7d; output_sha256=cffdcb4effd92b30c9f4ffcb8595fb36d033a2255b01b41b085b8db4e71268b0; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Completed a read-only code/document comparison and reported the SQL injection risk, but did not perform the required PM escalation workflow.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Provide the required PM/Security handoff context and confirmed feature_path, then perform the code verification and conditional escalation review.
+- Next: Provide the required PM/Security handoff and confirmed feature_path, then continue the mapped document and code review.
 
 ## Runtime Artifact Policy
 

--- a/agents/security/test/authz-reviewer/evals/workspace/eval-001-rbac/comparison.md
+++ b/agents/security/test/authz-reviewer/evals/workspace/eval-001-rbac/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `a079595e48d457c66e6bfba203a327a4dd2cee76937828205dc7d5ae1bf6d9ea` from `agents/security/test/authz-reviewer/evals/workspace/eval-001-rbac`.
 - Identity schema: `2`
-- target_skill_sha256: `28d6bd56202068b6de6f4e41d3bc74df73f15108b0013486fcd02eaa93f991d8`
+- target_skill_sha256: `560a4230ae443905926eeddf72dec9114fbb989ca3911007bb3d55a10a342e86`
 - eval_definition_sha256: `235137f94204f51e6c45d33016dc89d9789a6db39caeb6f905a7bece723a5a15`
 - metadata_sha256: `3631c1a666f99fa53cdd7f195ad887e6bb088a8209e8b065f9602b94a403934c`
 - fixture_sha256: `a079595e48d457c66e6bfba203a327a4dd2cee76937828205dc7d5ae1bf6d9ea`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `b9195372d92f3bbea03af4fc8ee3a7b882c68284b96da53cdd8cef5cf57e70e9`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `1a600a6512e0923d93e2001890b6b0e358c2e4b71aa4c63f0e217fc733bd66d6`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `217840028dda2eba806419edc71588064b0361d1a26fbfdbb7a47693678ccfa6`
+- Skill overlay SHA-256: `382daaa46e228ddafa411ea49b63d6055764b79f7917bec67fcebf40d2845479`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,21 +33,21 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `maps_expected_and_actual_access` | PASS | with_skill 的锁定交付报告包含 guest/user/admin 权限矩阵，并逐项对照 PRD 预期与 `admin-policy.js` 实际授权路径。 |
-| `finds_client_controlled_role_bypass` | PASS | 报告直接引用 `src/access/admin-policy.js:1-10`，说明 `request.headers["x-user-role"] === "admin"` 可被任意调用方伪造并返回审计日志。 |
-| `states_evidence_impact_and_limits` | PASS | 报告说明高敏管理审计数据泄露影响及 HIGH 严重度，并明确 session、JWT、可信身份存储、用户角色接口和其他 `/admin/*` 路由覆盖均无法从仓库验证。 |
-| `proposes_trusted_identity_fix_and_tests` | PASS | 报告建议服务端验证 session/token/identity store，并给出未认证、guest、user、admin 及伪造 `x-user-role` 的回归测试矩阵。 |
+| `maps_expected_and_actual_access` | PASS | The locked report contains a PRD-based guest/user/admin permission matrix and an actual-access matrix for `getAdminAuditLog`; raw trace execution confirms undefined/guest/user return 403 and admin header returns 200 with the audit log. |
+| `finds_client_controlled_role_bypass` | PASS | The locked report cites `src/access/admin-policy.js:1-3` and `:5-10`, explains direct trust of `request.headers["x-user-role"]`, and demonstrates the forged-admin 200 response. |
+| `states_evidence_impact_and_limits` | PASS | The report identifies management audit logs, affected guest/user roles, unauthorized disclosure and possible role-management impact, rates the issue HIGH, and explicitly marks session, JWT, role-management, and other-route coverage as unavailable or unverified. |
+| `proposes_trusted_identity_fix_and_tests` | PASS | The report recommends a verified server-side principal, trusted middleware and fail-closed authorization, and specifies regression coverage for unauthenticated, guest, user, admin, forged headers, invalid credentials, and all admin routes. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=1a600a6512e0923d93e2001890b6b0e358c2e4b71aa4c63f0e217fc733bd66d6; fixture_sha256=a079595e48d457c66e6bfba203a327a4dd2cee76937828205dc7d5ae1bf6d9ea; output_sha256=e098aa4a66a882b63282938dd76477f5b32e547a5550ebc1c4d318d56bbd502e; snapshot_sha256=30ba74063136b1022cfdb0a55c26a9ae7f6a474b6496c7f673574b2e8fa3ddcd
-- Behavior: 完成了基于 PRD 与代码的授权审查，交付结构化报告，准确识别客户端角色头越权、影响、限制、可信身份修复和回归测试建议。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=1a600a6512e0923d93e2001890b6b0e358c2e4b71aa4c63f0e217fc733bd66d6; fixture_sha256=a079595e48d457c66e6bfba203a327a4dd2cee76937828205dc7d5ae1bf6d9ea; output_sha256=483a1d455cda63ad630c07514b0f2bb7c5950469dd51a346485167d4503abeaf; snapshot_sha256=f29b74a78715afa6c8696b211e143e42d3ec0d526684e4679705680628cf5382
+- Behavior: Produced a complete evidence-backed authorization review, including the delivered report and runtime confirmation of the bypass.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=1a600a6512e0923d93e2001890b6b0e358c2e4b71aa4c63f0e217fc733bd66d6; fixture_sha256=a079595e48d457c66e6bfba203a327a4dd2cee76937828205dc7d5ae1bf6d9ea; output_sha256=782d0cac1e4e53904fef0d0f45abca642bb2b703dc110f2ea5117c52c901f884; snapshot_sha256=c71eb08d8693b2c0295c2ac5b037a436f23655457833b011abd94f6dda369092
-- Behavior: 同样完成了核心审查并交付报告；内容满足各断言，但相较 with_skill 报告更简略。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=1a600a6512e0923d93e2001890b6b0e358c2e4b71aa4c63f0e217fc733bd66d6; fixture_sha256=a079595e48d457c66e6bfba203a327a4dd2cee76937828205dc7d5ae1bf6d9ea; output_sha256=137f40b19f6d93ea332f02371779bec11fefc8dbba361ac646395f8b76493993; snapshot_sha256=21bc90b85091af57c32a93d2d7bec2f699494212d3cc7a510e3559e5a1a40b5b
+- Behavior: Produced a broadly similar authorization review and report, but is comparison context only.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/security/test/authz-reviewer/evals/workspace/eval-002-session/comparison.md
+++ b/agents/security/test/authz-reviewer/evals/workspace/eval-002-session/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `ef54897bb21af32853256277d12077e05ab3c6d281df76ae5f08944cb67d641a` from `agents/security/test/authz-reviewer/evals/workspace/eval-002-session`.
 - Identity schema: `2`
-- target_skill_sha256: `28d6bd56202068b6de6f4e41d3bc74df73f15108b0013486fcd02eaa93f991d8`
+- target_skill_sha256: `560a4230ae443905926eeddf72dec9114fbb989ca3911007bb3d55a10a342e86`
 - eval_definition_sha256: `86d9727a0807549b3bf3936da079aa7238a2b14b16eed4306c9bda4eb6d7be43`
 - metadata_sha256: `bc625033c4a7355e536aa9f113162cca0659e6b3b33765385304d88e087c3513`
 - fixture_sha256: `ef54897bb21af32853256277d12077e05ab3c6d281df76ae5f08944cb67d641a`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `a3c690bb602cdac9c05191ab0581fc35b8fd034dd27825093b3b51de5926404b`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `2d47191ee1ff1f15f350d3cf5e7d5d57f991913e4e2049f23f29264b335bfc56`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `217840028dda2eba806419edc71588064b0361d1a26fbfdbb7a47693678ccfa6`
+- Skill overlay SHA-256: `382daaa46e228ddafa411ea49b63d6055764b79f7917bec67fcebf40d2845479`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,21 +33,21 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `authorization_model` | PASS | 报告列出 anonymous/authenticated-user、用户资料与账户设置资源，并描述创建、解析、退出和受保护资源访问路径。 |
-| `access_control_findings` | PASS | 报告准确指出可预测会话 ID、无 30 分钟空闲过期、退出未撤销服务端会话，以及缺失登录/Cookie/端点集成证据。 |
-| `evidence_and_impact` | PASS | 各项发现均提供了 session-store.js 的具体行号、影响范围、账户接管或会话重放后果及严重度。 |
-| `remediation` | PASS | 报告提供了 CSPRNG opaque token、TTL/活动时间、服务端撤销、安全 Cookie 配置及单元/端到端回归验证建议。 |
+| `authorization_model` | PASS | 报告建立了 anonymous/authenticated-user 角色矩阵，覆盖用户资料和账户设置资源，并描述了创建、解析、受保护请求及退出失效路径。 |
+| `access_control_findings` | PASS | 报告指出会话 ID 可预测、无 30 分钟无活动过期、退出不撤销服务端会话，并识别 Cookie 安全属性和登录后轮换缺少实现证据。 |
+| `evidence_and_impact` | PASS | 各发现均提供了具体文件与代码行、严重度、攻击或账户接管等影响，以及上线阻断结论。 |
+| `remediation` | PASS | 报告提供了随机会话值、服务端过期删除/吊销、退出幂等及 Cookie/轮换集成修复建议，并列出边界、重放、并发和端到端回归验证。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2d47191ee1ff1f15f350d3cf5e7d5d57f991913e4e2049f23f29264b335bfc56; fixture_sha256=ef54897bb21af32853256277d12077e05ab3c6d281df76ae5f08944cb67d641a; output_sha256=339acdc111be851a47d99dff3f56e0cd793f72c66a2cbf45eff074eefd5e7ddb; snapshot_sha256=1c1a596d83c40aa30d58371651bd8d96ba5240e14313cc65a76bf071eb5960c7
-- Behavior: 完成结构化会话授权审查，覆盖角色边界、授权路径、缺陷证据、影响、严重度和修复验证建议。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2d47191ee1ff1f15f350d3cf5e7d5d57f991913e4e2049f23f29264b335bfc56; fixture_sha256=ef54897bb21af32853256277d12077e05ab3c6d281df76ae5f08944cb67d641a; output_sha256=c3d1bf9b7443679f436222e8fc93bd60c901dd9b4c859eef156f8d95251ee3f6; snapshot_sha256=d0fae43dcd70e8e8e757070ccf8ce32dfaf30247100a2cc53c52acee4b660516
+- Behavior: 交付了结构化会话授权审查，覆盖角色边界、会话缺陷、证据影响及修复验证建议。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2d47191ee1ff1f15f350d3cf5e7d5d57f991913e4e2049f23f29264b335bfc56; fixture_sha256=ef54897bb21af32853256277d12077e05ab3c6d281df76ae5f08944cb67d641a; output_sha256=35a0ac2d23a14260e7dca061d460ba0f9db40f57949b4ff900580a78ad8ec70f; snapshot_sha256=deb02e7459da8fa3c6bafa362cc1a7f41c4a3a852bc83a87247e8e3f665d7b71
-- Behavior: 完成静态会话安全审查并识别核心缺陷，但报告结构和授权模型覆盖较简略。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=2d47191ee1ff1f15f350d3cf5e7d5d57f991913e4e2049f23f29264b335bfc56; fixture_sha256=ef54897bb21af32853256277d12077e05ab3c6d281df76ae5f08944cb67d641a; output_sha256=6b07b32f54a023a6a9bba2e19e794028caabe3abcbc6d3c5a3dc44e5813a537b; snapshot_sha256=7a74c5140715e9d364173e997f305286a905fbef9a6084deb407a694228c9379
+- Behavior: 同样交付了会话安全审查并识别主要缺陷，作为 fresh baseline 对比。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/security/test/authz-reviewer/evals/workspace/eval-003-jwt/comparison.md
+++ b/agents/security/test/authz-reviewer/evals/workspace/eval-003-jwt/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `b22eea37eaa1e0fa82c96957a5790898e68b0e138db6319e88a5574aee2cf1f4` from `agents/security/test/authz-reviewer/evals/workspace/eval-003-jwt`.
 - Identity schema: `2`
-- target_skill_sha256: `28d6bd56202068b6de6f4e41d3bc74df73f15108b0013486fcd02eaa93f991d8`
+- target_skill_sha256: `560a4230ae443905926eeddf72dec9114fbb989ca3911007bb3d55a10a342e86`
 - eval_definition_sha256: `8f6e801f8a45c6ec677bbcaa4a56de6b68c935402a27b9f24ca631ffe0af8504`
 - metadata_sha256: `c70211d553dbd5b14945081d1a6afd8ffd4651a9a47e75788bc7a3313ea83fb9`
 - fixture_sha256: `b22eea37eaa1e0fa82c96957a5790898e68b0e138db6319e88a5574aee2cf1f4`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `a3c690bb602cdac9c05191ab0581fc35b8fd034dd27825093b3b51de5926404b`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `da9ecfe298cdea573f5e2d687f97fd893a94d3dc4b95b345575f1d452f32a2ab`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `217840028dda2eba806419edc71588064b0361d1a26fbfdbb7a47693678ccfa6`
+- Skill overlay SHA-256: `382daaa46e228ddafa411ea49b63d6055764b79f7917bec67fcebf40d2845479`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,21 +33,21 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `authorization_model` | PASS | 报告包含 user/admin/unauthenticated 角色矩阵、受保护 API 与 /api/admin/* 资源边界，并追踪 Authorization header → authenticateJwt → claims.role 授权路径。 |
-| `access_control_findings` | PASS | 报告明确指出未验证签名、算法未约束、exp 未校验，以及 canAccessAdminApi 直接信任未验证 role 导致伪造 admin 越权。 |
-| `evidence_and_impact` | PASS | 报告提供 src/auth/jwt.js 的具体行号证据，说明签名、过期和角色缺陷的影响，包括身份伪造、过期凭证继续有效和管理员权限提升。 |
-| `remediation` | PASS | 报告给出使用成熟 verify API、算法白名单、签名与 exp 校验、可信 claims 授权上下文，以及覆盖篡改 payload、alg:none、过期、角色和真实路由的回归验证建议。 |
+| `authorization_model` | PASS | 报告包含角色权限矩阵，明确 user/admin、受保护 API、/api/admin/* 及从 Authorization header 到认证和角色判断的完整路径。 |
+| `access_control_findings` | PASS | 报告逐项识别签名缺失、算法未约束、exp 未校验、未经验证的 role 导致 admin 越权，以及 Bearer 解析缺陷。 |
+| `evidence_and_impact` | PASS | 每项问题均提供 src/auth/jwt.js 行号、严重度、攻击方式及身份冒用、管理端越权和令牌重放等影响；同时准确说明缺少路由/中间件证据。 |
+| `remediation` | PASS | 报告提供固定算法和密钥、verify API、强制 exp、可信 claims 上下文、统一异常处理，以及签名篡改、alg none、过期令牌、角色越权和全路由回归测试建议。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=da9ecfe298cdea573f5e2d687f97fd893a94d3dc4b95b345575f1d452f32a2ab; fixture_sha256=b22eea37eaa1e0fa82c96957a5790898e68b0e138db6319e88a5574aee2cf1f4; output_sha256=ea439542343a4257e141ef42aa246ee9a2f09154ed05cc0adfeb0a835e0a03d8; snapshot_sha256=ba9b44b00cb162a22c44e7dc813324691c76a2baadd257637b3e6332809e67fe
-- Behavior: 完成结构化 JWT 安全审查并交付报告，覆盖授权模型、缺陷证据、影响和修复验证建议。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=da9ecfe298cdea573f5e2d687f97fd893a94d3dc4b95b345575f1d452f32a2ab; fixture_sha256=b22eea37eaa1e0fa82c96957a5790898e68b0e138db6319e88a5574aee2cf1f4; output_sha256=79b534a52b2b09a8f4d9286f86235aa69f62f9bcdcc5a4b75afcfcda8db60726; snapshot_sha256=424bd4003113c1ec7d8b8442bd755c5feb5a32710cb96a1502ac5316445a3228
+- Behavior: 交付了结构化 JWT 授权审查文件，覆盖角色边界、实际路径、缺陷证据、影响、严重度、修复和回归验证。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=da9ecfe298cdea573f5e2d687f97fd893a94d3dc4b95b345575f1d452f32a2ab; fixture_sha256=b22eea37eaa1e0fa82c96957a5790898e68b0e138db6319e88a5574aee2cf1f4; output_sha256=1c9656331ffced08de2fd223100025f99d6965bf64fabd46c806635a4835870e; snapshot_sha256=87ffba7143275a2fb445630b5c255aff0819fcada840e5677e694d73225c3162
-- Behavior: 同样识别了主要 JWT 缺陷并交付了详细报告，作为比较基线。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=da9ecfe298cdea573f5e2d687f97fd893a94d3dc4b95b345575f1d452f32a2ab; fixture_sha256=b22eea37eaa1e0fa82c96957a5790898e68b0e138db6319e88a5574aee2cf1f4; output_sha256=d5b055d2458c4bc1e111fcd86c0902653a964c1fb27b9ecd0a3016cfa2d65324; snapshot_sha256=6564bfff957161b3e39353a3319ebef00d6c1852c99db5b6febd9574d82a4bd5
+- Behavior: 提供了简洁的审查结论和主要风险、修复方向；覆盖核心问题，但未交付同等结构化的角色矩阵和完整授权路径分析。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/security/test/authz-reviewer/evals/workspace/eval-004-mapped-report-export-authz/comparison.md
+++ b/agents/security/test/authz-reviewer/evals/workspace/eval-004-mapped-report-export-authz/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `6b2ecd7bb8b1ef79f098d4d11a3ca4f93d8ab0f7969ef301d999bac9f594dbd1` from `agents/security/test/authz-reviewer/evals/workspace/eval-004-mapped-report-export-authz`.
 - Identity schema: `2`
-- target_skill_sha256: `28d6bd56202068b6de6f4e41d3bc74df73f15108b0013486fcd02eaa93f991d8`
+- target_skill_sha256: `560a4230ae443905926eeddf72dec9114fbb989ca3911007bb3d55a10a342e86`
 - eval_definition_sha256: `8fb5f1e36d08ae5ad3c1dfb46758101e4ce1413f28a63b591aee885fb67bbefb`
 - metadata_sha256: `ae7084c912c7a22c84bf1353aceb60530fc3393371ee2773e75ed9b9cc1b0840`
 - fixture_sha256: `6b2ecd7bb8b1ef79f098d4d11a3ca4f93d8ab0f7969ef301d999bac9f594dbd1`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `fe1f59786edfa4e3b7ee12601522d693ef12a42cdfce9b4a390ad6d7b95d03d2`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `956153b2567d541c97d7a49956fee1365b2dd3779decf5baff92a40059a84ff2`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `217840028dda2eba806419edc71588064b0361d1a26fbfdbb7a47693678ccfa6`
+- Skill overlay SHA-256: `382daaa46e228ddafa411ea49b63d6055764b79f7917bec67fcebf40d2845479`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,27 +33,27 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `reads_mapped_docs_first` | PASS | with_skill trace reads PM handoff, then change-map and its mapped required document, before reading the policy code; the delivered report records the mapped evidence and no unrelated formal-document contents. |
-| `verifies_against_code` | PASS | The locked report and trace identify `src/access/report-export-policy.js` as the decisive evidence, correctly state that exact `admin` and `analyst` values are allowed, and identify the admin-only documentation mismatch and resulting risk. |
-| `treats_unverified_as_low_trust` | PASS | The locked report explicitly identifies both the change-map and API page as `last_verified_version: unverified`, treats them as low-trust, and bases the authorization result on the implementation code. |
-| `escalates_fact_changing_conclusion_to_pm` | NOT_EXERCISED | The locked report and final output return the conclusion and evidence to `pm-agent` for classification and issue filing, while preserving the Security-owned report and avoiding direct Docs handoff or Security issue creation. Actual issue creation is not exercised because no user confirmation is present. |
+| `reads_mapped_docs_first` | PASS | Trace shows repository/evidence discovery followed by reading PM_HANDOFF.md, change-map.yaml, and the mapped report-export document before the target policy code was inspected; the delivered report records the mapped document. |
+| `verifies_against_code` | PASS | The locked report and final output identify the exact policy, show that strict equality allows admin and analyst, contrast this with the admin-only document, and assess analyst as unexpected access. |
+| `treats_unverified_as_low_trust` | PASS | The locked report explicitly identifies last_verified_version: unverified for the change map and formal page, treats the page as low-trust, and uses code as current behavior evidence. |
+| `escalates_fact_changing_conclusion_to_pm` | NOT_EXERCISED | The Security-owned report preserves the discrepancy and directs PM/Security classification and PM/docs routing. Actual PM classification and issue creation are not exercised in the locked evidence, so the later escalation step cannot be judged. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=956153b2567d541c97d7a49956fee1365b2dd3779decf5baff92a40059a84ff2; fixture_sha256=6b2ecd7bb8b1ef79f098d4d11a3ca4f93d8ab0f7969ef301d999bac9f594dbd1; output_sha256=a59a02e75ef8c45df6225ab239887c42948d73e075f91e89ab2c33732c81b4cd; snapshot_sha256=e90a8627801b062e638c5477a491233080d3d2dcd76e6c1e7a5088af5bc5905d
-- Behavior: Correctly follows mapped-document and low-trust verification requirements, grounds the finding in code, produces the required Security report, and hands the conclusion to PM.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=956153b2567d541c97d7a49956fee1365b2dd3779decf5baff92a40059a84ff2; fixture_sha256=6b2ecd7bb8b1ef79f098d4d11a3ca4f93d8ab0f7969ef301d999bac9f594dbd1; output_sha256=3a7a66b0c66133691d549a081dc5da5f38f7d7b904530af9e22edd5c7ee33e1e; snapshot_sha256=50768c06c7c5dbe8218fd26b5be11d4c200e53cfff23c7f5eca22d167be13c30
+- Behavior: Produced a file-backed authorization review grounded in the mapped document and policy code, correctly identifying admin and analyst as allowed and analyst as conflicting with the recorded admin-only boundary; routed the unresolved classification to PM/Security.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=956153b2567d541c97d7a49956fee1365b2dd3779decf5baff92a40059a84ff2; fixture_sha256=6b2ecd7bb8b1ef79f098d4d11a3ca4f93d8ab0f7969ef301d999bac9f594dbd1; output_sha256=3b726c9ca507bb91fb94d6f059d467538f128dba62e25a55783823278a9706dd; snapshot_sha256=7634e3ac80fe477997ae2a5114d5982394e38d941eec39f7d9a93aea61b70b90
-- Behavior: Fresh baseline reaches the core authorization finding and produces a report, but does not demonstrate the mapped-document trust handling or PM escalation process.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=956153b2567d541c97d7a49956fee1365b2dd3779decf5baff92a40059a84ff2; fixture_sha256=6b2ecd7bb8b1ef79f098d4d11a3ca4f93d8ab0f7969ef301d999bac9f594dbd1; output_sha256=1321c3c5c66001dd0099409ba66e0f360d4ff673e4cc6471b3ea11818482fd36; snapshot_sha256=ed6bd9aec9754952af6a2be4752e4255385d7be8bc0d7a1384a9f8c284ce08fb
+- Behavior: Correctly identified the authorization discrepancy and produced a basic Security report, but provided less explicit low-trust handling and escalation/classification routing.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: After PM classification is confirmed, PM should create the tracking issue and continue the prescribed handoff.
+- Next: Obtain PM/Security classification and, if required, exercise PM-owned issue creation.
 
 ## Runtime Artifact Policy
 

--- a/agents/security/test/dependency-risk-auditor/evals/workspace/eval-001-npm-audit/comparison.md
+++ b/agents/security/test/dependency-risk-auditor/evals/workspace/eval-001-npm-audit/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `5d978f8d24e5dad96aba91cd89101e33e9f1a0bda647abfca6c8a768de860caa` from `agents/security/test/dependency-risk-auditor/evals/workspace/eval-001-npm-audit`.
 - Identity schema: `2`
-- target_skill_sha256: `4936716a99cef8bc1e927ef64eaa0d20fa85f573a00b76c6ef0e6212ccbb3af0`
+- target_skill_sha256: `cd54295a0cbcb90462d5e5533bde1937cc7e871f8f4c9c53d7773ed40ace553e`
 - eval_definition_sha256: `971feaa0f85d14f75fe45df2640551915965f181de289e0a977efb57d2391e3e`
 - metadata_sha256: `b384f8f560614179a0a93d18259ac2f4d1d78a8283a28bd2f5b6097f32a74e67`
 - fixture_sha256: `5d978f8d24e5dad96aba91cd89101e33e9f1a0bda647abfca6c8a768de860caa`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `07345508cc5d326f024163cc8715111c4efeeb1bd80f16886d65b16eb2ef9292`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `77f74479311f236d7bdd232169db921b777009b1ba418244e6f3905f8b530b3e`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `41b45499ae9ca5616b92679964200469b31cddbc1797bbf9c8e3a1dc71be48a5`
+- Skill overlay SHA-256: `dede36cbf22736a6194a488a09a7dab4d5a1092bacb831a4913854fdff85a07a`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,21 +33,21 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `dependency_inventory` | PASS | 交付快照列出 Node.js 生产依赖 lodash@4.17.15 与 minimist@0.0.8，并说明对象路径、命令行参数、传递依赖和供应链风险来源。 |
-| `risk_classification` | PASS | 报告区分原型污染、模板代码注入、ReDoS、过期版本及 lockfile/完整性缺失导致的供应链风险，并标注 Critical/High/Moderate、P0/P1 和影响条件。 |
-| `evidence` | PASS | 报告引用 package.json、具体固定版本、CVE/GHSA 编号、受影响版本范围、修复版本和公开公告链接；同时明确缺少 lockfile 与源码调用点的证据边界。 |
-| `upgrade_plan` | PASS | 报告提出将 lodash 升级至 4.18.0+、minimist 升级至 1.2.8 或移除，生成并提交 lockfile/SBOM，重新扫描和测试，并给出危险键拒绝、静态模板、输入限制、隔离和监控等短期缓解措施。 |
+| `dependency_inventory` | PASS | The locked with_skill report identifies the Node.js ecosystem, both production packages (`minimist` and `lodash`), missing lockfiles, and relevant vulnerability/supply-chain risk sources. |
+| `risk_classification` | PASS | The report distinguishes Critical/High/Moderate vulnerabilities, discusses abandonment and provenance signals, and assigns P0/P1 priorities with impact and exploitability context. |
+| `evidence` | PASS | The locked report cites `package.json`, exact versions, CVE/GHSA identifiers, severity scores, affected ranges, fix versions, and advisory links. |
+| `upgrade_plan` | PASS | The report provides prioritized upgrades, lockfile/npm ci steps, regression checks, short-term input restrictions, and release-blocker guidance. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=77f74479311f236d7bdd232169db921b777009b1ba418244e6f3905f8b530b3e; fixture_sha256=5d978f8d24e5dad96aba91cd89101e33e9f1a0bda647abfca6c8a768de860caa; output_sha256=dd7bb5a83769e1e3e2f07af06aa87df11d61ed4de2155e8d8d73bc80097a0339; snapshot_sha256=2b0a24d8ec50a6734839fc7c3b093b23972623c7f0ffe89c04fcc7c9a559eb9b
-- Behavior: 完成了结构化依赖安全审计交付，识别两个直接生产依赖的多项风险，提供证据、严重度、影响、升级和缓解建议，并保留了证据边界。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=77f74479311f236d7bdd232169db921b777009b1ba418244e6f3905f8b530b3e; fixture_sha256=5d978f8d24e5dad96aba91cd89101e33e9f1a0bda647abfca6c8a768de860caa; output_sha256=e43366f10812d6448ebf24aac87af8739d8871fc64882f0de5e5e17bccff9bb6; snapshot_sha256=b1913cc5e73d5472a5ce18fd3212e175179dc6d7e153b0811efb2632b0a76a9d
+- Behavior: Delivered a complete structured dependency-risk audit covering inventory, classification, evidence, mitigations, upgrade sequencing, verification, and release readiness.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=77f74479311f236d7bdd232169db921b777009b1ba418244e6f3905f8b530b3e; fixture_sha256=5d978f8d24e5dad96aba91cd89101e33e9f1a0bda647abfca6c8a768de860caa; output_sha256=dc9fe1be794fd62e50ae9f1df83cacae866356137554fef7ca2531c4f6d5a6bc; snapshot_sha256=55b108e9918c2c7a37a72620437c75eefd345c67f734b15a7e68a0b45e2db863
-- Behavior: 提供了较简短的审计摘要和交付文件，覆盖主要依赖风险与升级方向，但细节和风险分类不如 with_skill 完整。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=77f74479311f236d7bdd232169db921b777009b1ba418244e6f3905f8b530b3e; fixture_sha256=5d978f8d24e5dad96aba91cd89101e33e9f1a0bda647abfca6c8a768de860caa; output_sha256=8a192e73a47e667892d9f77f06ebb8b4eb66c8ccbdc0cfcfdebe71f7f80d4dbe; snapshot_sha256=6c0fca61d993caf8176594464edb443757caf2531eb102a81b3df77cd32a58e6
+- Behavior: Fresh baseline also delivered a substantively complete audit, but with less detailed provenance and classification coverage.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/security/test/dependency-risk-auditor/evals/workspace/eval-002-abandoned/comparison.md
+++ b/agents/security/test/dependency-risk-auditor/evals/workspace/eval-002-abandoned/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `4ef6c6ec20f409ae50ba76d9496bdabb654cdb81289a7a2eacee1dc6b802832f` from `agents/security/test/dependency-risk-auditor/evals/workspace/eval-002-abandoned`.
 - Identity schema: `2`
-- target_skill_sha256: `4936716a99cef8bc1e927ef64eaa0d20fa85f573a00b76c6ef0e6212ccbb3af0`
+- target_skill_sha256: `cd54295a0cbcb90462d5e5533bde1937cc7e871f8f4c9c53d7773ed40ace553e`
 - eval_definition_sha256: `88dd9b929d53963534f872d5c6b43117be6b35cb41fa6b99bd7d05175018ade8`
 - metadata_sha256: `5e0c35c826a7733ee387d4f323da117f6699f11274aa5fd48097e667d23e3045`
 - fixture_sha256: `4ef6c6ec20f409ae50ba76d9496bdabb654cdb81289a7a2eacee1dc6b802832f`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `07345508cc5d326f024163cc8715111c4efeeb1bd80f16886d65b16eb2ef9292`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `89079b812ce4ce066ef86759ed6c1d41f09649e1cedce1ebb540e93d141b1137`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `41b45499ae9ca5616b92679964200469b31cddbc1797bbf9c8e3a1dc71be48a5`
+- Skill overlay SHA-256: `dede36cbf22736a6194a488a09a7dab4d5a1092bacb831a4913854fdff85a07a`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,21 +33,21 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `dependency_inventory` | PASS | The locked audit identifies the Node.js ecosystem and both direct production dependencies, `request@2.88.2` and `node-uuid@1.4.8`, with their relevant network-request and UUID risk sources. |
-| `risk_classification` | PASS | The audit distinguishes deprecation/unmaintained status from unassessed CVE/transitive risk, assigns High maintenance risk, and gives P0/P1 priorities with conditional escalation criteria. |
-| `evidence` | PASS | The delivered file cites `package.json`, PM handoff and PRD scope, exact package versions, npm deprecation evidence, Node.js documentation, the missing-lockfile `ENOLOCK` limitation, and relevant repository findings. |
-| `upgrade_plan` | PASS | The audit recommends replacing `request` with built-in `fetch` or a maintained client, replacing `node-uuid` with `crypto.randomUUID()` or `uuid` as appropriate, plus migration tests, isolation, outbound restrictions, lockfile creation, and follow-up ownership. |
+| `dependency_inventory` | PASS | The with_skill delivery snapshot identifies the Node.js ecosystem and both direct production dependencies: request@2.88.2 and node-uuid@1.4.8, including their external-request and UUID risk surfaces. |
+| `risk_classification` | PASS | It distinguishes deprecated/unmaintained status from unasserted CVEs, explains missing security maintenance and transitive-dependency exposure, and assigns high/P0 priorities. |
+| `evidence` | PASS | It cites package names and pinned versions, package metadata, Node.js documentation, PM_HANDOFF.md, and the PRD; the locked file content directly contains the evidence. |
+| `upgrade_plan` | PASS | It recommends fetch or undici for request, crypto.randomUUID or uuid for node-uuid, plus compatibility checks, lockfile generation, npm audit, migration tests, and release gates. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=89079b812ce4ce066ef86759ed6c1d41f09649e1cedce1ebb540e93d141b1137; fixture_sha256=4ef6c6ec20f409ae50ba76d9496bdabb654cdb81289a7a2eacee1dc6b802832f; output_sha256=2606ce730a43993086bbed000310bba9b01d8685e14930a997273031f6450c96; snapshot_sha256=3a54d54d56d9eb66a972be56b4124160ff85f4e6a0d6f9ea903bcba57ddb38e9
-- Behavior: Produced the required feature-scoped dependency audit in the PM-designated directory without modifying dependencies, covering both packages, evidence, risk classification, and a concrete replacement/mitigation plan.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=89079b812ce4ce066ef86759ed6c1d41f09649e1cedce1ebb540e93d141b1137; fixture_sha256=4ef6c6ec20f409ae50ba76d9496bdabb654cdb81289a7a2eacee1dc6b802832f; output_sha256=bf0273d801c90d91f487f30a9abeb319fdecc91d494d5b48dac3c60307c16efd; snapshot_sha256=4492ef122b8428a86ad09f80a6092d2b365322b9bb5e9d31816dc175b7d335e5
+- Behavior: Delivered a structured dependency risk audit with evidence-based classifications and an actionable replacement plan.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=89079b812ce4ce066ef86759ed6c1d41f09649e1cedce1ebb540e93d141b1137; fixture_sha256=4ef6c6ec20f409ae50ba76d9496bdabb654cdb81289a7a2eacee1dc6b802832f; output_sha256=0baebc92daca4e221c5335e70e228ed5a4d0cb28712bd491b7c9f5345640ef44; snapshot_sha256=71c412d5a83e795caad45aff6d13c16c7506450a5fa1fa6268313c9f36376180
-- Behavior: Produced a semantically complete audit with similar dependency findings, evidence, risk priorities, and migration guidance; used only as comparison context.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=89079b812ce4ce066ef86759ed6c1d41f09649e1cedce1ebb540e93d141b1137; fixture_sha256=4ef6c6ec20f409ae50ba76d9496bdabb654cdb81289a7a2eacee1dc6b802832f; output_sha256=db95711b442c7db7ec31e4d895ba48a25d7c429e413b5e24eb5617f6258dfe80; snapshot_sha256=16327196545aef402bb46bc436164ac41d1ae795fc7034d4ece91896f1b8d667
+- Behavior: Delivered a correct but less detailed dependency audit and replacement summary.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/security/test/dependency-risk-auditor/evals/workspace/eval-003-python/comparison.md
+++ b/agents/security/test/dependency-risk-auditor/evals/workspace/eval-003-python/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `8307ea1325de4c132e54824c9dd507ed174ce29fe901e9f04e5a56bc654490e3` from `agents/security/test/dependency-risk-auditor/evals/workspace/eval-003-python`.
 - Identity schema: `2`
-- target_skill_sha256: `4936716a99cef8bc1e927ef64eaa0d20fa85f573a00b76c6ef0e6212ccbb3af0`
+- target_skill_sha256: `cd54295a0cbcb90462d5e5533bde1937cc7e871f8f4c9c53d7773ed40ace553e`
 - eval_definition_sha256: `b851960b1dd4c6ab11f9c42f685034d6bd0e27ae3c26e4256af19942329ed614`
 - metadata_sha256: `ae72aa507a46a167a61a13af949f88d9dacf41d33161383d4a9754e7de06b4d8`
 - fixture_sha256: `8307ea1325de4c132e54824c9dd507ed174ce29fe901e9f04e5a56bc654490e3`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `07345508cc5d326f024163cc8715111c4efeeb1bd80f16886d65b16eb2ef9292`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `109b986b4018ed5121d20e83d0f03f39a0aaef687eb5dd7c1936ee4b3a089210`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `41b45499ae9ca5616b92679964200469b31cddbc1797bbf9c8e3a1dc71be48a5`
+- Skill overlay SHA-256: `dede36cbf22736a6194a488a09a7dab4d5a1092bacb831a4913854fdff85a07a`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,21 +33,21 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `dependency_inventory` | PASS | With-skill report inventories the Python ecosystem and identifies requests, urllib3, and Jinja2 with exact pinned versions and relevant HTTP, TLS, and template risk surfaces. |
-| `risk_classification` | PASS | With-skill report distinguishes public vulnerabilities, outdated versions, conditional exploitability, severity levels, and correctly notes that the projects remain maintained despite historical pinned versions. |
-| `evidence` | PASS | The locked delivery snapshot directly cites requirements.txt, exact versions, CVE/GHSA advisories, affected conditions, and remediation versions. |
-| `upgrade_plan` | PASS | The report provides coordinated upgrade targets, compatibility/testing order, temporary mitigations, release blocking criteria, and ownership/escalation guidance without modifying requirements.txt. |
+| `dependency_inventory` | PASS | With_skill inventory identifies the Python ecosystem, all three pinned packages, their roles, HTTP/TLS/template scope, stale dependencies, and provenance/lockfile risks. |
+| `risk_classification` | PASS | With_skill distinguishes CVEs from stale-version, abandonment-warning, missing-lockfile, and supply-chain/provenance risks, with High/Moderate severity and conditional exploitability. |
+| `evidence` | PASS | The delivered audit directly cites requirements.txt versions, package roles, CVE/GHSA identifiers, fixed versions, advisory links, and repository evidence. |
+| `upgrade_plan` | PASS | The delivered audit provides preferred upgrades, compatibility bridges, temporary mitigations, release gating, ownership, and verification/testing steps without modifying requirements.txt. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=109b986b4018ed5121d20e83d0f03f39a0aaef687eb5dd7c1936ee4b3a089210; fixture_sha256=8307ea1325de4c132e54824c9dd507ed174ce29fe901e9f04e5a56bc654490e3; output_sha256=c060b66ca6a3a8345bf126fdc4d81020f43d395428db80f61d19b66960bdeb24; snapshot_sha256=1bdf3c1c5d246ca2e26571ac0b35863bc151e73b0f9f1daef29d0d3fe12e3d73
-- Behavior: Delivered a detailed, evidence-backed Python dependency security audit covering inventory, risk classification, exact-version evidence, upgrade targets, mitigations, and release disposition.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=109b986b4018ed5121d20e83d0f03f39a0aaef687eb5dd7c1936ee4b3a089210; fixture_sha256=8307ea1325de4c132e54824c9dd507ed174ce29fe901e9f04e5a56bc654490e3; output_sha256=bf7a5137129a406f8e881b1e8539838776e91725b3e291821a83da80bb49a8bc; snapshot_sha256=f744253c33cd727a74a312b55f4ca9eea798c349cb66a7480fa6e12b37a39621
+- Behavior: Produced a structured dependency security audit covering inventory, classified risks, direct evidence, and actionable upgrades/mitigations; delivered the report without forbidden dependency changes.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=109b986b4018ed5121d20e83d0f03f39a0aaef687eb5dd7c1936ee4b3a089210; fixture_sha256=8307ea1325de4c132e54824c9dd507ed174ce29fe901e9f04e5a56bc654490e3; output_sha256=0c40d629e3d2e953e43fa6a693a6e2fb1a0b7ce04d750a24b29c4abe88b2cdff; snapshot_sha256=70960d51ae21afaa324866a28d3e9eb98ba32c769909692174954467447688f3
-- Behavior: Provided a shorter audit with useful findings and recommendations, but less complete coverage and less detailed evidence than the with_skill lane.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=109b986b4018ed5121d20e83d0f03f39a0aaef687eb5dd7c1936ee4b3a089210; fixture_sha256=8307ea1325de4c132e54824c9dd507ed174ce29fe901e9f04e5a56bc654490e3; output_sha256=4bb2da364f3504e392c9ecdd4801a5b097b859d0b647d8d3a201e38f4787b780; snapshot_sha256=d4dae3d71b2e3bfc13b38eb590faf499f92fdd0146db25884c63b5b741ab246f
+- Behavior: Produced a broadly similar audit and comparison report, including package risks and upgrade suggestions; used only as fresh-baseline context.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/security/test/dependency-risk-auditor/evals/workspace/eval-004-mapped-client-dependency/comparison.md
+++ b/agents/security/test/dependency-risk-auditor/evals/workspace/eval-004-mapped-client-dependency/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `9287a8fa578b5447f010eec525225500d555d9e2f5c2758277bcae9488425fa5` from `agents/security/test/dependency-risk-auditor/evals/workspace/eval-004-mapped-client-dependency`.
 - Identity schema: `2`
-- target_skill_sha256: `4936716a99cef8bc1e927ef64eaa0d20fa85f573a00b76c6ef0e6212ccbb3af0`
+- target_skill_sha256: `cd54295a0cbcb90462d5e5533bde1937cc7e871f8f4c9c53d7773ed40ace553e`
 - eval_definition_sha256: `8b3afd523591d93b0ae2bfbea1c5709666ee81c09a14160679da5b53064efb14`
 - metadata_sha256: `b2c29426ebf4eb7772788a981043f00672d29ff296d5629f3103cb3b99a34acd`
 - fixture_sha256: `9287a8fa578b5447f010eec525225500d555d9e2f5c2758277bcae9488425fa5`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `fe1f59786edfa4e3b7ee12601522d693ef12a42cdfce9b4a390ad6d7b95d03d2`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `7a3821e75530d0b15af01947cb71f52d6f838c90667f22241c35f06721254994`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `41b45499ae9ca5616b92679964200469b31cddbc1797bbf9c8e3a1dc71be48a5`
+- Skill overlay SHA-256: `dede36cbf22736a6194a488a09a7dab4d5a1092bacb831a4913854fdff85a07a`
 - Behavior result: **PASS**
 - Coverage result: **PARTIAL**
 Overall result: PASS (partial coverage)
@@ -33,27 +33,27 @@ Overall result: PASS (partial coverage)
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `reads_mapped_docs_first` | PASS | Trace shows the candidate located the manifest/change-map relationship, read only the mapped network-client document, and did not traverse unrelated formal documentation. |
-| `verifies_against_code` | PASS | The candidate explicitly reports manifest version 1.4.0 versus documented 2.1.0 and treats 1.4.0 as the actual repository dependency fact. |
-| `treats_unverified_as_low_trust` | PASS | The candidate identifies both freshness markers as unverified, treats them as low-trust navigation, and bases the version conclusion on the manifest rather than rejecting the documents outright. |
-| `escalates_fact_changing_conclusion_to_pm` | NOT_EXERCISED | A confirmed Security conclusion and PM handoff context are absent; the candidate correctly stops at the PM/Security entry gate and requests PM classification. Issue creation and escalation evidence are therefore not yet exercisable. |
+| `reads_mapped_docs_first` | PASS | Trace shows the mapped manifest, change-map, and required network-client document were read in sequence, with no unrelated formal documents inspected. |
+| `verifies_against_code` | PASS | The candidate explicitly reports manifest version 1.4.0 versus formal-document claim 2.1.0 and treats the manifest as the code fact. |
+| `treats_unverified_as_low_trust` | PASS | The candidate explicitly identifies both freshness markers as unverified, treats them as navigation only, and relies on the manifest for the version fact. |
+| `escalates_fact_changing_conclusion_to_pm` | NOT_EXERCISED | The candidate returns to pm-agent and requests the required handoff fields, but issue creation cannot yet occur without the missing PM confirmation/packet. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=7a3821e75530d0b15af01947cb71f52d6f838c90667f22241c35f06721254994; fixture_sha256=9287a8fa578b5447f010eec525225500d555d9e2f5c2758277bcae9488425fa5; output_sha256=e5bb02807d1a811d4d768d533326672daacf3d97879bc919069d706c620c8c53; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Followed the mapped-document and low-trust verification workflow, identified the 1.4.0/2.1.0 discrepancy, then correctly stopped at the missing PM/Security handoff gate.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=7a3821e75530d0b15af01947cb71f52d6f838c90667f22241c35f06721254994; fixture_sha256=9287a8fa578b5447f010eec525225500d555d9e2f5c2758277bcae9488425fa5; output_sha256=ff12912c76e45d680c8fa20f25be0ba8de9a4abaf75f3522b8b7c754596a081b; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Correctly applied the entry gate, read the mapped evidence, identified the 1.4.0 versus 2.1.0 conflict, downgraded unverified documentation, and returned the matter to pm-agent.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=7a3821e75530d0b15af01947cb71f52d6f838c90667f22241c35f06721254994; fixture_sha256=9287a8fa578b5447f010eec525225500d555d9e2f5c2758277bcae9488425fa5; output_sha256=dc6197ffe2931eba2ebc03bae1ae43a429a25af4e6b69f8cb2eb97ed938b0c09; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Produced a substantive version-conflict risk assessment and remediation suggestions, but did not follow the PM/Security handoff and escalation contract.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=7a3821e75530d0b15af01947cb71f52d6f838c90667f22241c35f06721254994; fixture_sha256=9287a8fa578b5447f010eec525225500d555d9e2f5c2758277bcae9488425fa5; output_sha256=329c99611df6adb350d2c2eabb346e0770fd720310f6dced73bb11512c687455; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Completed a broader dependency-risk audit and provided version, provenance, mitigation, and upgrade recommendations without the role-entry gate.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: Provide a confirmed PM/Security handoff packet, then complete the dependency audit and return any fact-changing conclusion and evidence to pm-agent for classification and issue filing.
+- Next: Obtain PM/Security handoff confirmation, then have pm-agent classify the conclusion and create the tracking issue if the documentation fact change is confirmed.
 
 ## Runtime Artifact Policy
 

--- a/agents/security/test/privacy-surface-mapper/evals/workspace/eval-001-gdpr/comparison.md
+++ b/agents/security/test/privacy-surface-mapper/evals/workspace/eval-001-gdpr/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `fc7c85721e9b7bd81a9ba3e487c8f00f57880deb91ce00e1ae1258884cc231db` from `agents/security/test/privacy-surface-mapper/evals/workspace/eval-001-gdpr`.
 - Identity schema: `2`
-- target_skill_sha256: `36470092bada7ef550e554a98c281f2fe94c427f5a20542e3fb5f13c69f3b496`
+- target_skill_sha256: `2d9aa34423715a24783169e774af3c68a95cbc320b5fc5af4b5753bd7785f2a0`
 - eval_definition_sha256: `3e00fd5f68469b1dbad14f0a400fd8e41079d5a8aa0df077168fd2333bd41a39`
 - metadata_sha256: `4d071b9edabea5e4f158bcdc27c2e5647782f2e593dd3fe3c48f455551d94297`
 - fixture_sha256: `fc7c85721e9b7bd81a9ba3e487c8f00f57880deb91ce00e1ae1258884cc231db`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `46c6f10cb2ee094e0f2d9b8cf0d9d794ebc801a301eb97187a76e961b4e37fd0`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `da21f882704758587ca44f889b8ee407dbf02d8334de8546d9781960b0a34c12`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `04d179782a25ad87f73775d407c14368f4301d86a871528ca2b66e82792a813b`
+- Skill overlay SHA-256: `2eea2d31331dfff7d98326573b856ca9f269bca068d5f182bf99e8b0d5d75219`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,21 +33,21 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `data_inventory` | PASS | 报告逐项列出姓名、邮箱、IP、User-Agent、用户 ID、行为事件，并追溯到注册代码、分析配置和处理目的。 |
-| `sharing_and_retention` | PASS | 报告识别 ExampleAnalytics 共享、数据库与日志存储风险、明文邮箱/IP、供应商保障缺失及 retentionDays 为 null 的保留风险。 |
-| `user_rights` | PASS | 报告检查并指出同意、访问、删除、导出和更正接口或流程均无实现证据，并提出覆盖第三方及备份的建议。 |
-| `compliance_gaps` | PASS | 报告给出按优先级划分的合规缺口、数据最小化、同意、保留删除、供应商和用户权利整改建议。 |
+| `data_inventory` | PASS | The locked privacy-map.md inventories name, email, IP, User-Agent, userId, and account_created, with code/config/PRD entry points and purposes. |
+| `sharing_and_retention` | PASS | The report identifies ExampleAnalytics sharing, enabled-by-default/no-consent configuration, null retention, unknown database/log retention, and missing deletion synchronization. |
+| `user_rights` | PASS | The report explicitly checks access, deletion, export/portability, and correction, and documents the absence of supporting interfaces or synchronization flows. |
+| `compliance_gaps` | PASS | The locked report provides prioritized remediation covering consent, minimization, retention/deletion, rights workflows, vendor governance, logging, and an onboarding/upcoming-release decision. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=da21f882704758587ca44f889b8ee407dbf02d8334de8546d9781960b0a34c12; fixture_sha256=fc7c85721e9b7bd81a9ba3e487c8f00f57880deb91ce00e1ae1258884cc231db; output_sha256=b59036c74c84fbce66b195d21feafc3e96bfd968e551adaeb4d024e50d86dd7e; snapshot_sha256=751bfaba66cae05b89f8143976861e573dc020d2006191dcb247d0da63703fa6
-- Behavior: 交付了结构化隐私处理面报告，基于代码、配置和文档证据覆盖数据清单、共享保留、用户权利及整改建议，并明确静态证据边界。
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=da21f882704758587ca44f889b8ee407dbf02d8334de8546d9781960b0a34c12; fixture_sha256=fc7c85721e9b7bd81a9ba3e487c8f00f57880deb91ce00e1ae1258884cc231db; output_sha256=6ff6377ae679598bb3b5be3ddd3c3440cb561ac0ccabdb745aa681f3d2e7fecd; snapshot_sha256=3e7e3db3a884dccbccc11c27ea76d74fdcf6e9fb35ae47d06ab7e3860dbefb19
+- Behavior: Delivered a traceable privacy-processing report with evidence-backed inventory, risks, rights gaps, prioritized recommendations, and handoff context.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=da21f882704758587ca44f889b8ee407dbf02d8334de8546d9781960b0a34c12; fixture_sha256=fc7c85721e9b7bd81a9ba3e487c8f00f57880deb91ce00e1ae1258884cc231db; output_sha256=eeeb89008d738032aa9d2cb8119c5c2e288ec0806df4c092de3942284fa5529c; snapshot_sha256=66a352ebd5de17a173f8119a39623a08d69e11837083f605ff4ffe3231abbb6b
-- Behavior: 新鲜基线同样交付了覆盖请求主题的隐私报告；作为比较上下文，未影响 with_skill 的独立判定。
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=da21f882704758587ca44f889b8ee407dbf02d8334de8546d9781960b0a34c12; fixture_sha256=fc7c85721e9b7bd81a9ba3e487c8f00f57880deb91ce00e1ae1258884cc231db; output_sha256=032f3329fceab7d051763d5b228881068a76074c57223de754cf167318dcaf37; snapshot_sha256=71ea472ea0e9f92baed7af5b2ee3b2fffb7b774c58ecdb11b3dea2c7f4889256
+- Behavior: Delivered a comparable privacy-processing report covering the requested areas and an explicit do-not-launch conclusion; less structured than the with_skill report.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/security/test/privacy-surface-mapper/evals/workspace/eval-002-user-rights/comparison.md
+++ b/agents/security/test/privacy-surface-mapper/evals/workspace/eval-002-user-rights/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `2a160ab6ab1065aa7d10a9502c97feefe12d13d5af072b1075181fbf932723d8` from `agents/security/test/privacy-surface-mapper/evals/workspace/eval-002-user-rights`.
 - Identity schema: `2`
-- target_skill_sha256: `36470092bada7ef550e554a98c281f2fe94c427f5a20542e3fb5f13c69f3b496`
+- target_skill_sha256: `2d9aa34423715a24783169e774af3c68a95cbc320b5fc5af4b5753bd7785f2a0`
 - eval_definition_sha256: `ba5034d1b895bcb95cc9d848045b869189eec2c98d23c0a5d5ce381059a73047`
 - metadata_sha256: `747c4437caa882844d7f4c740414dcda7c0dbb14392d11ed34230c9d397ac11a`
 - fixture_sha256: `2a160ab6ab1065aa7d10a9502c97feefe12d13d5af072b1075181fbf932723d8`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `46c6f10cb2ee094e0f2d9b8cf0d9d794ebc801a301eb97187a76e961b4e37fd0`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `f954f6fb2beee6f446fdaf1e7380f20a7139675884dad90e43a17db9c8bbe9d0`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `04d179782a25ad87f73775d407c14368f4301d86a871528ca2b66e82792a813b`
+- Skill overlay SHA-256: `2eea2d31331dfff7d98326573b856ca9f269bca068d5f182bf99e8b0d5d75219`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,21 +33,21 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `data_inventory` | PASS | The locked report inventories user profiles, orders, behavioral events, and deletion state, and maps them to the relevant endpoints and purposes. |
-| `sharing_and_retention` | PASS | The locked report identifies analytics, backups, caches, queues, and other replicas as unverified sharing/retention surfaces, with risks and remediation recommendations. |
-| `user_rights` | PASS | The locked report evaluates access, export, deletion, and correction support, including the concrete authorization and completeness failures. |
-| `compliance_gaps` | PASS | The locked report provides prioritized privacy/compliance gaps, impacts, release recommendation, and specific remediation actions. |
+| `data_inventory` | PASS | Locked privacy-map.md inventories user profiles, orders, behavioral events, and deletion markers, with purposes and endpoint/data-flow evidence. |
+| `sharing_and_retention` | PASS | Locked privacy-map.md identifies unknown retention, absent retention/legal-hold policy, unavailable processor/transfer evidence, and risks from incomplete deletion propagation. |
+| `user_rights` | PASS | Locked report evaluates access, export, deletion, rectification, authentication, tracking, and secure delivery; it identifies the IDOR and incomplete rights implementation. |
+| `compliance_gaps` | PASS | Locked report provides prioritized privacy/compliance gaps, impacts, remediation recommendations, testing needs, release decision, and ownership handoff. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f954f6fb2beee6f446fdaf1e7380f20a7139675884dad90e43a17db9c8bbe9d0; fixture_sha256=2a160ab6ab1065aa7d10a9502c97feefe12d13d5af072b1075181fbf932723d8; output_sha256=4fec90ad5171ffa1d71590300bb972d1db736310884a48b2577d188eec3d0711; snapshot_sha256=b0f2c05bdf064b6de3871991b0de177751e9cc6a0afb19a912b77cec7d0f67a1
-- Behavior: Delivered a complete, evidence-based privacy surface report covering inventory, sharing/retention, user rights, compliance gaps, impacts, and remediation.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f954f6fb2beee6f446fdaf1e7380f20a7139675884dad90e43a17db9c8bbe9d0; fixture_sha256=2a160ab6ab1065aa7d10a9502c97feefe12d13d5af072b1075181fbf932723d8; output_sha256=4f1686815c031c0354874ed2e02c4a5fef0e8862ea32de0f297fa15f8b6af614; snapshot_sha256=f4fff6995d67d1a0f1267bce96ae33a88f10531bf94d7ed8c75119eb65d2fbc4
+- Behavior: Delivered a substantive privacy surface map and Security-owned report covering data inventory, flows, rights status, retention/sharing uncertainty, risks, compliance gaps, remediation, testing, and ownership.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f954f6fb2beee6f446fdaf1e7380f20a7139675884dad90e43a17db9c8bbe9d0; fixture_sha256=2a160ab6ab1065aa7d10a9502c97feefe12d13d5af072b1075181fbf932723d8; output_sha256=19592d4e533b772e691eb1faba88cc94920ed2f24d611e4b12328d0f73d62e47; snapshot_sha256=639e6b256cf553b2976000518a3b8f4d3b8cf58bbb6d4b2eedbfc112270658bb
-- Behavior: Produced a solid comparison report covering the principal authorization, export, deletion, retention, and audit gaps, but with less complete inventory and compliance mapping.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f954f6fb2beee6f446fdaf1e7380f20a7139675884dad90e43a17db9c8bbe9d0; fixture_sha256=2a160ab6ab1065aa7d10a9502c97feefe12d13d5af072b1075181fbf932723d8; output_sha256=60f5e601c0ee402d8d5b0c6c71223b1d3524d376480603718345e5e1bb3f2066; snapshot_sha256=747c584d699b0109b79425e40cb79a3695b477ac37a195b823fcb9d57b261942
+- Behavior: Delivered a shorter security report identifying major authorization, deletion, export, retention, and abuse-control gaps, but with less complete data inventory and privacy-surface mapping.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps

--- a/agents/security/test/privacy-surface-mapper/evals/workspace/eval-003-third-party/comparison.md
+++ b/agents/security/test/privacy-surface-mapper/evals/workspace/eval-003-third-party/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `a0f9b5ed56aa92319d126897928b2da5ef1b5b085fbe003f0b4425dde5805c73` from `agents/security/test/privacy-surface-mapper/evals/workspace/eval-003-third-party`.
 - Identity schema: `2`
-- target_skill_sha256: `36470092bada7ef550e554a98c281f2fe94c427f5a20542e3fb5f13c69f3b496`
+- target_skill_sha256: `2d9aa34423715a24783169e774af3c68a95cbc320b5fc5af4b5753bd7785f2a0`
 - eval_definition_sha256: `fde37322a972618cf8b85d5463c8e7a856c7547f8c15123669fd15297f556852`
 - metadata_sha256: `2bb39446486b68c792ab91df36f237757842e6cc3f736b5a421d1cc25cf91455`
 - fixture_sha256: `a0f9b5ed56aa92319d126897928b2da5ef1b5b085fbe003f0b4425dde5805c73`
@@ -22,9 +22,9 @@
 - judge_schema_sha256: `46c6f10cb2ee094e0f2d9b8cf0d9d794ebc801a301eb97187a76e961b4e37fd0`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `f08db36d8714dffcf75b41015d8dc4b37be4570b39ece9523f67238ebf8ed935`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `04d179782a25ad87f73775d407c14368f4301d86a871528ca2b66e82792a813b`
+- Skill overlay SHA-256: `2eea2d31331dfff7d98326573b856ca9f269bca068d5f182bf99e8b0d5d75219`
 - Behavior result: **PASS**
 - Coverage result: **FULL**
 Overall result: PASS
@@ -33,27 +33,27 @@ Overall result: PASS
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `data_inventory` | PASS | With-skill delivery snapshot inventories all three vendors, fields, data categories, purposes, and code-triggered sending paths with direct file references. |
-| `sharing_and_retention` | PASS | With-skill report identifies sharing recipients, US/unknown regions, configured retention, missing or limited deletion support, and distinguishes configured policy from runtime proof. |
-| `user_rights` | PASS | With-skill report evaluates access, deletion, export, correction, consent, and propagation gaps, including the payment deletion API limitation. |
-| `compliance_gaps` | PASS | With-skill report provides prioritized compliance risks and concrete recommendations covering consent, minimization, rights propagation, regional transfer evidence, retention, deletion, and follow-up ownership. |
+| `data_inventory` | PASS | with_skill 的锁定报告逐项列出三类服务接收字段、个人数据类型、sendUserEvent 触发入口及处理目的，并有代码字段映射。 |
+| `sharing_and_retention` | PASS | with_skill 报告识别了三家第三方及 US/未配置地域、730/2555 天和未配置保留期，区分了删除 API 配置与实际删除编排，并说明配置不等同于运行时证据。 |
+| `user_rights` | PASS | with_skill 报告检查了同意/退出、访问、删除、导出/可携带和更正，明确指出未发现入口或第三方权利请求传播；同时区分 ExampleAnalytics 无删除 API 与 ExamplePay 有 API 但无调用。 |
+| `compliance_gaps` | PASS | with_skill 报告给出了按风险和责任方组织的整改建议，覆盖同意控制、字段最小化、地域/跨境、保留删除、权利请求编排及运行证据验证。 |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f08db36d8714dffcf75b41015d8dc4b37be4570b39ece9523f67238ebf8ed935; fixture_sha256=a0f9b5ed56aa92319d126897928b2da5ef1b5b085fbe003f0b4425dde5805c73; output_sha256=972b8801eb902b8f1e90ac6658596ecfab64aceac7a9af580fdc8975ef01c1aa; snapshot_sha256=5721405a998f34cb0c5b70271637df91afbf8ab3911ebbc1a905c9d336c83c6c
-- Behavior: Delivered a complete, evidence-linked privacy processing map and actionable compliance assessment without implementing unrelated fixes.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f08db36d8714dffcf75b41015d8dc4b37be4570b39ece9523f67238ebf8ed935; fixture_sha256=a0f9b5ed56aa92319d126897928b2da5ef1b5b085fbe003f0b4425dde5805c73; output_sha256=fd7498a8b00746f292901acec04c9ac2b914677a11e172207e0724bec1c9219e; snapshot_sha256=84bf85e6360eece4f445f5d3117990226fcaa108b7c274bb0d9b3a458395c84e
+- Behavior: 完成并交付结构化隐私处理面报告，覆盖数据清单、共享与保留、用户权利、风险和整改建议；未修改代码或正式文档。
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f08db36d8714dffcf75b41015d8dc4b37be4570b39ece9523f67238ebf8ed935; fixture_sha256=a0f9b5ed56aa92319d126897928b2da5ef1b5b085fbe003f0b4425dde5805c73; output_sha256=d0319b007fdf0d61094c0552b74470891cbe8ec9a300cfc6e4cdbe87b264ae93; snapshot_sha256=fb6708495744d5e5bd995c66cc80bb7e2b7ce1041c9583867560c13b64e96052
-- Behavior: Provided a shorter third-party sharing report covering the main findings, useful as a fresh baseline comparison.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=f08db36d8714dffcf75b41015d8dc4b37be4570b39ece9523f67238ebf8ed935; fixture_sha256=a0f9b5ed56aa92319d126897928b2da5ef1b5b085fbe003f0b4425dde5805c73; output_sha256=7c39094e69da1657afc869a50a410d570e3a2c67fdca3eba258ea8b8a4646437; snapshot_sha256=c7d37fac447c089c01c44b745d0b03b20eb9d55826f09b7dbb83e82b4914919b
+- Behavior: 同样交付了结构化第三方共享报告并覆盖主要结论，作为基线比较；其表现不影响 with_skill 判定。
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
 - None.
-- Next: None.
+- Next: 由 PM 对高风险整改进行分类，再交应用工程和平台工程处理。
 
 ## Runtime Artifact Policy
 

--- a/agents/security/test/privacy-surface-mapper/evals/workspace/eval-004-mapped-profile-retention/comparison.md
+++ b/agents/security/test/privacy-surface-mapper/evals/workspace/eval-004-mapped-profile-retention/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `770d05d85a5304099a8f9433d2be942409c59c2f8ece13f985350673cd6e1b76` from `agents/security/test/privacy-surface-mapper/evals/workspace/eval-004-mapped-profile-retention`.
 - Identity schema: `2`
-- target_skill_sha256: `36470092bada7ef550e554a98c281f2fe94c427f5a20542e3fb5f13c69f3b496`
+- target_skill_sha256: `2d9aa34423715a24783169e774af3c68a95cbc320b5fc5af4b5753bd7785f2a0`
 - eval_definition_sha256: `4636a9753113bcd43710d7f9510814811413ce11cdc5e68daebdc570220f08a9`
 - metadata_sha256: `77d448d668cd55f753d5775b3a1d6295d66bd9b2b4219c2edf0b6a48f8bc6666`
 - fixture_sha256: `770d05d85a5304099a8f9433d2be942409c59c2f8ece13f985350673cd6e1b76`
@@ -22,38 +22,38 @@
 - judge_schema_sha256: `fe1f59786edfa4e3b7ee12601522d693ef12a42cdfce9b4a390ad6d7b95d03d2`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `90526a6f11b7d07cc96154485f1093a95a1e0a80c1ca3d9a35272a8e6b6e737f`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `04d179782a25ad87f73775d407c14368f4301d86a871528ca2b66e82792a813b`
-- Behavior result: **PASS**
+- Skill overlay SHA-256: `2eea2d31331dfff7d98326573b856ca9f269bca068d5f182bf99e8b0d5d75219`
+- Behavior result: **FAIL**
 - Coverage result: **PARTIAL**
-Overall result: PASS (partial coverage)
+Overall result: FAIL
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `reads_mapped_docs_first` | PASS | Raw trace shows the task landing was identified, the change-map entry was located, and the required document was read; no unrelated formal documents were present or traversed. |
-| `verifies_against_code` | PASS | The locked report directly records the YAML configuration as 90 days, the formal document as 30 days, distinguishes configured policy from runtime behavior, and states the compliance impact. |
-| `treats_unverified_as_low_trust` | PASS | The report explicitly marks both mapped documents as unverified/low-trust and bases the retention conclusion on configuration evidence, while noting runtime behavior is unverified. |
-| `escalates_fact_changing_conclusion_to_pm` | NOT_EXERCISED | The Security report correctly specifies return to pm-agent for classification and PM-owned issue filing, and forbids direct Docs handoff or Security issue creation. PM confirmation and subsequent issue creation are not exercised in the locked run. |
+| `reads_mapped_docs_first` | FAIL | Trace shows docs/site/api/profile-data.md was read at item_9 before docs/site/standards/change-map.yaml at item_11; the required document was not selected by first reverse-mapping from the target YAML. |
+| `verifies_against_code` | PASS | The delivered report directly cites src/privacy/profile-processing.yaml, identifies configured retention as 90 days versus the documented 30 days, and explains the 60-day compliance discrepancy. |
+| `treats_unverified_as_low_trust` | PASS | The delivered report records last_verified_version as unverified, treats the document as low trust, and distinguishes configured policy from unverified runtime behavior. |
+| `escalates_fact_changing_conclusion_to_pm` | NOT_EXERCISED | The report was delivered as a Security-owned docs/security process report and the final output states the conclusion and evidence should return to pm-agent. Actual issue creation is not exercised; the evidence contains no issue-creation event, and the next PM action would require confirmation. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=90526a6f11b7d07cc96154485f1093a95a1e0a80c1ca3d9a35272a8e6b6e737f; fixture_sha256=770d05d85a5304099a8f9433d2be942409c59c2f8ece13f985350673cd6e1b76; output_sha256=9c7e95407603399df3b76f759feef2ed3ca553441863830296c007a07ace7a32; snapshot_sha256=fa1579182bf2b73c49d39b4e6ec3201f88de1b2cd8295a9032228ed8344420ab
-- Behavior: Produced the required Security-owned privacy report with correct field, purpose, retention discrepancy, low-trust handling, compliance impact, and escalation guidance.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=90526a6f11b7d07cc96154485f1093a95a1e0a80c1ca3d9a35272a8e6b6e737f; fixture_sha256=770d05d85a5304099a8f9433d2be942409c59c2f8ece13f985350673cd6e1b76; output_sha256=67fe414e755418ecb155dd856b8d148bb0129b71bb8b3c50e881eff7982879cc; snapshot_sha256=160d76b8c9d74cdc4cf190414d343bea54974903851145897c1f961120660d25
+- Behavior: Produced the required privacy report with accurate field, purpose, retention mismatch, low-trust documentation handling, runtime-evidence caveat, and PM escalation guidance.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=90526a6f11b7d07cc96154485f1093a95a1e0a80c1ca3d9a35272a8e6b6e737f; fixture_sha256=770d05d85a5304099a8f9433d2be942409c59c2f8ece13f985350673cd6e1b76; output_sha256=5def917fe5f2346a9c41166d364abe2fbb963482194cfb8dc118c7537983e89f; snapshot_sha256=4de68a4022355757154dd1cbbd3d67506c0211a88c0b020c37863aa0d1b2c20f
-- Behavior: Produced a broadly correct privacy summary and report, but did not evidence the mapped-document workflow or PM escalation behavior; this is comparison context only.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=90526a6f11b7d07cc96154485f1093a95a1e0a80c1ca3d9a35272a8e6b6e737f; fixture_sha256=770d05d85a5304099a8f9433d2be942409c59c2f8ece13f985350673cd6e1b76; output_sha256=17cf1d791aa83ff0b61c2dbe35f66d82bac2d0c482c6bd2993cbaad0488f7889; snapshot_sha256=3960338f58730f6fcbe76685934331a934140964c45ad460c19b6e1e31e100d1
+- Behavior: Produced a similar report identifying the 90-day versus 30-day mismatch and runtime evidence gap, but did not demonstrate low-trust handling or PM escalation.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- None.
-- Next: After user confirmation, have pm-agent classify the escalation and create the tracking issue.
+- The with_skill trace reads the mapped formal document before reading the change-map, contrary to the required reverse-mapping/read-order assertion.
+- Next: After PM confirmation, classify the escalation and create the tracking issue.
 
 ## Runtime Artifact Policy
 

--- a/agents/security/test/security-agent/evals/workspace/eval-1-route-auth-release-risk/comparison.md
+++ b/agents/security/test/security-agent/evals/workspace/eval-1-route-auth-release-risk/comparison.md
@@ -13,7 +13,7 @@
 - Judge: third independent fresh judge completed after both candidates were locked.
 - Fixture version/source: canonical manifest `6becbc324dd17ee4f5ba7cdf2d867ad58ae183800d34e6d3eb510323380d49a0` from `agents/security/test/security-agent/evals/workspace/eval-1-route-auth-release-risk`.
 - Identity schema: `2`
-- target_skill_sha256: `02e38e560c7190aeb913b7c5d8c7a2d7815e82ab5a7f447a1c96c00f49f9f173`
+- target_skill_sha256: `3fda47276f652c3a8bf71ee145e10142e5e8e52ecaf4fa1602d50b284a2d428a`
 - eval_definition_sha256: `d5973b25612b7e076dab35db16f38a088f965995470b2ae2a1e956ac49b1959d`
 - metadata_sha256: `10861a3430f4e9df517502c7dede98b52c06228662db21b0d8914dd6b558a77c`
 - fixture_sha256: `6becbc324dd17ee4f5ba7cdf2d867ad58ae183800d34e6d3eb510323380d49a0`
@@ -22,40 +22,41 @@
 - judge_schema_sha256: `d09f4cbeb933e811c934cf8e665fe7675560abe0fc34d7865e0c67a56b1f4b12`
 - Source lock SHA-256: `3ebae34325936f4e2e3c026a791153749d1badc2d4c3b3ad70f2bd4ca2256b13`
 - Prompt SHA-256: `5a4bc456b36f0fe19e8d15843877f0c9ef8daed9d99b67bdcc85d65720c79c5b`
-- Repository HEAD: `9ea58cf4e8c46064bd1a2c1cb2ca632f0a385fa0`
+- Repository HEAD: `f7c125e9c3f465c6345737b1b5941915ca530ba1`
 - Repository worktree state: **DIRTY**
-- Skill overlay SHA-256: `fd5b004e70c26dca0a4abf3ce0d7b2fe1350c24120a987bbc6ab7abf7df07079`
-- Behavior result: **PASS**
+- Skill overlay SHA-256: `5a1cae404d0abcef05fcdec59cac49a5b24d80a8810e8c341d88e853203b4442`
+- Behavior result: **FAIL**
 - Coverage result: **PARTIAL**
-Overall result: PASS (partial coverage)
+Overall result: FAIL
 
 ## Assertion Results
 
 | Assertion | Result | Evidence |
 | --- | --- | --- |
-| `routes_primary_to_authz` | PASS | With-skill output explicitly selects `authz-reviewer` as the priority route for admin cross-tenant/platform authorization risks. |
-| `names_dependency_followup` | PASS | It explicitly assigns dependency supply-chain review to `dependency-risk-auditor` after the authorization review. |
-| `collects_security_context` | PASS | It lists authentication/session lifecycle, the four-role permission matrix, all three sensitive routes, negative-test evidence, and dependency/lockfile/CVE evidence as required review inputs. |
-| `structured_risk_output` | PASS | It specifies a structured security review under `docs/security/auth-model/` containing a risk matrix, evidence, impact, remediation recommendations, and evidence gaps, and says it is not an implementation patch. |
-| `hands_off_remediation` | PASS | It assigns application/authentication fixes to `engineer-agent` and dependency/build/deployment fixes to `devops-agent`. |
-| `evaluates_escalation_to_pm_at_closeout` | NOT_EXERCISED | The candidate correctly marks PM escalation as not applicable yet and requires a later security conclusion before returning findings to `pm-agent`, but the interactive workflow stops pending confirmation to start `authz-reviewer`; closeout evaluation is therefore not exercised. |
+| `routes_primary_to_authz` | FAIL | The with_skill output places `appsec-checklist` first and `authz-reviewer` second, so it does not select `authz-reviewer` as the current primary route. |
+| `names_dependency_followup` | PASS | It explicitly routes dependency vulnerability and supply-chain review to `dependency-risk-auditor` as a later stage. |
+| `collects_security_context` | PASS | It identifies authentication/session flow, the guest/member/admin/platform-ops role matrix, sensitive routes, related test evidence, and dependency-version evidence as required review inputs or outputs. |
+| `structured_risk_output` | PASS | It explicitly requires a structured security review/risk report containing a risk matrix, evidence, impact, and remediation suggestions, rather than an implementation patch. |
+| `hands_off_remediation` | PASS | It hands application authorization fixes to `engineer-agent` and dependency/build/deployment fixes to `devops-agent`. |
+| `evaluates_escalation_to_pm_at_closeout` | NOT_EXERCISED | The workflow stops before closeout pending confirmation and an unavailable `appsec-checklist`; the output states escalation is not applicable yet but does not exercise the full closeout evaluation. |
 
 ## With-Skill Behavior
 
-- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5a4bc456b36f0fe19e8d15843877f0c9ef8daed9d99b67bdcc85d65720c79c5b; fixture_sha256=6becbc324dd17ee4f5ba7cdf2d867ad58ae183800d34e6d3eb510323380d49a0; output_sha256=dccd8fe75eff7024a45b5de8da013da1815cbc9351f5ccc9273126624a47a777; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Correctly routes authorization first, names dependency follow-up, identifies required security evidence, defines structured outputs, and assigns remediation ownership. It pauses for user confirmation before downstream execution.
+- Run source: fresh with_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5a4bc456b36f0fe19e8d15843877f0c9ef8daed9d99b67bdcc85d65720c79c5b; fixture_sha256=6becbc324dd17ee4f5ba7cdf2d867ad58ae183800d34e6d3eb510323380d49a0; output_sha256=932f21d1367e02b72f15b7c2f59bea778fa83370ad431aa9fc58c2ce3f98f539; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+- Behavior: Provides named security routes, required review context, structured deliverables, remediation ownership, and a conditional PM escalation note, but orders `appsec-checklist` before the required primary authorization review and stops before closeout.
 - The with-skill context was created only after the baseline evidence was locked and destroyed.
 
 ## Fresh Without-Skill Baseline
 
-- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5a4bc456b36f0fe19e8d15843877f0c9ef8daed9d99b67bdcc85d65720c79c5b; fixture_sha256=6becbc324dd17ee4f5ba7cdf2d867ad58ae183800d34e6d3eb510323380d49a0; output_sha256=92ed16a254dfa602e3029c64dc34f9cfba14daafa650e12b5d3ba7e8b6c01f5c; snapshot_sha256=4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
-- Behavior: Provides a detailed review sequence and evidence requirements but does not establish the required named routes, remediation handoff, or closeout escalation policy.
+- Run source: fresh without_skill candidate; model=gpt-5.6-luna; effort=medium; returncode=0; timed_out=False; prompt_sha256=5a4bc456b36f0fe19e8d15843877f0c9ef8daed9d99b67bdcc85d65720c79c5b; fixture_sha256=6becbc324dd17ee4f5ba7cdf2d867ad58ae183800d34e6d3eb510323380d49a0; output_sha256=35e82060dfb8b7c6517d4711070875cc65899f59a24274ab31f9ec8f65868af3; snapshot_sha256=65aac036b6562a5c68f9ebc5b01774410c41b40b46b7e088773c558412b775f8
+- Behavior: Provides a generic security review plan and blockers but does not name the required specialist routes or the PM escalation/role handoff behavior.
 - The baseline was generated fresh first, its output and delivery snapshot were locked, then its context was destroyed.
 
 ## Failures and Next Steps
 
-- None.
-- Next: Confirm starting `authz-reviewer`, then run the dependency audit and perform closeout escalation evaluation after security conclusions are available.
+- The primary route is `appsec-checklist`, not the required `authz-reviewer`.
+- Next: Make `authz-reviewer` the primary route, with dependency review as the follow-up.
+- Next: Resolve or explicitly hand off the unavailable `appsec-checklist`, then obtain confirmation before continuing to closeout evaluation.
 
 ## Runtime Artifact Policy
 

--- a/agents/test_eval_contract.py
+++ b/agents/test_eval_contract.py
@@ -1336,6 +1336,7 @@ class EvalContractTests(unittest.TestCase):
                     {
                         "name": "engineer-agent",
                         "version": "1.2.3-rc.10",
+                        "description": "Engineering work",
                     }
                 )
             )
@@ -1358,6 +1359,7 @@ class EvalContractTests(unittest.TestCase):
                         "plugins": [
                             {
                                 "name": "engineer-agent",
+                                "description": "Engineering work",
                                 "source": "./agents/engineer",
                                 "skills": ["./skills/example"],
                             }

--- a/scripts/check_repository_contract.py
+++ b/scripts/check_repository_contract.py
@@ -20,6 +20,7 @@ except ModuleNotFoundError:  # Imported as scripts.check_repository_contract in 
 
 SKILL_NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 LOCK_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
+SKILL_DESCRIPTION_MAX_CHARS = 500
 SEMVER_CORE_PATTERN = r"(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)"
 SEMVER_PRERELEASE_IDENTIFIER_PATTERN = (
     r"(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)"
@@ -365,6 +366,27 @@ def validate_skill_visibility(root: Path, errors: list[ContractError]) -> None:
             )
 
 
+def validate_skill_description_lengths(
+    root: Path, errors: list[ContractError]
+) -> None:
+    for pattern in ("agents/*/skills/*/SKILL.md", ".agents/skills/*/SKILL.md"):
+        for skill_doc in sorted(root.glob(pattern)):
+            metadata = parse_frontmatter(skill_doc, errors)
+            if metadata is None:
+                continue
+            description = metadata.get("description")
+            if (
+                isinstance(description, str)
+                and len(description) > SKILL_DESCRIPTION_MAX_CHARS
+            ):
+                add_error(
+                    errors,
+                    skill_doc,
+                    "frontmatter description exceeds "
+                    f"{SKILL_DESCRIPTION_MAX_CHARS} characters: {len(description)}",
+                )
+
+
 def prerelease_identifier_key(identifier: str) -> tuple[int, int | str]:
     if identifier.isdigit():
         return 0, int(identifier)
@@ -446,6 +468,7 @@ def validate_plugin_manifest(
     plugin_index: int,
     plugin_name: Any,
     metadata_version: Any,
+    marketplace_description: Any,
     errors: list[ContractError],
 ) -> None:
     if not manifest_path.exists():
@@ -479,6 +502,19 @@ def validate_plugin_manifest(
             errors,
             manifest_path,
             f"version must match marketplace metadata.version {metadata_version!r}",
+        )
+
+    if not isinstance(marketplace_description, str) or not marketplace_description.strip():
+        add_error(
+            errors,
+            marketplace_path,
+            f"plugins[{plugin_index}].description must be a non-empty string",
+        )
+    elif payload.get("description") != marketplace_description:
+        add_error(
+            errors,
+            manifest_path,
+            f"description must match marketplace plugins[{plugin_index}].description",
         )
 
 
@@ -543,6 +579,7 @@ def validate_marketplace(root: Path, errors: list[ContractError]) -> None:
             index,
             plugin.get("name"),
             metadata_version,
+            plugin.get("description"),
             errors,
         )
 
@@ -1810,6 +1847,7 @@ def validate_all(root: Path | None = None) -> list[ContractError]:
     validate_marketplace_document_status(root, errors)
     validate_skill_references(root, errors)
     validate_skill_visibility(root, errors)
+    validate_skill_description_lengths(root, errors)
     validate_skills_lock(root, errors)
     validate_feature_document_metadata(root, errors)
     validate_implementation_plan_metadata(root, errors)

--- a/scripts/test_check_repository_contract.py
+++ b/scripts/test_check_repository_contract.py
@@ -259,6 +259,67 @@ def test_skill_description_must_front_load_user_trigger(tmp_path: Path) -> None:
     )
 
 
+@pytest.mark.parametrize(
+    ("relative_path", "length", "should_fail"),
+    [
+        ("agents/engineer/skills/debugger/SKILL.md", 500, False),
+        (".agents/skills/maintain-skills/SKILL.md", 501, True),
+    ],
+)
+def test_skill_description_length_limit_includes_project_skills(
+    tmp_path: Path,
+    relative_path: str,
+    length: int,
+    should_fail: bool,
+) -> None:
+    skill_doc = tmp_path / relative_path
+    skill_doc.parent.mkdir(parents=True)
+    skill_doc.write_text(
+        "---\n"
+        f"name: {skill_doc.parent.name}\n"
+        f'description: "{"x" * length}"\n'
+        "---\n",
+        encoding="utf-8",
+    )
+
+    errors: list[contract.ContractError] = []
+    contract.validate_skill_description_lengths(tmp_path, errors)
+
+    assert bool(errors) is should_fail
+    if should_fail:
+        assert "exceeds 500 characters: 501" in errors[0].message
+
+
+def test_plugin_description_must_match_marketplace(tmp_path: Path) -> None:
+    marketplace_path = tmp_path / ".claude-plugin/marketplace.json"
+    manifest_path = tmp_path / "agents/engineer/.claude-plugin/plugin.json"
+    manifest_path.parent.mkdir(parents=True)
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "name": "engineer-agent",
+                "version": "0.5.1",
+                "description": "Stale plugin description",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    errors: list[contract.ContractError] = []
+    contract.validate_plugin_manifest(
+        manifest_path,
+        marketplace_path,
+        0,
+        "engineer-agent",
+        "0.5.1",
+        "Current marketplace description",
+        errors,
+    )
+
+    assert len(errors) == 1
+    assert "description must match marketplace" in errors[0].message
+
+
 def test_active_plan_status_is_unconditionally_required(tmp_path: Path) -> None:
     root = initialize_repo(tmp_path, base_status=None)
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -4,197 +4,197 @@
     "pm-agent": {
       "source": "agents/product_manager/skills/pm-agent",
       "sourceType": "local",
-      "computedHash": "1f111541a8b23978e9e8870fb80cf304de9daec81cb9020cce9a411f3c4f9efc"
+      "computedHash": "9a5831ad2e758d08191ab9a6675b7ed97ea38cd9459f08e1fe99f78e50b57d2e"
     },
     "idea-to-spec": {
       "source": "agents/product_manager/skills/idea-to-spec",
       "sourceType": "local",
-      "computedHash": "977126a37285964b5712f7b4a454d5a15ed5d0c87adc757a94d37dea4c62ca85"
+      "computedHash": "172318c43e2a12bdf6829ce33c92c6eed9f6895c86237882179b139df31f4e7d"
     },
     "feature-catalog": {
       "source": "agents/product_manager/skills/feature-catalog",
       "sourceType": "local",
-      "computedHash": "8203e04666bdfc9a8f25b28cd8f83340884dcbbc1966e1c3726218c9bddc64b8"
+      "computedHash": "8a9a4e52a3f669b9c5e299509c065da2138682d75d3d86ab11e28e1544afb89f"
     },
     "competitive-brief": {
       "source": "agents/product_manager/skills/competitive-brief",
       "sourceType": "local",
-      "computedHash": "4967bba96ddedc9bdf5505d66e652ee59087706612b70d63bd6fcbc39da2b087"
+      "computedHash": "398049416998d93e91c6ddcb29cb99cda139bc5310b201f04a09c18396db44dc"
     },
     "changelog-gen": {
       "source": "agents/product_manager/skills/changelog-gen",
       "sourceType": "local",
-      "computedHash": "57d7880178005c10ef9f526f6e4ca08544e4cb0b054345327b40fae14cfc3ddb"
+      "computedHash": "df5da596144229f49001d7516aa7d85b956aed27cdeecc1d1c8a0af1429f3f94"
     },
     "github-release-gen": {
       "source": "agents/product_manager/skills/github-release-gen",
       "sourceType": "local",
-      "computedHash": "800a02c7e27c3d421ec9ce8b95bce56452299d1c57ec454ac1341b6f2259fcea"
+      "computedHash": "0fcb5115287d7d3e335adbb0a3765f00db28d756d5603060d112da9c557279d8"
     },
     "release-notes-gen": {
       "source": "agents/docs/skills/release-notes-gen",
       "sourceType": "local",
-      "computedHash": "42bb93809185b2b7e4c5fbdb6fb017b91aa9a2bd176e922888aedd25c94b336c"
+      "computedHash": "a0021ac22dbfb78b68ec75cb06e73d63c0edb94613c2571393e2e766b13f1f0e"
     },
     "roadmap-gen": {
       "source": "agents/product_manager/skills/roadmap-gen",
       "sourceType": "local",
-      "computedHash": "1ceedda90c8e87b7ff7c34f665d69f8fdf25b4ec176f25a2486a15190b7701ec"
+      "computedHash": "a2260bc816c7811a1eea59eb270a25a00b5eb3012692e6687c4dd0e833e160e6"
     },
     "github-reader": {
       "source": "agents/product_manager/skills/github-reader",
       "sourceType": "local",
-      "computedHash": "75bec1956a5ad60ad497980fe4a6533d5bae68a2e4e6eeeeac8080690efa8c90"
+      "computedHash": "970cb9c3b9364a4552b67103f3f4284a549e6e1b6b975ec90779682412ac9205"
     },
     "engineer-agent": {
       "source": "agents/engineer/skills/engineer-agent",
       "sourceType": "local",
-      "computedHash": "109618c42f98cea53ce777cd3d3a593d259b84683ad8d5cd3287d68fac1ce77b"
+      "computedHash": "5e8c9b0dacf0d2ea3dccdbbcb6789d3655e08815265bb4c53073bc56a3175234"
     },
     "codebase-analyzer": {
       "source": "agents/engineer/skills/codebase-analyzer",
       "sourceType": "local",
-      "computedHash": "daa94a44e9f4115c1c78c1b8a70236e1dc68e7b3d57096b07123eaa815b9ad0d"
+      "computedHash": "fc751387d84253843eb2af368a6d85f86bb5c66f1155dc9b083e0b5f5b9f5d67"
     },
     "trd-gen": {
       "source": "agents/engineer/skills/trd-gen",
       "sourceType": "local",
-      "computedHash": "9e1ccba236c8d842c0b5d7c0ec0b981bacdbb18b3021e1a35892317a1a667a93"
+      "computedHash": "4508e8a44de1311c317e9f75e3dc69a65dcba854cc945ff057a5c2b94f843e95"
     },
     "feature-implementor": {
       "source": "agents/engineer/skills/feature-implementor",
       "sourceType": "local",
-      "computedHash": "50ccda568d5279a00c60be44d98a6532d62d92376cdc5e9f4e2aa8e0993f4768"
+      "computedHash": "42590aa733d69255fb21c998c7a8d34d560d11d5321057fe7da137bada1662c2"
     },
     "test-writer": {
       "source": "agents/engineer/skills/test-writer",
       "sourceType": "local",
-      "computedHash": "7b7dd6a1ac1cbe4fcbd6412bbe5a61047b09808dc96a14d55b1f95b69a4519e2"
+      "computedHash": "a072be58e511fbce5a460786f1f805af160d38b7ec5e7b8e35e48c1cf4f301a9"
     },
     "debugger": {
       "source": "agents/engineer/skills/debugger",
       "sourceType": "local",
-      "computedHash": "f3df0db3c1afdec11003a72e25b887f0245549030f3614ccfdf5b272ebef9dc3"
+      "computedHash": "516d5ca0eece7f70ba742ade109ac940c9cd483852113c38dd4709c52cd2bca1"
     },
     "delivery": {
       "source": "agents/engineer/skills/delivery",
       "sourceType": "local",
-      "computedHash": "1a13562b9a7d22f9a6e405abde5b4e9e50c0f34336898302d1e297db17f31130"
+      "computedHash": "8a1fea8508d488245d95361cdd6a6b79455ebfa0a6c4869703dfb43a1a8013a9"
     },
     "qa-agent": {
       "source": "agents/qa/skills/qa-agent",
       "sourceType": "local",
-      "computedHash": "3ece815fad2c225affcc6e59f55eb463c80ad1cb5a1a4b2d9a39edcd582c869e"
+      "computedHash": "99ba7935c43fa34646757c046a4ccfd7c610fe935b0637a41bf1251c0ca6a57c"
     },
     "exploratory-tester": {
       "source": "agents/qa/skills/exploratory-tester",
       "sourceType": "local",
-      "computedHash": "308bd9bfab58b72c3f2fdc1ec8a2f96e760b53e76b1b0d15d7f631cc7a2f97af"
+      "computedHash": "f035358f8286c44dc281e9c131319375b8fda03d1d42e17ff8dc85342eb0a634"
     },
     "spec-based-tester": {
       "source": "agents/qa/skills/spec-based-tester",
       "sourceType": "local",
-      "computedHash": "47d7d70bed4fe7b36b4e0a85c90e07def41657e6d49a84d7db964cfb139a4155"
+      "computedHash": "8c20281924eadd58c2f88b66be5c74456b4661ed4349e9ca0e7aa3a39a1ec6e3"
     },
     "bug-analyzer": {
       "source": "agents/qa/skills/bug-analyzer",
       "sourceType": "local",
-      "computedHash": "d37c42da90e47b8e81a678466f2efb9cd544cdedf66ccbf341056e72b8aa7eb9"
+      "computedHash": "77ab65ccb1a6190581d2e715459eef52365e10e74ba2e16a778b1314c8dea1df"
     },
     "regression-suite": {
       "source": "agents/qa/skills/regression-suite",
       "sourceType": "local",
-      "computedHash": "7a411e10b603ec8e662cf94401b8978a7c1b38dde838747e90787497c2a85f1c"
+      "computedHash": "e4add1bc4d58bddd52be42a566fb0954abdffe2f7ab61b233bcea4528ba18a82"
     },
     "devops-agent": {
       "source": "agents/devops/skills/devops-agent",
       "sourceType": "local",
-      "computedHash": "acf99de99d06d4a94ce772fed6e0924f2bf58542a61cefa6736c9530b80a86fc"
+      "computedHash": "bdcc8c658ff3603ca0e34fa82f0c2d2437b49da9b4b332f67f334525ade78441"
     },
     "deployment-planner": {
       "source": "agents/devops/skills/deployment-planner",
       "sourceType": "local",
-      "computedHash": "e67c35fb221e76b887004809f798dca0f32a3327dc69e28f854df12f8b465487"
+      "computedHash": "4a22c33d3396171f19abea38e92c8fc7c4c3422ffb8db96b09615fe1da99f20c"
     },
     "cicd-bootstrap": {
       "source": "agents/devops/skills/cicd-bootstrap",
       "sourceType": "local",
-      "computedHash": "159d836de38f442d529f3dc42fe0ecab87b3c7c9bf91398aa31bf5d4a0c3801b"
+      "computedHash": "05f168101ac9531834dd4ee3f5f9c70df1e0347de76fe67be4b77c135f8504e4"
     },
     "env-config-auditor": {
       "source": "agents/devops/skills/env-config-auditor",
       "sourceType": "local",
-      "computedHash": "16694e0576841516b4f2c1622c0cea95e0504a0b61afc6db088cc7ab95fb878b"
+      "computedHash": "0c5ee33f35d5288f75262916110c5473ebf72f569b67e7c03ded485edc52a6fe"
     },
     "incident-playbook-writer": {
       "source": "agents/devops/skills/incident-playbook-writer",
       "sourceType": "local",
-      "computedHash": "dd00cc4f139b41414edb61bff75ebd2c9738152b8b660f31c0b69e31f6b37f99"
+      "computedHash": "4af8491cdda49b9fa91d5cf58a3965046eb88a00047e66c8c9fddc2789c67ee8"
     },
     "designer-agent": {
       "source": "agents/designer/skills/designer-agent",
       "sourceType": "local",
-      "computedHash": "221422fac8da273157ec1600504707b0d7d2b4047a141e160854f2d8de44dd53"
+      "computedHash": "4363c3d0fcd6dd87a90ab3c9de72d2bdf35fb65cc43a5181c81cc3c0f4f2b7f6"
     },
     "ui-ux-design": {
       "source": "agents/designer/skills/ui-ux-design",
       "sourceType": "local",
-      "computedHash": "0174533debf4c433ed86a83ab1973eb0fa02f92ca83126c002f7c20355aee4f0"
+      "computedHash": "06e74c2eadf9afd01aac40c6fc820c8722f3fe64be01fba84379bef567093126"
     },
     "visual-design": {
       "source": "agents/designer/skills/visual-design",
       "sourceType": "local",
-      "computedHash": "ac15d716c3a6f548f105dc00929760adfd0c695f860ba1fc16bae1801ec7b7ab"
+      "computedHash": "cc3237f77a3024a4fc95e8877c2de2a51b402d9e68bfc09d744e53e7d682a854"
     },
     "security-agent": {
       "source": "agents/security/skills/security-agent",
       "sourceType": "local",
-      "computedHash": "2763c3d82c5c76bd47ba9b17bca5559d114163cf79f69977ebf6e4b9f0cd4099"
+      "computedHash": "63869ca94162b7457972b7740a3f190f29962a53954e0f9eca10bfd208b6f9a7"
     },
     "appsec-checklist": {
       "source": "agents/security/skills/appsec-checklist",
       "sourceType": "local",
-      "computedHash": "95394b1cb4c9bd976b35d7860b716a9556837aef46d97cb19c23b2b67f8ff7f5"
+      "computedHash": "414550aff8995337a408e932978253d85ce968ec6e5545ec398c76a3615fb4bb"
     },
     "authz-reviewer": {
       "source": "agents/security/skills/authz-reviewer",
       "sourceType": "local",
-      "computedHash": "d4af04b9d52b6aa0955aa07e46ce8937a21fad99e975fdf0d84cc4d57ef5bda9"
+      "computedHash": "c083f898da7ea675b73014dd34493783aad6c2a36b750c4d745c57149a4feede"
     },
     "dependency-risk-auditor": {
       "source": "agents/security/skills/dependency-risk-auditor",
       "sourceType": "local",
-      "computedHash": "fc28c3a40b4f20df32b38e4a34e63babae46c5cf96ce7b59a951e2d9b57fb8fc"
+      "computedHash": "9c0279a9328c5d7409521b4bdfd3743cfd51337e767ab629aa0e0d3bd850eecd"
     },
     "privacy-surface-mapper": {
       "source": "agents/security/skills/privacy-surface-mapper",
       "sourceType": "local",
-      "computedHash": "e9943ddfc911de54e2dea53064d0b6d0fc26b78bb6007c9cf740a3eb48342ba3"
+      "computedHash": "fde3433a92158b0f0fb89b7ed2a200c9735998bf07e8442efeef27aa409ec9af"
     },
     "docs-agent": {
       "source": "agents/docs/skills/docs-agent",
       "sourceType": "local",
-      "computedHash": "a860fdb7ab7781e378015c866bdece7f9a00aa97d366bdd1416b8ddb3abe2953"
+      "computedHash": "9b12db96bf1ad2872829db054f2d6ca5a35783994495702c2ee1fd79d21bba36"
     },
     "docs-site-bootstrap": {
       "source": "agents/docs/skills/docs-site-bootstrap",
       "sourceType": "local",
-      "computedHash": "f33a4d62de254ff67189afedd88da1318987568a4b7278fcecbddd4cb14870f1"
+      "computedHash": "a8d37d257871ffdb186877bab9fc2e960c1c55b97a507c82ba7257b502f43dd4"
     },
     "formal-docs-sync": {
       "source": "agents/docs/skills/formal-docs-sync",
       "sourceType": "local",
-      "computedHash": "e3ada3d5ee039e83691c73132beca760968f9272f8a8ccbbc6c6a471f4dcf070"
+      "computedHash": "41c2b55701d1d501e5de64c9f9fde8e03b8c70fb4c234d9daea787f79844795b"
     },
     "manual-gen": {
       "source": "agents/docs/skills/manual-gen",
       "sourceType": "local",
-      "computedHash": "8708d610c0ae750f9de3e00e7b1e24b3267aac3b7795f8f18a83453705c9a58d"
+      "computedHash": "299e9e7f15f7fdbefa7cd74a9e894e72cbde63c9aab725605e1f13c771aff7f8"
     },
     "docs-audit": {
       "source": "agents/docs/skills/docs-audit",
       "sourceType": "local",
-      "computedHash": "eaa729457df48518a515cf938ad3e503c152a6f8cdc19debe49f9abf670b1f10"
+      "computedHash": "00f56cf5a617302033e5ed3e88240b2489a2561a657d2891212723471209cd8f"
     }
   }
 }


### PR DESCRIPTION
## 变更内容

- 精简全部 41 个正式 `SKILL.md` description，只保留能力、使用时机和关键边界
- 为 description 增加 500 个 Unicode 字符的契约上限与边界测试
- 增加 Marketplace 与角色 plugin description 的一致性检查，并修复 Engineer plugin 的既有漂移
- 将脆弱的精确措辞断言调整为语义锚点
- 刷新 `skills-lock.json` 中 39 个角色 Skill 哈希
- 按新 Skill 身份完整刷新 201 份 eval comparison

## 背景与影响

部分 description 混入了工作流细节、实现步骤和重复边界，最长超过 700 字符，增加了路由契约的维护成本。治理后 41 个 description 全部缩短，最长 223 字符，能力边界仍由各 Skill 正文负责。

新增的仓库契约会阻止 description 超过 500 字符，也会阻止 Marketplace 与角色插件说明再次漂移。

## 验证

- `uv run scripts/generate_shared_contracts.py --check`
- `uv run scripts/check_repository_contract.py`
- `uv run scripts/check_doc_contract.py`
- `uv run scripts/check_eval_contract.py`
- `uv run scripts/check_eval_artifacts.py`
- `git diff --check`
- description/契约相关测试：94 passed
- eval 基础设施测试：170 passed，6 subtests passed
- 全量 Skill eval：201/201 完成，无 BLOCKED、超时或不完整项
  - 131 PASS
  - 40 PASS (partial coverage)
  - 30 FAIL

30 个 FAIL 均保留为完整、有效的模型评测结果，未进行选择性重跑。