### PR TITLE
fix(eval): runner 支持首次创建 comparison.md

### DIFF
--- a/.agents/skills/skill-eval-runner/SKILL.md
+++ b/.agents/skills/skill-eval-runner/SKILL.md
@@ -75,6 +75,12 @@ it. This does not relax the single-runner-process rule for model evals.
 Stop and repair a static contract failure before spending model calls. Do not convert a
 static failure into `BLOCKED` by manually editing `comparison.md`.
 
+One expected pre-run state is not a static failure: for a brand-new eval whose workspace
+has no `comparison.md` yet, `check_eval_contract.py` reports `missing durable
+comparison.md` until the first model run persists it. Proceed with the first run when
+this is the only contract failure for that eval; after the run, every static gate must
+pass.
+
 ## Preserve the Execution Boundary
 
 - Launch one `run_skill_eval.py` process. Let its `--jobs` pool provide concurrency.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,7 @@ uv run --with pytest pytest \
   scripts/test_eval_runtime.py \
   scripts/test_run_skill_eval.py \
   scripts/test_check_eval_artifacts.py \
+  scripts/test_generate_shared_contracts.py \
   scripts/test_install_codex_skills.py \
   scripts/test_summarize_eval_results.py \
   scripts/test_check_repository_contract.py
@@ -66,7 +67,8 @@ The repository keeps only eval definitions and the latest persisted conclusions;
 
 1. Create or update the skill and eval fixtures.
 2. Run the relevant deterministic checks and the approved manual evals.
-3. Write the latest persisted result into `comparison.md`.
+3. Let the eval runner transactionally persist the latest result into `comparison.md`;
+   do not hand-edit it.
 4. Remove runtime artifacts before opening a PR.
 5. Commit only eval definitions, metadata, fixtures, README files, and `comparison.md`.
 
@@ -76,13 +78,12 @@ The repository keeps only eval definitions and the latest persisted conclusions;
 # Eval Result: <eval-name>
 
 ## Evaluation Target
-## Test Set / Fixture Version
-## Latest Result
-## With Skill
-## Without Skill / Baseline
-## Failures
-## Next Steps
-## Runtime Artifacts Policy
+## Current Result
+## Assertion Results
+## With-Skill Behavior
+## Fresh Without-Skill Baseline
+## Failures and Next Steps
+## Runtime Artifact Policy
 ```
 
 ## Maintenance Index

--- a/CONTRIBUTING_zh.md
+++ b/CONTRIBUTING_zh.md
@@ -34,6 +34,7 @@ uv run --with pytest pytest \
   scripts/test_eval_runtime.py \
   scripts/test_run_skill_eval.py \
   scripts/test_check_eval_artifacts.py \
+  scripts/test_generate_shared_contracts.py \
   scripts/test_install_codex_skills.py \
   scripts/test_summarize_eval_results.py \
   scripts/test_check_repository_contract.py
@@ -66,7 +67,7 @@ uv run scripts/run_skill_eval.py --jobs 10
 
 1. 新建或更新 skill 与 eval fixture。
 2. 运行相关确定性检查和已批准的手动 eval。
-3. 将最新持久化结果写入 `comparison.md`。
+3. 由评测 runner 将最新结果事务性持久化到 `comparison.md`，不手工编辑。
 4. 开 PR 前删除运行期产物。
 5. 只提交 eval 定义、metadata、fixture、README 文件和 `comparison.md`。
 
@@ -76,13 +77,12 @@ uv run scripts/run_skill_eval.py --jobs 10
 # Eval Result: <eval-name>
 
 ## Evaluation Target
-## Test Set / Fixture Version
-## Latest Result
-## With Skill
-## Without Skill / Baseline
-## Failures
-## Next Steps
-## Runtime Artifacts Policy
+## Current Result
+## Assertion Results
+## With-Skill Behavior
+## Fresh Without-Skill Baseline
+## Failures and Next Steps
+## Runtime Artifact Policy
 ```
 
 ## 维护索引

--- a/docs/cookbook/run-skill-evals.md
+++ b/docs/cookbook/run-skill-evals.md
@@ -2,7 +2,9 @@
 
 1. 使用仓库 `skill-eval-runner` Skill，并读取其 runbook。
 2. 只选择真正受影响的目标；修改 eval 定义或 fixture 前先读取 authoring contract。
-3. 模型执行前先运行确定性 eval contract 检查。
+3. 模型执行前先运行确定性 eval contract 检查。新 eval 首跑前，contract 仅报该 eval
+   缺少 `comparison.md` 属预期预运行状态，不视为需修复的静态失败；首跑由 runner
+   持久化后必须全部通过。
 4. 使用仓库固定模型设置启动一个 fresh paired 进程，worker 不超过 10 个。
 5. 检查场景结果，区分 eval 缺陷、Skill 缺陷和基础设施阻塞；只更新有证据支持的持久化
    `comparison.md`。

--- a/scripts/eval_persistence.py
+++ b/scripts/eval_persistence.py
@@ -43,7 +43,8 @@ def transactional_replace(updates: dict[Path, bytes]) -> None:
         for path in reversed(replaced):
             backup = backups[path]
             if backup is None:
-                path.unlink()
+                if path.read_bytes() == updates[path]:
+                    path.unlink()
             else:
                 os.replace(backup, path)
         raise

