### PR TITLE
fix(docs): 清理 skill PRD persona 行与守护句中的惰性 eval 提及

### DIFF
--- a/docs/engineer/agents/pm-agent/skills/idea-to-spec/TRD.md
+++ b/docs/engineer/agents/pm-agent/skills/idea-to-spec/TRD.md
@@ -1,7 +1,7 @@
 ---
 title: "idea-to-spec author 元数据规范 — Technical Requirements Document"
 type: TRD
-version: "0.1.0"
+version: "0.1.1"
 status: Approved
 feature: "skill-idea-to-spec"
 feature_path: "agents/pm-agent/skills/idea-to-spec"
@@ -9,7 +9,7 @@ parent_feature: "agents/pm-agent/skills"
 feature_level: "4"
 author: "Neplich Codex"
 date: "2026-06-12"
-last_updated: "2026-08-24"
+last_updated: "2026-09-01"
 generated_by: "trd-gen"
 related_prd: "docs/pm/agents/pm-agent/skills/idea-to-spec/PRD.md"
 related_docs:
@@ -82,8 +82,8 @@ Examples:
 The repository contract only validates committed formal Markdown frontmatter with an
 existing `author` field. It rejects empty values, one-part values, and placeholders
 such as `AI Assistant`, but it does not parse or enumerate Agent platform names. It
-also does not parse arbitrary prose, eval fixture author values such as
-`Eval Fixture`, or data set examples where `AI Assistant` is not a document author.
+also does not parse arbitrary prose, author values from test or evaluation
+fixtures, or data set examples where `AI Assistant` is not a document author.
 
 ## 5. Implementation Constraints
 
@@ -92,7 +92,7 @@ also does not parse arbitrary prose, eval fixture author values such as
   to formal document metadata.
 - Use direct wording in docs; avoid process commentary in the final user-facing
   documents.
-- Do not modify eval runtime artifacts or data set examples that are not formal docs.
+- Do not modify test or evaluation runtime artifacts or data set examples that are not formal docs.
 - Preserve current document structure and add minimal requirement rows or metadata
   guidance instead of rewriting full PRDs.
 
@@ -122,7 +122,7 @@ machine hostnames, or other sensitive local identifiers.
 
 | Type | Item | Owner | Blocking |
 | --- | --- | --- | --- |
-| Risk | Over-broad scanning may flag prose examples or eval fixtures that are not formal docs. | Engineer | Yes |
+| Risk | Over-broad scanning may flag prose examples or test and evaluation fixtures that are not formal docs. | Engineer | Yes |
 | Risk | Bare `Codex` appears in many newly generated Agent / Skill PRDs and must be cleaned in the same change as the checker. | Engineer | Yes |
 | Assumption | `Neplich Codex` is the correct display value for this repo and current platform. | Maintainer | No |
 

--- a/docs/pm/agents/designer-agent/skills/designer-agent/PRD.md
+++ b/docs/pm/agents/designer-agent/skills/designer-agent/PRD.md
@@ -5,7 +5,7 @@ feature: "skill-designer-agent"
 feature_path: "agents/designer-agent/skills/designer-agent"
 parent_feature: "agents/designer-agent/skills"
 feature_level: "4"
-version: "1.2.3"
+version: "1.2.4"
 status: Approved
 author: "Neplich Codex"
 date: "2026-06-12"
@@ -22,6 +22,9 @@ related_docs:
   - "docs/pm/agent-collaboration/frontend-ui-routing-contract/PRD.md"
   - "docs/engineer/agent-collaboration/frontend-ui-routing-contract/TRD.md"
 changelog:
+  - version: "1.2.4"
+    date: "2026-09-01"
+    changes: "清理维护者画像中已失效的 eval 机制提及"
   - version: "1.2.3"
     date: "2026-09-01"
     changes: "清理已失效的 eval 机制残留引用"
@@ -67,7 +70,7 @@ changelog:
 |---------|-------------|-----------|-------------|
 | 直接调用用户 | 已知道要使用 `designer-agent` 的用户 | 直接获得当前 skill 的真实产物 | 泛化 PRD 会误导输入和输出 |
 | `designer-agent` Dispatcher | 根据用户意图选择下游 skill | 清晰 trigger 和 route boundary | 描述过宽会误路由 |
-| 维护者 | 维护 skill 文档和 eval 的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
+| 维护者 | 维护 skill 文档和确定性检查的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
 
 ## 用户故事与场景
 

--- a/docs/pm/agents/designer-agent/skills/ui-ux-design/PRD.md
+++ b/docs/pm/agents/designer-agent/skills/ui-ux-design/PRD.md
@@ -5,7 +5,7 @@ feature: "skill-ui-ux-design"
 feature_path: "agents/designer-agent/skills/ui-ux-design"
 parent_feature: "agents/designer-agent/skills"
 feature_level: "4"
-version: "1.0.3"
+version: "1.0.4"
 status: Approved
 author: "Neplich Codex"
 date: "2026-06-12"
@@ -21,6 +21,9 @@ related_docs:
   - "docs/engineer/repository-governance/feature-path-contract/TRD.md"
   - "docs/engineer/repository-governance/feature-path-contract/IMPLEMENTATION_PLAN.md"
 changelog:
+  - version: "1.0.4"
+    date: "2026-09-01"
+    changes: "清理维护者画像中已失效的 eval 机制提及"
   - version: "1.0.3"
     date: "2026-09-01"
     changes: "清理已失效的 eval 机制残留引用"
@@ -60,7 +63,7 @@ changelog:
 |---------|-------------|-----------|-------------|
 | 直接调用用户 | 已知道要使用 `ui-ux-design` 的用户 | 直接获得当前 skill 的真实产物 | 泛化 PRD 会误导输入和输出 |
 | `designer-agent` Dispatcher | 根据用户意图选择下游 skill | 清晰 trigger 和 route boundary | 描述过宽会误路由 |
-| 维护者 | 维护 skill 文档和 eval 的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
+| 维护者 | 维护 skill 文档和确定性检查的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
 
 ## 用户故事与场景
 

--- a/docs/pm/agents/designer-agent/skills/visual-design/PRD.md
+++ b/docs/pm/agents/designer-agent/skills/visual-design/PRD.md
@@ -5,7 +5,7 @@ feature: "skill-visual-design"
 feature_path: "agents/designer-agent/skills/visual-design"
 parent_feature: "agents/designer-agent/skills"
 feature_level: "4"
-version: "1.0.3"
+version: "1.0.4"
 status: Approved
 author: "Neplich Codex"
 date: "2026-06-12"
