### PR TITLE
chore(release): 发布 v0.6.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "PM-first agent skill marketplace with one public pm-agent entry and downstream PM-orchestrated engineering, QA, DevOps, design, security, and documentation capabilities",
-    "version": "0.6.1"
+    "version": "0.6.2"
   },
   "plugins": [
     {

--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-agent-skills",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "PM-first agent skill marketplace with one public pm-agent entry and downstream PM-orchestrated engineering, QA, DevOps, design, security, and documentation capabilities",
   "keywords": [
     "agent-skills",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 仓库级发布变更记录按版本归档到 `docs/changelog/`。
 
+- [v0.6.2](./docs/changelog/changelog-v0.6.2.md)
 - [v0.6.1](./docs/changelog/changelog-v0.6.1.md)
 - [v0.6.0](./docs/changelog/changelog-v0.6.0.md)
 - [v0.5.1](./docs/changelog/changelog-v0.5.1.md)

--- a/agents/designer/.claude-plugin/plugin.json
+++ b/agents/designer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "designer-agent",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Downstream design capability invoked after pm-agent handoff for confirmed UX flows, information architecture, wireframes, reference-pattern analysis, and reference-backed visual system work.",
   "author": {
     "name": "Neplich"

--- a/agents/devops/.claude-plugin/plugin.json
+++ b/agents/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops-agent",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Downstream DevOps capability invoked after pm-agent handoff for confirmed deployment planning, CI/CD automation, environment audits, release readiness, rollback, and runbook preparation.",
   "author": {
     "name": "Neplich"

--- a/agents/docs/.claude-plugin/plugin.json
+++ b/agents/docs/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "docs-agent",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Downstream documentation capability invoked after pm-agent handoff for confirmed formal documentation bootstrap, synchronization, backfill, illustrated user operation manuals from real running interfaces, site Release Notes, and release audit.",
   "author": {
     "name": "Neplich"

--- a/agents/engineer/.claude-plugin/plugin.json
+++ b/agents/engineer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "engineer-agent",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Downstream engineering capability invoked after pm-agent handoff for confirmed codebase analysis, TRDs, implementation, tests, debugging, and delivery. Skills remain available for PM-orchestrated execution, not as standalone starting points.",
   "author": {
     "name": "Neplich"

--- a/agents/product_manager/.claude-plugin/plugin.json
+++ b/agents/product_manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pm-agent",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Default entry plugin for product and engineering R&D requests when no other agent or skill is named. Explicitly naming pm-agent selects it even when a downstream capability is also named; naming another role agent or skill without pm-agent excludes pm-agent and leaves that capability to enforce its own gate. Routes product ideas, features, changes, bugs, implementation, testing, design, deployment, security, formal docs, delivery, planning, and repository status work.",
   "author": {
     "name": "Neplich"

--- a/agents/qa/.claude-plugin/plugin.json
+++ b/agents/qa/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qa-agent",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Downstream QA capability invoked after pm-agent handoff for confirmed acceptance, exploratory testing, bug analysis, and regression verification. Requirement or implementation gaps return through the PM-orchestrated handoff path.",
   "author": {
     "name": "Neplich"

--- a/agents/security/.claude-plugin/plugin.json
+++ b/agents/security/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "security-agent",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Downstream security capability invoked after pm-agent handoff for confirmed AppSec, auth/authz, dependency risk, privacy, and data-flow reviews, with remediation routed through the PM handoff path.",
   "author": {
     "name": "Neplich"

--- a/docs/changelog/changelog-v0.6.2.md
+++ b/docs/changelog/changelog-v0.6.2.md
@@ -1,0 +1,21 @@
+---
+feature: release-changelog
+version: 0.6.2
+date: 2026-08-18
+last_updated: 2026-08-18
+---
+
+# Changelog - v0.6.2
+
+## [v0.6.2] - 2026-08-18
+
+本版本修正 docs-agent manual-gen 的全量手册范围与覆盖门禁。本版本覆盖 v0.6.1 之后合并到 `main` 的 1 个 PR。
+
+### Fixed
+
+- **manual-gen:** 修正全量手册范围与覆盖门禁 ([#307](https://github.com/Neplich/dev-agent-skills/pull/307))。手册覆盖范围与目录处理方式拆分为独立的 `scope_mode` 和 `change_mode`，支持局部补增、完整手册以及完整站点中的手册切片；完整手册增加写前覆盖矩阵、按独立用户任务拆页、全量计划分批执行，以及写后双向覆盖校验和独立复核；修正 Chrome 截图契约，分别记录实际窗口与内容视口，保持截图自然宽高比，不再强制内容视口等于 1920×1080。
+
+## 发布说明
+
+- 发版清单：`.claude-plugin/marketplace.json` 的 `metadata.version` 更新为 `0.6.2`；7 个 `agents/*/.claude-plugin/plugin.json` 与 `.kimi-plugin/plugin.json` 的 `version` 同步为 `0.6.2`（由 `check_repository_contract.py` 强制校验）。
+- 行为变更：manual-gen 的入口门禁、执行协议与结果报告字段有变化；宿主 `doc-granularity.md` 的 Manual 页面粒度标准更新，已有宿主需重跑 `docs-site-bootstrap` 或显式合并该标准文件。


### PR DESCRIPTION
## 变更摘要

- 将 9 个版本面从 `0.6.1` 更新为 `0.6.2`
- 新增 `docs/changelog/changelog-v0.6.2.md`
- 更新根目录 `CHANGELOG.md` 索引

## 验证清单

- [x] `uv run scripts/generate_shared_contracts.py --check`
- [x] `uv run scripts/check_repository_contract.py`
- [x] `uv run scripts/check_doc_contract.py`
- [x] `git diff --cached --check`
