### PR TITLE
feat(contract): check_doc_contract 加严正式文档必填字段校验

### DIFF
--- a/agents/test_doc_contract.py
+++ b/agents/test_doc_contract.py
@@ -39,6 +39,31 @@ def add_tracked_file(root: Path, rel: str, content: str) -> Path:
     return path
 
 
+def formal_doc_frontmatter(doc_type: str) -> str:
+    child_features = 'child_features: "N/A"\n' if doc_type == "PRD" else ""
+    return (
+        "---\n"
+        'title: "Example"\n'
+        f"type: {doc_type}\n"
+        'feature: "example"\n'
+        'feature_path: "example"\n'
+        'parent_feature: "N/A"\n'
+        'feature_level: "1"\n'
+        'version: "0.1.0"\n'
+        "status: Draft\n"
+        'author: "Tester Codex"\n'
+        'date: "2026-07-06"\n'
+        'last_updated: "2026-07-06"\n'
+        'generated_by: "prd-gen"\n'
+        f"{child_features}"
+        "changelog:\n"
+        '  - version: "0.1.0"\n'
+        '    date: "2026-07-06"\n'
+        '    changes: "Initial version"\n'
+        "---\n\n"
+    )
+
+
 class DocContractTests(unittest.TestCase):
     def test_doc_contract_rejects_missing_required_formal_metadata(self):
         checker = load_doc_checker_module()
@@ -61,6 +86,10 @@ class DocContractTests(unittest.TestCase):
         rendered = "\n".join(error.render(root) for error in errors)
         self.assertIn("frontmatter 'date' must be non-empty", rendered)
         self.assertIn("frontmatter 'last_updated' must be non-empty", rendered)
+        self.assertIn("frontmatter 'title' must be non-empty", rendered)
+        self.assertIn(
+            "frontmatter 'changelog' must contain at least one entry", rendered
+        )
 
     def test_doc_contract_archive_segment_pm_doc_still_requires_frontmatter(self):
         checker = load_doc_checker_module()
@@ -78,6 +107,66 @@ class DocContractTests(unittest.TestCase):
 
         rendered = "\n".join(error.render(root) for error in errors)
         self.assertIn("docs/pm/payments/archive/PRD.md", rendered)
+
+    def test_doc_contract_rejects_prd_without_child_features(self):
+        checker = load_doc_checker_module()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            init_git(root)
+            add_tracked_file(
+                root,
+                "docs/pm/example/PRD.md",
+                formal_doc_frontmatter("PRD").replace('child_features: "N/A"\n', "")
+                + "# Example PRD\n",
+            )
+
+            errors = checker.validate_all(root)
+
+        rendered = "\n".join(error.render(root) for error in errors)
+        self.assertIn("frontmatter 'child_features' must be non-empty for PRDs", rendered)
+
+    def test_doc_contract_rejects_changelog_entry_without_changes(self):
+        checker = load_doc_checker_module()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            init_git(root)
+            add_tracked_file(
+                root,
+                "docs/engineer/example/TRD.md",
+                formal_doc_frontmatter("TRD").replace(
+                    '    changes: "Initial version"\n', ""
+                )
+                + "# Example TRD\n",
+            )
+
+            errors = checker.validate_all(root)
+
+        rendered = "\n".join(error.render(root) for error in errors)
+        self.assertIn("must have non-empty 'changes'", rendered)
+
+    def test_doc_contract_registered_exemption_skips_extended_fields(self):
+        checker = load_doc_checker_module()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            init_git(root)
+            add_tracked_file(
+                root,
+                "docs/pm/repository-ci-governance/CI_PLAN.md",
+                "---\n"
+                'feature: "repository-ci-governance"\n'
+                'version: "0.1.0-draft"\n'
+                'date: "2026-05-06"\n'
+                'last_updated: "2026-09-01"\n'
+                "---\n\n"
+                "# Repository CI Governance Plan\n",
+            )
+
+            errors = checker.validate_all(root)
+
+        self.assertEqual([], errors)
 
     def test_doc_contract_rejects_non_pm_description_trigger_phrase(self):
         checker = load_doc_checker_module()