@@ -30,6 +30,9 @@ related_docs:
   - "docs/engineer/repository-governance/feature-path-contract/TRD.md"
   - "docs/engineer/repository-governance/feature-path-contract/IMPLEMENTATION_PLAN.md"
 changelog:
+  - version: "1.0.4"
+    date: "2026-09-01"
+    changes: "清理维护者画像中已失效的 eval 机制提及"
   - version: "1.0.3"
     date: "2026-09-01"
     changes: "清理已失效的 eval 机制残留引用"
@@ -69,7 +72,7 @@ changelog:
 |---------|-------------|-----------|-------------|
 | 直接调用用户 | 已知道要使用 `visual-design` 的用户 | 直接获得当前 skill 的真实产物 | 泛化 PRD 会误导输入和输出 |
 | `designer-agent` Dispatcher | 根据用户意图选择下游 skill | 清晰 trigger 和 route boundary | 描述过宽会误路由 |
-| 维护者 | 维护 skill 文档和 eval 的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
+| 维护者 | 维护 skill 文档和确定性检查的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
 
 ## 用户故事与场景
 

--- a/docs/pm/agents/devops-agent/skills/cicd-bootstrap/PRD.md
+++ b/docs/pm/agents/devops-agent/skills/cicd-bootstrap/PRD.md
@@ -5,7 +5,7 @@ feature: "skill-cicd-bootstrap"
 feature_path: "agents/devops-agent/skills/cicd-bootstrap"
 parent_feature: "agents/devops-agent/skills"
 feature_level: "4"
-version: "1.0.3"
+version: "1.0.4"
 status: Approved
 author: "Neplich Codex"
 date: "2026-06-12"
@@ -18,6 +18,9 @@ related_docs:
   - "agents/devops/skills/cicd-bootstrap/SKILL.md"
   - ".claude-plugin/marketplace.json"
 changelog:
+  - version: "1.0.4"
+    date: "2026-09-01"
+    changes: "清理维护者画像中已失效的 eval 机制提及"
   - version: "1.0.3"
     date: "2026-09-01"
     changes: "清理已失效的 eval 机制残留引用"
@@ -57,7 +60,7 @@ changelog:
 |---------|-------------|-----------|-------------|
 | 直接调用用户 | 已知道要使用 `cicd-bootstrap` 的用户 | 直接获得当前 skill 的真实产物 | 泛化 PRD 会误导输入和输出 |
 | `devops-agent` Dispatcher | 根据用户意图选择下游 skill | 清晰 trigger 和 route boundary | 描述过宽会误路由 |
-| 维护者 | 维护 skill 文档和 eval 的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
+| 维护者 | 维护 skill 文档和确定性检查的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
 
 ## 用户故事与场景
 

--- a/docs/pm/agents/devops-agent/skills/deployment-planner/PRD.md
+++ b/docs/pm/agents/devops-agent/skills/deployment-planner/PRD.md
@@ -5,7 +5,7 @@ feature: "skill-deployment-planner"
 feature_path: "agents/devops-agent/skills/deployment-planner"
 parent_feature: "agents/devops-agent/skills"
 feature_level: "4"
-version: "1.0.3"
+version: "1.0.4"
 status: Approved
 author: "Neplich Codex"
 date: "2026-06-12"
@@ -18,6 +18,9 @@ related_docs:
   - "agents/devops/skills/deployment-planner/SKILL.md"
   - ".claude-plugin/marketplace.json"
 changelog:
+  - version: "1.0.4"
+    date: "2026-09-01"
+    changes: "清理维护者画像中已失效的 eval 机制提及"
   - version: "1.0.3"
     date: "2026-09-01"
     changes: "清理已失效的 eval 机制残留引用"
@@ -57,7 +60,7 @@ changelog:
 |---------|-------------|-----------|-------------|
 | 直接调用用户 | 已知道要使用 `deployment-planner` 的用户 | 直接获得当前 skill 的真实产物 | 泛化 PRD 会误导输入和输出 |
 | `devops-agent` Dispatcher | 根据用户意图选择下游 skill | 清晰 trigger 和 route boundary | 描述过宽会误路由 |
-| 维护者 | 维护 skill 文档和 eval 的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
+| 维护者 | 维护 skill 文档和确定性检查的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
 
 ## 用户故事与场景
 

--- a/docs/pm/agents/devops-agent/skills/devops-agent/PRD.md
+++ b/docs/pm/agents/devops-agent/skills/devops-agent/PRD.md
@@ -5,7 +5,7 @@ feature: "skill-devops-agent"
 feature_path: "agents/devops-agent/skills/devops-agent"
 parent_feature: "agents/devops-agent/skills"
 feature_level: "4"
-version: "1.1.3"
+version: "1.1.4"
 status: Approved
 author: "Neplich Codex"
 date: "2026-06-12"
@@ -17,6 +17,9 @@ related_docs:
   - "agents/devops/skills/devops-agent/SKILL.md"
   - ".claude-plugin/marketplace.json"
 changelog:
+  - version: "1.1.4"
+    date: "2026-09-01"
+    changes: "清理维护者画像中已失效的 eval 机制提及"
   - version: "1.1.3"
     date: "2026-09-01"
     changes: "清理已失效的 eval 机制残留引用"
@@ -60,7 +63,7 @@ changelog:
 |---------|-------------|-----------|-------------|
 | 直接调用用户 | 已知道要使用 `devops-agent` 的用户 | 直接获得当前 skill 的真实产物 | 泛化 PRD 会误导输入和输出 |
 | `devops-agent` Dispatcher | 根据用户意图选择下游 skill | 清晰 trigger 和 route boundary | 描述过宽会误路由 |
-| 维护者 | 维护 skill 文档和 eval 的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
+| 维护者 | 维护 skill 文档和确定性检查的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
 
 ## 用户故事与场景
 

--- a/docs/pm/agents/devops-agent/skills/env-config-auditor/PRD.md
+++ b/docs/pm/agents/devops-agent/skills/env-config-auditor/PRD.md
@@ -5,7 +5,7 @@ feature: "skill-env-config-auditor"
 feature_path: "agents/devops-agent/skills/env-config-auditor"
 parent_feature: "agents/devops-agent/skills"
 feature_level: "4"
-version: "1.0.3"
+version: "1.0.4"
 status: Approved
 author: "Neplich Codex"
 date: "2026-06-12"
@@ -18,6 +18,9 @@ related_docs:
   - "agents/devops/skills/env-config-auditor/SKILL.md"
   - ".claude-plugin/marketplace.json"
 changelog:
