### PR TITLE
chore(release): 发布 v0.6.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "PM-first agent skill marketplace with one public pm-agent entry, reader-facing human writing composition, and downstream PM-orchestrated engineering, QA, DevOps, design, security, and documentation capabilities",
-    "version": "0.6.3"
+    "version": "0.6.4"
   },
   "plugins": [
     {

--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-agent-skills",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "PM-first agent skill marketplace with one public pm-agent entry, reader-facing human writing composition, and downstream PM-orchestrated engineering, QA, DevOps, design, security, and documentation capabilities",
   "keywords": [
     "agent-skills",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 仓库级发布变更记录按版本归档到 `docs/changelog/`。
 
+- [v0.6.4](./docs/changelog/changelog-v0.6.4.md)
 - [v0.6.3](./docs/changelog/changelog-v0.6.3.md)
 - [v0.6.2](./docs/changelog/changelog-v0.6.2.md)
 - [v0.6.1](./docs/changelog/changelog-v0.6.1.md)

--- a/agents/designer/.claude-plugin/plugin.json
+++ b/agents/designer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "designer-agent",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Downstream design capability invoked after pm-agent handoff for confirmed UX flows, information architecture, wireframes, reference-pattern analysis, and reference-backed visual system work.",
   "author": {
     "name": "Neplich"

--- a/agents/devops/.claude-plugin/plugin.json
+++ b/agents/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops-agent",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Downstream DevOps capability invoked after pm-agent handoff for confirmed deployment planning, CI/CD automation, environment audits, release readiness, rollback, and runbook preparation.",
   "author": {
     "name": "Neplich"

--- a/agents/docs/.claude-plugin/plugin.json
+++ b/agents/docs/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "docs-agent",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Downstream documentation capability invoked after pm-agent handoff for confirmed formal documentation bootstrap, synchronization, backfill, illustrated user operation manuals from real running interfaces, site Release Notes, and release audit.",
   "author": {
     "name": "Neplich"

--- a/agents/engineer/.claude-plugin/plugin.json
+++ b/agents/engineer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "engineer-agent",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Downstream engineering capability invoked after pm-agent handoff for confirmed codebase analysis, TRDs, implementation, tests, debugging, and delivery. Skills remain available for PM-orchestrated execution, not as standalone starting points.",
   "author": {
     "name": "Neplich"

--- a/agents/product_manager/.claude-plugin/plugin.json
+++ b/agents/product_manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pm-agent",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Default entry plugin for product and engineering R&D requests when no other agent or skill is named. Explicitly naming pm-agent selects it even when a downstream capability is also named; naming another role agent or skill without pm-agent excludes pm-agent and leaves that capability to enforce its own gate. Routes product ideas, features, changes, bugs, implementation, testing, design, deployment, security, formal docs, delivery, planning, and repository status work, with human-writing composition for reader-facing documents.",
   "author": {
     "name": "Neplich"

--- a/agents/qa/.claude-plugin/plugin.json
+++ b/agents/qa/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qa-agent",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Downstream QA capability invoked after pm-agent handoff for confirmed acceptance, exploratory testing, bug analysis, and regression verification. Requirement or implementation gaps return through the PM-orchestrated handoff path.",
   "author": {
     "name": "Neplich"

--- a/agents/security/.claude-plugin/plugin.json
+++ b/agents/security/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "security-agent",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Downstream security capability invoked after pm-agent handoff for confirmed AppSec, auth/authz, dependency risk, privacy, and data-flow reviews, with remediation routed through the PM handoff path.",
   "author": {
     "name": "Neplich"

--- a/docs/changelog/changelog-v0.6.4.md
+++ b/docs/changelog/changelog-v0.6.4.md
@@ -1,0 +1,27 @@
+---
+feature: release-changelog
+version: 0.6.4
+date: 2026-08-20
+last_updated: 2026-08-20
+---
+
+# Changelog - v0.6.4
+
+## [v0.6.4] - 2026-08-20
+
+本版本为 feature-implementor 建立实施计划预期对账与门禁授权自动审查者，补齐 human-writing 的范围判断、结构权限与高风险事实回传，并修正其英文描述。本版本覆盖 v0.6.3 之后合并到 `main` 的 3 个 PR。
+
+### Added
+
+- **feature-implementor:** 实施计划预期对账与门禁授权自动审查者 ([#317](https://github.com/Neplich/dev-agent-skills/pull/317))。为 `feature-implementor` 增加六字段预期改动声明，在实施证据、closeout 与 reviewer 之间建立预期/实际对账；偏离记录补充统一字段、分类与处置规则（`scope_up` / `design_gap` 默认拆分 Issue，纯 `estimate_wrong` 仅留 closeout 记录）；PM handoff contract 增加 `plan_approval` / `trd_approval` 可选授权，并定义自动审查者的独立上下文、non-goals、发现定级、收敛和人工升级要求。
+
+- **human-writing:** 补齐范围判断、结构权限与高风险事实回传 ([#314](https://github.com/Neplich/dev-agent-skills/pull/314))。工作方式扩展为创建/改写/审查三种，写前先判断模式与范围（passage/单文档/文档集/整站），局部任务不强制全站盘点，整站任务先查章节分组与读者路径；明确保留的是主 Skill 规定的必要结构与真实流程而非现有布局，授权后可重分章节；高风险事实变更需回传主 Skill。
+
+### Fixed
+
+- **human-writing:** 将发现描述改为英文 ([#312](https://github.com/Neplich/dev-agent-skills/pull/312))。将 human-writing 的显示名和短描述改为全英文，并同步刷新技能锁文件哈希。
+
+## 发布说明
+
+- 发版清单：`.claude-plugin/marketplace.json` 的 `metadata.version` 更新为 `0.6.4`；7 个 `agents/*/.claude-plugin/plugin.json` 与 `.kimi-plugin/plugin.json` 的 `version` 同步为 `0.6.4`（由 `check_repository_contract.py` 强制校验）。
+- 行为变更：feature-implementor 的 closeout 与 review 流程引入预期/实际对账，偏离记录需按统一字段与分类处置；human-writing 的执行方式扩展为创建/改写/审查，写前需先判断模式与范围，结构保留以主 Skill 规定为准而非现有布局。


### PR DESCRIPTION
# v0.6.4 发布

## 变更内容

- 新增 [changelog-v0.6.4](./docs/changelog/changelog-v0.6.4.md)，覆盖 v0.6.3 之后合并到 `main` 的 3 个 PR（#317 / #314 / #312）
- 版本面同步为 `0.6.4`（不带 v 前缀）：`.claude-plugin/marketplace.json` 的 `metadata.version`、7 个 `agents/*/.claude-plugin/plugin.json` 与 `.kimi-plugin/plugin.json` 的 `version`
- 根 `CHANGELOG.md` 新增 v0.6.4 索引条目

## 验证

- `uv run scripts/generate_shared_contracts.py --check`：PASS
- `uv run scripts/check_repository_contract.py`：PASS
- `uv run scripts/check_doc_contract.py`：PASS
- pytest（test_check_repository_contract / test_generate_shared_contracts / test_install_codex_skills）：104 passed
- `git diff --check`：PASS