@@ -113,25 +202,16 @@ class DocContractTests(unittest.TestCase):
             add_tracked_file(
                 root,
                 "docs/pm/example/PRD.md",
-                "---\n"
-                'feature: "example"\n'
-                'version: "0.1.0"\n'
-                'date: "2026-07-06"\n'
-                'last_updated: "2026-07-06"\n'
-                "---\n\n"
-                "# Example PRD\n",
+                formal_doc_frontmatter("PRD") + "# Example PRD\n",
             )
             add_tracked_file(
                 root,
                 "docs/engineer/example/TRD.md",
-                "---\n"
-                'feature: "example"\n'
-                'version: "0.1.0"\n'
-                'date: "2026-07-06"\n'
-                'last_updated: "2026-07-06"\n'
-                'related_prd: "docs/pm/example/PRD.md"\n'
-                "---\n\n"
-                "# Example TRD\n",
+                formal_doc_frontmatter("TRD").replace(
+                    "changelog:\n",
+                    'related_prd: "docs/pm/example/PRD.md"\nchangelog:\n',
+                )
+                + "# Example TRD\n",
             )
 
             pm_agent = root / "agents/product_manager/skills/pm-agent/SKILL.md"

--- a/agents/test_doc_contract.py
+++ b/agents/test_doc_contract.py
@@ -146,6 +146,46 @@ class DocContractTests(unittest.TestCase):
         rendered = "\n".join(error.render(root) for error in errors)
         self.assertIn("must have non-empty 'changes'", rendered)
 
+    def test_doc_contract_rejects_quoted_whitespace_changelog_value(self):
+        checker = load_doc_checker_module()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            init_git(root)
+            add_tracked_file(
+                root,
+                "docs/engineer/example/TRD.md",
+                formal_doc_frontmatter("TRD").replace(
+                    '    changes: "Initial version"\n', '    changes: "   "\n'
+                )
+                + "# Example TRD\n",
+            )
+
+            errors = checker.validate_all(root)
+
+        rendered = "\n".join(error.render(root) for error in errors)
+        self.assertIn("must have non-empty 'changes'", rendered)
+
+    def test_doc_contract_rejects_empty_child_features_collection(self):
+        checker = load_doc_checker_module()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            init_git(root)
+            add_tracked_file(
+                root,
+                "docs/pm/example/PRD.md",
+                formal_doc_frontmatter("PRD").replace(
+                    'child_features: "N/A"\n', "child_features: []\n"
+                )
+                + "# Example PRD\n",
+            )
+
+            errors = checker.validate_all(root)
+
+        rendered = "\n".join(error.render(root) for error in errors)
+        self.assertIn("frontmatter 'child_features' must be non-empty for PRDs", rendered)
+
     def test_doc_contract_registered_exemption_skips_extended_fields(self):
         checker = load_doc_checker_module()
 

--- a/agents/test_doc_contract.py
+++ b/agents/test_doc_contract.py
@@ -290,6 +290,12 @@ class DocContractTests(unittest.TestCase):
 
         self.assertFalse(checker.frontmatter_field_has_value(content, "child_features"))
 
+    def test_doc_contract_rejects_blank_child_features_list_item(self):
+        checker = load_doc_checker_module()
+        content = '---\nchild_features:\n  - ""\nchangelog:\n---\n'
+
+        self.assertFalse(checker.frontmatter_field_has_value(content, "child_features"))
+
     def test_doc_contract_registered_exemption_skips_extended_fields(self):
         checker = load_doc_checker_module()
 

--- a/agents/test_doc_contract.py
+++ b/agents/test_doc_contract.py
@@ -109,6 +109,42 @@ class DocContractTests(unittest.TestCase):
         rendered = "\n".join(error.render(root) for error in errors)
         self.assertIn("frontmatter 'title' must be non-empty", rendered)
 