+  - version: "1.0.4"
+    date: "2026-09-01"
+    changes: "清理维护者画像中已失效的 eval 机制提及"
   - version: "1.0.3"
     date: "2026-09-01"
     changes: "清理已失效的 eval 机制残留引用"
@@ -57,7 +60,7 @@ changelog:
 |---------|-------------|-----------|-------------|
 | 直接调用用户 | 已知道要使用 `env-config-auditor` 的用户 | 直接获得当前 skill 的真实产物 | 泛化 PRD 会误导输入和输出 |
 | `devops-agent` Dispatcher | 根据用户意图选择下游 skill | 清晰 trigger 和 route boundary | 描述过宽会误路由 |
-| 维护者 | 维护 skill 文档和 eval 的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
+| 维护者 | 维护 skill 文档和确定性检查的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
 
 ## 用户故事与场景
 

--- a/docs/pm/agents/devops-agent/skills/incident-playbook-writer/PRD.md
+++ b/docs/pm/agents/devops-agent/skills/incident-playbook-writer/PRD.md
@@ -5,7 +5,7 @@ feature: "skill-incident-playbook-writer"
 feature_path: "agents/devops-agent/skills/incident-playbook-writer"
 parent_feature: "agents/devops-agent/skills"
 feature_level: "4"
-version: "1.0.3"
+version: "1.0.4"
 status: Approved
 author: "Neplich Codex"
 date: "2026-06-12"
@@ -18,6 +18,9 @@ related_docs:
   - "agents/devops/skills/incident-playbook-writer/SKILL.md"
   - ".claude-plugin/marketplace.json"
 changelog:
+  - version: "1.0.4"
+    date: "2026-09-01"
+    changes: "清理维护者画像中已失效的 eval 机制提及"
   - version: "1.0.3"
     date: "2026-09-01"
     changes: "清理已失效的 eval 机制残留引用"
@@ -57,7 +60,7 @@ changelog:
 |---------|-------------|-----------|-------------|
 | 直接调用用户 | 已知道要使用 `incident-playbook-writer` 的用户 | 直接获得当前 skill 的真实产物 | 泛化 PRD 会误导输入和输出 |
 | `devops-agent` Dispatcher | 根据用户意图选择下游 skill | 清晰 trigger 和 route boundary | 描述过宽会误路由 |
-| 维护者 | 维护 skill 文档和 eval 的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
+| 维护者 | 维护 skill 文档和确定性检查的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
 
 ## 用户故事与场景
 

--- a/docs/pm/agents/engineer-agent/skills/codebase-analyzer/PRD.md
+++ b/docs/pm/agents/engineer-agent/skills/codebase-analyzer/PRD.md
@@ -5,7 +5,7 @@ feature: "skill-codebase-analyzer"
 feature_path: "agents/engineer-agent/skills/codebase-analyzer"
 parent_feature: "agents/engineer-agent/skills"
 feature_level: "4"
-version: "1.0.3"
+version: "1.0.4"
 status: Approved
 author: "Neplich Codex"
 date: "2026-06-12"
@@ -21,6 +21,9 @@ related_docs:
   - "docs/engineer/repository-governance/feature-path-contract/TRD.md"
   - "docs/engineer/repository-governance/feature-path-contract/IMPLEMENTATION_PLAN.md"
 changelog:
+  - version: "1.0.4"
+    date: "2026-09-01"
+    changes: "清理维护者画像中已失效的 eval 机制提及"
   - version: "1.0.3"
     date: "2026-09-01"
     changes: "清理已失效的 eval 机制残留引用"
@@ -60,7 +63,7 @@ changelog:
 |---------|-------------|-----------|-------------|
 | 直接调用用户 | 已知道要使用 `codebase-analyzer` 的用户 | 直接获得当前 skill 的真实产物 | 泛化 PRD 会误导输入和输出 |
 | `engineer-agent` Dispatcher | 根据用户意图选择下游 skill | 清晰 trigger 和 route boundary | 描述过宽会误路由 |
-| 维护者 | 维护 skill 文档和 eval 的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
+| 维护者 | 维护 skill 文档和确定性检查的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
 
 ## 用户故事与场景
 

--- a/docs/pm/agents/engineer-agent/skills/debugger/PRD.md
+++ b/docs/pm/agents/engineer-agent/skills/debugger/PRD.md
@@ -5,7 +5,7 @@ feature: "skill-debugger"
 feature_path: "agents/engineer-agent/skills/debugger"
 parent_feature: "agents/engineer-agent/skills"
 feature_level: "4"
-version: "1.2.2"
+version: "1.2.3"
 status: Approved
 author: "Neplich Codex"
 date: "2026-06-12"
@@ -24,6 +24,9 @@ related_docs:
   - "docs/pm/agents/engineer-agent/skills/debugger/DECISIONS.md"
   - "docs/engineer/agents/engineer-agent/skills/debugger/TRD.md"
 changelog:
+  - version: "1.2.3"
+    date: "2026-09-01"
+    changes: "清理维护者画像中已失效的 eval 机制提及"
   - version: "1.2.2"
     date: "2026-09-01"
     changes: "清理已失效的 eval 机制残留引用"
@@ -71,7 +74,7 @@ changelog:
 |---------|-------------|-----------|-------------|
 | 直接调用用户 | 已知道要使用 `debugger` 的用户 | 直接获得当前 skill 的真实产物 | 泛化 PRD 会误导输入和输出 |
 | `engineer-agent` Dispatcher | 根据用户意图选择下游 skill | 清晰 trigger 和 route boundary | 描述过宽会误路由 |
-| 维护者 | 维护 skill 文档和 eval 的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
+| 维护者 | 维护 skill 文档和确定性检查的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
 
 ## 用户故事与场景
 

--- a/docs/pm/agents/engineer-agent/skills/delivery/PRD.md
+++ b/docs/pm/agents/engineer-agent/skills/delivery/PRD.md
@@ -5,7 +5,7 @@ feature: "skill-delivery"
 feature_path: "agents/engineer-agent/skills/delivery"
 parent_feature: "agents/engineer-agent/skills"
 feature_level: "4"
-version: "1.0.3"
+version: "1.0.4"
 status: Approved
 author: "Neplich Codex"
 date: "2026-06-12"
@@ -21,6 +21,9 @@ related_docs:
   - "docs/engineer/repository-governance/feature-path-contract/TRD.md"
   - "docs/engineer/repository-governance/feature-path-contract/IMPLEMENTATION_PLAN.md"
 changelog:
+  - version: "1.0.4"
+    date: "2026-09-01"
+    changes: "清理维护者画像中已失效的 eval 机制提及"
   - version: "1.0.3"
     date: "2026-09-01"
     changes: "清理已失效的 eval 机制残留引用"
