### PR TITLE
chore(release): 发布 v0.6.6

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "PM-first agent skill marketplace with one public pm-agent entry, reader-facing human writing composition, and downstream PM-orchestrated engineering, QA, DevOps, design, security, and documentation capabilities",
-    "version": "0.6.5"
+    "version": "0.6.6"
   },
   "plugins": [
     {

--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-agent-skills",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "PM-first agent skill marketplace with one public pm-agent entry, reader-facing human writing composition, and downstream PM-orchestrated engineering, QA, DevOps, design, security, and documentation capabilities",
   "keywords": [
     "agent-skills",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 仓库级发布变更记录按版本归档到 `docs/changelog/`。
 
+- [v0.6.6](./docs/changelog/changelog-v0.6.6.md)
 - [v0.6.5](./docs/changelog/changelog-v0.6.5.md)
 - [v0.6.4](./docs/changelog/changelog-v0.6.4.md)
 - [v0.6.3](./docs/changelog/changelog-v0.6.3.md)

--- a/agents/designer/.claude-plugin/plugin.json
+++ b/agents/designer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "designer-agent",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "Downstream design capability invoked after pm-agent handoff for confirmed UX flows, information architecture, wireframes, reference-pattern analysis, and reference-backed visual system work.",
   "author": {
     "name": "Neplich"

--- a/agents/devops/.claude-plugin/plugin.json
+++ b/agents/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops-agent",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "Downstream DevOps capability invoked after pm-agent handoff for confirmed deployment planning, CI/CD automation, environment audits, release readiness, rollback, and runbook preparation.",
   "author": {
     "name": "Neplich"

--- a/agents/docs/.claude-plugin/plugin.json
+++ b/agents/docs/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "docs-agent",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "Downstream documentation capability invoked after pm-agent handoff for confirmed formal documentation bootstrap, synchronization, backfill, illustrated user operation manuals from real running interfaces, site Release Notes, and release audit.",
   "author": {
     "name": "Neplich"

--- a/agents/engineer/.claude-plugin/plugin.json
+++ b/agents/engineer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "engineer-agent",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "Downstream engineering capability invoked after pm-agent handoff for confirmed codebase analysis, TRDs, implementation, tests, debugging, and delivery. Skills remain available for PM-orchestrated execution, not as standalone starting points.",
   "author": {
     "name": "Neplich"

--- a/agents/product_manager/.claude-plugin/plugin.json
+++ b/agents/product_manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pm-agent",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "Default entry plugin for product and engineering R&D requests when no other agent or skill is named. Explicitly naming pm-agent selects it even when a downstream capability is also named; naming another role agent or skill without pm-agent excludes pm-agent and leaves that capability to enforce its own gate. Routes product ideas, features, changes, bugs, implementation, testing, design, deployment, security, formal docs, delivery, planning, and repository status work, with human-writing composition for reader-facing documents.",
   "author": {
     "name": "Neplich"

--- a/agents/qa/.claude-plugin/plugin.json
+++ b/agents/qa/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qa-agent",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "Downstream QA capability invoked after pm-agent handoff for confirmed acceptance, exploratory testing, bug analysis, and regression verification. Requirement or implementation gaps return through the PM-orchestrated handoff path.",
   "author": {
     "name": "Neplich"

--- a/agents/security/.claude-plugin/plugin.json
+++ b/agents/security/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "security-agent",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "Downstream security capability invoked after pm-agent handoff for confirmed AppSec, auth/authz, dependency risk, privacy, and data-flow reviews, with remediation routed through the PM handoff path.",
   "author": {
     "name": "Neplich"

--- a/docs/changelog/changelog-v0.6.6.md
+++ b/docs/changelog/changelog-v0.6.6.md
@@ -1,0 +1,30 @@
+---
+feature: release-changelog
+version: 0.6.6
+date: 2026-09-03
+last_updated: 2026-09-03
+---
+
+# Changelog - v0.6.6
+
+## [v0.6.6] - 2026-09-03
+
+本版本统一正式文档 frontmatter 字段口径并加严契约校验：迭代类 skill 更新既有文档时当场补齐缺失必填字段，文档契约检查从静默放低升级为硬失败；另完成 eval 机制移除后的文档残留清理，覆盖 v0.6.5 之后合并到 `main` 的 4 个 PR。
+
+### Added
+
+- **contract:** 正式文档必填字段校验加严与豁免显式登记 ([#333](https://github.com/Neplich/dev-agent-skills/pull/333))。`check_doc_contract.py` 在既有四字段基础上扩展至 output-conventions 必填全集（`title`/`type`/`feature_path`/`parent_feature`/`feature_level`/`status`/`author`/`generated_by`），缺失即报错；新增 changelog frontmatter 结构逐条校验与 PRD `child_features` 非空要求；新增 `FORMAL_DOC_FIELD_EXEMPTIONS` 豁免注册表，`CI_PLAN.md` 为当前唯一登记条目，基础四字段校验对豁免文档仍然生效。
+
+### Changed
+
+- 统一正式文档字段口径，迭代触及既有文档时补齐缺失必填字段 ([#332](https://github.com/Neplich/dev-agent-skills/pull/332))。`idea-to-spec` 输出约定移除必填字段的"仅新建"限定并新增 Updating Existing Documents 规则：`prd-iteration`、`trd-iteration`、`tspecs-iteration` 与 `trd-gen` 更新既有文档时当场补建缺失必填字段与 changelog 结构、按规则 bump 版本，不再因文档早于约定而跳过；可选字段与有文档化 fallback 的字段属设计意图，维持不变。65 份历史文档同步补齐 `child_features`、`changelog` 与 `generated_by`，`CI_PLAN.md` 登记豁免并维持最小 frontmatter。
+
+### Fixed
+
+- 清理活跃规格中的 eval 残留并对齐 human-writing 验收契约 ([#327](https://github.com/Neplich/dev-agent-skills/pull/327))。72 份活跃 PRD/TRD/CI_PLAN/DECISIONS 中以现行语气引用已移除 eval 机制的内容删除或改挂现存确定性检查；DECISIONS 新增 D-023，明确真实项目案例与人工语义验收是能力迭代原则、不作为完成门禁，不恢复 Skill eval 体系的结论不变。
+- 清理 skill PRD persona 行与守护句中的惰性 eval 提及 ([#329](https://github.com/Neplich/dev-agent-skills/pull/329))。30 份 skill 级 PRD 的维护者 persona 行统一为"维护 skill 文档和确定性检查的人"；`idea-to-spec` TRD 三处防误扫守护句的 eval fixture 举例泛化为测试/评测夹具表述，守护语义不变。
+
+## 发布说明
+
+- 发版清单：`.claude-plugin/marketplace.json` 的 `metadata.version` 更新为 `0.6.6`；7 个 `agents/*/.claude-plugin/plugin.json` 与 `.kimi-plugin/plugin.json` 的 `version` 同步为 `0.6.6`（由 `check_repository_contract.py` 强制校验）。
+- 行为变更：迭代类 skill 更新既有正式文档时须当场补齐缺失必填字段，不再按"仅新建"限定跳过（#332）；仓库文档契约校验扩展至必填全集并硬失败（#333）。其余为文档残留清理，不改变 skill 运行行为。


### PR DESCRIPTION
## 发布 v0.6.6

### 变更窗口

v0.6.5 之后合并到 `main` 的 4 个 PR：

- #327 fix(docs): 清理活跃规格中的 eval 残留并对齐 human-writing 验收契约
- #329 fix(docs): 清理 skill PRD persona 行与守护句中的惰性 eval 提及
- #332 docs(governance): 统一正式文档字段口径并补齐历史文档 metadata
- #333 feat(contract): check_doc_contract 加严正式文档必填字段校验

### 本 PR 内容

- 新增 `docs/changelog/changelog-v0.6.6.md`，并在根 `CHANGELOG.md` 索引登记
- 9 个版本面统一为 `0.6.6`：`.claude-plugin/marketplace.json` 的 `metadata.version`、7 个 `agents/*/.claude-plugin/plugin.json`、`.kimi-plugin/plugin.json`

### 验证

- `uv run scripts/generate_shared_contracts.py --check` ✅
- `uv run scripts/check_repository_contract.py` ✅
- `uv run scripts/check_doc_contract.py` ✅
- `git diff --check` ✅
