### PR TITLE
docs(eval): 修正贡献指南的 comparison 模板与 CI 测试清单

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,7 @@ uv run --with pytest pytest \
   scripts/test_eval_runtime.py \
   scripts/test_run_skill_eval.py \
   scripts/test_check_eval_artifacts.py \
+  scripts/test_generate_shared_contracts.py \
   scripts/test_install_codex_skills.py \
   scripts/test_summarize_eval_results.py \
   scripts/test_check_repository_contract.py
@@ -66,7 +67,8 @@ The repository keeps only eval definitions and the latest persisted conclusions;
 
 1. Create or update the skill and eval fixtures.
 2. Run the relevant deterministic checks and the approved manual evals.
-3. Write the latest persisted result into `comparison.md`.
+3. Let the eval runner transactionally persist the latest result into `comparison.md`;
+   do not hand-edit it.
 4. Remove runtime artifacts before opening a PR.
 5. Commit only eval definitions, metadata, fixtures, README files, and `comparison.md`.
 
@@ -76,13 +78,12 @@ The repository keeps only eval definitions and the latest persisted conclusions;
 # Eval Result: <eval-name>
 
 ## Evaluation Target
-## Test Set / Fixture Version
-## Latest Result
-## With Skill
-## Without Skill / Baseline
-## Failures
-## Next Steps
-## Runtime Artifacts Policy
+## Current Result
+## Assertion Results
+## With-Skill Behavior
+## Fresh Without-Skill Baseline
+## Failures and Next Steps
+## Runtime Artifact Policy
 ```
 
 ## Maintenance Index

--- a/CONTRIBUTING_zh.md
+++ b/CONTRIBUTING_zh.md
@@ -34,6 +34,7 @@ uv run --with pytest pytest \
   scripts/test_eval_runtime.py \
   scripts/test_run_skill_eval.py \
   scripts/test_check_eval_artifacts.py \
+  scripts/test_generate_shared_contracts.py \
   scripts/test_install_codex_skills.py \
   scripts/test_summarize_eval_results.py \
   scripts/test_check_repository_contract.py
@@ -66,7 +67,7 @@ uv run scripts/run_skill_eval.py --jobs 10
 
 1. 新建或更新 skill 与 eval fixture。
 2. 运行相关确定性检查和已批准的手动 eval。
-3. 将最新持久化结果写入 `comparison.md`。
+3. 由评测 runner 将最新结果事务性持久化到 `comparison.md`，不手工编辑。
 4. 开 PR 前删除运行期产物。
 5. 只提交 eval 定义、metadata、fixture、README 文件和 `comparison.md`。
 
@@ -76,13 +77,12 @@ uv run scripts/run_skill_eval.py --jobs 10
 # Eval Result: <eval-name>
 
 ## Evaluation Target
-## Test Set / Fixture Version
-## Latest Result
-## With Skill
-## Without Skill / Baseline
-## Failures
-## Next Steps
-## Runtime Artifacts Policy
+## Current Result
+## Assertion Results
+## With-Skill Behavior
+## Fresh Without-Skill Baseline
+## Failures and Next Steps
+## Runtime Artifact Policy
 ```
 
 ## 维护索引


### PR DESCRIPTION
## 背景

Closes #291

两份贡献指南存在三处与仓库现状不一致的事实：

1. 测试命令清单缺少 CI 实际运行的 `scripts/test_generate_shared_contracts.py`。
2. `comparison.md` 示例模板仍用 `Latest Result` / `With Skill` 等旧标题；当前 201 份持久化 comparison 文件统一使用 `Current Result`、`Assertion Results`、`With-Skill Behavior`、`Fresh Without-Skill Baseline`、`Failures and Next Steps`、`Runtime Artifact Policy` 结构。
3. 步骤 3"将最新持久化结果写入 comparison.md"暗示手工维护；`skill-eval-runner` 的 SKILL.md 已声明 comparison 由 runner 事务性持久化。

## 改动

- `CONTRIBUTING.md` / `CONTRIBUTING_zh.md` 测试清单补入 `scripts/test_generate_shared_contracts.py`（位置与 CI 一致）。
- comparison 模板标题更新为当前持久化结构。
- 步骤 3 措辞改为"由评测 runner 事务性持久化，不手工编辑"。

## 验证

- `uv run scripts/check_doc_contract.py`：PASS
- `uv run scripts/check_repository_contract.py`：PASS
- `git diff --check`：干净
- 模板结构依据全仓 202 份 comparison.md 中 201 份的统一标题（唯一例外是 `agents/docs/test/manual-gen/comparison.md` 的中文标题结构，不在本 issue 边界内，未改动）