@@ -60,7 +63,7 @@ changelog:
 |---------|-------------|-----------|-------------|
 | 直接调用用户 | 已知道要使用 `delivery` 的用户 | 直接获得当前 skill 的真实产物 | 泛化 PRD 会误导输入和输出 |
 | `engineer-agent` Dispatcher | 根据用户意图选择下游 skill | 清晰 trigger 和 route boundary | 描述过宽会误路由 |
-| 维护者 | 维护 skill 文档和 eval 的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
+| 维护者 | 维护 skill 文档和确定性检查的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
 
 ## 用户故事与场景
 

--- a/docs/pm/agents/engineer-agent/skills/engineer-agent/PRD.md
+++ b/docs/pm/agents/engineer-agent/skills/engineer-agent/PRD.md
@@ -5,7 +5,7 @@ feature: "skill-engineer-agent"
 feature_path: "agents/engineer-agent/skills/engineer-agent"
 parent_feature: "agents/engineer-agent/skills"
 feature_level: "4"
-version: "1.3.3"
+version: "1.3.4"
 status: Approved
 author: "Neplich Codex"
 date: "2026-06-12"
@@ -21,6 +21,9 @@ related_docs:
   - "docs/engineer/agent-collaboration/frontend-ui-routing-contract/TRD.md"
   - ".claude-plugin/marketplace.json"
 changelog:
+  - version: "1.3.4"
+    date: "2026-09-01"
+    changes: "清理维护者画像中已失效的 eval 机制提及"
   - version: "1.3.3"
     date: "2026-09-01"
     changes: "清理已失效的 eval 机制残留引用"
@@ -69,7 +72,7 @@ changelog:
 |---------|-------------|-----------|-------------|
 | 直接调用用户 | 已知道要使用 `engineer-agent` 的用户 | 直接获得当前 skill 的真实产物 | 泛化 PRD 会误导输入和输出 |
 | `engineer-agent` Dispatcher | 根据用户意图选择下游 skill | 清晰 trigger 和 route boundary | 描述过宽会误路由 |
-| 维护者 | 维护 skill 文档和 eval 的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
+| 维护者 | 维护 skill 文档和确定性检查的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
 
 ## 用户故事与场景
 

--- a/docs/pm/agents/engineer-agent/skills/feature-implementor/PRD.md
+++ b/docs/pm/agents/engineer-agent/skills/feature-implementor/PRD.md
@@ -10,7 +10,7 @@ child_features:
   - "agents/engineer-agent/skills/feature-implementor/implementation-plan-archive-gate"
   - "agents/engineer-agent/skills/feature-implementor/gate-approver-authorization"
   - "agents/engineer-agent/skills/feature-implementor/plan-expectation-reconciliation"
-version: "1.5.3"
+version: "1.5.4"
 status: Approved
 author: "Neplich Codex"
 date: "2026-06-12"
@@ -36,6 +36,9 @@ related_docs:
   - "agents/engineer/skills/feature-implementor/_internal/implementor/INSTRUCTIONS.md"
   - "agents/engineer/skills/feature-implementor/_internal/reviewer/INSTRUCTIONS.md"
 changelog:
+  - version: "1.5.4"
+    date: "2026-09-01"
+    changes: "清理维护者画像中已失效的 eval 机制提及"
   - version: "1.5.3"
     date: "2026-09-01"
     changes: "清理已失效的 eval 机制残留引用"
@@ -90,7 +93,7 @@ changelog:
 |---------|-------------|-----------|-------------|
 | 直接调用用户 | 已知道要使用 `feature-implementor` 的用户 | 直接获得当前 skill 的真实产物 | 泛化 PRD 会误导输入和输出 |
 | `engineer-agent` Dispatcher | 根据用户意图选择下游 skill | 清晰 trigger 和 route boundary | 描述过宽会误路由 |
-| 维护者 | 维护 skill 文档和 eval 的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
+| 维护者 | 维护 skill 文档和确定性检查的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
 
 ## 用户故事与场景
 

--- a/docs/pm/agents/engineer-agent/skills/test-writer/PRD.md
+++ b/docs/pm/agents/engineer-agent/skills/test-writer/PRD.md
@@ -5,7 +5,7 @@ feature: "skill-test-writer"
 feature_path: "agents/engineer-agent/skills/test-writer"
 parent_feature: "agents/engineer-agent/skills"
 feature_level: "4"
-version: "1.0.3"
+version: "1.0.4"
 status: Approved
 author: "Neplich Codex"
 date: "2026-06-12"
@@ -21,6 +21,9 @@ related_docs:
   - "docs/engineer/repository-governance/feature-path-contract/TRD.md"
   - "docs/engineer/repository-governance/feature-path-contract/IMPLEMENTATION_PLAN.md"
 changelog:
+  - version: "1.0.4"
+    date: "2026-09-01"
+    changes: "清理维护者画像中已失效的 eval 机制提及"
   - version: "1.0.3"
     date: "2026-09-01"
     changes: "清理已失效的 eval 机制残留引用"
@@ -60,7 +63,7 @@ changelog:
 |---------|-------------|-----------|-------------|
 | 直接调用用户 | 已知道要使用 `test-writer` 的用户 | 直接获得当前 skill 的真实产物 | 泛化 PRD 会误导输入和输出 |
 | `engineer-agent` Dispatcher | 根据用户意图选择下游 skill | 清晰 trigger 和 route boundary | 描述过宽会误路由 |
-| 维护者 | 维护 skill 文档和 eval 的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
+| 维护者 | 维护 skill 文档和确定性检查的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
 
 ## 用户故事与场景
 

--- a/docs/pm/agents/engineer-agent/skills/trd-gen/PRD.md
+++ b/docs/pm/agents/engineer-agent/skills/trd-gen/PRD.md
@@ -5,7 +5,7 @@ feature: "skill-trd-gen"
 feature_path: "agents/engineer-agent/skills/trd-gen"
 parent_feature: "agents/engineer-agent/skills"
 feature_level: "4"
-version: "1.2.4"
+version: "1.2.5"
 status: Approved
 author: "Neplich Codex"
 date: "2026-06-12"
@@ -21,6 +21,9 @@ related_docs:
   - ".claude-plugin/marketplace.json"
   - "agents/engineer/skills/trd-gen/_internal/trd-schema.md"
 changelog:
+  - version: "1.2.5"
+    date: "2026-09-01"
+    changes: "清理维护者画像中已失效的 eval 机制提及"
   - version: "1.2.4"
     date: "2026-09-01"
     changes: "清理已失效的 eval 机制残留引用"
