### PR TITLE
chore(release): 发布 v0.6.5

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "PM-first agent skill marketplace with one public pm-agent entry, reader-facing human writing composition, and downstream PM-orchestrated engineering, QA, DevOps, design, security, and documentation capabilities",
-    "version": "0.6.4"
+    "version": "0.6.5"
   },
   "plugins": [
     {

--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-agent-skills",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "PM-first agent skill marketplace with one public pm-agent entry, reader-facing human writing composition, and downstream PM-orchestrated engineering, QA, DevOps, design, security, and documentation capabilities",
   "keywords": [
     "agent-skills",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 仓库级发布变更记录按版本归档到 `docs/changelog/`。
 
+- [v0.6.5](./docs/changelog/changelog-v0.6.5.md)
 - [v0.6.4](./docs/changelog/changelog-v0.6.4.md)
 - [v0.6.3](./docs/changelog/changelog-v0.6.3.md)
 - [v0.6.2](./docs/changelog/changelog-v0.6.2.md)

--- a/agents/designer/.claude-plugin/plugin.json
+++ b/agents/designer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "designer-agent",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Downstream design capability invoked after pm-agent handoff for confirmed UX flows, information architecture, wireframes, reference-pattern analysis, and reference-backed visual system work.",
   "author": {
     "name": "Neplich"

--- a/agents/devops/.claude-plugin/plugin.json
+++ b/agents/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops-agent",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Downstream DevOps capability invoked after pm-agent handoff for confirmed deployment planning, CI/CD automation, environment audits, release readiness, rollback, and runbook preparation.",
   "author": {
     "name": "Neplich"

--- a/agents/docs/.claude-plugin/plugin.json
+++ b/agents/docs/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "docs-agent",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Downstream documentation capability invoked after pm-agent handoff for confirmed formal documentation bootstrap, synchronization, backfill, illustrated user operation manuals from real running interfaces, site Release Notes, and release audit.",
   "author": {
     "name": "Neplich"

--- a/agents/engineer/.claude-plugin/plugin.json
+++ b/agents/engineer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "engineer-agent",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Downstream engineering capability invoked after pm-agent handoff for confirmed codebase analysis, TRDs, implementation, tests, debugging, and delivery. Skills remain available for PM-orchestrated execution, not as standalone starting points.",
   "author": {
     "name": "Neplich"

--- a/agents/product_manager/.claude-plugin/plugin.json
+++ b/agents/product_manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pm-agent",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Default entry plugin for product and engineering R&D requests when no other agent or skill is named. Explicitly naming pm-agent selects it even when a downstream capability is also named; naming another role agent or skill without pm-agent excludes pm-agent and leaves that capability to enforce its own gate. Routes product ideas, features, changes, bugs, implementation, testing, design, deployment, security, formal docs, delivery, planning, and repository status work, with human-writing composition for reader-facing documents.",
   "author": {
     "name": "Neplich"

--- a/agents/qa/.claude-plugin/plugin.json
+++ b/agents/qa/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qa-agent",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Downstream QA capability invoked after pm-agent handoff for confirmed acceptance, exploratory testing, bug analysis, and regression verification. Requirement or implementation gaps return through the PM-orchestrated handoff path.",
   "author": {
     "name": "Neplich"

--- a/agents/security/.claude-plugin/plugin.json
+++ b/agents/security/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "security-agent",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Downstream security capability invoked after pm-agent handoff for confirmed AppSec, auth/authz, dependency risk, privacy, and data-flow reviews, with remediation routed through the PM handoff path.",
   "author": {
     "name": "Neplich"

--- a/docs/changelog/changelog-v0.6.5.md
+++ b/docs/changelog/changelog-v0.6.5.md
@@ -1,0 +1,21 @@
+---
+feature: release-changelog
+version: 0.6.5
+date: 2026-08-24
+last_updated: 2026-08-24
+---
+
+# Changelog - v0.6.5
+
+## [v0.6.5] - 2026-08-24
+
+本版本修复 eval 机制移除后文档中遗留的失效引用，校正实施计划的归档状态，并清理外部项目遗留，覆盖 v0.6.4 之后合并到 `main` 的 1 个 PR。
+
+### Fixed
+
+- 修复失效 eval 引用、计划归档状态与外部项目遗留 ([#324](https://github.com/Neplich/dev-agent-skills/pull/324))。为已交付的实施计划补充六字段 Closeout 对账，写入归档批准信息并移动到各自 `archive/` 路径；清理 61 份活跃文档中指向已删除 eval 文件、脚本、runner、workflow 和持久化证据步骤的引用，保留明确记录既往决策或执行事实的历史叙述；匿名化 `human-writing` 文档中的外部项目名称，补充文档站整站优化 user story，并移除无法追踪的一次性人工验收承诺。
+
+## 发布说明
+
+- 发版清单：`.claude-plugin/marketplace.json` 的 `metadata.version` 更新为 `0.6.5`；7 个 `agents/*/.claude-plugin/plugin.json` 与 `.kimi-plugin/plugin.json` 的 `version` 同步为 `0.6.5`（由 `check_repository_contract.py` 强制校验）。
+- 行为变更：无。本版本为纯文档修正，不改变任何 skill 行为或契约。


### PR DESCRIPTION
# v0.6.5 发布

## 变更内容

- 新增 [changelog-v0.6.5](./docs/changelog/changelog-v0.6.5.md)，覆盖 v0.6.4 之后合并到 `main` 的 1 个 PR（#324）
- 版本面同步为 `0.6.5`（不带 v 前缀）：`.claude-plugin/marketplace.json` 的 `metadata.version`、7 个 `agents/*/.claude-plugin/plugin.json` 与 `.kimi-plugin/plugin.json` 的 `version`
- 根 `CHANGELOG.md` 新增 v0.6.5 索引条目

## 验证

- `uv run scripts/generate_shared_contracts.py --check`：PASS
- `uv run scripts/check_repository_contract.py`：PASS
- `uv run scripts/check_doc_contract.py`：PASS
- pytest（test_check_repository_contract / test_generate_shared_contracts / test_install_codex_skills）：104 passed
- `git diff --check`：PASS
