### PR TITLE
chore(release): 发布 v0.6.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "PM-first agent skill marketplace with one public pm-agent entry and downstream PM-orchestrated engineering, QA, DevOps, design, security, and documentation capabilities",
-    "version": "0.5.1"
+    "version": "0.6.0"
   },
   "plugins": [
     {

--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-agent-skills",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "PM-first agent skill marketplace with one public pm-agent entry and downstream PM-orchestrated engineering, QA, DevOps, design, security, and documentation capabilities",
   "keywords": [
     "agent-skills",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 仓库级发布变更记录按版本归档到 `docs/changelog/`。
 
+- [v0.6.0](./docs/changelog/changelog-v0.6.0.md)
 - [v0.5.1](./docs/changelog/changelog-v0.5.1.md)
 - [v0.5.0](./docs/changelog/changelog-v0.5.0.md)
 - [v0.4.1](./docs/changelog/changelog-v0.4.1.md)

--- a/agents/designer/.claude-plugin/plugin.json
+++ b/agents/designer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "designer-agent",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Downstream design capability invoked after pm-agent handoff for confirmed UX flows, information architecture, wireframes, reference-pattern analysis, and reference-backed visual system work.",
   "author": {
     "name": "Neplich"

--- a/agents/devops/.claude-plugin/plugin.json
+++ b/agents/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops-agent",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Downstream DevOps capability invoked after pm-agent handoff for confirmed deployment planning, CI/CD automation, environment audits, release readiness, rollback, and runbook preparation.",
   "author": {
     "name": "Neplich"

--- a/agents/docs/.claude-plugin/plugin.json
+++ b/agents/docs/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "docs-agent",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Downstream documentation capability invoked after pm-agent handoff for confirmed formal documentation bootstrap, synchronization, backfill, illustrated user operation manuals from real running interfaces, site Release Notes, and release audit.",
   "author": {
     "name": "Neplich"

--- a/agents/engineer/.claude-plugin/plugin.json
+++ b/agents/engineer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "engineer-agent",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Downstream engineering capability invoked after pm-agent handoff for confirmed codebase analysis, TRDs, implementation, tests, debugging, and delivery. Skills remain available for PM-orchestrated execution, not as standalone starting points.",
   "author": {
     "name": "Neplich"

--- a/agents/product_manager/.claude-plugin/plugin.json
+++ b/agents/product_manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pm-agent",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Default entry plugin for product and engineering R&D requests when no other agent or skill is named. Explicitly naming pm-agent selects it even when a downstream capability is also named; naming another role agent or skill without pm-agent excludes pm-agent and leaves that capability to enforce its own gate. Routes product ideas, features, changes, bugs, implementation, testing, design, deployment, security, formal docs, delivery, planning, and repository status work.",
   "author": {
     "name": "Neplich"

--- a/agents/qa/.claude-plugin/plugin.json
+++ b/agents/qa/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qa-agent",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Downstream QA capability invoked after pm-agent handoff for confirmed acceptance, exploratory testing, bug analysis, and regression verification. Requirement or implementation gaps return through the PM-orchestrated handoff path.",
   "author": {
     "name": "Neplich"

--- a/agents/security/.claude-plugin/plugin.json
+++ b/agents/security/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "security-agent",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Downstream security capability invoked after pm-agent handoff for confirmed AppSec, auth/authz, dependency risk, privacy, and data-flow reviews, with remediation routed through the PM handoff path.",
   "author": {
     "name": "Neplich"

--- a/docs/changelog/changelog-v0.6.0.md
+++ b/docs/changelog/changelog-v0.6.0.md
@@ -1,0 +1,29 @@
+---
+feature: release-changelog
+version: 0.6.0
+date: 2026-08-18
+last_updated: 2026-08-18
+---
+
+# Changelog - v0.6.0
+
+## [v0.6.0] - 2026-08-18
+
+本版本移除整套 skill eval 机制，Skill 迭代依据转向用户体验；安装策略统一为全量安装，不再提供 routers-only 选项。本版本覆盖 v0.5.1 之后合并到 `main` 的 7 个 PR 与 2 个直接提交。
+
+### Removed
+
+- 移除整套 skill eval 机制，迭代依据转向用户体验 ([#301](https://github.com/Neplich/dev-agent-skills/pull/301))。eval 脚本、fixture、durable `comparison.md` 与相关 CI 检查一并删除；本窗口内的 eval 校准与修复（[#296](https://github.com/Neplich/dev-agent-skills/pull/296)、[#297](https://github.com/Neplich/dev-agent-skills/pull/297)、[#298](https://github.com/Neplich/dev-agent-skills/pull/298)）随机制移除不再单独列出。
+
+### Changed
+
+- 移除 routers-only 安装策略，统一全量安装 ([#293](https://github.com/Neplich/dev-agent-skills/pull/293))
+- 精简 Skill 描述（直接提交，无关联 PR）
+- 收敛文档权威与共享契约（直接提交，无关联 PR）
+- 修正安装文档中不存在的版本示例与过期发布表述 ([#294](https://github.com/Neplich/dev-agent-skills/pull/294))
+- 补全 release cookbook 的版本同步面 ([#295](https://github.com/Neplich/dev-agent-skills/pull/295))
+
+## 发布说明
+
+- 发版清单：`.claude-plugin/marketplace.json` 的 `metadata.version` 更新为 `0.6.0`；7 个 `agents/*/.claude-plugin/plugin.json` 与 `.kimi-plugin/plugin.json` 的 `version` 同步为 `0.6.0`（由 `check_repository_contract.py` 强制校验）。
+- ⚠️ 行为变更：skill eval 机制整体移除，依赖 eval runner、`evals.json` 或 durable `comparison.md` 的本地工作流不再可用；routers-only 安装方式取消，安装即全量。


### PR DESCRIPTION
## 概要

发布 v0.6.0：

- 新增 `docs/changelog/changelog-v0.6.0.md`，并更新根 `CHANGELOG.md` 索引
- 版本面同步为 `0.6.0`：`.claude-plugin/marketplace.json` 的 `metadata.version`、7 个 `agents/*/.claude-plugin/plugin.json`、`.kimi-plugin/plugin.json`

## 版本内容（v0.5.1 以来 7 个 PR + 2 个直接提交）

- 移除整套 skill eval 机制，迭代依据转向用户体验（#301）
- 移除 routers-only 安装策略，统一全量安装（#293）
- 精简 Skill 描述；收敛文档权威与共享契约
- 安装文档与 release cookbook 修正（#294、#295）

## 验证

- `uv run scripts/generate_shared_contracts.py --check` 通过
- `uv run scripts/check_repository_contract.py` 通过
- `uv run scripts/check_doc_contract.py` 通过
- `git diff --check` 通过