@@ -69,7 +72,7 @@ changelog:
 |---------|-------------|-----------|-------------|
 | 直接调用用户 | 已知道要使用 `trd-gen` 的用户 | 直接获得当前 skill 的真实产物 | 泛化 PRD 会误导输入和输出 |
 | `engineer-agent` Dispatcher | 根据用户意图选择下游 skill | 清晰 trigger 和 route boundary | 描述过宽会误路由 |
-| 维护者 | 维护 skill 文档和 eval 的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
+| 维护者 | 维护 skill 文档和确定性检查的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
 
 ## 用户故事与场景
 

--- a/docs/pm/agents/pm-agent/skills/competitive-brief/PRD.md
+++ b/docs/pm/agents/pm-agent/skills/competitive-brief/PRD.md
@@ -5,7 +5,7 @@ feature: "skill-competitive-brief"
 feature_path: "agents/pm-agent/skills/competitive-brief"
 parent_feature: "agents/pm-agent/skills"
 feature_level: "4"
-version: "1.0.3"
+version: "1.0.4"
 status: Approved
 author: "Neplich Codex"
 date: "2026-06-12"
@@ -21,6 +21,9 @@ related_docs:
   - "docs/engineer/repository-governance/feature-path-contract/TRD.md"
   - "docs/engineer/repository-governance/feature-path-contract/IMPLEMENTATION_PLAN.md"
 changelog:
+  - version: "1.0.4"
+    date: "2026-09-01"
+    changes: "清理维护者画像中已失效的 eval 机制提及"
   - version: "1.0.3"
     date: "2026-09-01"
     changes: "清理已失效的 eval 机制残留引用"
@@ -60,7 +63,7 @@ changelog:
 |---------|-------------|-----------|-------------|
 | 直接调用用户 | 已知道要使用 `competitive-brief` 的用户 | 直接获得当前 skill 的真实产物 | 泛化 PRD 会误导输入和输出 |
 | `pm-agent` Dispatcher | 根据用户意图选择下游 skill | 清晰 trigger 和 route boundary | 描述过宽会误路由 |
-| 维护者 | 维护 skill 文档和 eval 的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
+| 维护者 | 维护 skill 文档和确定性检查的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
 
 ## 用户故事与场景
 

--- a/docs/pm/agents/pm-agent/skills/github-reader/PRD.md
+++ b/docs/pm/agents/pm-agent/skills/github-reader/PRD.md
@@ -5,7 +5,7 @@ feature: "skill-github-reader"
 feature_path: "agents/pm-agent/skills/github-reader"
 parent_feature: "agents/pm-agent/skills"
 feature_level: "4"
-version: "1.0.3"
+version: "1.0.4"
 status: Approved
 author: "Neplich Codex"
 date: "2026-06-12"
@@ -21,6 +21,9 @@ related_docs:
   - "docs/engineer/repository-governance/feature-path-contract/TRD.md"
   - "docs/engineer/repository-governance/feature-path-contract/IMPLEMENTATION_PLAN.md"
 changelog:
+  - version: "1.0.4"
+    date: "2026-09-01"
+    changes: "清理维护者画像中已失效的 eval 机制提及"
   - version: "1.0.3"
     date: "2026-09-01"
     changes: "清理已失效的 eval 机制残留引用"
@@ -60,7 +63,7 @@ changelog:
 |---------|-------------|-----------|-------------|
 | 直接调用用户 | 已知道要使用 `github-reader` 的用户 | 直接获得当前 skill 的真实产物 | 泛化 PRD 会误导输入和输出 |
 | `pm-agent` Dispatcher | 根据用户意图选择下游 skill | 清晰 trigger 和 route boundary | 描述过宽会误路由 |
-| 维护者 | 维护 skill 文档和 eval 的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
+| 维护者 | 维护 skill 文档和确定性检查的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
 
 ## 用户故事与场景
 

--- a/docs/pm/agents/pm-agent/skills/idea-to-spec/PRD.md
+++ b/docs/pm/agents/pm-agent/skills/idea-to-spec/PRD.md
@@ -5,7 +5,7 @@ feature: "skill-idea-to-spec"
 feature_path: "agents/pm-agent/skills/idea-to-spec"
 parent_feature: "agents/pm-agent/skills"
 feature_level: "4"
-version: "1.2.4"
+version: "1.2.5"
 status: Approved
 author: "Neplich Codex"
 date: "2026-06-12"
@@ -22,6 +22,9 @@ related_docs:
   - "agents/product_manager/skills/idea-to-spec/_internal/_shared/doc-schemas/"
   - "agents/product_manager/skills/idea-to-spec/_internal/gen/prd-gen/INSTRUCTIONS.md"
 changelog:
+  - version: "1.2.5"
+    date: "2026-09-01"
+    changes: "清理维护者画像中已失效的 eval 机制提及"
   - version: "1.2.4"
     date: "2026-09-01"
     changes: "清理已失效的 eval 机制残留引用"
@@ -70,7 +73,7 @@ changelog:
 |---------|-------------|-----------|-------------|
 | 直接调用用户 | 已知道要使用 `idea-to-spec` 的用户 | 直接获得当前 skill 的真实产物 | 泛化 PRD 会误导输入和输出 |
 | `pm-agent` Dispatcher | 根据用户意图选择下游 skill | 清晰 trigger 和 route boundary | 描述过宽会误路由 |
-| 维护者 | 维护 skill 文档和 eval 的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
+| 维护者 | 维护 skill 文档和确定性检查的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
 
 ## 用户故事与场景
 

--- a/docs/pm/agents/pm-agent/skills/pm-agent/PRD.md
+++ b/docs/pm/agents/pm-agent/skills/pm-agent/PRD.md
@@ -5,7 +5,7 @@ feature: "skill-pm-agent"
 feature_path: "agents/pm-agent/skills/pm-agent"
 parent_feature: "agents/pm-agent/skills"
 feature_level: "4"
-version: "1.1.3"
+version: "1.1.4"
 status: Approved
 author: "Neplich Codex"
 date: "2026-06-12"
@@ -20,6 +20,9 @@ related_docs:
   - "docs/engineer/repository-governance/feature-path-contract/TRD.md"
   - "docs/engineer/repository-governance/feature-path-contract/IMPLEMENTATION_PLAN.md"
 changelog:
+  - version: "1.1.4"
+    date: "2026-09-01"
+    changes: "清理维护者画像中已失效的 eval 机制提及"
   - version: "1.1.3"
     date: "2026-09-01"
     changes: "清理已失效的 eval 机制残留引用"