+    def test_doc_contract_rejects_quoted_empty_feature_with_comment(self):
+        checker = load_doc_checker_module()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            init_git(root)
+            add_tracked_file(
+                root,
+                "docs/engineer/example/TRD.md",
+                formal_doc_frontmatter("TRD").replace(
+                    'feature: "example"\n', 'feature: "" # absent\n'
+                ),
+            )
+            errors = checker.validate_all(root)
+
+        rendered = "\n".join(error.render(root) for error in errors)
+        self.assertIn("frontmatter 'feature' must be non-empty", rendered)
+
+    def test_doc_contract_rejects_bare_block_feature(self):
+        checker = load_doc_checker_module()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            init_git(root)
+            add_tracked_file(
+                root,
+                "docs/engineer/example/TRD.md",
+                formal_doc_frontmatter("TRD").replace(
+                    'feature: "example"\n', "feature: |\n"
+                ),
+            )
+            errors = checker.validate_all(root)
+
+        rendered = "\n".join(error.render(root) for error in errors)
+        self.assertIn("frontmatter 'feature' must be non-empty", rendered)
+
     def test_doc_contract_archive_segment_pm_doc_still_requires_frontmatter(self):
         checker = load_doc_checker_module()
 
@@ -190,6 +226,18 @@ class DocContractTests(unittest.TestCase):
 
         self.assertIn("must have non-empty 'changes'", errors[0].message)
 
+    def test_doc_contract_accepts_quoted_block_marker_changelog_value(self):
+        checker = load_doc_checker_module()
+        content = (
+            '---\nchangelog:\n  - version: "0.1.0"\n'
+            '    date: "2026-07-06"\n    changes: "|"\n---\n'
+        )
+        errors = []
+
+        checker.validate_changelog_entries(Path("TRD.md"), content, errors)
+
+        self.assertEqual([], errors)
+
     def test_doc_contract_rejects_quoted_whitespace_changelog_value(self):
         checker = load_doc_checker_module()
 
@@ -233,6 +281,12 @@ class DocContractTests(unittest.TestCase):
     def test_doc_contract_rejects_spaced_empty_child_features_collection(self):
         checker = load_doc_checker_module()
         content = "---\nchild_features: [ ]\n---\n"
+
+        self.assertFalse(checker.frontmatter_field_has_value(content, "child_features"))
+
+    def test_doc_contract_rejects_comment_only_child_features(self):
+        checker = load_doc_checker_module()
+        content = "---\nchild_features:\n  # absent\nchangelog:\n---\n"
 
         self.assertFalse(checker.frontmatter_field_has_value(content, "child_features"))
 

--- a/agents/test_doc_contract.py
+++ b/agents/test_doc_contract.py
@@ -91,6 +91,24 @@ class DocContractTests(unittest.TestCase):
             "frontmatter 'changelog' must contain at least one entry", rendered
         )
 
+    def test_doc_contract_rejects_inline_comment_title(self):
+        checker = load_doc_checker_module()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            init_git(root)
+            add_tracked_file(
+                root,
+                "docs/engineer/example/TRD.md",
+                formal_doc_frontmatter("TRD").replace(
+                    'title: "Example"\n', "title: # absent\n"
+                ),
+            )
+            errors = checker.validate_all(root)
+
+        rendered = "\n".join(error.render(root) for error in errors)
+        self.assertIn("frontmatter 'title' must be non-empty", rendered)
+
     def test_doc_contract_archive_segment_pm_doc_still_requires_frontmatter(self):
         checker = load_doc_checker_module()
 
@@ -146,6 +164,32 @@ class DocContractTests(unittest.TestCase):
         rendered = "\n".join(error.render(root) for error in errors)
         self.assertIn("must have non-empty 'changes'", rendered)
 
+    def test_doc_contract_rejects_wrapped_changelog(self):
+        checker = load_doc_checker_module()
+        content = (
+            "---\nchangelog:\n  wrapper:\n"
+            "    - version: 0.1.0\n"
+            "      date: 2026-07-06\n"
+            "      changes: Initial version\n---\n"
+        )
+        errors = []
+
+        checker.validate_changelog_entries(Path("TRD.md"), content, errors)
+
+        self.assertIn("must be a flat list", errors[0].message)
+
+    def test_doc_contract_rejects_inline_comment_changelog_value(self):
+        checker = load_doc_checker_module()
+        content = (
+            "---\nchangelog:\n  - version: 0.1.0\n"
+            "    date: 2026-07-06\n    changes: # absent\n---\n"
+        )
+        errors = []
+
+        checker.validate_changelog_entries(Path("TRD.md"), content, errors)
+
+        self.assertIn("must have non-empty 'changes'", errors[0].message)
+
     def test_doc_contract_rejects_quoted_whitespace_changelog_value(self):
         checker = load_doc_checker_module()
 
