### PR TITLE
chore(release): 发布 v0.6.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "PM-first agent skill marketplace with one public pm-agent entry and downstream PM-orchestrated engineering, QA, DevOps, design, security, and documentation capabilities",
-    "version": "0.6.0"
+    "version": "0.6.1"
   },
   "plugins": [
     {

--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-agent-skills",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "PM-first agent skill marketplace with one public pm-agent entry and downstream PM-orchestrated engineering, QA, DevOps, design, security, and documentation capabilities",
   "keywords": [
     "agent-skills",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 仓库级发布变更记录按版本归档到 `docs/changelog/`。
 
+- [v0.6.1](./docs/changelog/changelog-v0.6.1.md)
 - [v0.6.0](./docs/changelog/changelog-v0.6.0.md)
 - [v0.5.1](./docs/changelog/changelog-v0.5.1.md)
 - [v0.5.0](./docs/changelog/changelog-v0.5.0.md)

--- a/agents/designer/.claude-plugin/plugin.json
+++ b/agents/designer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "designer-agent",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Downstream design capability invoked after pm-agent handoff for confirmed UX flows, information architecture, wireframes, reference-pattern analysis, and reference-backed visual system work.",
   "author": {
     "name": "Neplich"

--- a/agents/devops/.claude-plugin/plugin.json
+++ b/agents/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops-agent",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Downstream DevOps capability invoked after pm-agent handoff for confirmed deployment planning, CI/CD automation, environment audits, release readiness, rollback, and runbook preparation.",
   "author": {
     "name": "Neplich"

--- a/agents/docs/.claude-plugin/plugin.json
+++ b/agents/docs/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "docs-agent",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Downstream documentation capability invoked after pm-agent handoff for confirmed formal documentation bootstrap, synchronization, backfill, illustrated user operation manuals from real running interfaces, site Release Notes, and release audit.",
   "author": {
     "name": "Neplich"

--- a/agents/engineer/.claude-plugin/plugin.json
+++ b/agents/engineer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "engineer-agent",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Downstream engineering capability invoked after pm-agent handoff for confirmed codebase analysis, TRDs, implementation, tests, debugging, and delivery. Skills remain available for PM-orchestrated execution, not as standalone starting points.",
   "author": {
     "name": "Neplich"

--- a/agents/product_manager/.claude-plugin/plugin.json
+++ b/agents/product_manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pm-agent",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Default entry plugin for product and engineering R&D requests when no other agent or skill is named. Explicitly naming pm-agent selects it even when a downstream capability is also named; naming another role agent or skill without pm-agent excludes pm-agent and leaves that capability to enforce its own gate. Routes product ideas, features, changes, bugs, implementation, testing, design, deployment, security, formal docs, delivery, planning, and repository status work.",
   "author": {
     "name": "Neplich"

--- a/agents/qa/.claude-plugin/plugin.json
+++ b/agents/qa/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qa-agent",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Downstream QA capability invoked after pm-agent handoff for confirmed acceptance, exploratory testing, bug analysis, and regression verification. Requirement or implementation gaps return through the PM-orchestrated handoff path.",
   "author": {
     "name": "Neplich"

--- a/agents/security/.claude-plugin/plugin.json
+++ b/agents/security/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "security-agent",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Downstream security capability invoked after pm-agent handoff for confirmed AppSec, auth/authz, dependency risk, privacy, and data-flow reviews, with remediation routed through the PM handoff path.",
   "author": {
     "name": "Neplich"

--- a/docs/changelog/changelog-v0.6.1.md
+++ b/docs/changelog/changelog-v0.6.1.md
@@ -1,0 +1,21 @@
+---
+feature: release-changelog
+version: 0.6.1
+date: 2026-08-18
+last_updated: 2026-08-18
+---
+
+# Changelog - v0.6.1
+
+## [v0.6.1] - 2026-08-18
+
+本版本统一 docs-agent 文档站的导航与页面骨架。本版本覆盖 v0.6.0 之后合并到 `main` 的 1 个 PR。
+
+### Fixed
+
+- **docs-site-bootstrap:** 统一站点导航与页面骨架 ([#305](https://github.com/Neplich/dev-agent-skills/pull/305))。public docs 与 docs-internal 各自定义独立入口顺序，根首页与顶部导航消费同一份目标配置；固定根首页、分区首页与具体文档页的页面骨架，按页面类型控制左侧栏与右侧文档目录；修正顶部栏与左侧栏层级，宽屏文档骨架限制为 1440px 居中布局。
+
+## 发布说明
+
+- 发版清单：`.claude-plugin/marketplace.json` 的 `metadata.version` 更新为 `0.6.1`；7 个 `agents/*/.claude-plugin/plugin.json` 与 `.kimi-plugin/plugin.json` 的 `version` 同步为 `0.6.1`（由 `check_repository_contract.py` 强制校验）。
+- 行为变更：docs-site-bootstrap 生成的文档站导航顺序与页面骨架（左侧栏、右侧目录、宽屏布局）有可见变化，重新运行脚手架或升级站点时以新骨架为准。


### PR DESCRIPTION
## 概要

发布 v0.6.1。本版本覆盖 v0.6.0 之后合并到 main 的 1 个 PR：

- fix(docs-site-bootstrap): 统一站点导航与页面骨架 (#305)

## 变更

- 新增 `docs/changelog/changelog-v0.6.1.md`，根 `CHANGELOG.md` 加索引
- 版本面同步为 0.6.1：`.claude-plugin/marketplace.json`、7 个 `agents/*/.claude-plugin/plugin.json`、`.kimi-plugin/plugin.json`

## 验证

- [x] `uv run scripts/generate_shared_contracts.py --check`
- [x] `uv run scripts/check_repository_contract.py`
- [x] `uv run scripts/check_doc_contract.py`
- [x] CI 对应 pytest 集合 112/112
- [x] `git diff --check`