@@ -62,7 +65,7 @@ changelog:
 |---------|-------------|-----------|-------------|
 | 直接调用用户 | 已知道要使用 `pm-agent` 的用户 | 直接获得当前 skill 的真实产物 | 泛化 PRD 会误导输入和输出 |
 | `pm-agent` Dispatcher | 根据用户意图选择下游 skill | 清晰 trigger 和 route boundary | 描述过宽会误路由 |
-| 维护者 | 维护 skill 文档和 eval 的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
+| 维护者 | 维护 skill 文档和确定性检查的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
 
 ## 用户故事与场景
 

--- a/docs/pm/agents/pm-agent/skills/roadmap-gen/PRD.md
+++ b/docs/pm/agents/pm-agent/skills/roadmap-gen/PRD.md
@@ -5,7 +5,7 @@ feature: "skill-roadmap-gen"
 feature_path: "agents/pm-agent/skills/roadmap-gen"
 parent_feature: "agents/pm-agent/skills"
 feature_level: "4"
-version: "1.0.3"
+version: "1.0.4"
 status: Approved
 author: "Neplich Codex"
 date: "2026-06-12"
@@ -21,6 +21,9 @@ related_docs:
   - "docs/engineer/repository-governance/feature-path-contract/TRD.md"
   - "docs/engineer/repository-governance/feature-path-contract/IMPLEMENTATION_PLAN.md"
 changelog:
+  - version: "1.0.4"
+    date: "2026-09-01"
+    changes: "清理维护者画像中已失效的 eval 机制提及"
   - version: "1.0.3"
     date: "2026-09-01"
     changes: "清理已失效的 eval 机制残留引用"
@@ -60,7 +63,7 @@ changelog:
 |---------|-------------|-----------|-------------|
 | 直接调用用户 | 已知道要使用 `roadmap-gen` 的用户 | 直接获得当前 skill 的真实产物 | 泛化 PRD 会误导输入和输出 |
 | `pm-agent` Dispatcher | 根据用户意图选择下游 skill | 清晰 trigger 和 route boundary | 描述过宽会误路由 |
-| 维护者 | 维护 skill 文档和 eval 的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
+| 维护者 | 维护 skill 文档和确定性检查的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
 
 ## 用户故事与场景
 

--- a/docs/pm/agents/qa-agent/skills/bug-analyzer/PRD.md
+++ b/docs/pm/agents/qa-agent/skills/bug-analyzer/PRD.md
@@ -5,7 +5,7 @@ feature: "skill-bug-analyzer"
 feature_path: "agents/qa-agent/skills/bug-analyzer"
 parent_feature: "agents/qa-agent/skills"
 feature_level: "4"
-version: "1.0.3"
+version: "1.0.4"
 status: Approved
 author: "Neplich Codex"
 date: "2026-06-12"
@@ -21,6 +21,9 @@ related_docs:
   - "docs/engineer/repository-governance/feature-path-contract/TRD.md"
   - "docs/engineer/repository-governance/feature-path-contract/IMPLEMENTATION_PLAN.md"
 changelog:
+  - version: "1.0.4"
+    date: "2026-09-01"
+    changes: "清理维护者画像中已失效的 eval 机制提及"
   - version: "1.0.3"
     date: "2026-09-01"
     changes: "清理已失效的 eval 机制残留引用"
@@ -60,7 +63,7 @@ changelog:
 |---------|-------------|-----------|-------------|
 | 直接调用用户 | 已知道要使用 `bug-analyzer` 的用户 | 直接获得当前 skill 的真实产物 | 泛化 PRD 会误导输入和输出 |
 | `qa-agent` Dispatcher | 根据用户意图选择下游 skill | 清晰 trigger 和 route boundary | 描述过宽会误路由 |
-| 维护者 | 维护 skill 文档和 eval 的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
+| 维护者 | 维护 skill 文档和确定性检查的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
 
 ## 用户故事与场景
 

--- a/docs/pm/agents/qa-agent/skills/exploratory-tester/PRD.md
+++ b/docs/pm/agents/qa-agent/skills/exploratory-tester/PRD.md
@@ -5,7 +5,7 @@ feature: "skill-exploratory-tester"
 feature_path: "agents/qa-agent/skills/exploratory-tester"
 parent_feature: "agents/qa-agent/skills"
 feature_level: "4"
-version: "1.0.3"
+version: "1.0.4"
 status: Approved
 author: "Neplich Codex"
 date: "2026-06-12"
@@ -21,6 +21,9 @@ related_docs:
   - "docs/engineer/repository-governance/feature-path-contract/TRD.md"
   - "docs/engineer/repository-governance/feature-path-contract/IMPLEMENTATION_PLAN.md"
 changelog:
+  - version: "1.0.4"
+    date: "2026-09-01"
+    changes: "清理维护者画像中已失效的 eval 机制提及"
   - version: "1.0.3"
     date: "2026-09-01"
     changes: "清理已失效的 eval 机制残留引用"
@@ -60,7 +63,7 @@ changelog:
 |---------|-------------|-----------|-------------|
 | 直接调用用户 | 已知道要使用 `exploratory-tester` 的用户 | 直接获得当前 skill 的真实产物 | 泛化 PRD 会误导输入和输出 |
 | `qa-agent` Dispatcher | 根据用户意图选择下游 skill | 清晰 trigger 和 route boundary | 描述过宽会误路由 |
-| 维护者 | 维护 skill 文档和 eval 的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
+| 维护者 | 维护 skill 文档和确定性检查的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
 
 ## 用户故事与场景
 

--- a/docs/pm/agents/qa-agent/skills/qa-agent/PRD.md
+++ b/docs/pm/agents/qa-agent/skills/qa-agent/PRD.md
@@ -5,7 +5,7 @@ feature: "skill-qa-agent"
 feature_path: "agents/qa-agent/skills/qa-agent"
 parent_feature: "agents/qa-agent/skills"
 feature_level: "4"
-version: "1.1.3"
+version: "1.1.4"
 status: Approved
 author: "Neplich Codex"
 date: "2026-06-12"
@@ -22,6 +22,9 @@ related_docs:
   - "docs/engineer/repository-governance/feature-path-contract/TRD.md"
   - "docs/engineer/repository-governance/feature-path-contract/IMPLEMENTATION_PLAN.md"
 changelog:
+  - version: "1.1.4"
+    date: "2026-09-01"
+    changes: "清理维护者画像中已失效的 eval 机制提及"
   - version: "1.1.3"
     date: "2026-09-01"
     changes: "清理已失效的 eval 机制残留引用"
