### PR TITLE
fix(human-writing): 将发现描述改为英文

### DIFF
--- a/agents/product_manager/skills/human-writing/agents/openai.yaml
+++ b/agents/product_manager/skills/human-writing/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "活人感写作"
-  short_description: "为面向真实读者的文档提供自然、清楚且保留事实的中文写作规则"
+  display_name: "Human Writing"
+  short_description: "Write natural, clear Chinese prose for real readers while preserving facts"
   default_prompt: "Use $human-writing together with the primary document skill to write or revise content for its actual readers while preserving facts, structure, and delivery requirements."

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -49,7 +49,7 @@
     "human-writing": {
       "source": "agents/product_manager/skills/human-writing",
       "sourceType": "local",
-      "computedHash": "949c37b1fd367416eeefe5c910eec7d245a20c572b160a3885770ac7e5ece382"
+      "computedHash": "013cc5079055cf0877b2009b39e7a17452d8c341b4add881decc1d9f7fe6a222"
     },
     "engineer-agent": {
       "source": "agents/engineer/skills/engineer-agent",


### PR DESCRIPTION
## 摘要

- 将 human-writing 的显示名和短描述改为全英文
- 同步刷新 human-writing 的技能锁文件哈希

## 相关文档

- PRD: `docs/pm/agents/pm-agent/skills/human-writing/PRD.md`
- TRD: `docs/engineer/agents/pm-agent/skills/human-writing/TRD.md`

## 验证

- `uv run scripts/generate_shared_contracts.py --check`
- `uv run scripts/check_repository_contract.py`
- `uv run scripts/check_doc_contract.py`
- `uv run --with pytest pytest scripts/test_check_repository_contract.py`（78 passed）
- `git diff --check`