@@ -185,6 +229,12 @@ class DocContractTests(unittest.TestCase):
 
         rendered = "\n".join(error.render(root) for error in errors)
         self.assertIn("frontmatter 'child_features' must be non-empty for PRDs", rendered)
+
+    def test_doc_contract_rejects_spaced_empty_child_features_collection(self):
+        checker = load_doc_checker_module()
+        content = "---\nchild_features: [ ]\n---\n"
+
+        self.assertFalse(checker.frontmatter_field_has_value(content, "child_features"))
 
     def test_doc_contract_registered_exemption_skips_extended_fields(self):
         checker = load_doc_checker_module()

--- a/docs/engineer/repository-governance/document-authority/TRD.md
+++ b/docs/engineer/repository-governance/document-authority/TRD.md
@@ -1,7 +1,7 @@
 ---
 title: "仓库文档权威与生命周期治理 — Technical Requirements Document"
 type: TRD
-version: "0.1.7"
+version: "0.1.8"
 status: Approved
 author: "Neplich Codex"
 date: "2026-08-15"
@@ -25,6 +25,9 @@ related_code:
   - "scripts/install_codex_skills.py"
   - "skills-lock.json"
 changelog:
+  - version: "0.1.8"
+    date: "2026-09-01"
+    changes: "check_doc_contract 加严：output-conventions 必填字段与 changelog 条目结构硬失败，登记 CI_PLAN 显式豁免（#331）"
   - version: "0.1.7"
     date: "2026-09-01"
     changes: "清理已失效的 eval 机制残留引用"
@@ -321,7 +324,7 @@ slug（含重复标题序号）验证锚点存在。URL percent-decoding 后再�
 | --- | --- | --- | --- |
 | 生成 | 权威源与 24 份副本 | `uv run scripts/generate_shared_contracts.py --check` | missing/extra/stale 为 0 |
 | 仓库契约 | plan 生命周期、Router 预算、marketplace 文档状态、hash | `uv run scripts/check_repository_contract.py` | PASS |
-| 文档契约 | frontmatter、本地链接与锚点、归档路径 | `uv run scripts/check_doc_contract.py` | PASS |
+| 文档契约 | frontmatter 必填字段（对齐 output-conventions 全集、PRD `child_features`、changelog 条目结构；豁免经 `FORMAL_DOC_FIELD_EXEMPTIONS` 显式登记）、本地链接与锚点、归档路径 | `uv run scripts/check_doc_contract.py` | PASS |
 | 定向单测 | 生成、repository/doc checker、安装镜像 | `uv run --with pytest pytest scripts/test_generate_shared_contracts.py scripts/test_check_repository_contract.py agents/test_doc_contract.py scripts/test_install_codex_skills.py` | 全部通过 |
 | Codex 安装 | 全量安装临时目标 | `uv run scripts/install_codex_skills.py --target <tmp>` | 引用可读、生成副本存在 |
 | Claude 打包 | marketplace 七 plugin 临时复制测试 | pytest 内按 manifest source/skills 复制并解析引用 | 六个 plugin 自包含 |

--- a/scripts/check_doc_contract.py
+++ b/scripts/check_doc_contract.py
@@ -50,8 +50,8 @@ FORMAL_DOC_FIELD_EXEMPTIONS: dict[str, str] = {
         " output-conventions enum and its version is a non-SemVer draft (#331)"
     ),
 }