@@ -64,7 +67,7 @@ changelog:
 |---------|-------------|-----------|-------------|
 | 直接调用用户 | 已知道要使用 `qa-agent` 的用户 | 直接获得当前 skill 的真实产物 | 泛化 PRD 会误导输入和输出 |
 | `qa-agent` Dispatcher | 根据用户意图选择下游 skill | 清晰 trigger 和 route boundary | 描述过宽会误路由 |
-| 维护者 | 维护 skill 文档和 eval 的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
+| 维护者 | 维护 skill 文档和确定性检查的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
 
 ## 用户故事与场景
 

--- a/docs/pm/agents/qa-agent/skills/regression-suite/PRD.md
+++ b/docs/pm/agents/qa-agent/skills/regression-suite/PRD.md
@@ -5,7 +5,7 @@ feature: "skill-regression-suite"
 feature_path: "agents/qa-agent/skills/regression-suite"
 parent_feature: "agents/qa-agent/skills"
 feature_level: "4"
-version: "1.0.3"
+version: "1.0.4"
 status: Approved
 author: "Neplich Codex"
 date: "2026-06-12"
@@ -22,6 +22,9 @@ related_docs:
   - "docs/engineer/repository-governance/feature-path-contract/TRD.md"
   - "docs/engineer/repository-governance/feature-path-contract/IMPLEMENTATION_PLAN.md"
 changelog:
+  - version: "1.0.4"
+    date: "2026-09-01"
+    changes: "清理维护者画像中已失效的 eval 机制提及"
   - version: "1.0.3"
     date: "2026-09-01"
     changes: "清理已失效的 eval 机制残留引用"
@@ -61,7 +64,7 @@ changelog:
 |---------|-------------|-----------|-------------|
 | 直接调用用户 | 已知道要使用 `regression-suite` 的用户 | 直接获得当前 skill 的真实产物 | 泛化 PRD 会误导输入和输出 |
 | `qa-agent` Dispatcher | 根据用户意图选择下游 skill | 清晰 trigger 和 route boundary | 描述过宽会误路由 |
-| 维护者 | 维护 skill 文档和 eval 的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
+| 维护者 | 维护 skill 文档和确定性检查的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
 
 ## 用户故事与场景
 

--- a/docs/pm/agents/qa-agent/skills/spec-based-tester/PRD.md
+++ b/docs/pm/agents/qa-agent/skills/spec-based-tester/PRD.md
@@ -5,7 +5,7 @@ feature: "skill-spec-based-tester"
 feature_path: "agents/qa-agent/skills/spec-based-tester"
 parent_feature: "agents/qa-agent/skills"
 feature_level: "4"
-version: "1.0.3"
+version: "1.0.4"
 status: Approved
 author: "Neplich Codex"
 date: "2026-06-12"
@@ -21,6 +21,9 @@ related_docs:
   - "docs/engineer/repository-governance/feature-path-contract/TRD.md"
   - "docs/engineer/repository-governance/feature-path-contract/IMPLEMENTATION_PLAN.md"
 changelog:
+  - version: "1.0.4"
+    date: "2026-09-01"
+    changes: "清理维护者画像中已失效的 eval 机制提及"
   - version: "1.0.3"
     date: "2026-09-01"
     changes: "清理已失效的 eval 机制残留引用"
@@ -60,7 +63,7 @@ changelog:
 |---------|-------------|-----------|-------------|
 | 直接调用用户 | 已知道要使用 `spec-based-tester` 的用户 | 直接获得当前 skill 的真实产物 | 泛化 PRD 会误导输入和输出 |
 | `qa-agent` Dispatcher | 根据用户意图选择下游 skill | 清晰 trigger 和 route boundary | 描述过宽会误路由 |
-| 维护者 | 维护 skill 文档和 eval 的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
+| 维护者 | 维护 skill 文档和确定性检查的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
 
 ## 用户故事与场景
 

--- a/docs/pm/agents/security-agent/skills/appsec-checklist/PRD.md
+++ b/docs/pm/agents/security-agent/skills/appsec-checklist/PRD.md
@@ -5,7 +5,7 @@ feature: "skill-appsec-checklist"
 feature_path: "agents/security-agent/skills/appsec-checklist"
 parent_feature: "agents/security-agent/skills"
 feature_level: "4"
-version: "1.0.3"
+version: "1.0.4"
 status: Approved
 author: "Neplich Codex"
 date: "2026-06-12"
@@ -18,6 +18,9 @@ related_docs:
   - "agents/security/skills/appsec-checklist/SKILL.md"
   - ".claude-plugin/marketplace.json"
 changelog:
+  - version: "1.0.4"
+    date: "2026-09-01"
+    changes: "清理维护者画像中已失效的 eval 机制提及"
   - version: "1.0.3"
     date: "2026-09-01"
     changes: "清理已失效的 eval 机制残留引用"
@@ -57,7 +60,7 @@ changelog:
 |---------|-------------|-----------|-------------|
 | 直接调用用户 | 已知道要使用 `appsec-checklist` 的用户 | 直接获得当前 skill 的真实产物 | 泛化 PRD 会误导输入和输出 |
 | `security-agent` Dispatcher | 根据用户意图选择下游 skill | 清晰 trigger 和 route boundary | 描述过宽会误路由 |
-| 维护者 | 维护 skill 文档和 eval 的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
+| 维护者 | 维护 skill 文档和确定性检查的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
 
 ## 用户故事与场景
 

--- a/docs/pm/agents/security-agent/skills/authz-reviewer/PRD.md
+++ b/docs/pm/agents/security-agent/skills/authz-reviewer/PRD.md
@@ -5,7 +5,7 @@ feature: "skill-authz-reviewer"
 feature_path: "agents/security-agent/skills/authz-reviewer"
 parent_feature: "agents/security-agent/skills"
 feature_level: "4"
-version: "1.0.3"
+version: "1.0.4"
 status: Approved
 author: "Neplich Codex"
 date: "2026-06-12"
@@ -18,6 +18,9 @@ related_docs:
   - "agents/security/skills/authz-reviewer/SKILL.md"
   - ".claude-plugin/marketplace.json"
 changelog:
+  - version: "1.0.4"
+    date: "2026-09-01"
+    changes: "清理维护者画像中已失效的 eval 机制提及"
   - version: "1.0.3"
     date: "2026-09-01"
     changes: "清理已失效的 eval 机制残留引用"
@@ -57,7 +60,7 @@ changelog:
 |---------|-------------|-----------|-------------|
 | 直接调用用户 | 已知道要使用 `authz-reviewer` 的用户 | 直接获得当前 skill 的真实产物 | 泛化 PRD 会误导输入和输出 |
 | `security-agent` Dispatcher | 根据用户意图选择下游 skill | 清晰 trigger 和 route boundary | 描述过宽会误路由 |
