### PR TITLE
docs(install): 修正安装文档中不存在的版本示例与过期发布表述

### DIFF
--- a/.codex/INSTALL.md
+++ b/.codex/INSTALL.md
@@ -70,7 +70,7 @@ SKILL_ROOT="$PROJECT_ROOT/.agents/skills"
 
 ### 2. Clone Or Update The Repository
 
-Set `TARGET_TAG` to a release tag (for example `v0.3.6`) when this install
+Set `TARGET_TAG` to a release tag (for example `v0.5.1`) when this install
 must match a specific released version, as the Release upgrade instructions
 do. Omit it for a plain latest install.
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Implementation details and troubleshooting are in the [Codex Guide](./docs/READM
 /plugins install https://github.com/Neplich/dev-agent-skills/tree/main
 ```
 
-The repository ships a `.kimi-plugin/plugin.json` manifest: all seven role skill directories are registered as a single plugin, and `pm-agent` loads automatically at session start via `sessionStart.skill`. The `tree/main` form installs the latest development state, where explicit capability names take priority and otherwise product or engineering R&D intent enters `pm-agent`. Once this policy is released, pin an immutable version with `/plugins install https://github.com/Neplich/dev-agent-skills/releases/tag/vX.Y.Z`.
+The repository ships a `.kimi-plugin/plugin.json` manifest: all seven role skill directories are registered as a single plugin, and `pm-agent` loads automatically at session start via `sessionStart.skill`. The `tree/main` form installs the latest development state, where explicit capability names take priority and otherwise product or engineering R&D intent enters `pm-agent`. To pin an immutable version instead, install from a release tag: `/plugins install https://github.com/Neplich/dev-agent-skills/releases/tag/vX.Y.Z`.
 
 Skills previously installed Codex-style into `~/.agents/skills/` are also discovered by Kimi Code automatically; the native plugin above is the recommended path.
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -69,7 +69,7 @@ Fetch and follow instructions from https://raw.githubusercontent.com/Neplich/dev
 /plugins install https://github.com/Neplich/dev-agent-skills/tree/main
 ```
 
-仓库内置 `.kimi-plugin/plugin.json` manifest：7 个角色 skill 目录注册为单个插件，`pm-agent` 随会话启动自动加载（`sessionStart.skill`）。上面的 `tree/main` 形式安装最新开发状态；版本发布后，可改用 `/plugins install https://github.com/Neplich/dev-agent-skills/releases/tag/vX.Y.Z` 固定不可变版本。
+仓库内置 `.kimi-plugin/plugin.json` manifest：7 个角色 skill 目录注册为单个插件，`pm-agent` 随会话启动自动加载（`sessionStart.skill`）。上面的 `tree/main` 形式安装最新开发状态；如需固定不可变版本，可改用 `/plugins install https://github.com/Neplich/dev-agent-skills/releases/tag/vX.Y.Z`。
 
 已按 Codex 方式安装到 `~/.agents/skills/` 的 skill 也会被 Kimi Code 自动扫描到；推荐优先使用上面的原生插件方式。
 


### PR DESCRIPTION
## 背景

Closes #292

安装文档存在两处过期版本事实：`.codex/INSTALL.md` 的固定版本示例 `v0.3.6` 在远端不存在；README 的 Kimi 安装说明仍用未来时描述"策略发布后固定版本"，但 v0.5.1 已发布且包含该策略。

## 改动

- `.codex/INSTALL.md`：`TARGET_TAG` 示例由不存在的 `v0.3.6` 改为已发布的 `v0.5.1`。
- `README.md` / `README_zh.md`：Kimi 安装主入口保持 `tree/main`（维护者决策，延续 PR #283 现状），将"版本发布后可固定"的未来时改为现在时，固定版本作为可选形式说明。

## 决策记录

Kimi 主入口形态经维护者确认为 `tree/main` 为主（2026-08-17，issue #292 处理过程中）；#261/PR #272 的固定版本决策不再作为主入口形态，固定版本保留为可选说明。

## 验证

- `uv run scripts/check_doc_contract.py`：PASS
- `uv run scripts/check_repository_contract.py`：PASS
- `git diff --check`：干净
- tag 存在性已核验：`git tag -l` 含 v0.5.1，无 v0.3.6
