### PR TITLE
docs(release): 补全 release cookbook 的版本同步面

### DIFF
--- a/docs/cookbook/release.md
+++ b/docs/cookbook/release.md
@@ -1,8 +1,11 @@
 # 手动发布
 
 1. 确认发布范围与目标不可变 SemVer。
-2. 把 `.claude-plugin/marketplace.json` 的 `metadata.version` 和
-   `.kimi-plugin/plugin.json` 的 `version` 更新为相同、不带 `v` 前缀的版本。
+2. 把以下版本面更新为相同、不带 `v` 前缀的版本（`check_repository_contract.py`
+   逐项强制一致）：
+   - `.claude-plugin/marketplace.json` 的 `metadata.version`；
+   - 七个角色 Agent 的 `agents/{agent}/.claude-plugin/plugin.json` 的 `version`；
+   - `.kimi-plugin/plugin.json` 的 `version`。
 3. 确认 `docs/changelog/changelog-v{version}.md` 存在，并被根 `CHANGELOG.md` 索引。
 4. 运行生成契约、repository/doc/eval contract、eval artifact、安装与受影响测试；执行
    必需的 fresh eval，并汇总其持久化 comparison。


### PR DESCRIPTION
## 背景

Closes #290

`docs/cookbook/release.md` 是人工发布顺序的权威入口，但其版本一致性步骤只列出 marketplace 的 `metadata.version` 和 Kimi 插件版本两处；`scripts/check_repository_contract.py` 实际还要求七个角色 Agent 的 `.claude-plugin/plugin.json` 版本与 marketplace 一致（v0.5.1 的发布 PR #284 即同步了全部 9 处）。文档权威范围与机器检查范围不一致，维护者可能漏改角色插件清单直到契约检查失败才发现。

## 改动

`docs/cookbook/release.md` 第 2 步改为列全契约强制的全部版本同步面：

- `.claude-plugin/marketplace.json` 的 `metadata.version`
- 七个角色 Agent 的 `agents/{agent}/.claude-plugin/plugin.json` 的 `version`
- `.kimi-plugin/plugin.json` 的 `version`

根 `AGENTS.md` 不改：它只声明 cookbook 为权威入口，cookbook 补全后组合即完整。

## 验证

- `uv run scripts/check_doc_contract.py`：PASS
- `uv run scripts/check_repository_contract.py`：PASS
- `git diff --check`：干净
- 版本面清单依据 `check_repository_contract.py` 的逐插件 version 校验与 PR #284 的实际同步范围