--- a/scripts/eval_persistence.py
+++ b/scripts/eval_persistence.py
@@ -29,22 +29,26 @@ def _stage_file(path: Path, content: bytes) -> Path:
 
 def transactional_replace(updates: dict[Path, bytes]) -> None:
     staged: dict[Path, Path] = {}
-    backups: dict[Path, Path] = {}
+    backups: dict[Path, Path | None] = {}
     replaced: list[Path] = []
     try:
         for path, content in updates.items():
             staged[path] = _stage_file(path, content)
         for path in updates:
-            backups[path] = _stage_file(path, path.read_bytes())
+            backups[path] = _stage_file(path, path.read_bytes()) if path.exists() else None
         for path in updates:
             os.replace(staged[path], path)
             replaced.append(path)
     except Exception:
         for path in reversed(replaced):
-            os.replace(backups[path], path)
+            backup = backups[path]
+            if backup is None:
+                path.unlink()
+            else:
+                os.replace(backup, path)
         raise
     finally:
-        for temporary in (*staged.values(), *backups.values()):
+        for temporary in (*staged.values(), *(b for b in backups.values() if b is not None)):
             if temporary.exists():
                 temporary.unlink()
 

--- a/scripts/test_run_skill_eval.py
+++ b/scripts/test_run_skill_eval.py
@@ -1110,3 +1110,27 @@ def test_transactional_replace_rollback_removes_created_target(
 
     assert not created.exists()
     assert existing.read_bytes() == b"old-inventory"
+
+
+def test_transactional_replace_rollback_keeps_externally_modified_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created = tmp_path / "comparison.md"
+    existing = tmp_path / "migration-inventory.json"
+    existing.write_bytes(b"old-inventory")
+    real_replace = run_skill_eval.os.replace
+
+    def fail_on_existing(source, destination):
+        if Path(destination) == existing:
+            created.write_bytes(b"external content")
+            raise OSError("injected replace failure")
+        return real_replace(source, destination)
+
+    monkeypatch.setattr(run_skill_eval.os, "replace", fail_on_existing)
+    with pytest.raises(OSError, match="injected"):
+        run_skill_eval._transactional_replace(
+            {created: b"new-comparison", existing: b"new-inventory"}
+        )
+
+    assert created.read_bytes() == b"external content"
+    assert existing.read_bytes() == b"old-inventory"

--- a/scripts/test_run_skill_eval.py
+++ b/scripts/test_run_skill_eval.py
@@ -1079,3 +1079,34 @@ def test_transaction_cleans_staged_files_when_staging_fails(
     assert all(not path.exists() for path in created)
     assert first.read_bytes() == b"old-first"
     assert second.read_bytes() == b"old-second"
+
+
+def test_transactional_replace_creates_missing_target(tmp_path: Path) -> None:
+    target = tmp_path / "comparison.md"
+
+    run_skill_eval._transactional_replace({target: b"initial durable content"})
+
+    assert target.read_bytes() == b"initial durable content"
+
+
+def test_transactional_replace_rollback_removes_created_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created = tmp_path / "comparison.md"
+    existing = tmp_path / "migration-inventory.json"
+    existing.write_bytes(b"old-inventory")
+    real_replace = run_skill_eval.os.replace
+
+    def fail_on_existing(source, destination):
+        if Path(destination) == existing:
+            raise OSError("injected replace failure")
+        return real_replace(source, destination)
+
+    monkeypatch.setattr(run_skill_eval.os, "replace", fail_on_existing)
+    with pytest.raises(OSError, match="injected"):
+        run_skill_eval._transactional_replace(
+            {created: b"new-comparison", existing: b"new-inventory"}
+        )
+
+    assert not created.exists()
+    assert existing.read_bytes() == b"old-inventory"


### PR DESCRIPTION
## 背景

关联 #291 与 PR #296 的 review 意见。

新增 eval 的首份 `comparison.md` 此前无自动化创建路径：`persist_durable_result` 走 `transactional_replace`，后者在备份阶段对目标 `read_bytes()`，文件不存在即失败（且在模型运行完成后才失败）；`--skip-generate` 读回路径同样要求文件已存在。维护者决策：不文档化"手工创建首份"的例外，而是让 runner 支持首次创建，使"comparison 由 runner 事务性持久化、不手工编辑"的口径完整成立。

## 改动

- `scripts/eval_persistence.py` `transactional_replace`：目标路径不存在时备份记为"无"，异常回滚时删除已创建文件而非恢复备份；首次创建与既有更新共用同一事务路径。
- `scripts/test_run_skill_eval.py` 新增两个用例：目标不存在时首次创建成功；替换阶段失败时回滚删除新建文件且既有文件内容不变。

不改 `--skip-generate` 读回路径（无持久化结果可读时报错是正确行为），不改 `check_eval_contract.py`（新 eval 先运行生成 comparison，提交态必须存在 comparison 的契约不变）。

## 验证

- `uv run --with pytest pytest scripts/test_run_skill_eval.py scripts/test_eval_runtime.py`：83 passed
- `uv run scripts/check_eval_contract.py` / `check_eval_artifacts.py` / `check_repository_contract.py` / `check_doc_contract.py`：PASS
- `git diff --check`：干净
