### PR TITLE
chore(release): 发布 v0.6.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "PM-first agent skill marketplace with one public pm-agent entry, reader-facing human writing composition, and downstream PM-orchestrated engineering, QA, DevOps, design, security, and documentation capabilities",
-    "version": "0.6.2"
+    "version": "0.6.3"
   },
   "plugins": [
     {

--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-agent-skills",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "PM-first agent skill marketplace with one public pm-agent entry, reader-facing human writing composition, and downstream PM-orchestrated engineering, QA, DevOps, design, security, and documentation capabilities",
   "keywords": [
     "agent-skills",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 仓库级发布变更记录按版本归档到 `docs/changelog/`。
 
+- [v0.6.3](./docs/changelog/changelog-v0.6.3.md)
 - [v0.6.2](./docs/changelog/changelog-v0.6.2.md)
 - [v0.6.1](./docs/changelog/changelog-v0.6.1.md)
 - [v0.6.0](./docs/changelog/changelog-v0.6.0.md)

--- a/agents/designer/.claude-plugin/plugin.json
+++ b/agents/designer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "designer-agent",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Downstream design capability invoked after pm-agent handoff for confirmed UX flows, information architecture, wireframes, reference-pattern analysis, and reference-backed visual system work.",
   "author": {
     "name": "Neplich"

--- a/agents/devops/.claude-plugin/plugin.json
+++ b/agents/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops-agent",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Downstream DevOps capability invoked after pm-agent handoff for confirmed deployment planning, CI/CD automation, environment audits, release readiness, rollback, and runbook preparation.",
   "author": {
     "name": "Neplich"

--- a/agents/docs/.claude-plugin/plugin.json
+++ b/agents/docs/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "docs-agent",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Downstream documentation capability invoked after pm-agent handoff for confirmed formal documentation bootstrap, synchronization, backfill, illustrated user operation manuals from real running interfaces, site Release Notes, and release audit.",
   "author": {
     "name": "Neplich"

--- a/agents/engineer/.claude-plugin/plugin.json
+++ b/agents/engineer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "engineer-agent",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Downstream engineering capability invoked after pm-agent handoff for confirmed codebase analysis, TRDs, implementation, tests, debugging, and delivery. Skills remain available for PM-orchestrated execution, not as standalone starting points.",
   "author": {
     "name": "Neplich"

--- a/agents/product_manager/.claude-plugin/plugin.json
+++ b/agents/product_manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pm-agent",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Default entry plugin for product and engineering R&D requests when no other agent or skill is named. Explicitly naming pm-agent selects it even when a downstream capability is also named; naming another role agent or skill without pm-agent excludes pm-agent and leaves that capability to enforce its own gate. Routes product ideas, features, changes, bugs, implementation, testing, design, deployment, security, formal docs, delivery, planning, and repository status work, with human-writing composition for reader-facing documents.",
   "author": {
     "name": "Neplich"

--- a/agents/qa/.claude-plugin/plugin.json
+++ b/agents/qa/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qa-agent",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Downstream QA capability invoked after pm-agent handoff for confirmed acceptance, exploratory testing, bug analysis, and regression verification. Requirement or implementation gaps return through the PM-orchestrated handoff path.",
   "author": {
     "name": "Neplich"

--- a/agents/security/.claude-plugin/plugin.json
+++ b/agents/security/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "security-agent",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Downstream security capability invoked after pm-agent handoff for confirmed AppSec, auth/authz, dependency risk, privacy, and data-flow reviews, with remediation routed through the PM handoff path.",
   "author": {
     "name": "Neplich"

--- a/docs/changelog/changelog-v0.6.3.md
+++ b/docs/changelog/changelog-v0.6.3.md
@@ -1,0 +1,25 @@
+---
+feature: release-changelog
+version: 0.6.3
+date: 2026-08-19
+last_updated: 2026-08-19
+---
+
+# Changelog - v0.6.3
+
+## [v0.6.3] - 2026-08-19
+
+本版本新增 human-writing Skill 并接入文档生成流程，同时修正 docs-site-bootstrap 的文档站页面骨架。本版本覆盖 v0.6.2 之后合并到 `main` 的 2 个 PR。
+
+### Added
+
+- **skills:** 新增 human-writing 并接入文档生成流程 ([#310](https://github.com/Neplich/dev-agent-skills/pull/310))。新增独立的 `human-writing` Skill，为面向真实读者的文档提供读者视角、信息顺序和自然表达规则；注册到 PM 插件和发现入口，并适配 6 个下游 Router 与 32 个文档类 Specialist，Router 路由和直接调用均可按需共同加载；主 Skill 保留对事实、结构、路径、门禁和验证的所有权，纯代码、配置、Schema、锁文件和数据输出不触发。
+
+### Fixed
+
+- **docs-site-bootstrap:** 对齐 Kimi 文档站页面骨架 ([#309](https://github.com/Neplich/dev-agent-skills/pull/309))。移除会让顶部栏覆盖侧栏滚动区域的自定义桌面栏位，恢复 VitePress 默认骨架关系；保留现有蓝色主题色和 Mermaid 样式，无右侧目录页面限制正文最大宽度为 688px 并保留 256px 空目录列；增补主题契约测试。
+
+## 发布说明
+
+- 发版清单：`.claude-plugin/marketplace.json` 的 `metadata.version` 更新为 `0.6.3`；7 个 `agents/*/.claude-plugin/plugin.json` 与 `.kimi-plugin/plugin.json` 的 `version` 同步为 `0.6.3`（由 `check_repository_contract.py` 强制校验）。
+- 行为变更：docs-site-bootstrap 的 custom.css 骨架关系有变化，现有宿主不会被静默覆盖，需要重新执行 docs-site-bootstrap 并按冲突门禁明确合并 custom.css。


### PR DESCRIPTION
# 发布 v0.6.3

## 变更

- 新增 `docs/changelog/changelog-v0.6.3.md`：覆盖 v0.6.2 之后合并的 2 个 PR（#309、#310）。
- 版本面同步为 `0.6.3`：`.claude-plugin/marketplace.json` 的 `metadata.version`、7 个 `agents/*/.claude-plugin/plugin.json`、`.kimi-plugin/plugin.json`。
- 根 `CHANGELOG.md` 新增 v0.6.3 索引条目。

## 验证

- [x] `uv run scripts/generate_shared_contracts.py --check`
- [x] `uv run scripts/check_repository_contract.py`
- [x] `uv run scripts/check_doc_contract.py`
- [x] 契约与安装器 Python 测试：112 passed
- [x] `git diff --check`