-| 维护者 | 维护 skill 文档和 eval 的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
+| 维护者 | 维护 skill 文档和确定性检查的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
 
 ## 用户故事与场景
 

--- a/docs/pm/agents/security-agent/skills/dependency-risk-auditor/PRD.md
+++ b/docs/pm/agents/security-agent/skills/dependency-risk-auditor/PRD.md
@@ -5,7 +5,7 @@ feature: "skill-dependency-risk-auditor"
 feature_path: "agents/security-agent/skills/dependency-risk-auditor"
 parent_feature: "agents/security-agent/skills"
 feature_level: "4"
-version: "1.0.3"
+version: "1.0.4"
 status: Approved
 author: "Neplich Codex"
 date: "2026-06-12"
@@ -18,6 +18,9 @@ related_docs:
   - "agents/security/skills/dependency-risk-auditor/SKILL.md"
   - ".claude-plugin/marketplace.json"
 changelog:
+  - version: "1.0.4"
+    date: "2026-09-01"
+    changes: "清理维护者画像中已失效的 eval 机制提及"
   - version: "1.0.3"
     date: "2026-09-01"
     changes: "清理已失效的 eval 机制残留引用"
@@ -57,7 +60,7 @@ changelog:
 |---------|-------------|-----------|-------------|
 | 直接调用用户 | 已知道要使用 `dependency-risk-auditor` 的用户 | 直接获得当前 skill 的真实产物 | 泛化 PRD 会误导输入和输出 |
 | `security-agent` Dispatcher | 根据用户意图选择下游 skill | 清晰 trigger 和 route boundary | 描述过宽会误路由 |
-| 维护者 | 维护 skill 文档和 eval 的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
+| 维护者 | 维护 skill 文档和确定性检查的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
 
 ## 用户故事与场景
 

--- a/docs/pm/agents/security-agent/skills/privacy-surface-mapper/PRD.md
+++ b/docs/pm/agents/security-agent/skills/privacy-surface-mapper/PRD.md
@@ -5,7 +5,7 @@ feature: "skill-privacy-surface-mapper"
 feature_path: "agents/security-agent/skills/privacy-surface-mapper"
 parent_feature: "agents/security-agent/skills"
 feature_level: "4"
-version: "1.0.3"
+version: "1.0.4"
 status: Approved
 author: "Neplich Codex"
 date: "2026-06-12"
@@ -18,6 +18,9 @@ related_docs:
   - "agents/security/skills/privacy-surface-mapper/SKILL.md"
   - ".claude-plugin/marketplace.json"
 changelog:
+  - version: "1.0.4"
+    date: "2026-09-01"
+    changes: "清理维护者画像中已失效的 eval 机制提及"
   - version: "1.0.3"
     date: "2026-09-01"
     changes: "清理已失效的 eval 机制残留引用"
@@ -57,7 +60,7 @@ changelog:
 |---------|-------------|-----------|-------------|
 | 直接调用用户 | 已知道要使用 `privacy-surface-mapper` 的用户 | 直接获得当前 skill 的真实产物 | 泛化 PRD 会误导输入和输出 |
 | `security-agent` Dispatcher | 根据用户意图选择下游 skill | 清晰 trigger 和 route boundary | 描述过宽会误路由 |
-| 维护者 | 维护 skill 文档和 eval 的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
+| 维护者 | 维护 skill 文档和确定性检查的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
 
 ## 用户故事与场景
 

--- a/docs/pm/agents/security-agent/skills/security-agent/PRD.md
+++ b/docs/pm/agents/security-agent/skills/security-agent/PRD.md
@@ -5,7 +5,7 @@ feature: "skill-security-agent"
 feature_path: "agents/security-agent/skills/security-agent"
 parent_feature: "agents/security-agent/skills"
 feature_level: "4"
-version: "1.1.3"
+version: "1.1.4"
 status: Approved
 author: "Neplich Codex"
 date: "2026-06-12"
@@ -17,6 +17,9 @@ related_docs:
   - "agents/security/skills/security-agent/SKILL.md"
   - ".claude-plugin/marketplace.json"
 changelog:
+  - version: "1.1.4"
+    date: "2026-09-01"
+    changes: "清理维护者画像中已失效的 eval 机制提及"
   - version: "1.1.3"
     date: "2026-09-01"
     changes: "清理已失效的 eval 机制残留引用"
@@ -60,7 +63,7 @@ changelog:
 |---------|-------------|-----------|-------------|
 | 直接调用用户 | 已知道要使用 `security-agent` 的用户 | 直接获得当前 skill 的真实产物 | 泛化 PRD 会误导输入和输出 |
 | `security-agent` Dispatcher | 根据用户意图选择下游 skill | 清晰 trigger 和 route boundary | 描述过宽会误路由 |
-| 维护者 | 维护 skill 文档和 eval 的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
+| 维护者 | 维护 skill 文档和确定性检查的人 | 可追溯、可校验的契约 | related docs 不全会漏掉真实实现 |
 
 ## 用户故事与场景
 


### PR DESCRIPTION
Close #328。

## 背景

PR #301 移除整套 Skill eval 机制，#327 完成活跃规格中现行式 eval 残留清理。#328 登记了扫尾时有意豁免的两类惰性 eval 提及：不声称机制存在、不构成验证依据，但措辞仍引用已删除对象。本 PR 一次性批次清理并关闭该登记。

## 变更

**A：30 份 skill 级 PRD 维护者 persona 行**

"维护 skill 文档和 eval 的人" → "维护 skill 文档和确定性检查的人"（qa / security / devops / designer / pm / engineer 各 skill PRD 统一模板行，每份一处）。

**B：`idea-to-spec` TRD 防误扫守护句举例泛化**

`docs/engineer/agents/pm-agent/skills/idea-to-spec/TRD.md` 三处以 eval fixture 为"非正式文档"的举例（§4 契约说明、§5 实施约束、§9 风险表）泛化为测试/评测夹具表述，守护语义不变。

**版本元数据**：触及文档统一 bump patch 版本；`last_updated` 经 #327 已是 2026-09-01 无需变更；有 changelog 的 30 份 PRD 追加条目（`idea-to-spec` TRD 无 changelog 字段，按 #327 先例不新增）。

## 验证

- `generate_shared_contracts.py --check`、`check_repository_contract.py`、`check_doc_contract.py`、`git diff --check` 全部通过
- 本机无 uv，脚本无第三方依赖，使用系统 python3 直接运行；本机无 pytest 环境未跑 pytest，本次为纯文档变更、不触及脚本