-CHANGELOG_ENTRY_START_RE = re.compile(r"^\s*-\s+version:\s*(.*?)\s*$")
-CHANGELOG_ENTRY_FIELD_RE = re.compile(r"^\s+(date|changes):\s*(.*?)\s*$")
+CHANGELOG_ENTRY_START_RE = re.compile(r"^  - version:\s*(.*?)\s*$")
+CHANGELOG_ENTRY_FIELD_RE = re.compile(r"^    (date|changes):\s*(.*?)\s*$")
 FORMAL_DOC_PREFIXES = ("docs/pm/", "docs/engineer/")
 NON_FORMAL_DOC_NAMES = {"README.md", "README_zh.md", "CHANGELOG.md"}
 
@@ -108,6 +108,13 @@ def is_formal_pm_or_engineer_document(rel: str) -> bool:
     return not is_implementation_plan_artifact_path(rel)
 
 
+def normalize_frontmatter_scalar(value: str) -> str:
+    normalized = value.strip()
+    if not normalized.startswith(("'", '"')):
+        normalized = re.split(r"(?:^|\s+)#", normalized, maxsplit=1)[0]
+    return normalized.strip("'\"").strip()
+
+
 def validate_changelog_entries(
     path: Path,
     content: str,
@@ -122,16 +129,23 @@ def validate_changelog_entries(
     entries: list[dict[str, str]] = []
     current: dict[str, str] | None = None
     for line in block.splitlines():
+        if not line.strip():
+            continue
         start = CHANGELOG_ENTRY_START_RE.match(line)
         if start is not None:
             current = {"version": start.group(1)}
             entries.append(current)
             continue
-        if current is None:
-            continue
         field = CHANGELOG_ENTRY_FIELD_RE.match(line)
-        if field is not None:
+        if field is not None and current is not None:
             current[field.group(1)] = field.group(2)
+            continue
+        add_error(
+            errors,
+            path,
+            "frontmatter 'changelog' must be a flat list of '- version:' entries",
+        )
+        return
     if not entries:
         add_error(
             errors,
@@ -141,7 +155,8 @@ def validate_changelog_entries(
         return
     for entry in entries:
         for key in ("version", "date", "changes"):
-            if not entry.get(key, "").strip().strip("'\"").strip():
+            normalized = normalize_frontmatter_scalar(entry.get(key, ""))
+            if not normalized or normalized in ("|", ">"):
                 add_error(
                     errors,
                     path,
@@ -163,8 +178,9 @@ def frontmatter_field_has_value(content: str, field: str) -> bool:
         if key.strip() != field:
             continue
         if value.strip():
-            inline = value.strip().strip("'\"")
-            return bool(inline) and inline.lower() not in ("[]", "{}", "~", "null")
+            inline = normalize_frontmatter_scalar(value)
+            compact = re.sub(r"\s+", "", inline).lower()
+            return bool(inline) and compact not in ("[]", "{}", "~", "null")
         for child in lines[index + 1 :]:
             if child.strip() and not child.startswith((" ", "\t", "-")):
                 break
@@ -190,19 +206,25 @@ def validate_required_formal_frontmatter(
         parsed = parse_markdown_frontmatter(path, content, errors)
         if parsed is None:
             continue
-        metadata, _ = parsed
+        raw_metadata: dict[str, str] = {}
+        for line in markdown_frontmatter_block(content).splitlines():
+            if line.startswith((" ", "\t", "-")) or ":" not in line:
+                continue
+            key, value = line.split(":", 1)
+            if key.strip():
+                raw_metadata[key.strip()] = value.strip()
 
         for field in REQUIRED_FORMAL_FRONTMATTER_FIELDS:
-            value = metadata.get(field)
-            if not isinstance(value, str) or not value.strip():
+            value = raw_metadata.get(field)
+            if value is None or not normalize_frontmatter_scalar(value):
                 add_error(errors, path, f"frontmatter {field!r} must be non-empty")
 
         if rel in FORMAL_DOC_FIELD_EXEMPTIONS:
             continue
 
         for field in EXTENDED_FORMAL_FRONTMATTER_FIELDS:
-            value = metadata.get(field)
-            if not isinstance(value, str) or not value.strip():
+            value = raw_metadata.get(field)
+            if value is None or not normalize_frontmatter_scalar(value):
                 add_error(errors, path, f"frontmatter {field!r} must be non-empty")
 
         validate_changelog_entries(path, content, errors)

--- a/scripts/check_doc_contract.py
+++ b/scripts/check_doc_contract.py
@@ -141,7 +141,7 @@ def validate_changelog_entries(
         return
     for entry in entries:
         for key in ("version", "date", "changes"):
-            if not entry.get(key, "").strip().strip("'\""):
+            if not entry.get(key, "").strip().strip("'\"").strip():
                 add_error(
                     errors,
                     path,
@@ -163,7 +163,8 @@ def frontmatter_field_has_value(content: str, field: str) -> bool:
         if key.strip() != field:
             continue
         if value.strip():
-            return True
+            inline = value.strip().strip("'\"")
+            return bool(inline) and inline.lower() not in ("[]", "{}", "~", "null")
         for child in lines[index + 1 :]:
             if child.strip() and not child.startswith((" ", "\t", "-")):
                 break

--- a/scripts/check_doc_contract.py
+++ b/scripts/check_doc_contract.py
@@ -110,9 +110,14 @@ def is_formal_pm_or_engineer_document(rel: str) -> bool:
 
 def normalize_frontmatter_scalar(value: str) -> str:
     normalized = value.strip()
-    if not normalized.startswith(("'", '"')):
-        normalized = re.split(r"(?:^|\s+)#", normalized, maxsplit=1)[0]
-    return normalized.strip("'\"").strip()
+    if normalized.startswith(("'", '"')):
+        quote = normalized[0]
+        closing_quote = normalized.find(quote, 1)
+        if closing_quote == -1:
+            return ""
+        return normalized[1:closing_quote].strip()
+    normalized = re.split(r"(?:^|\s+)#", normalized, maxsplit=1)[0].strip()
+    return "" if normalized in ("|", ">") else normalized
 
 
 def validate_changelog_entries(
@@ -156,7 +161,7 @@ def validate_changelog_entries(
     for entry in entries:
         for key in ("version", "date", "changes"):
             normalized = normalize_frontmatter_scalar(entry.get(key, ""))
-            if not normalized or normalized in ("|", ">"):
+            if not normalized:
                 add_error(
                     errors,
                     path,
@@ -182,9 +187,12 @@ def frontmatter_field_has_value(content: str, field: str) -> bool:
             compact = re.sub(r"\s+", "", inline).lower()
             return bool(inline) and compact not in ("[]", "{}", "~", "null")
         for child in lines[index + 1 :]:
-            if child.strip() and not child.startswith((" ", "\t", "-")):
+            stripped = child.strip()
+            if stripped.startswith("#"):
+                continue
+            if stripped and not child.startswith((" ", "\t", "-")):
                 break
-            if child.strip():
+            if stripped:
                 return True
         return False
     return False

--- a/scripts/check_doc_contract.py
+++ b/scripts/check_doc_contract.py
@@ -193,7 +193,9 @@ def frontmatter_field_has_value(content: str, field: str) -> bool:
             if stripped and not child.startswith((" ", "\t", "-")):
                 break
             if stripped:
-                return True
+                item = stripped[1:] if stripped.startswith("-") else stripped
+                if normalize_frontmatter_scalar(item):
+                    return True
         return False
     return False
 

--- a/scripts/check_doc_contract.py
+++ b/scripts/check_doc_contract.py
@@ -12,6 +12,8 @@ from check_repository_contract import (
     ContractError,
     add_error,
     is_legacy_artifact_path,
+    markdown_frontmatter_block,
+    markdown_frontmatter_changelog_block,
     parse_markdown_frontmatter,
     repo_root,
     tracked_files,
@@ -19,6 +21,37 @@ from check_repository_contract import (
 
 
 REQUIRED_FORMAL_FRONTMATTER_FIELDS = ("feature", "version", "date", "last_updated")
+# Extended presence set aligning with the output-conventions required fields
+# (agents/product_manager/skills/idea-to-spec/_internal/_shared/
+# output-conventions.md). `changelog` is validated structurally below because
+# the frontmatter parser flattens block values to empty strings; the PRD-only
+# `child_features` field is validated per document type.
+EXTENDED_FORMAL_FRONTMATTER_FIELDS = (
+    "title",
+    "type",
+    "feature",
+    "feature_path",
+    "parent_feature",
+    "feature_level",
+    "version",
+    "status",
+    "author",
+    "date",
+    "last_updated",
+    "generated_by",
+)
+# Explicit registry of formal documents exempt from the extended field set (the
+# base four fields still apply). Every entry must name an existing tracked file
+# and record the reason; retire an entry by bringing the document up to the
+# output-conventions field set.
+FORMAL_DOC_FIELD_EXEMPTIONS: dict[str, str] = {
+    "docs/pm/repository-ci-governance/CI_PLAN.md": (
+        "checklist-style CI governance ledger; its document type is outside the"
+        " output-conventions enum and its version is a non-SemVer draft (#331)"
+    ),
+}
+CHANGELOG_ENTRY_START_RE = re.compile(r"^\s*-\s+version:\s*(.*?)\s*$")
+CHANGELOG_ENTRY_FIELD_RE = re.compile(r"^\s+(date|changes):\s*(.*?)\s*$")
 FORMAL_DOC_PREFIXES = ("docs/pm/", "docs/engineer/")
 NON_FORMAL_DOC_NAMES = {"README.md", "README_zh.md", "CHANGELOG.md"}
 
@@ -69,8 +102,75 @@ def is_formal_pm_or_engineer_document(rel: str) -> bool:
         return False
     # Implementation plan metadata, including archive-specific fields, is owned
     # by check_repository_contract.py. Keep this checker focused on the gap:
-    # PRD/TRD plus other formal PM/Engineer docs such as DECISIONS and CI_PLAN.
+    # PRD/TRD plus other formal PM/Engineer docs such as DECISIONS and CI_PLAN
+    # (CI_PLAN carries a registered exemption from the extended field set; see
+    # FORMAL_DOC_FIELD_EXEMPTIONS).
     return not is_implementation_plan_artifact_path(rel)
+
+
+def validate_changelog_entries(
+    path: Path,
+    content: str,
+    errors: list[ContractError],
+) -> None:
+    block = markdown_frontmatter_changelog_block(content)
+    if not block.strip():
+        add_error(
+            errors, path, "frontmatter 'changelog' must contain at least one entry"
+        )
+        return
+    entries: list[dict[str, str]] = []
+    current: dict[str, str] | None = None
+    for line in block.splitlines():
+        start = CHANGELOG_ENTRY_START_RE.match(line)
+        if start is not None:
+            current = {"version": start.group(1)}
+            entries.append(current)
+            continue
+        if current is None:
+            continue
+        field = CHANGELOG_ENTRY_FIELD_RE.match(line)
+        if field is not None:
+            current[field.group(1)] = field.group(2)
+    if not entries:
+        add_error(
+            errors,
+            path,
+            "frontmatter 'changelog' must contain at least one '- version:' entry",
+        )
+        return
+    for entry in entries:
+        for key in ("version", "date", "changes"):
+            if not entry.get(key, "").strip().strip("'\""):
+                add_error(
+                    errors,
+                    path,
+                    "frontmatter 'changelog' entry for version"
+                    f" {entry.get('version') or '<unknown>'!r}"
+                    f" must have non-empty {key!r}",
+                )
+
+
+def frontmatter_field_has_value(content: str, field: str) -> bool:
+    block = markdown_frontmatter_block(content)
+    if not block:
+        return False
+    lines = block.splitlines()
+    for index, line in enumerate(lines):
+        if line.startswith((" ", "\t", "-")) or ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        if key.strip() != field:
+            continue
+        if value.strip():
+            return True
+        for child in lines[index + 1 :]:
+            if child.strip() and not child.startswith((" ", "\t", "-")):
+                break
+            if child.strip():
+                return True
+        return False
+    return False
 
 
 def validate_required_formal_frontmatter(
@@ -85,7 +185,8 @@ def validate_required_formal_frontmatter(
         if not path.exists():
             continue
 
-        parsed = parse_markdown_frontmatter(path, path.read_text(), errors)
+        content = path.read_text()
+        parsed = parse_markdown_frontmatter(path, content, errors)
         if parsed is None:
             continue
         metadata, _ = parsed
@@ -94,6 +195,28 @@ def validate_required_formal_frontmatter(
             value = metadata.get(field)
             if not isinstance(value, str) or not value.strip():
                 add_error(errors, path, f"frontmatter {field!r} must be non-empty")
+
+        if rel in FORMAL_DOC_FIELD_EXEMPTIONS:
+            continue
+
+        for field in EXTENDED_FORMAL_FRONTMATTER_FIELDS:
+            value = metadata.get(field)
+            if not isinstance(value, str) or not value.strip():
+                add_error(errors, path, f"frontmatter {field!r} must be non-empty")
+
+        validate_changelog_entries(path, content, errors)
+
+        if (
+            rel.startswith("docs/pm/")
+            and Path(rel).name == "PRD.md"
+            and not frontmatter_field_has_value(content, "child_features")
+        ):
+            add_error(
+                errors,
+                path,
+                "frontmatter 'child_features' must be non-empty for PRDs"
+                ' (use "N/A" when the PRD has no direct children)',
+            )
 
 
 def validate_prd_related_trd_mirror(


### PR DESCRIPTION
Close #331。

## 背景

#330 完成字段口径统一与历史补齐后，#331 要求把 `check_doc_contract.py` 从静默放低校验面加严为硬失败，并为豁免提供显式登记机制。

## 变更（3 文件，+225/−19）

**`scripts/check_doc_contract.py`**

- 扩展必填集：`title`/`type`/`feature_path`/`parent_feature`/`feature_level`/`status`/`author`/`generated_by` 缺失即报错（在既有 `feature`/`version`/`date`/`last_updated` 基础上对齐 output-conventions 必填全集）。
- `changelog` 结构校验：frontmatter 解析器会把块值展平为空串，故复用 `check_repository_contract.py` 的 `markdown_frontmatter_changelog_block` 提取块，逐条要求 `- version:` 条目且 `version`/`date`/`changes` 非空。
- PRD 专项：`child_features` 必须非空（行内 `N/A` 或列表均可；无直接子功能填 `N/A`）。
- 豁免显式登记：新增 `FORMAL_DOC_FIELD_EXEMPTIONS` 路径→理由注册表，当前唯一条目 `docs/pm/repository-ci-governance/CI_PLAN.md`；基础四字段对被豁免文档仍然生效。

**`agents/test_doc_contract.py`**：验收 fixture 升至完整字段；新增三个负向/豁免用例（PRD 缺 `child_features`、changelog 条目缺 `changes`、登记豁免跳过扩展字段）；既有缺失字段用例补断言。

**`docs/engineer/repository-governance/document-authority/TRD.md`**：§13 文档契约行对齐新校验范围，bump 0.1.8 并记 changelog。

## 对齐与范围说明

- `feature_path`/`parent_feature`/`feature_level` 的一致性语义（期望值推导）仍只由 `check_repository_contract.py` 定义；本 checker 只做存在性校验，不重复定义逻辑。
- 明确非目标：`status`/`type` 的枚举值校验（现存 2 份 `status: Implemented` 文档超出 output-conventions 状态枚举，需先另行对齐再加严）。
- 无 skill 生命周期变更：不动 marketplace / lockfile / 生成副本 / CI 测试清单（`agents/test_doc_contract.py` 已在 CI 显式列表中）。

## 验证

- `agents/test_doc_contract.py` 11 个 unittest 全部通过
- 隔离 venv 中 pytest 37 passed（`scripts/test_check_repository_contract.py` 因需 Python 3.10+ 在本机 3.9 无法收集，与本次改动无关，CI 会覆盖）
- `generate_shared_contracts.py --check`、`check_repository_contract.py`、`check_doc_contract.py`、`git diff --check` 全部通过
- 加严后的 checker 对 95 份真实文档零误报，等于反向回归验证了 #332 的补齐质量